### PR TITLE
[2.8][WebProfilerBundle] Fix search button click listener

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -390,6 +390,13 @@
                         e.preventDefault();
 
                         var toggle = e.target || e.srcElement;
+
+                        /* needed because when the toggle contains HTML contents, user can click */
+                        /* on any of those elements instead of their parent '.sf-toggle' element */
+                        while (!Sfjs.hasClass(toggle, 'sf-toggle')) {
+                            toggle = toggle.parentNode;
+                        }
+
                         var element = document.querySelector(toggle.getAttribute('data-toggle-selector'));
 
                         Sfjs.toggleClass(element, 'sf-toggle-hidden');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This fixes an issue when clicking the sidebar "Search" button **text** instead of the **button**. Then the click event target/srcElement is the _span_ child-element, instead of the listening _a_ element, which causes errors in the listener, since it expects the listening element. In consequence of that the search form isn't shown.

To fix this, the same technique is used, as for the navigation tabs. Traversing the DOM up to the expected _a_ element.
