### PR TITLE
[3.0][Config] Remove ResourceInterface::getResource() which was deprecated in 2.8

### DIFF
--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * removed `ReferenceDumper` class
  * removed the `ResourceInterface::isFresh()` method
  * removed `BCResourceInterfaceChecker` class
+ * removed `ResourceInterface::getResource()` method
 
 2.8.0
 -----

--- a/src/Symfony/Component/Config/Resource/DirectoryResource.php
+++ b/src/Symfony/Component/Config/Resource/DirectoryResource.php
@@ -42,7 +42,7 @@ class DirectoryResource implements SelfCheckingResourceInterface, \Serializable
     }
 
     /**
-     * {@inheritdoc}
+     * @return string The file path to the resource
      */
     public function getResource()
     {

--- a/src/Symfony/Component/Config/Resource/FileExistenceResource.php
+++ b/src/Symfony/Component/Config/Resource/FileExistenceResource.php
@@ -45,7 +45,7 @@ class FileExistenceResource implements SelfCheckingResourceInterface, \Serializa
     }
 
     /**
-     * {@inheritdoc}
+     * @return string The file path to the resource
      */
     public function getResource()
     {

--- a/src/Symfony/Component/Config/Resource/FileResource.php
+++ b/src/Symfony/Component/Config/Resource/FileResource.php
@@ -44,7 +44,7 @@ class FileResource implements SelfCheckingResourceInterface, \Serializable
     }
 
     /**
-     * @return string The file path to the resource
+     * @return string|false The canonicalized, absolute path to the resource or false if the resource does not exist.
      */
     public function getResource()
     {

--- a/src/Symfony/Component/Config/Resource/FileResource.php
+++ b/src/Symfony/Component/Config/Resource/FileResource.php
@@ -44,7 +44,7 @@ class FileResource implements SelfCheckingResourceInterface, \Serializable
     }
 
     /**
-     * {@inheritdoc}
+     * @return string The file path to the resource
      */
     public function getResource()
     {

--- a/src/Symfony/Component/Config/Resource/ResourceInterface.php
+++ b/src/Symfony/Component/Config/Resource/ResourceInterface.php
@@ -30,17 +30,4 @@ interface ResourceInterface
      * @return string A string representation unique to the underlying Resource
      */
     public function __toString();
-
-    /**
-     * Returns the tied resource.
-     *
-     * @return mixed The resource
-     *
-     * @deprecated since 2.8, to be removed in 3.0. As there are many different kinds of resource,
-     *             a single getResource() method does not make sense at the interface level. You
-     *             can still call getResource() on implementing classes, probably after performing
-     *             a type check. If you know the concrete type of Resource at hand, the return value
-     *             of this method may make sense to you.
-     */
-    public function getResource();
 }

--- a/src/Symfony/Component/Config/Tests/Resource/ResourceStub.php
+++ b/src/Symfony/Component/Config/Tests/Resource/ResourceStub.php
@@ -31,9 +31,4 @@ class ResourceStub implements SelfCheckingResourceInterface
     {
         return $this->fresh;
     }
-
-    public function getResource()
-    {
-        return 'stub';
-    }
 }

--- a/src/Symfony/Component/HttpKernel/Config/EnvParametersResource.php
+++ b/src/Symfony/Component/HttpKernel/Config/EnvParametersResource.php
@@ -50,7 +50,7 @@ class EnvParametersResource implements SelfCheckingResourceInterface, \Serializa
     }
 
     /**
-     * {@inheritdoc}
+     * @return array An array with two keys: 'prefix' for the prefix used and 'variables' containing all the variables watched by this resource
      */
     public function getResource()
     {

--- a/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorCacheTest.php
@@ -288,10 +288,6 @@ class StaleResource implements SelfCheckingResourceInterface
         return false;
     }
 
-    public function getResource()
-    {
-    }
-
     public function __toString()
     {
         return '';


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Deprecated in #15719.
