### PR TITLE
Fixed incorrect and inconsistent translations

### DIFF
--- a/src/Symfony/Component/Security/Core/Resources/translations/security.tr.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.tr.xlf
@@ -8,7 +8,7 @@
             </trans-unit>
             <trans-unit id="2">
                 <source>Authentication credentials could not be found.</source>
-                <target>Yetkilendirme girdileri bulunamadı.</target>
+                <target>Kimlik bilgileri bulunamadı.</target>
             </trans-unit>
             <trans-unit id="3">
                 <source>Authentication request could not be processed due to a system problem.</source>
@@ -16,7 +16,7 @@
             </trans-unit>
             <trans-unit id="4">
                 <source>Invalid credentials.</source>
-                <target>Geçersiz girdiler.</target>
+                <target>Geçersiz kimlik bilgileri.</target>
             </trans-unit>
             <trans-unit id="5">
                 <source>Cookie has already been used by someone else.</source>
@@ -32,7 +32,7 @@
             </trans-unit>
             <trans-unit id="8">
                 <source>Digest nonce has expired.</source>
-                <target>Derleme zaman aşımı gerçekleşti.</target>
+                <target>Derleme zaman aşımına uğradı.</target>
             </trans-unit>
             <trans-unit id="9">
                 <source>No authentication provider found to support the authentication token.</source>
@@ -44,7 +44,7 @@
             </trans-unit>
             <trans-unit id="11">
                 <source>No token could be found.</source>
-                <target>Bilet bulunamadı.</target>
+                <target>Fiş bulunamadı.</target>
             </trans-unit>
             <trans-unit id="12">
                 <source>Username could not be found.</source>
@@ -56,11 +56,11 @@
             </trans-unit>
             <trans-unit id="14">
                 <source>Credentials have expired.</source>
-                <target>Girdiler zaman aşımına uğradı.</target>
+                <target>Kimlik bilgileri zaman aşımına uğradı.</target>
             </trans-unit>
             <trans-unit id="15">
                 <source>Account is disabled.</source>
-                <target>Hesap devre dışı bırakılmış.</target>
+                <target>Hesap engellenmiş.</target>
             </trans-unit>
             <trans-unit id="16">
                 <source>Account is locked.</source>


### PR DESCRIPTION
This PR was submitted on the symfony/security read-only repository by @lashae and moved automatically to the main Symfony repository (closes symfony/security#8).

"Fiş" is a correct translation for "token", however "bilet" is also used, I fixed that inconsistency. Moreover, "kimlik bilgileri" is a better translation for "credentials" than "girdiler". "Girdiler" is the translation of "inputs", so I fixed sentences with "credentials". "Hesap engellenmiş" is better than "Hesap devre dışı bırakılmış" for "Account is disabled.". "Digest nonce has expired" can be translated better as "Derleme zaman aşımına uğradı." because "Derleme zaman aşımı gerçekleşti" has a confirmation sense like user requested it to expire and it has expired. 

References:

token: http://tureng.com/search/token (3rd entry)
credentials: http://www2.zargan.com/tr/q/credentials-ceviri-nedir (1st entry)
disable: http://tureng.com/search/disable (15th entry)
