### PR TITLE
[WIP] Route building in the kernel

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernel.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Kernel;
+
+use Symfony\Bundle\FrameworkBundle\Routing\RouteCollectionBuilder;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\MicroKernel as BaseMicroKernel;
+use Symfony\Component\Routing\Loader\RouteLoaderInterface;
+
+/**
+ * A kernel that adds some functionality that depends on FrameworkBundle.
+ *
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+abstract class MicroKernel extends BaseMicroKernel implements RouteLoaderInterface
+{
+    /**
+     * Add or import routes into your application.
+     *
+     *     $routes->import('config/routing.yml');
+     *     $routes->add('/admin', 'AppBundle:Admin:dashboard', 'admin_dashboard');
+     *
+     * @param RouteCollectionBuilder $routes
+     */
+    abstract protected function configureRoutes(RouteCollectionBuilder $routes);
+
+    /**
+     * Creates a RouteCollectionBuilder for convenience and calls configureRoutes.
+     *
+     * @param LoaderInterface $loader
+     *
+     * @return \Symfony\Component\Routing\RouteCollection
+     */
+    public function getRouteCollection(LoaderInterface $loader)
+    {
+        $routes = new RouteCollectionBuilder($loader);
+
+        $this->configureRoutes($routes);
+
+        return $routes->build();
+    }
+
+    /**
+     * Overridden to make the routing resource be the kernel.
+     *
+     * @param LoaderInterface $loader
+     */
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(function (ContainerBuilder $container) {
+            $container->prependExtensionConfig('framework', array(
+                'router' => array(
+                    'resource' => 'kernel',
+                    'type' => 'service',
+                ),
+            ));
+        });
+
+        parent::registerContainerConfiguration($loader);
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | Partially #15864 |
| License | MIT |
| Doc PR | not yet |

WIP, because it depends on the unmerged PR's #15742, #15778 and #15820. But since this completes the picture (and I'm pushing this for 2.8), I needed to get this PR created.

The idea is to make a "normal" kernel look like this: https://gist.github.com/weaverryan/e4b19cabb1d9286c4217#file-smallkernel-php, which has some nice benefit that `routing_dev.yml` isn't needed anymore, because you can import those routes conditionally here.

But, you could also create an entire kernel without external files. A complex example (probably more complex than you'd have without using external files) is here: https://gist.github.com/weaverryan/e4b19cabb1d9286c4217#file-appkernel-php.

Thanks!
