### PR TITLE
[HttpFoundation] removed the ParameterBag::get() deep argument

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -78,67 +78,16 @@ class ParameterBag implements \IteratorAggregate, \Countable
     /**
      * Returns a parameter by name.
      *
-     * Note: Finding deep items is deprecated since version 2.8, to be removed in 3.0.
-     *
      * @param string $key     The key
      * @param mixed  $default The default value if the parameter key does not exist
-     * @param bool   $deep    If true, a path like foo[bar] will find deeper items
      *
      * @return mixed
      *
      * @throws \InvalidArgumentException
      */
-    public function get($key, $default = null, $deep = false)
+    public function get($key, $default = null)
     {
-        if (true === $deep) {
-            @trigger_error('Using paths to find deeper items in '.__METHOD__.' is deprecated since version 2.8 and will be removed in 3.0. Filter the returned value in your own code instead.', E_USER_DEPRECATED);
-        }
-
-        if (!$deep || false === $pos = strpos($key, '[')) {
-            return array_key_exists($key, $this->parameters) ? $this->parameters[$key] : $default;
-        }
-
-        $root = substr($key, 0, $pos);
-        if (!array_key_exists($root, $this->parameters)) {
-            return $default;
-        }
-
-        $value = $this->parameters[$root];
-        $currentKey = null;
-        for ($i = $pos, $c = strlen($key); $i < $c; ++$i) {
-            $char = $key[$i];
-
-            if ('[' === $char) {
-                if (null !== $currentKey) {
-                    throw new \InvalidArgumentException(sprintf('Malformed path. Unexpected "[" at position %d.', $i));
-                }
-
-                $currentKey = '';
-            } elseif (']' === $char) {
-                if (null === $currentKey) {
-                    throw new \InvalidArgumentException(sprintf('Malformed path. Unexpected "]" at position %d.', $i));
-                }
-
-                if (!is_array($value) || !array_key_exists($currentKey, $value)) {
-                    return $default;
-                }
-
-                $value = $value[$currentKey];
-                $currentKey = null;
-            } else {
-                if (null === $currentKey) {
-                    throw new \InvalidArgumentException(sprintf('Malformed path. Unexpected "%s" at position %d.', $char, $i));
-                }
-
-                $currentKey .= $char;
-            }
-        }
-
-        if (null !== $currentKey) {
-            throw new \InvalidArgumentException(sprintf('Malformed path. Path must end with "]".'));
-        }
-
-        return $value;
+        return array_key_exists($key, $this->parameters) ? $this->parameters[$key] : $default;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -714,29 +714,22 @@ class Request
      * It is better to explicitly get request parameters from the appropriate
      * public property instead (query, attributes, request).
      *
-     * Note: Finding deep items is deprecated since version 2.8, to be removed in 3.0.
-     *
      * @param string $key     the key
      * @param mixed  $default the default value
-     * @param bool   $deep    is parameter deep in multidimensional array
      *
      * @return mixed
      */
-    public function get($key, $default = null, $deep = false)
+    public function get($key, $default = null)
     {
-        if (true === $deep) {
-            @trigger_error('Using paths to find deeper items in '.__METHOD__.' is deprecated since version 2.8 and will be removed in 3.0. Filter the returned value in your own code instead.', E_USER_DEPRECATED);
-        }
-
-        if ($this !== $result = $this->query->get($key, $this, $deep)) {
+        if ($this !== $result = $this->query->get($key, $this)) {
             return $result;
         }
 
-        if ($this !== $result = $this->attributes->get($key, $this, $deep)) {
+        if ($this !== $result = $this->attributes->get($key, $this)) {
             return $result;
         }
 
-        if ($this !== $result = $this->request->get($key, $this, $deep)) {
+        if ($this !== $result = $this->request->get($key, $this)) {
             return $result;
         }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -86,41 +86,6 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @group legacy
-     * @dataProvider getInvalidPaths
-     * @expectedException \InvalidArgumentException
-     */
-    public function testGetDeepWithInvalidPaths($path)
-    {
-        $bag = new ParameterBag(array('foo' => array('bar' => 'moo')));
-
-        $bag->get($path, null, true);
-    }
-
-    public function getInvalidPaths()
-    {
-        return array(
-            array('foo[['),
-            array('foo[d'),
-            array('foo[bar]]'),
-            array('foo[bar]d'),
-        );
-    }
-
-    /**
-     * @group legacy
-     */
-    public function testGetDeep()
-    {
-        $bag = new ParameterBag(array('foo' => array('bar' => array('moo' => 'boo'))));
-
-        $this->assertEquals(array('moo' => 'boo'), $bag->get('foo[bar]', null, true));
-        $this->assertEquals('boo', $bag->get('foo[bar][moo]', null, true));
-        $this->assertEquals('default', $bag->get('foo[bar][foo]', 'default', true));
-        $this->assertEquals('default', $bag->get('bar[moo][foo]', 'default', true));
-    }
-
-    /**
      * @covers Symfony\Component\HttpFoundation\ParameterBag::set
      */
     public function testSet()

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
@@ -145,7 +145,7 @@ class DefaultAuthenticationFailureHandlerTest extends \PHPUnit_Framework_TestCas
     public function testFailurePathCanBeOverwrittenWithRequest()
     {
         $this->request->expects($this->once())
-            ->method('get')->with('_failure_path', null, false)
+            ->method('get')->with('_failure_path')
             ->will($this->returnValue('/auth/login'));
 
         $this->httpUtils->expects($this->once())
@@ -158,7 +158,7 @@ class DefaultAuthenticationFailureHandlerTest extends \PHPUnit_Framework_TestCas
     public function testFailurePathCanBeOverwrittenWithNestedAttributeInRequest()
     {
         $this->request->expects($this->once())
-            ->method('get')->with('_failure_path', null, false)
+            ->method('get')->with('_failure_path')
             ->will($this->returnValue(array('value' => '/auth/login')));
 
         $this->httpUtils->expects($this->once())
@@ -173,7 +173,7 @@ class DefaultAuthenticationFailureHandlerTest extends \PHPUnit_Framework_TestCas
         $options = array('failure_path_parameter' => '_my_failure_path');
 
         $this->request->expects($this->once())
-            ->method('get')->with('_my_failure_path', null, false)
+            ->method('get')->with('_my_failure_path')
             ->will($this->returnValue('/auth/login'));
 
         $this->httpUtils->expects($this->once())


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |
