### PR TITLE
[FrameworkBundle] Tag deprecated services

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_csrf.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_csrf.xml
@@ -7,6 +7,7 @@
     <services>
         <service id="form.csrf_provider" class="Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfTokenManagerAdapter">
             <argument type="service" id="security.csrf.token_manager" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 2.4 and will be removed in 3.0. Use the "security.csrf.token_manager" service instead.</deprecated>
         </service>
 
         <service id="form.type_extension.csrf" class="Symfony\Component\Form\Extension\Csrf\Type\FormTypeCsrfExtension">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -38,16 +38,9 @@
             <argument type="collection" />
         </service>
 
-        <!--
-            If you want to change the Request class, modify the code in
-            your front controller (app.php) so that it passes an instance of
-            YourRequestClass to the Kernel.
-            This service definition only defines the scope of the request.
-            It is used to check references scope.
-
-            This service is deprecated, you should use the request_stack service instead.
-        -->
-        <service id="request" scope="request" synthetic="true" synchronized="true" />
+        <service id="request" scope="request" synthetic="true" synchronized="true">
+            <deprecated>The "%service_id%" service is deprecated since Symfony 2.7 and will be removed in 3.0. Use the "request_stack" service instead.</deprecated>
+        </service>
 
         <service id="service_container" synthetic="true" />
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
@@ -47,6 +47,7 @@
                     </call>
                 </service>
             </argument>
+            <deprecated>The "%service_id%" service is deprecated since Symfony 2.8 and will be removed in 3.0.</deprecated>
         </service>
 
         <service id="validator.validator_factory" class="%validator.validator_factory.class%" public="false">

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -53,6 +53,7 @@
         <service id="security.context" class="%security.context.class%">
             <argument type="service" id="security.token_storage" />
             <argument type="service" id="security.authorization_checker" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 2.6 and will be removed in 3.0.</deprecated>
         </service>
 
         <service id="security.authorization_checker" class="Symfony\Component\Security\Core\Authorization\AuthorizationChecker">


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Tag deprecated services as such. Some are deprecated by transitivity with their class definition.
Having given some workshops on migrating to sf 3.0, the deprecation triggered at the class level is cryptic to most. Triggering a more tailored one about the service is really important to me in order to help users migrate.
