### PR TITLE
[2.8][Form] Deprecate alias tag option

### DIFF
--- a/UPGRADE-2.8.md
+++ b/UPGRADE-2.8.md
@@ -236,7 +236,7 @@ Form
    implementation to define the right type.
 
  * The alias option of the `form.type_extension` tag is deprecated in favor of
-   the `extended_type` option.
+   the `extended_type`/`extended-type` option.
 
    Before:
    ```xml

--- a/UPGRADE-2.8.md
+++ b/UPGRADE-2.8.md
@@ -235,6 +235,23 @@ Form
    match the type returned by `getExtendedType` is now forbidden. Fix your
    implementation to define the right type.
 
+ * The alias option of the `form.type_extension` tag is deprecated in favor of
+   the `extended_type` option.
+
+   Before:
+   ```xml
+   <service id="app.type_extension" class="Vendor\Form\Extension\MyTypeExtension">
+       <tag name="form.type_extension" alias="text" />
+   </service>
+   ```
+
+   After:
+   ```xml
+   <service id="app.type_extension" class="Vendor\Form\Extension\MyTypeExtension">
+       <tag name="form.type_extension" extended-type="Symfony\Component\Form\Extension\Core\Type\TextType" />
+   </service>
+   ```
+
 Translator
 ----------
 

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG
 2.8.0
 -----
 
+ * Deprecated the `alias` option of the `form.type_extension` tag in favor of the
+   `extended_type`/`extended-type` option
+ * Deprecated the `alias` option of the `form.type` tag
  * Deprecated the Shell
 
 2.7.0

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FormPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FormPass.php
@@ -53,11 +53,17 @@ class FormPass implements CompilerPassInterface
         $typeExtensions = array();
 
         foreach ($container->findTaggedServiceIds('form.type_extension') as $serviceId => $tag) {
-            $alias = isset($tag[0]['alias'])
-                ? $tag[0]['alias']
-                : $serviceId;
+            $extendedType = $serviceId;
+            if (isset($tag[0]['extended_type'])) {
+                $extendedType = $tag[0]['extended_type'];
+            } elseif (isset($tag[0]['alias'])) {
+                @trigger_error('The alias option of the form.type_extension tag is deprecated since version 2.8 and will be removed in 3.0. Use the extended_type option instead.', E_USER_DEPRECATED);
+                $extendedType = $tag[0]['alias'];
+            } else {
+                @trigger_error('The extended_type option of the form.type_extension tag is required since version 2.8 and will be removed in 3.0.', E_USER_DEPRECATED);
+            }
 
-            $typeExtensions[$alias][] = $serviceId;
+            $typeExtensions[$extendedType][] = $serviceId;
         }
 
         $definition->replaceArgument(2, $typeExtensions);

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FormPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FormPass.php
@@ -53,7 +53,7 @@ class FormPass implements CompilerPassInterface
         $typeExtensions = array();
 
         foreach ($container->findTaggedServiceIds('form.type_extension') as $serviceId => $tag) {
-            $extendedType = $serviceId;
+            $extendedType = null;
             if (isset($tag[0]['extended_type'])) {
                 $extendedType = $tag[0]['extended_type'];
             } elseif (isset($tag[0]['alias'])) {
@@ -61,6 +61,7 @@ class FormPass implements CompilerPassInterface
                 $extendedType = $tag[0]['alias'];
             } else {
                 @trigger_error('The extended_type option of the form.type_extension tag is required since version 2.8 and will be removed in 3.0.', E_USER_DEPRECATED);
+                $extendedType = $serviceId;
             }
 
             $typeExtensions[$extendedType][] = $serviceId;

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
@@ -155,7 +155,7 @@
         <!-- FormTypeHttpFoundationExtension -->
         <service id="form.type_extension.form.http_foundation" class="Symfony\Component\Form\Extension\HttpFoundation\Type\FormTypeHttpFoundationExtension">
             <argument type="service" id="form.type_extension.form.request_handler" />
-            <tag name="form.type_extension" alias="Symfony\Component\Form\Extension\Core\Type\FormType" />
+            <tag name="form.type_extension" extended-type="Symfony\Component\Form\Extension\Core\Type\FormType" />
         </service>
 
         <!-- HttpFoundationRequestHandler -->
@@ -169,14 +169,14 @@
 
         <!-- FormTypeValidatorExtension -->
         <service id="form.type_extension.form.validator" class="Symfony\Component\Form\Extension\Validator\Type\FormTypeValidatorExtension">
-            <tag name="form.type_extension" alias="Symfony\Component\Form\Extension\Core\Type\FormType" />
+            <tag name="form.type_extension" extended-type="Symfony\Component\Form\Extension\Core\Type\FormType" />
             <argument type="service" id="validator" />
         </service>
         <service id="form.type_extension.repeated.validator" class="Symfony\Component\Form\Extension\Validator\Type\RepeatedTypeValidatorExtension">
-            <tag name="form.type_extension" alias="Symfony\Component\Form\Extension\Core\Type\RepeatedType" />
+            <tag name="form.type_extension" extended-type="Symfony\Component\Form\Extension\Core\Type\RepeatedType" />
         </service>
         <service id="form.type_extension.submit.validator" class="Symfony\Component\Form\Extension\Validator\Type\SubmitTypeValidatorExtension">
-            <tag name="form.type_extension" alias="Symfony\Component\Form\Extension\Core\Type\SubmitType" />
+            <tag name="form.type_extension" extended-type="Symfony\Component\Form\Extension\Core\Type\SubmitType" />
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_csrf.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_csrf.xml
@@ -11,7 +11,7 @@
         </service>
 
         <service id="form.type_extension.csrf" class="Symfony\Component\Form\Extension\Csrf\Type\FormTypeCsrfExtension">
-            <tag name="form.type_extension" alias="Symfony\Component\Form\Extension\Core\Type\FormType" />
+            <tag name="form.type_extension" extended-type="Symfony\Component\Form\Extension\Core\Type\FormType" />
             <argument type="service" id="security.csrf.token_manager" />
             <argument>%form.type_extension.csrf.enabled%</argument>
             <argument>%form.type_extension.csrf.field_name%</argument>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_debug.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_debug.xml
@@ -21,7 +21,7 @@
 
         <!-- DataCollectorTypeExtension -->
         <service id="form.type_extension.form.data_collector" class="%form.type_extension.form.data_collector.class%">
-            <tag name="form.type_extension" alias="Symfony\Component\Form\Extension\Core\Type\FormType" />
+            <tag name="form.type_extension" extended-type="Symfony\Component\Form\Extension\Core\Type\FormType" />
             <argument type="service" id="data_collector.form" />
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/FormPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/FormPassTest.php
@@ -68,6 +68,9 @@ class FormPassTest extends \PHPUnit_Framework_TestCase
         ), $extDefinition->getArgument(1));
     }
 
+    /**
+     * @group legacy
+     */
     public function testUseCustomAliasIfSet()
     {
         $container = new ContainerBuilder();
@@ -107,25 +110,20 @@ class FormPassTest extends \PHPUnit_Framework_TestCase
         $container = new ContainerBuilder();
         $container->addCompilerPass(new FormPass());
 
-        $extDefinition = new Definition('Symfony\Component\Form\Extension\DependencyInjection\DependencyInjectionExtension');
-        $extDefinition->setArguments(array(
+        $extDefinition = new Definition('Symfony\Component\Form\Extension\DependencyInjection\DependencyInjectionExtension', array(
             new Reference('service_container'),
             array(),
             array(),
             array(),
         ));
 
-        $definition1 = new Definition('stdClass');
-        $definition1->addTag('form.type_extension', array('alias' => 'type1'));
-        $definition2 = new Definition('stdClass');
-        $definition2->addTag('form.type_extension', array('alias' => 'type1'));
-        $definition3 = new Definition('stdClass');
-        $definition3->addTag('form.type_extension', array('alias' => 'type2'));
-
         $container->setDefinition('form.extension', $extDefinition);
-        $container->setDefinition('my.type_extension1', $definition1);
-        $container->setDefinition('my.type_extension2', $definition2);
-        $container->setDefinition('my.type_extension3', $definition3);
+        $container->register('my.type_extension1', 'stdClass')
+            ->addTag('form.type_extension', array('extended_type' => 'type1'));
+        $container->register('my.type_extension2', 'stdClass')
+            ->addTag('form.type_extension', array('extended_type' => 'type1'));
+        $container->register('my.type_extension3', 'stdClass')
+            ->addTag('form.type_extension', array('extended_type' => 'type2'));
 
         $container->compile();
 
@@ -138,6 +136,41 @@ class FormPassTest extends \PHPUnit_Framework_TestCase
             ),
             'type2' => array(
                 'my.type_extension3',
+            ),
+        ), $extDefinition->getArgument(2));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testAliasOptionForTaggedTypeExtensions()
+    {
+        $container = new ContainerBuilder();
+        $container->addCompilerPass(new FormPass());
+
+        $extDefinition = new Definition('Symfony\Component\Form\Extension\DependencyInjection\DependencyInjectionExtension', array(
+            new Reference('service_container'),
+            array(),
+            array(),
+            array(),
+        ));
+
+        $container->setDefinition('form.extension', $extDefinition);
+        $container->register('my.type_extension1', 'stdClass')
+            ->addTag('form.type_extension', array('alias' => 'type1'));
+        $container->register('my.type_extension2', 'stdClass')
+            ->addTag('form.type_extension', array('alias' => 'type2'));
+
+        $container->compile();
+
+        $extDefinition = $container->getDefinition('form.extension');
+
+        $this->assertSame(array(
+            'type1' => array(
+                'my.type_extension1',
+            ),
+            'type2' => array(
+                'my.type_extension2',
             ),
         ), $extDefinition->getArgument(2));
     }


### PR DESCRIPTION
FQCN should be used since 2.8 instead, so a deprecation error should be triggered when the `alias` setting is used.

Furthermore, the name of the option doesn't make much sense for form types (as it's the alias of the field it applies to), so I renamed it to `extended_type`. I'm open to any other suggestions.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
