### PR TITLE
Proper inheritance when merging references and inline

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -155,11 +155,7 @@ class Parser
                             throw new ParseException('YAML merge keys used with a scalar value instead of an array.', $this->getRealCurrentLineNb() + 1, $this->currentLine);
                         }
 
-                        foreach ($refValue as $key => $value) {
-                            if (!isset($data[$key])) {
-                                $data[$key] = $value;
-                            }
-                        }
+                        $data = array_replace_recursive($data, $refValue);
                     } else {
                         if (isset($values['value']) && $values['value'] !== '') {
                             $value = $values['value'];
@@ -193,11 +189,7 @@ class Parser
                         } else {
                             // If the value associated with the key is a single mapping node, each of its key/value pairs is inserted into the
                             // current mapping, unless the key already exists in it.
-                            foreach ($parsed as $key => $value) {
-                                if (!isset($data[$key])) {
-                                    $data[$key] = $value;
-                                }
-                            }
+                            $data = array_replace_recursive($data, $parsed);
                         }
                     }
                 } elseif (isset($values['value']) && preg_match('#^&(?P<ref>[^ ]+) *(?P<value>.*)#u', $values['value'], $matches)) {
@@ -224,7 +216,11 @@ class Parser
                         // Spec: Keys MUST be unique; first one wins.
                         // But overwriting is allowed when a merge node is used in current block.
                         if ($allowOverwrite || !isset($data[$key])) {
-                            $data[$key] = $value;
+                            if (isset($data[$key]) && is_array($data[$key]) && is_array($value)) {
+                                $data[$key] = array_replace_recursive($data[$key], $value);
+                            } else {
+                                $data[$key] = $value;
+                            }
                         }
                     }
                 } else {


### PR DESCRIPTION
This PR was submitted on the symfony/yaml read-only repository by @petougao and moved automatically to the main Symfony repository (closes symfony/yaml#11).

Items now get referenced sub-properties merged:

```
refDef: &reference
    subitem:
        refUnique: true
        shared: "Reference value"

item:
    <<: *reference
    subitem:
        itemUnique: true
        shared: "Item value"
```

OLD RESULT:

```
item:
    subitem:
        itemUnique: true
        shared: "Item value"
```

NEW RESULT

```
item:
    subitem:
        itemUnique: true
        shared: "Item value"
        refUnique: true
```

Inheritance is reversed when reference is pulled-in after all the elements:

```
item:
    subitem:
        itemUnique: true
        shared: "Item value"
    <<: *reference
```

NEW RESULT

```
item:
    subitem:
        itemUnique: true
        shared: "Reference value"
        refUnique: true
```

Inline definitions will pick-up the same behavior.
