### PR TITLE
Updated the style of the translation commands

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -104,6 +104,8 @@ EOF
         /** @var Kernel $kernel */
         $kernel = $this->getContainer()->get('kernel');
 
+        $output->title('Translation Messages Debugger');
+
         // Define Root Path to App folder
         $transPaths = array($kernel->getRootDir().'/Resources/');
 
@@ -207,15 +209,15 @@ EOF
     private function formatState($state)
     {
         if (self::MESSAGE_MISSING === $state) {
-            return '<error>missing</error>';
+            return '<error> missing </error>';
         }
 
         if (self::MESSAGE_UNUSED === $state) {
-            return '<comment>unused</comment>';
+            return '<comment> unused </comment>';
         }
 
         if (self::MESSAGE_EQUALS_FALLBACK === $state) {
-            return '<info>fallback</info>';
+            return '<info> fallback </info>';
         }
 
         return $state;
@@ -233,7 +235,7 @@ EOF
 
     private function formatId($id)
     {
-        return sprintf('<fg=cyan;options=bold>%s</fg=cyan;options=bold>', $id);
+        return sprintf('<fg=cyan;options=bold>%s</>', $id);
     }
 
     private function sanitizeString($string, $length = 40)

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -104,8 +104,6 @@ EOF
         /** @var Kernel $kernel */
         $kernel = $this->getContainer()->get('kernel');
 
-        $output->title('Translation Messages Debugger');
-
         // Define Root Path to App folder
         $transPaths = array($kernel->getRootDir().'/Resources/');
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -151,7 +151,7 @@ EOF
         }
 
         // show compiled list of messages
-        if ($input->getOption('dump-messages') === true) {
+        if (true === $input->getOption('dump-messages')) {
             $extractedMessagesCount = 0;
             $output->newLine();
             foreach ($operation->getDomains() as $domain) {
@@ -201,7 +201,7 @@ EOF
                 $writer->writeTranslations($operation->getResult(), $input->getOption('output-format'), array('path' => $bundleTransPath, 'default_locale' => $this->getContainer()->getParameter('kernel.default_locale')));
             }
 
-            if ($input->getOption('dump-messages') === true) {
+            if (true === $input->getOption('dump-messages')) {
                 $resultMessage .= ' and translation files were updated.';
             } else {
                 $resultMessage = 'Translation files were successfully updated.';

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -150,7 +150,6 @@ EOF
             return;
         }
 
-
         // show compiled list of messages
         if ($input->getOption('dump-messages') === true) {
             $extractedMessagesCount = 0;

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -21,7 +21,8 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Translation\MessageCatalogue;
 
 /**
- * A command that parse templates to extract translation messages and add them into the translation files.
+ * A command that parses templates to extract translation messages and adds them
+ * into the translation files.
  *
  * @author Michel Salib <michelsalib@hotmail.com>
  */
@@ -81,7 +82,7 @@ EOF
         $writer = $this->getContainer()->get('translation.writer');
         $supportedFormats = $writer->getFormats();
         if (!in_array($input->getOption('output-format'), $supportedFormats)) {
-            $output->error(array('Wrong output format', 'Supported formats are '.implode(', ', $supportedFormats).'.'));
+            $output->error(array('Wrong output format', 'Supported formats are: '.implode(', ', $supportedFormats).'.'));
 
             return 1;
         }
@@ -111,12 +112,12 @@ EOF
             }
         }
 
-        $output->title('Symfony translation update command');
-        $output->text(sprintf('Generating "<info>%s</info>" translation files for "<info>%s</info>"', $input->getArgument('locale'), $currentName));
+        $output->title('Translation Messages Extractor and Dumper');
+        $output->comment(sprintf('Generating "<info>%s</info>" translation files for "<info>%s</info>"', $input->getArgument('locale'), $currentName));
 
         // load any messages from templates
         $extractedCatalogue = new MessageCatalogue($input->getArgument('locale'));
-        $output->text('Parsing templates');
+        $output->comment('Parsing templates...');
         $extractor = $this->getContainer()->get('translation.extractor');
         $extractor->setPrefix($input->getOption('prefix'));
         foreach ($transPaths as $path) {
@@ -128,7 +129,7 @@ EOF
 
         // load any existing messages from the translation files
         $currentCatalogue = new MessageCatalogue($input->getArgument('locale'));
-        $output->text('Loading translation files');
+        $output->comment('Loading translation files...');
         $loader = $this->getContainer()->get('translation.loader');
         foreach ($transPaths as $path) {
             $path .= 'translations';
@@ -144,18 +145,23 @@ EOF
 
         // Exit if no messages found.
         if (!count($operation->getDomains())) {
-            $output->warning('No translation found.');
+            $output->warning('No translation messages were found.');
 
             return;
         }
 
+
         // show compiled list of messages
         if ($input->getOption('dump-messages') === true) {
+            $extractedMessagesCount = 0;
             $output->newLine();
             foreach ($operation->getDomains() as $domain) {
-                $output->section(sprintf('Displaying messages for domain <info>%s</info>:', $domain));
                 $newKeys = array_keys($operation->getNewMessages($domain));
                 $allKeys = array_keys($operation->getMessages($domain));
+                $domainMessagesCount = count($newKeys) + count($allKeys);
+
+                $output->section(sprintf('Messages extracted for domain "<info>%s</info>" (%d messages)', $domain, $domainMessagesCount));
+
                 $output->listing(array_merge(
                     array_diff($allKeys, $newKeys),
                     array_map(function ($id) {
@@ -165,11 +171,15 @@ EOF
                         return sprintf('<fg=red>%s</>', $id);
                     }, array_keys($operation->getObsoleteMessages($domain)))
                 ));
+
+                $extractedMessagesCount += $domainMessagesCount;
             }
 
             if ($input->getOption('output-format') == 'xlf') {
-                $output->writeln('Xliff output version is <info>1.2</info>');
+                $output->comment('Xliff output version is <info>1.2</info>');
             }
+
+            $resultMessage = sprintf('%d messages were successfully extracted', $extractedMessagesCount);
         }
 
         if ($input->getOption('no-backup') === true) {
@@ -178,7 +188,7 @@ EOF
 
         // save the files
         if ($input->getOption('force') === true) {
-            $output->text('Writing files');
+            $output->comment('Writing files...');
 
             $bundleTransPath = false;
             foreach ($transPaths as $path) {
@@ -191,9 +201,14 @@ EOF
             if ($bundleTransPath) {
                 $writer->writeTranslations($operation->getResult(), $input->getOption('output-format'), array('path' => $bundleTransPath, 'default_locale' => $this->getContainer()->getParameter('kernel.default_locale')));
             }
+
+            if ($input->getOption('dump-messages') === true) {
+                $resultMessage .= ' and translation files were updated.';
+            } else {
+                $resultMessage = 'Translation files were successfully updated.';
+            }
         }
 
-        $output->newLine();
-        $output->success('Success');
+        $output->success($resultMessage);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

@ogizanagi did a great job updating the styles of these commands. This is just a bit of tweaking here and there:

(Left = old; Right = new)

![comparison_1](https://cloud.githubusercontent.com/assets/73419/10136622/b2d049d2-65f5-11e5-9efe-ae74d546298d.png)

![comparison_2](https://cloud.githubusercontent.com/assets/73419/10136625/b8f96e24-65f5-11e5-8726-f092fc10ac38.png)

![comparison_3](https://cloud.githubusercontent.com/assets/73419/10136626/bb34a6cc-65f5-11e5-8312-0f084f04f0df.png)

![comparison_4](https://cloud.githubusercontent.com/assets/73419/10136630/bd851fd8-65f5-11e5-8ef0-71cce64fd2d7.png)

![comparison_5](https://cloud.githubusercontent.com/assets/73419/10136635/bf6173e2-65f5-11e5-9a25-8f04664cfe5a.png)
