### PR TITLE
Issue 13852 - Added omit_action option to form type

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -269,7 +269,7 @@
     {%- else -%}
         {% set form_method = "POST" %}
     {%- endif -%}
-    <form name="{{ name }}" method="{{ form_method|lower }}" action="{{ action }}"{% for attrname, attrvalue in attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}{% if multipart %} enctype="multipart/form-data"{% endif %}>
+    <form name="{{ name }}" method="{{ form_method|lower }}"{% if not omit_action %} action="{{ action }}"{% endif %}{% for attrname, attrvalue in attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}{% if multipart %} enctype="multipart/form-data"{% endif %}>
     {%- if form_method != method -%}
         <input type="hidden" name="_method" value="{{ method }}" />
     {%- endif -%}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_start.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_start.html.php
@@ -1,6 +1,6 @@
 <?php $method = strtoupper($method) ?>
 <?php $form_method = $method === 'GET' || $method === 'POST' ? $method : 'POST' ?>
-<form name="<?php echo $name ?>" method="<?php echo strtolower($form_method) ?>"<?php if (! $omit_action) : ?> action="<?php echo $action ?>"<?php endif ?><?php foreach ($attr as $k => $v) { printf(' %s="%s"', $view->escape($k), $view->escape($v)); } ?><?php if ($multipart): ?> enctype="multipart/form-data"<?php endif ?>>
+<form name="<?php echo $name ?>" method="<?php echo strtolower($form_method) ?>"<?php if (!$omit_action) : ?> action="<?php echo $action ?>"<?php endif ?><?php foreach ($attr as $k => $v) { printf(' %s="%s"', $view->escape($k), $view->escape($v)); } ?><?php if ($multipart): ?> enctype="multipart/form-data"<?php endif ?>>
 <?php if ($form_method !== $method): ?>
     <input type="hidden" name="_method" value="<?php echo $method ?>" />
 <?php endif ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_start.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_start.html.php
@@ -1,6 +1,6 @@
 <?php $method = strtoupper($method) ?>
 <?php $form_method = $method === 'GET' || $method === 'POST' ? $method : 'POST' ?>
-<form name="<?php echo $name ?>" method="<?php echo strtolower($form_method) ?>" action="<?php echo $action ?>"<?php foreach ($attr as $k => $v) { printf(' %s="%s"', $view->escape($k), $view->escape($v)); } ?><?php if ($multipart): ?> enctype="multipart/form-data"<?php endif ?>>
+<form name="<?php echo $name ?>" method="<?php echo strtolower($form_method) ?>"<?php if (! $omit_action) : ?> action="<?php echo $action ?>"<?php endif ?><?php foreach ($attr as $k => $v) { printf(' %s="%s"', $view->escape($k), $view->escape($v)); } ?><?php if ($multipart): ?> enctype="multipart/form-data"<?php endif ?>>
 <?php if ($form_method !== $method): ?>
     <input type="hidden" name="_method" value="<?php echo $method ?>" />
 <?php endif ?>

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -99,6 +99,7 @@ class FormType extends BaseType
             'method' => $form->getConfig()->getMethod(),
             'action' => $form->getConfig()->getAction(),
             'submitted' => $form->isSubmitted(),
+            'omit_action' => $options['omit_action'],
         ));
     }
 
@@ -207,6 +208,7 @@ class FormType extends BaseType
             'action' => '',
             'attr' => $defaultAttr,
             'post_max_size_message' => 'The uploaded file was too large. Please try to upload a smaller file.',
+            'omit_action' => false,
         ));
 
         $resolver->setAllowedTypes('label_attr', 'array');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [no] |
| New feature? | [yes] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| Fixed tickets | [13852] |
| License | MIT |
| Doc PR |  |

This patch simply adds an `omit_action` option to `formType`, which allows users to omit the action attribute from a rendered `<form>` element. According to the original issue #13852 this serves two purposes: 1. HTML5 forms who don't want to explicitly add an action will be valid (an empty `action` is not allowed in HTML5, and 2. Ajax forms and AngularJS will function without overriding the `form_start` template.
