### PR TITLE
Support "!!binary" syntax (decodes base64 string).

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -21,6 +21,7 @@ use Symfony\Component\Yaml\Exception\DumpException;
  */
 class Inline
 {
+    const REGEX_TAG_PATTERN = '((?P<tag>![\w!.\/:-]+) +)?';
     const REGEX_QUOTED_STRING = '(?:"([^"\\\\]*(?:\\\\.[^"\\\\]*)*)"|\'([^\']*(?:\'\'[^\']*)*)\')';
 
     private static $exceptionOnInvalidType = false;
@@ -481,6 +482,8 @@ class Inline
                         return;
                     case 0 === strpos($scalar, '!!float '):
                         return (float) substr($scalar, 8);
+                    case 0 === strncmp($scalar, '!!binary ', 9):
+                        return base64_decode(self::parseScalar(substr($scalar, 9)));
                     case ctype_digit($scalar):
                         $raw = $scalar;
                         $cast = (int) $scalar;

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -464,10 +464,13 @@ class Parser
             return $this->refs[$value];
         }
 
-        if (preg_match('/^'.self::FOLDED_SCALAR_PATTERN.'$/', $value, $matches)) {
+        if (preg_match('/^'.Inline::REGEX_TAG_PATTERN.self::FOLDED_SCALAR_PATTERN.'$/', $value, $matches)) {
             $modifiers = isset($matches['modifiers']) ? $matches['modifiers'] : '';
 
-            return $this->parseFoldedScalar($matches['separator'], preg_replace('#\d+#', '', $modifiers), (int) abs($modifiers));
+            $output = $this->parseFoldedScalar($matches['separator'], preg_replace('#\d+#', '', $modifiers), (int) abs($modifiers));
+            if (isset($matches['tag']) && $matches['tag'] == '!!binary')
+                $output = base64_decode($output);
+            return $output;
         }
 
         try {


### PR DESCRIPTION
This PR was submitted on the symfony/yaml read-only repository by @johnnytemp and moved automatically to the main Symfony repository (closes symfony/yaml#13).

Only supported in folded-scalar (lines ending with | or >) form, or inline form.

Example Yaml:
items
  -
    name_enc: !!binary "SGVsbG8sIHdvcmxkLg=="
    desc_enc: !!binary |
        SGVsbG8sIH
        dvcmxkLg==
