### PR TITLE
Add a non-static API for the CssSelector component

### DIFF
--- a/src/Symfony/Component/CssSelector/CHANGELOG.md
+++ b/src/Symfony/Component/CssSelector/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+2.8.0
+-----
+
+ * Added the ConverterInterface and the Converter implementation as a non-static API for the component.
+ * Deprecated the `CssSelector` static API of the component.
+
 2.1.0
 -----
 

--- a/src/Symfony/Component/CssSelector/Converter.php
+++ b/src/Symfony/Component/CssSelector/Converter.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\CssSelector;
+
+use Symfony\Component\CssSelector\Parser\Shortcut\ClassParser;
+use Symfony\Component\CssSelector\Parser\Shortcut\ElementParser;
+use Symfony\Component\CssSelector\Parser\Shortcut\EmptyStringParser;
+use Symfony\Component\CssSelector\Parser\Shortcut\HashParser;
+use Symfony\Component\CssSelector\XPath\Extension\HtmlExtension;
+use Symfony\Component\CssSelector\XPath\Translator;
+
+/**
+ * @author Christophe Coevoet <stof@notk.org>
+ *
+ * @api
+ */
+class Converter implements ConverterInterface
+{
+    private $translator;
+
+    /**
+     * @param bool $html Whether HTML support should be enabled. Disable it for XML documents.
+     */
+    public function __construct($html = true)
+    {
+        $this->translator = new Translator();
+
+        if ($html) {
+            $this->translator->registerExtension(new HtmlExtension($this->translator));
+        }
+
+        $this->translator
+            ->registerParserShortcut(new EmptyStringParser())
+            ->registerParserShortcut(new ElementParser())
+            ->registerParserShortcut(new ClassParser())
+            ->registerParserShortcut(new HashParser())
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toXPath($cssExpr, $prefix = 'descendant-or-self::')
+    {
+        return $this->translator->cssToXPath($cssExpr, $prefix);
+    }
+}

--- a/src/Symfony/Component/CssSelector/ConverterInterface.php
+++ b/src/Symfony/Component/CssSelector/ConverterInterface.php
@@ -11,13 +11,9 @@
 
 namespace Symfony\Component\CssSelector;
 
-@trigger_error('The '.__NAMESPACE__.'\CssSelector class is deprecated since version 2.8 and will be removed in 3.0. Use directly the \Symfony\Component\CssSelector\Converter class instead.', E_USER_DEPRECATED);
-
 /**
- * CssSelector is the main entry point of the component and can convert CSS
+ * ConverterInterface is the main entry point of the component and can convert CSS
  * selectors to XPath expressions.
- *
- * $xpath = CssSelector::toXpath('h1.foo');
  *
  * This component is a port of the Python cssselect library,
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
@@ -55,48 +51,25 @@ namespace Symfony\Component\CssSelector;
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * @author Fabien Potencier <fabien@symfony.com>
- *
- * @deprecated as of 2.8, will be removed in 3.0. Use the \Symfony\Component\CssSelector\Converter class instead.
+ * @author Christophe Coevoet <stof@notk.org>
  *
  * @api
  */
-class CssSelector
+interface ConverterInterface
 {
-    private static $html = true;
-
     /**
      * Translates a CSS expression to its XPath equivalent.
+     *
      * Optionally, a prefix can be added to the resulting XPath
      * expression with the $prefix parameter.
      *
-     * @param mixed  $cssExpr The CSS expression.
+     * @param string $cssExpr The CSS expression.
      * @param string $prefix  An optional prefix for the XPath expression.
      *
      * @return string
      *
      * @api
      */
-    public static function toXPath($cssExpr, $prefix = 'descendant-or-self::')
-    {
-        $converter = new Converter(self::$html);
+    public function toXPath($cssExpr, $prefix = 'descendant-or-self::');
 
-        return $converter->toXPath($cssExpr, $prefix);
-    }
-
-    /**
-     * Enables the HTML extension.
-     */
-    public static function enableHtmlExtension()
-    {
-        self::$html = true;
-    }
-
-    /**
-     * Disables the HTML extension.
-     */
-    public static function disableHtmlExtension()
-    {
-        self::$html = false;
-    }
 }

--- a/src/Symfony/Component/CssSelector/Node/AbstractNode.php
+++ b/src/Symfony/Component/CssSelector/Node/AbstractNode.php
@@ -18,6 +18,8 @@ namespace Symfony\Component\CssSelector\Node;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 abstract class AbstractNode implements NodeInterface
 {

--- a/src/Symfony/Component/CssSelector/Node/AttributeNode.php
+++ b/src/Symfony/Component/CssSelector/Node/AttributeNode.php
@@ -18,6 +18,8 @@ namespace Symfony\Component\CssSelector\Node;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class AttributeNode extends AbstractNode
 {

--- a/src/Symfony/Component/CssSelector/Node/ClassNode.php
+++ b/src/Symfony/Component/CssSelector/Node/ClassNode.php
@@ -18,6 +18,8 @@ namespace Symfony\Component\CssSelector\Node;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class ClassNode extends AbstractNode
 {

--- a/src/Symfony/Component/CssSelector/Node/CombinedSelectorNode.php
+++ b/src/Symfony/Component/CssSelector/Node/CombinedSelectorNode.php
@@ -18,6 +18,8 @@ namespace Symfony\Component\CssSelector\Node;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class CombinedSelectorNode extends AbstractNode
 {

--- a/src/Symfony/Component/CssSelector/Node/ElementNode.php
+++ b/src/Symfony/Component/CssSelector/Node/ElementNode.php
@@ -18,6 +18,8 @@ namespace Symfony\Component\CssSelector\Node;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class ElementNode extends AbstractNode
 {

--- a/src/Symfony/Component/CssSelector/Node/FunctionNode.php
+++ b/src/Symfony/Component/CssSelector/Node/FunctionNode.php
@@ -20,6 +20,8 @@ use Symfony\Component\CssSelector\Parser\Token;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class FunctionNode extends AbstractNode
 {

--- a/src/Symfony/Component/CssSelector/Node/HashNode.php
+++ b/src/Symfony/Component/CssSelector/Node/HashNode.php
@@ -18,6 +18,8 @@ namespace Symfony\Component\CssSelector\Node;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class HashNode extends AbstractNode
 {

--- a/src/Symfony/Component/CssSelector/Node/NegationNode.php
+++ b/src/Symfony/Component/CssSelector/Node/NegationNode.php
@@ -18,6 +18,8 @@ namespace Symfony\Component\CssSelector\Node;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class NegationNode extends AbstractNode
 {

--- a/src/Symfony/Component/CssSelector/Node/NodeInterface.php
+++ b/src/Symfony/Component/CssSelector/Node/NodeInterface.php
@@ -18,6 +18,8 @@ namespace Symfony\Component\CssSelector\Node;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 interface NodeInterface
 {

--- a/src/Symfony/Component/CssSelector/Node/PseudoNode.php
+++ b/src/Symfony/Component/CssSelector/Node/PseudoNode.php
@@ -18,6 +18,8 @@ namespace Symfony\Component\CssSelector\Node;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class PseudoNode extends AbstractNode
 {

--- a/src/Symfony/Component/CssSelector/Node/SelectorNode.php
+++ b/src/Symfony/Component/CssSelector/Node/SelectorNode.php
@@ -18,6 +18,8 @@ namespace Symfony\Component\CssSelector\Node;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class SelectorNode extends AbstractNode
 {

--- a/src/Symfony/Component/CssSelector/Node/Specificity.php
+++ b/src/Symfony/Component/CssSelector/Node/Specificity.php
@@ -20,6 +20,8 @@ namespace Symfony\Component\CssSelector\Node;
  * @see http://www.w3.org/TR/selectors/#specificity
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class Specificity
 {

--- a/src/Symfony/Component/CssSelector/Parser/Handler/CommentHandler.php
+++ b/src/Symfony/Component/CssSelector/Parser/Handler/CommentHandler.php
@@ -21,6 +21,8 @@ use Symfony\Component\CssSelector\Parser\TokenStream;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class CommentHandler implements HandlerInterface
 {

--- a/src/Symfony/Component/CssSelector/Parser/Handler/HandlerInterface.php
+++ b/src/Symfony/Component/CssSelector/Parser/Handler/HandlerInterface.php
@@ -21,6 +21,8 @@ use Symfony\Component\CssSelector\Parser\TokenStream;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 interface HandlerInterface
 {

--- a/src/Symfony/Component/CssSelector/Parser/Handler/HashHandler.php
+++ b/src/Symfony/Component/CssSelector/Parser/Handler/HashHandler.php
@@ -24,6 +24,8 @@ use Symfony\Component\CssSelector\Parser\Tokenizer\TokenizerPatterns;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class HashHandler implements HandlerInterface
 {

--- a/src/Symfony/Component/CssSelector/Parser/Handler/IdentifierHandler.php
+++ b/src/Symfony/Component/CssSelector/Parser/Handler/IdentifierHandler.php
@@ -24,6 +24,8 @@ use Symfony\Component\CssSelector\Parser\Tokenizer\TokenizerPatterns;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class IdentifierHandler implements HandlerInterface
 {

--- a/src/Symfony/Component/CssSelector/Parser/Handler/NumberHandler.php
+++ b/src/Symfony/Component/CssSelector/Parser/Handler/NumberHandler.php
@@ -23,6 +23,8 @@ use Symfony\Component\CssSelector\Parser\Tokenizer\TokenizerPatterns;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class NumberHandler implements HandlerInterface
 {

--- a/src/Symfony/Component/CssSelector/Parser/Handler/StringHandler.php
+++ b/src/Symfony/Component/CssSelector/Parser/Handler/StringHandler.php
@@ -26,6 +26,8 @@ use Symfony\Component\CssSelector\Parser\Tokenizer\TokenizerPatterns;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class StringHandler implements HandlerInterface
 {

--- a/src/Symfony/Component/CssSelector/Parser/Handler/WhitespaceHandler.php
+++ b/src/Symfony/Component/CssSelector/Parser/Handler/WhitespaceHandler.php
@@ -22,6 +22,8 @@ use Symfony\Component\CssSelector\Parser\TokenStream;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class WhitespaceHandler implements HandlerInterface
 {

--- a/src/Symfony/Component/CssSelector/Parser/Parser.php
+++ b/src/Symfony/Component/CssSelector/Parser/Parser.php
@@ -22,6 +22,8 @@ use Symfony\Component\CssSelector\Parser\Tokenizer\Tokenizer;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class Parser implements ParserInterface
 {

--- a/src/Symfony/Component/CssSelector/Parser/ParserInterface.php
+++ b/src/Symfony/Component/CssSelector/Parser/ParserInterface.php
@@ -20,6 +20,8 @@ use Symfony\Component\CssSelector\Node\SelectorNode;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 interface ParserInterface
 {

--- a/src/Symfony/Component/CssSelector/Parser/Reader.php
+++ b/src/Symfony/Component/CssSelector/Parser/Reader.php
@@ -18,6 +18,8 @@ namespace Symfony\Component\CssSelector\Parser;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class Reader
 {

--- a/src/Symfony/Component/CssSelector/Parser/Shortcut/ClassParser.php
+++ b/src/Symfony/Component/CssSelector/Parser/Shortcut/ClassParser.php
@@ -23,6 +23,8 @@ use Symfony\Component\CssSelector\Parser\ParserInterface;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class ClassParser implements ParserInterface
 {

--- a/src/Symfony/Component/CssSelector/Parser/Shortcut/ElementParser.php
+++ b/src/Symfony/Component/CssSelector/Parser/Shortcut/ElementParser.php
@@ -22,6 +22,8 @@ use Symfony\Component\CssSelector\Parser\ParserInterface;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class ElementParser implements ParserInterface
 {

--- a/src/Symfony/Component/CssSelector/Parser/Shortcut/EmptyStringParser.php
+++ b/src/Symfony/Component/CssSelector/Parser/Shortcut/EmptyStringParser.php
@@ -26,6 +26,8 @@ use Symfony\Component\CssSelector\Parser\ParserInterface;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class EmptyStringParser implements ParserInterface
 {

--- a/src/Symfony/Component/CssSelector/Parser/Shortcut/HashParser.php
+++ b/src/Symfony/Component/CssSelector/Parser/Shortcut/HashParser.php
@@ -23,6 +23,8 @@ use Symfony\Component\CssSelector\Parser\ParserInterface;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class HashParser implements ParserInterface
 {

--- a/src/Symfony/Component/CssSelector/Parser/Token.php
+++ b/src/Symfony/Component/CssSelector/Parser/Token.php
@@ -18,6 +18,8 @@ namespace Symfony\Component\CssSelector\Parser;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class Token
 {

--- a/src/Symfony/Component/CssSelector/Parser/TokenStream.php
+++ b/src/Symfony/Component/CssSelector/Parser/TokenStream.php
@@ -21,6 +21,8 @@ use Symfony\Component\CssSelector\Exception\SyntaxErrorException;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class TokenStream
 {

--- a/src/Symfony/Component/CssSelector/Parser/Tokenizer/Tokenizer.php
+++ b/src/Symfony/Component/CssSelector/Parser/Tokenizer/Tokenizer.php
@@ -23,6 +23,8 @@ use Symfony\Component\CssSelector\Parser\TokenStream;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class Tokenizer
 {

--- a/src/Symfony/Component/CssSelector/Parser/Tokenizer/TokenizerEscaping.php
+++ b/src/Symfony/Component/CssSelector/Parser/Tokenizer/TokenizerEscaping.php
@@ -18,6 +18,8 @@ namespace Symfony\Component\CssSelector\Parser\Tokenizer;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class TokenizerEscaping
 {

--- a/src/Symfony/Component/CssSelector/Parser/Tokenizer/TokenizerPatterns.php
+++ b/src/Symfony/Component/CssSelector/Parser/Tokenizer/TokenizerPatterns.php
@@ -18,6 +18,8 @@ namespace Symfony\Component\CssSelector\Parser\Tokenizer;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class TokenizerPatterns
 {

--- a/src/Symfony/Component/CssSelector/Tests/ConverterTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/ConverterTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\CssSelector\Tests;
+
+use Symfony\Component\CssSelector\Converter;
+
+class ConverterTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCssToXPath()
+    {
+        $converter = new Converter();
+
+        $this->assertEquals('descendant-or-self::*', $converter->toXPath(''));
+        $this->assertEquals('descendant-or-self::h1', $converter->toXPath('h1'));
+        $this->assertEquals("descendant-or-self::h1[@id = 'foo']", $converter->toXPath('h1#foo'));
+        $this->assertEquals("descendant-or-self::h1[@class and contains(concat(' ', normalize-space(@class), ' '), ' foo ')]", $converter->toXPath('h1.foo'));
+        $this->assertEquals('descendant-or-self::foo:h1', $converter->toXPath('foo|h1'));
+        $this->assertEquals('descendant-or-self::h1', $converter->toXPath('H1'));
+    }
+
+    public function testCssToXPathXml()
+    {
+        $converter = new Converter(false);
+
+        $this->assertEquals('descendant-or-self::H1', $converter->toXPath('H1'));
+    }
+}

--- a/src/Symfony/Component/CssSelector/Tests/CssSelectorTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/CssSelectorTest.php
@@ -13,6 +13,9 @@ namespace Symfony\Component\CssSelector\Tests;
 
 use Symfony\Component\CssSelector\CssSelector;
 
+/**
+ * @group legacy
+ */
 class CssSelectorTest extends \PHPUnit_Framework_TestCase
 {
     public function testCssToXPath()

--- a/src/Symfony/Component/CssSelector/XPath/Extension/AbstractExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/AbstractExtension.php
@@ -18,6 +18,8 @@ namespace Symfony\Component\CssSelector\XPath\Extension;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 abstract class AbstractExtension implements ExtensionInterface
 {

--- a/src/Symfony/Component/CssSelector/XPath/Extension/AttributeMatchingExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/AttributeMatchingExtension.php
@@ -21,6 +21,8 @@ use Symfony\Component\CssSelector\XPath\XPathExpr;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class AttributeMatchingExtension extends AbstractExtension
 {

--- a/src/Symfony/Component/CssSelector/XPath/Extension/CombinationExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/CombinationExtension.php
@@ -20,6 +20,8 @@ use Symfony\Component\CssSelector\XPath\XPathExpr;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class CombinationExtension extends AbstractExtension
 {

--- a/src/Symfony/Component/CssSelector/XPath/Extension/ExtensionInterface.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/ExtensionInterface.php
@@ -18,6 +18,8 @@ namespace Symfony\Component\CssSelector\XPath\Extension;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 interface ExtensionInterface
 {

--- a/src/Symfony/Component/CssSelector/XPath/Extension/FunctionExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/FunctionExtension.php
@@ -25,6 +25,8 @@ use Symfony\Component\CssSelector\XPath\XPathExpr;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class FunctionExtension extends AbstractExtension
 {

--- a/src/Symfony/Component/CssSelector/XPath/Extension/HtmlExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/HtmlExtension.php
@@ -23,6 +23,8 @@ use Symfony\Component\CssSelector\XPath\XPathExpr;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class HtmlExtension extends AbstractExtension
 {

--- a/src/Symfony/Component/CssSelector/XPath/Extension/NodeExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/NodeExtension.php
@@ -22,6 +22,8 @@ use Symfony\Component\CssSelector\XPath\XPathExpr;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class NodeExtension extends AbstractExtension
 {

--- a/src/Symfony/Component/CssSelector/XPath/Extension/PseudoClassExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/PseudoClassExtension.php
@@ -21,6 +21,8 @@ use Symfony\Component\CssSelector\XPath\XPathExpr;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class PseudoClassExtension extends AbstractExtension
 {

--- a/src/Symfony/Component/CssSelector/XPath/Translator.php
+++ b/src/Symfony/Component/CssSelector/XPath/Translator.php
@@ -25,6 +25,8 @@ use Symfony\Component\CssSelector\Parser\ParserInterface;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class Translator implements TranslatorInterface
 {

--- a/src/Symfony/Component/CssSelector/XPath/TranslatorInterface.php
+++ b/src/Symfony/Component/CssSelector/XPath/TranslatorInterface.php
@@ -20,6 +20,8 @@ use Symfony\Component\CssSelector\Node\SelectorNode;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 interface TranslatorInterface
 {

--- a/src/Symfony/Component/CssSelector/XPath/XPathExpr.php
+++ b/src/Symfony/Component/CssSelector/XPath/XPathExpr.php
@@ -18,6 +18,8 @@ namespace Symfony\Component\CssSelector\XPath;
  * which is copyright Ian Bicking, @see https://github.com/SimonSapin/cssselect.
  *
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ *
+ * @internal
  */
 class XPathExpr
 {

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\DomCrawler\Tests;
 
-use Symfony\Component\CssSelector\CssSelector;
 use Symfony\Component\DomCrawler\Crawler;
 
 class CrawlerTest extends \PHPUnit_Framework_TestCase
@@ -618,16 +617,12 @@ EOF
 
     public function testFilterWithNamespace()
     {
-        CssSelector::disableHtmlExtension();
-
         $crawler = $this->createTestXmlCrawler()->filter('yt|accessControl');
         $this->assertCount(2, $crawler, '->filter() automatically registers namespaces');
     }
 
     public function testFilterWithMultipleNamespaces()
     {
-        CssSelector::disableHtmlExtension();
-
         $crawler = $this->createTestXmlCrawler()->filter('media|group yt|aspectRatio');
         $this->assertCount(1, $crawler, '->filter() automatically registers namespaces');
         $this->assertSame('widescreen', $crawler->text());

--- a/src/Symfony/Component/DomCrawler/composer.json
+++ b/src/Symfony/Component/DomCrawler/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "symfony/phpunit-bridge": "~2.7|~3.0.0",
-        "symfony/css-selector": "~2.3|~3.0.0"
+        "symfony/css-selector": "~2.8|~3.0.0"
     },
     "suggest": {
         "symfony/css-selector": ""


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #15850, #8404 |
| License | MIT |
| Doc PR | todo |

This implements a non-static API for the CssSelector component.

I decided to keep the static API too, as it is convenient when you just need a one-shot conversion (if you need lots of conversions, keeping a reference to the Converter and all its internal object graph may be faster than releasing it all the time and rebuilding it).
I deprecated the global state to choose between HTML and XML conversion. The static API would always enable the HTML extension in 3.0. Dealing with XML would be done by using the Converter class.

A second commit also tags all internal classes of the component as `@internal`, as there is really no reason for a user to deal with them (btw, we already considered them fully internal in the past, as we broke BC on them in a patch release to fix memory performance of the component in the past).

TODOs:
- [x] Validate whether we keep the static facade to the component
- [ ] send a PR on the documentation to document this new API.
- [x]  handle usage of the deprecated API in the DomCrawler testsuite

The DomCrawler component does not use the new API yet. I will do it in a separate PR, as distinguishing between HTML and XML modes for a crawler will be easier once I deprecate the possibility to load multiple documents (which I will do tomorrow).
