### PR TITLE
[Security] add dependency required by a replaced package

### DIFF
--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -20,7 +20,8 @@
         "symfony/security-acl": "~2.7",
         "symfony/event-dispatcher": "~2.2|~3.0.0",
         "symfony/http-foundation": "~2.1|~3.0.0",
-        "symfony/http-kernel": "~2.4|~3.0.0"
+        "symfony/http-kernel": "~2.4|~3.0.0",
+        "symfony/property-access": "~2.3|~3.0.0"
     },
     "replace": {
         "symfony/security-core": "self.version",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Since #16007, the Security HTTP component requires the PropertyAccess
component to access nested parameter bag values. Since the Security
component replaces the Security HTTP component, all dependencies of the
replaced packages must be mirrored here.
