### PR TITLE
Updated default German IBAN validation message

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.de.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.de.xlf
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Dieser Wert ist keine gültige IBAN-Kontonummer.</target>
+                <target>Dieser Wert ist keine gültige internationale Bankkontonummer (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>


### PR DESCRIPTION
This PR was submitted on the symfony/validator read-only repository by @synaris and moved automatically to the main Symfony repository (closes symfony/validator#15).

IBAN is an acronym. The term 'IBAN-Kontonummer' is redundant, since the 'AN' part (Account Number) already translates to 'Kontonummer'. It's like saying 'International Bank Account Number Account Number'.
