### PR TITLE
[RFC] Removed the web_profiler.position config option

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -32,7 +32,6 @@ class ProfilerController
     private $profiler;
     private $twig;
     private $templates;
-    private $toolbarPosition;
 
     /**
      * Constructor.
@@ -41,7 +40,7 @@ class ProfilerController
      * @param Profiler              $profiler        The profiler
      * @param \Twig_Environment     $twig            The twig environment
      * @param array                 $templates       The templates
-     * @param string                $toolbarPosition The toolbar position (top, bottom, normal, or null -- use the configuration)
+     * @param string                $toolbarPosition (Deprecated - This option is ignored) The toolbar position (top, bottom, normal, or null -- use the configuration)
      */
     public function __construct(UrlGeneratorInterface $generator, Profiler $profiler = null, \Twig_Environment $twig, array $templates, $toolbarPosition = 'normal')
     {
@@ -49,7 +48,6 @@ class ProfilerController
         $this->profiler = $profiler;
         $this->twig = $twig;
         $this->templates = $templates;
-        $this->toolbarPosition = $toolbarPosition;
     }
 
     /**
@@ -190,11 +188,6 @@ class ProfilerController
             return new Response('', 404, array('Content-Type' => 'text/html'));
         }
 
-        // the toolbar position (top, bottom, normal, or null -- use the configuration)
-        if (null === $position = $request->query->get('position')) {
-            $position = $this->toolbarPosition;
-        }
-
         $url = null;
         try {
             $url = $this->generator->generate('_profiler', array('token' => $token));
@@ -203,7 +196,6 @@ class ProfilerController
         }
 
         return new Response($this->twig->render('@WebProfiler/Profiler/toolbar.html.twig', array(
-            'position' => $position,
             'profile' => $profile,
             'templates' => $this->getTemplateManager()->getTemplates($profile),
             'profiler_url' => $url,

--- a/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/Configuration.php
@@ -36,7 +36,7 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->beforeNormalization()
-                ->ifTrue(function ($v) { return isset($v['position']); })
+                ->ifTrue(function ($v) { return array_key_exists('position', $v); })
                 ->then(function ($v) {
                     @trigger_error('The web_profiler.position configuration key is deprecated since version 2.8 and will be removed in 3.0. No alternative configuration is available because the underlying feature has been removed.', E_USER_DEPRECATED);
 

--- a/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/Configuration.php
@@ -35,6 +35,14 @@ class Configuration implements ConfigurationInterface
         $rootNode = $treeBuilder->root('web_profiler');
 
         $rootNode
+            ->beforeNormalization()
+                ->ifTrue(function ($v) { return isset($v['position']); })
+                ->then(function ($v) {
+                    @trigger_error('The web_profiler.position configuration key is deprecated since version 2.8 and will be removed in 3.0. No alternative configuration is available because the underlying feature has been removed.', E_USER_DEPRECATED);
+
+                    return $v;
+                })
+            ->end()
             ->children()
                 ->booleanNode('toolbar')->defaultFalse()->end()
                 ->scalarNode('position')

--- a/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
@@ -38,7 +38,6 @@ class WebDebugToolbarListener implements EventSubscriberInterface
     protected $urlGenerator;
     protected $interceptRedirects;
     protected $mode;
-    protected $position;
     protected $excludedAjaxPaths;
 
     public function __construct(\Twig_Environment $twig, $interceptRedirects = false, $mode = self::ENABLED, $position = 'bottom', UrlGeneratorInterface $urlGenerator = null, $excludedAjaxPaths = '^/bundles|^/_wdt')
@@ -47,7 +46,6 @@ class WebDebugToolbarListener implements EventSubscriberInterface
         $this->urlGenerator = $urlGenerator;
         $this->interceptRedirects = (bool) $interceptRedirects;
         $this->mode = (int) $mode;
-        $this->position = $position;
         $this->excludedAjaxPaths = $excludedAjaxPaths;
     }
 
@@ -119,7 +117,6 @@ class WebDebugToolbarListener implements EventSubscriberInterface
             $toolbar = "\n".str_replace("\n", '', $this->twig->render(
                 '@WebProfiler/Profiler/toolbar_js.html.twig',
                 array(
-                    'position' => $this->position,
                     'excluded_ajax_paths' => $this->excludedAjaxPaths,
                     'token' => $response->headers->get('X-Debug-Token'),
                     'request' => $request,

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -335,26 +335,6 @@
     display: none;
 }
 
-/* Override the setting when the toolbar is on the top */
-{% if position == 'top' %}
-    .sf-minitoolbar {
-        bottom: auto;
-        right: 0;
-        top: 0;
-    }
-
-    .sf-toolbarreset {
-        bottom: auto;
-        box-shadow: 0 1px 0px rgba(0, 0, 0, 0.2);
-        top: 0;
-    }
-
-    .sf-toolbar-block .sf-toolbar-info {
-        bottom: auto;
-        top: 36px;
-    }
-{% endif %}
-
 {% if not floatable %}
     .sf-toolbarreset {
         position: static;

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -335,12 +335,6 @@
     display: none;
 }
 
-{% if not floatable %}
-    .sf-toolbarreset {
-        position: static;
-    }
-{% endif %}
-
 /* Responsive Design */
 .sf-toolbar-icon .sf-toolbar-label,
 .sf-toolbar-icon .sf-toolbar-value {

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
@@ -19,7 +19,7 @@
         </a>
     </div>
     <style>
-        {{ include('@WebProfiler/Profiler/toolbar.css.twig', { 'floatable': true }) }}
+        {{ include('@WebProfiler/Profiler/toolbar.css.twig') }}
     </style>
     <div id="sfToolbarClearer-{{ token }}" style="clear: both; height: 38px;"></div>
 {% endif %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
@@ -19,7 +19,7 @@
         </a>
     </div>
     <style>
-        {{ include('@WebProfiler/Profiler/toolbar.css.twig', { 'position': position, 'floatable': true }) }}
+        {{ include('@WebProfiler/Profiler/toolbar.css.twig', { 'floatable': true }) }}
     </style>
     <div id="sfToolbarClearer-{{ token }}" style="clear: both; height: 38px;"></div>
 {% endif %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -2,14 +2,6 @@
 {{ include('@WebProfiler/Profiler/base_js.html.twig') }}
 <script>/*<![CDATA[*/
     (function () {
-        {% if 'top' == position %}
-            var sfwdt = document.getElementById('sfwdt{{ token }}');
-            document.body.insertBefore(
-                document.body.removeChild(sfwdt),
-                document.body.firstChild
-            );
-        {% endif %}
-
         Sfjs.load(
             'sfwdt{{ token }}',
             '{{ path("_wdt", { "token": token }) }}',

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -35,7 +35,6 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             array(array('intercept_redirects' => true), array('intercept_redirects' => true, 'toolbar' => false, 'position' => 'bottom', 'excluded_ajax_paths' => '^/(app(_[\\w]+)?\\.php/)?_wdt')),
             array(array('intercept_redirects' => false), array('intercept_redirects' => false, 'toolbar' => false, 'position' => 'bottom', 'excluded_ajax_paths' => '^/(app(_[\\w]+)?\\.php/)?_wdt')),
             array(array('toolbar' => true), array('intercept_redirects' => false, 'toolbar' => true, 'position' => 'bottom', 'excluded_ajax_paths' => '^/(app(_[\\w]+)?\\.php/)?_wdt')),
-            array(array('position' => 'top'), array('intercept_redirects' => false, 'toolbar' => false, 'position' => 'top', 'excluded_ajax_paths' => '^/(app(_[\\w]+)?\\.php/)?_wdt')),
             array(array('excluded_ajax_paths' => 'test'), array('intercept_redirects' => false, 'toolbar' => false, 'position' => 'bottom', 'excluded_ajax_paths' => 'test')),
         );
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

In the past we needed this option because the profiler displayed the toolbar on the top. Right now this option is only used by end-users. When Symfony 2 was published, this option was useful because symfony 1 displayed the toolbar on the top and therefore, some developers were mad at the new toolbar which was displayed at the bottom. Nowadays everybody is happy with the bottom toolbar.
