### PR TITLE
use try-finally when possible

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Routing/DelegatingLoader.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/DelegatingLoader.php
@@ -56,7 +56,7 @@ class DelegatingLoader extends BaseDelegatingLoader
             // Here is the scenario:
             // - while routes are being loaded by parent::load() below, a fatal error
             //   occurs (e.g. parse error in a controller while loading annotations);
-            // - PHP abruptly empties the stack trace, bypassing all catch blocks;
+            // - PHP abruptly empties the stack trace, bypassing all catch/finally blocks;
             //   it then calls the registered shutdown functions;
             // - the ErrorHandler catches the fatal error and re-injects it for rendering
             //   thanks to HttpKernel->terminateWithException() (that calls handleException());
@@ -74,12 +74,9 @@ class DelegatingLoader extends BaseDelegatingLoader
 
         try {
             $collection = parent::load($resource, $type);
-        } catch (\Exception $e) {
+        } finally {
             $this->loading = false;
-            throw $e;
         }
-
-        $this->loading = false;
 
         foreach ($collection->all() as $route) {
             if ($controller = $route->getDefault('_controller')) {

--- a/src/Symfony/Component/Config/Loader/FileLoader.php
+++ b/src/Symfony/Component/Config/Loader/FileLoader.php
@@ -101,12 +101,9 @@ abstract class FileLoader extends Loader
 
             try {
                 $ret = $loader->load($resource, $type);
-            } catch (\Exception $e) {
+            } finally {
                 unset(self::$loading[$resource]);
-                throw $e;
             }
-
-            unset(self::$loading[$resource]);
 
             return $ret;
         } catch (FileLoaderImportCircularReferenceException $e) {

--- a/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
+++ b/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
@@ -169,15 +169,10 @@ class XmlUtilsTest extends \PHPUnit_Framework_TestCase
             } catch (\InvalidArgumentException $e) {
                 $this->assertEquals(sprintf('File %s does not contain valid XML, it is empty.', $file), $e->getMessage());
             }
-        } catch (\Exception $e) {
+        } finally {
             restore_error_handler();
             error_reporting($errorReporting);
-
-            throw $e;
         }
-
-        restore_error_handler();
-        error_reporting($errorReporting);
 
         $disableEntities = libxml_disable_entity_loader(true);
         libxml_disable_entity_loader($disableEntities);

--- a/src/Symfony/Component/Debug/DebugClassLoader.php
+++ b/src/Symfony/Component/Debug/DebugClassLoader.php
@@ -130,13 +130,9 @@ class DebugClassLoader
                 call_user_func($this->classLoader, $class);
                 $file = false;
             }
-        } catch (\Exception $e) {
+        } finally {
             ErrorHandler::unstackErrors();
-
-            throw $e;
         }
-
-        ErrorHandler::unstackErrors();
 
         $exists = class_exists($class, false) || interface_exists($class, false) || trait_exists($class, false);
 

--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -468,11 +468,8 @@ class ErrorHandler
             try {
                 $this->isRecursive = true;
                 $this->loggers[$type][0]->log(($type & $level) ? $this->loggers[$type][1] : LogLevel::DEBUG, $message, $e);
+            } finally {
                 $this->isRecursive = false;
-            } catch (\Exception $e) {
-                $this->isRecursive = false;
-
-                throw $e;
             }
         }
 

--- a/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
@@ -108,8 +108,6 @@ class DebugClassLoaderTest extends \PHPUnit_Framework_TestCase
             $this->fail('ContextErrorException expected');
         } catch (\ErrorException $exception) {
             // if an exception is thrown, the test passed
-            restore_error_handler();
-            restore_exception_handler();
             $this->assertStringStartsWith(__FILE__, $exception->getFile());
             if (PHP_VERSION_ID < 70000) {
                 $this->assertRegExp('/^Runtime Notice: Declaration/', $exception->getMessage());
@@ -118,11 +116,9 @@ class DebugClassLoaderTest extends \PHPUnit_Framework_TestCase
                 $this->assertRegExp('/^Warning: Declaration/', $exception->getMessage());
                 $this->assertEquals(E_WARNING, $exception->getSeverity());
             }
-        } catch (\Exception $exception) {
+        } finally {
             restore_error_handler();
             restore_exception_handler();
-
-            throw $exception;
         }
     }
 

--- a/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
@@ -73,9 +73,6 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
             $this->fail('ContextErrorException expected');
         } catch (ContextErrorException $exception) {
             // if an exception is thrown, the test passed
-            restore_error_handler();
-            restore_exception_handler();
-
             $this->assertEquals(E_NOTICE, $exception->getSeverity());
             $this->assertEquals(__FILE__, $exception->getFile());
             $this->assertRegExp('/^Notice: Undefined variable: (foo|bar)/', $exception->getMessage());
@@ -96,11 +93,9 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals(__CLASS__, $trace[2]['class']);
             $this->assertEquals(__FUNCTION__, $trace[2]['function']);
             $this->assertEquals('->', $trace[2]['type']);
-        } catch (\Exception $e) {
+        } finally {
             restore_error_handler();
             restore_exception_handler();
-
-            throw $e;
         }
     }
 
@@ -118,14 +113,9 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
             $handler = ErrorHandler::register();
             $handler->throwAt(3, true);
             $this->assertEquals(3 | E_RECOVERABLE_ERROR | E_USER_ERROR, $handler->throwAt(0));
-
+        } finally {
             restore_error_handler();
             restore_exception_handler();
-        } catch (\Exception $e) {
-            restore_error_handler();
-            restore_exception_handler();
-
-            throw $e;
         }
     }
 
@@ -157,14 +147,9 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
                 E_CORE_ERROR => array(null, LogLevel::CRITICAL),
             );
             $this->assertSame($loggers, $handler->setLoggers(array()));
-
+        } finally {
             restore_error_handler();
             restore_exception_handler();
-        } catch (\Exception $e) {
-            restore_error_handler();
-            restore_exception_handler();
-
-            throw $e;
         }
     }
 
@@ -283,14 +268,9 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
             }
 
             $this->assertSame($x, $e);
-
+        } finally {
             restore_error_handler();
             restore_exception_handler();
-        } catch (\Exception $e) {
-            restore_error_handler();
-            restore_exception_handler();
-
-            throw $e;
         }
     }
 
@@ -350,14 +330,9 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
             });
 
             $handler->handleException($exception);
-
+        } finally {
             restore_error_handler();
             restore_exception_handler();
-        } catch (\Exception $e) {
-            restore_error_handler();
-            restore_exception_handler();
-
-            throw $e;
         }
     }
 
@@ -384,14 +359,9 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
             @trigger_error('Silenced warning', E_USER_WARNING);
             $logger->log(LogLevel::WARNING, 'Dummy log');
             ErrorHandler::unstackErrors();
-
+        } finally {
             restore_error_handler();
             restore_exception_handler();
-        } catch (\Exception $e) {
-            restore_error_handler();
-            restore_exception_handler();
-
-            throw $e;
         }
     }
 
@@ -513,14 +483,9 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
 
             call_user_func_array(array($handler, 'handleError'), $error);
             $handler->handleFatalError($error);
-
+        } finally {
             restore_error_handler();
             restore_exception_handler();
-        } catch (\Exception $e) {
-            restore_error_handler();
-            restore_exception_handler();
-
-            throw $e;
         }
     }
 }

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -457,13 +457,9 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
 
         try {
             $service = $this->createService($definition, $id);
-        } catch (\Exception $e) {
+        } finally {
             unset($this->loading[$id]);
-
-            throw $e;
         }
-
-        unset($this->loading[$id]);
 
         return $service;
     }

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -783,11 +783,9 @@ class OptionsResolver implements Options
                 foreach ($this->lazy[$option] as $closure) {
                     $value = $closure($this, $value);
                 }
-            } catch (\Exception $e) {
+            } finally {
                 unset($this->calling[$option]);
-                throw $e;
             }
-            unset($this->calling[$option]);
             // END
         }
 
@@ -885,11 +883,9 @@ class OptionsResolver implements Options
             $this->calling[$option] = true;
             try {
                 $value = $normalizer($this, $value);
-            } catch (\Exception $e) {
+            } finally {
                 unset($this->calling[$option]);
-                throw $e;
             }
-            unset($this->calling[$option]);
             // END
         }
 

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -58,10 +58,8 @@ class InlineTest extends \PHPUnit_Framework_TestCase
 
             $this->assertEquals('1.2', Inline::dump(1.2));
             $this->assertContains('fr', strtolower(setlocale(LC_NUMERIC, 0)));
+        } finally {
             setlocale(LC_NUMERIC, $locale);
-        } catch (\Exception $e) {
-            setlocale(LC_NUMERIC, $locale);
-            throw $e;
         }
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | I hope |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Found those with regex `catch \(\\Exception[^\}]+throw \$`
