### PR TITLE
Minor fixes for the profiler and toolbar

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/DebugBundle/Resources/config/services.xml
@@ -11,7 +11,7 @@
         </service>
 
         <service id="data_collector.dump" class="Symfony\Component\HttpKernel\DataCollector\DumpDataCollector">
-            <tag name="data_collector" id="dump" template="@Debug/Profiler/dump.html.twig" />
+            <tag name="data_collector" id="dump" template="@Debug/Profiler/dump.html.twig" priority="255" />
             <argument type="service" id="debug.stopwatch" on-invalid="ignore" />
             <argument>null</argument><!-- %templating.helper.code.file_link_format% -->
             <argument>%kernel.charset%</argument>

--- a/src/Symfony/Bundle/DebugBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/DebugBundle/Resources/config/services.xml
@@ -11,7 +11,7 @@
         </service>
 
         <service id="data_collector.dump" class="Symfony\Component\HttpKernel\DataCollector\DumpDataCollector">
-            <tag name="data_collector" id="dump" template="@Debug/Profiler/dump.html.twig" priority="255" />
+            <tag name="data_collector" id="dump" template="@Debug/Profiler/dump.html.twig" priority="240" />
             <argument type="service" id="debug.stopwatch" on-invalid="ignore" />
             <argument>null</argument><!-- %templating.helper.code.file_link_format% -->
             <argument>%kernel.charset%</argument>

--- a/src/Symfony/Bundle/DebugBundle/Tests/DependencyInjection/DebugExtensionTest.php
+++ b/src/Symfony/Bundle/DebugBundle/Tests/DependencyInjection/DebugExtensionTest.php
@@ -28,6 +28,7 @@ class DebugExtensionTest extends \PHPUnit_Framework_TestCase
             array(
                 'id' => 'dump',
                 'template' => '@Debug/Profiler/dump.html.twig',
+                'priority' => 240,
             ),
         );
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.xml
@@ -23,41 +23,41 @@
 
         <service id="data_collector.request" class="%data_collector.request.class%">
             <tag name="kernel.event_subscriber" />
-            <tag name="data_collector" template="@WebProfiler/Collector/request.html.twig" id="request" priority="260" />
+            <tag name="data_collector" template="@WebProfiler/Collector/request.html.twig" id="request" priority="335" />
         </service>
 
         <service id="data_collector.ajax" class="Symfony\Bundle\FrameworkBundle\DataCollector\AjaxDataCollector" public="false">
-            <tag name="data_collector" template="@WebProfiler/Collector/ajax.html.twig" id="ajax" priority="256" />
+            <tag name="data_collector" template="@WebProfiler/Collector/ajax.html.twig" id="ajax" priority="315" />
         </service>
 
         <service id="data_collector.exception" class="%data_collector.exception.class%" public="false">
-            <tag name="data_collector" template="@WebProfiler/Collector/exception.html.twig" id="exception" priority="255" />
+            <tag name="data_collector" template="@WebProfiler/Collector/exception.html.twig" id="exception" priority="305" />
         </service>
 
         <service id="data_collector.events" class="%data_collector.events.class%" public="false">
-            <tag name="data_collector" template="@WebProfiler/Collector/events.html.twig" id="events" priority="255" />
+            <tag name="data_collector" template="@WebProfiler/Collector/events.html.twig" id="events" priority="290" />
             <argument type="service" id="event_dispatcher" on-invalid="ignore" />
         </service>
 
         <service id="data_collector.logger" class="%data_collector.logger.class%" public="false">
-            <tag name="data_collector" template="@WebProfiler/Collector/logger.html.twig" id="logger" priority="255" />
+            <tag name="data_collector" template="@WebProfiler/Collector/logger.html.twig" id="logger" priority="300" />
             <tag name="monolog.logger" channel="profiler" />
             <argument type="service" id="logger" on-invalid="ignore" />
         </service>
 
         <service id="data_collector.time" class="%data_collector.time.class%" public="false">
-            <tag name="data_collector" template="@WebProfiler/Collector/time.html.twig" id="time" priority="259" />
+            <tag name="data_collector" template="@WebProfiler/Collector/time.html.twig" id="time" priority="330" />
             <argument type="service" id="kernel" on-invalid="ignore" />
             <argument type="service" id="debug.stopwatch" on-invalid="ignore" />
         </service>
 
         <service id="data_collector.memory" class="%data_collector.memory.class%" public="false">
-            <tag name="data_collector" template="@WebProfiler/Collector/memory.html.twig" id="memory" priority="258" />
+            <tag name="data_collector" template="@WebProfiler/Collector/memory.html.twig" id="memory" priority="325" />
         </service>
 
         <service id="data_collector.router" class="%data_collector.router.class%" >
             <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController"/>
-            <tag name="data_collector" template="@WebProfiler/Collector/router.html.twig" id="router" priority="255" />
+            <tag name="data_collector" template="@WebProfiler/Collector/router.html.twig" id="router" priority="285" />
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_debug.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_debug.xml
@@ -29,7 +29,7 @@
         <service id="data_collector.form.extractor" class="%data_collector.form.extractor.class%" />
 
         <service id="data_collector.form" class="%data_collector.form.class%">
-            <tag name="data_collector" template="@WebProfiler/Collector/form.html.twig" id="form" priority="255" />
+            <tag name="data_collector" template="@WebProfiler/Collector/form.html.twig" id="form" priority="310" />
             <argument type="service" id="data_collector.form.extractor" />
         </service>
     </services>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation_debug.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation_debug.xml
@@ -12,7 +12,7 @@
 
         <!-- DataCollector -->
         <service id="data_collector.translation" class="Symfony\Component\Translation\DataCollector\TranslationDataCollector">
-            <tag name="data_collector" template="@WebProfiler/Collector/translation.html.twig" id="translation" priority="255" />
+            <tag name="data_collector" template="@WebProfiler/Collector/translation.html.twig" id="translation" priority="275" />
             <argument type="service" id="translator.data_collector" />
         </service>
     </services>

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/collectors.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/collectors.xml
@@ -10,7 +10,7 @@
 
     <services>
         <service id="data_collector.security" class="%data_collector.security.class%" public="false">
-            <tag name="data_collector" template="@Security/Collector/security.html.twig" id="security" />
+            <tag name="data_collector" template="@Security/Collector/security.html.twig" id="security" priority="270" />
             <argument type="service" id="security.token_storage" on-invalid="ignore" />
             <argument type="service" id="security.role_hierarchy" />
             <argument type="service" id="security.logout_url_generator" />

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -53,7 +53,7 @@
 }
 .sf-toolbarreset .hide-button svg {
     max-height: 18px;
-    padding-top: 10px;
+    margin-top: 10px;
 }
 
 .sf-toolbar-block {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | partially #15439 |
| License | MIT |
| Doc PR | - |

Changes:
- Fixed a misaligned icon
- Changed the priorities of the collectors to better control their position and to leave a "gap" between priorities so custom panels can be displayed between the default panels. This idea came from @stof.

By the way, @stof do you know how can I set the priority of the SwiftMailer collector? Its definition is the only one that doesn't use the `<tag name="data_collector" />`:

``` xml
<service id="swiftmailer.data_collector" class="%swiftmailer.data_collector.class%">
    <argument type="service" id="service_container" />
</service>
```

https://github.com/symfony/swiftmailer-bundle/blob/master/Resources/config/swiftmailer.xml#L90-L92
