### PR TITLE
[WebProfilerBundle] reflect latest changes in test

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
@@ -110,6 +110,13 @@ class ProfilerControllerTest extends \PHPUnit_Framework_TestCase
             ->method('find')
             ->will($this->returnValue($tokens));
 
+        $request = Request::create('/_profiler/empty/search/results', 'GET', array(
+                'limit' => 2,
+                'ip' => '127.0.0.1',
+                'method' => 'GET',
+                'url' => 'http://example.com/',
+        ));
+
         $twig->expects($this->once())
             ->method('render')
             ->with($this->stringEndsWith('results.html.twig'), $this->equalTo(array(
@@ -123,16 +130,10 @@ class ProfilerControllerTest extends \PHPUnit_Framework_TestCase
                 'end' => null,
                 'limit' => 2,
                 'panel' => null,
+                'request' => $request,
             )));
 
-        $response = $controller->searchResultsAction(
-            Request::create(
-                '/_profiler/empty/search/results',
-                'GET',
-                array('limit' => 2, 'ip' => '127.0.0.1', 'method' => 'GET', 'url' => 'http://example.com/')
-            ),
-            'empty'
-        );
+        $response = $controller->searchResultsAction($request, 'empty');
         $this->assertEquals(200, $response->getStatusCode());
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

In #15973, the `searchResultsAction()` of the `ProfilerController` was
updated to pass the current request to the rendered template. However,
this change was not reflected in the test thus letting it fail.
