### PR TITLE
[Console] do not make the getHelp() method smart

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -491,7 +491,7 @@ class Command
      */
     public function getHelp()
     {
-        return $this->help ?: $this->description;
+        return $this->help;
     }
 
     /**
@@ -513,7 +513,7 @@ class Command
             $_SERVER['PHP_SELF'].' '.$name,
         );
 
-        return str_replace($placeholders, $replacements, $this->getHelp());
+        return str_replace($placeholders, $replacements, $this->getHelp() ?: $this->getDescription());
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -132,7 +132,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($command, $ret, '->setHelp() implements a fluent interface');
         $this->assertEquals('help1', $command->getHelp(), '->setHelp() sets the help');
         $command->setHelp('');
-        $this->assertEquals('description', $command->getHelp(), '->getHelp() fallback to the description');
+        $this->assertEquals('', $command->getHelp(), '->getHelp() does not fall back to the description');
     }
 
     public function testGetProcessedHelp()
@@ -141,6 +141,10 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $command->setHelp('The %command.name% command does... Example: php %command.full_name%.');
         $this->assertContains('The namespace:name command does...', $command->getProcessedHelp(), '->getProcessedHelp() replaces %command.name% correctly');
         $this->assertNotContains('%command.full_name%', $command->getProcessedHelp(), '->getProcessedHelp() replaces %command.full_name%');
+
+        $command = new \TestCommand();
+        $command->setHelp('');
+        $this->assertContains('description', $command->getProcessedHelp(), '->getProcessedHelp() falls back to the description');
     }
 
     public function testGetSetAliases()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | kind of |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

In my opinion, the way to always display a help message to the user was implemented in #15601 is not good enough. The getter method for the help should only return the actual value. Otherwise, user's would not have a way to check if a command really has a help message (for example, when building their own CLI applications or whatever). Instead, we should only return the description as a fallback of the help message when it is processed to present it to the user.
