### PR TITLE
Only add salt to password_hash on PHP < 7

### DIFF
--- a/src/Symfony/Component/Security/Core/Encoder/BCryptPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/BCryptPasswordEncoder.php
@@ -74,7 +74,7 @@ class BCryptPasswordEncoder extends BasePasswordEncoder
 
         $options = array('cost' => $this->cost);
 
-        if ($salt) {
+        if ($salt && PHP_VERSION_ID < 70000) {
             $options['salt'] = $salt;
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The `salt` option for the `password_hash` function is deprecated since PHP 7, so it should not be added when running on PHP 7
