### PR TITLE
Update ChoiceFormField.php

### DIFF
--- a/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
@@ -61,6 +61,9 @@ class ChoiceFormField extends FormField
      */
     public function isDisabled()
     {
+        if (parent::isDisabled()) {
+            return true;
+        }
         foreach ($this->options as $option) {
             if ($option['value'] == $this->value && $option['disabled']) {
                 return true;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This PR was submitted on the symfony/dom-crawler read-only repository by @bouland and moved automatically to the main Symfony repository (closes symfony/dom-crawler#20).

Hi,

A select could be "globaly" disabled not only one of its options.
http://www.w3schools.com/tags/att_select_disabled.asp
