### PR TITLE
[2.8][Translation] added DoctrineMessageCatalogue.

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Translation/DoctrineMessageCatalogueProviderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Translation/DoctrineMessageCatalogueProviderTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\MessageCatalogueProvider\Tests;
+
+use Symfony\Component\Translation\Tests\MessageCatalogueProvider\CachedMessageCatalogueProviderTest;
+use Symfony\Bridge\Doctrine\Translation\DoctrineMessageCatalogueProvider;
+use Symfony\Component\Translation\MessageCatalogueProvider\ResourceMessageCatalogueProvider;
+use Doctrine\Common\Cache\ArrayCache;
+
+class DoctrineMessageCatalogueProviderTest extends CachedMessageCatalogueProviderTest
+{
+    private $cache;
+
+    protected function setUp()
+    {
+        if (!interface_exists('Doctrine\Common\Cache\Cache')) {
+            $this->markTestSkipped('The "Doctrine Cache" is not available');
+        }
+
+        $this->cache = new ArrayCache();
+    }
+
+    protected function getMessageCatalogueProvider($debug, $loaders = array(), $resources = array(), $fallbackLocales = array())
+    {
+        $resourceCatalogue = new ResourceMessageCatalogueProvider($loaders, $resources, $fallbackLocales);
+
+        return new DoctrineMessageCatalogueProvider($resourceCatalogue, $this->cache, $debug);
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Translation/DoctrineMessageCatalogueTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Translation/DoctrineMessageCatalogueTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Translation;
+
+use Symfony\Bridge\Doctrine\Translation\DoctrineMessageCatalogue;
+use Doctrine\Common\Cache\ArrayCache;
+use Symfony\Component\Translation\Tests\MessageCatalogueTest;
+
+class DoctrineMessageCatalogueTest extends MessageCatalogueTest
+{
+    protected function setUp()
+    {
+        if (!interface_exists('Doctrine\Common\Cache\Cache')) {
+            $this->markTestSkipped('The "Doctrine Cache" is not available');
+        }
+    }
+
+    public function testAll()
+    {
+        if (!interface_exists('Doctrine\Common\Cache\MultiGetCache')) {
+            $this->markTestSkipped('The "Doctrine MultiGetCache" is not available');
+        }
+
+        parent::testAll();
+    }
+
+    protected function getCatalogue($locale, $messages = array())
+    {
+        $catalogue = new DoctrineMessageCatalogue($locale, new ArrayCache());
+        foreach ($messages as $domain => $domainMessages) {
+            $catalogue->add($domainMessages, $domain);
+        }
+
+        return $catalogue;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Translation/DoctrineMessageCatalogue.php
+++ b/src/Symfony/Bridge/Doctrine/Translation/DoctrineMessageCatalogue.php
@@ -1,0 +1,224 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Translation;
+
+use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Cache\MultiGetCache;
+use Symfony\Component\Translation\MessageCatalogue;
+
+/**
+ * @author Abdellatif Ait boudad <a.aitboudad@gmail.com>
+ */
+class DoctrineMessageCatalogue extends MessageCatalogue
+{
+    const PREFIX = 'sf2_translation';
+    const CATALOGUE_DOMAINS = 'domains';
+    const CATALOGUE_DOMAIN_METADATA = 'domain_meta_';
+
+    /**
+     * @var Cache
+     */
+    private $cache;
+
+    /**
+     * @var string
+     */
+    private $prefix;
+
+    /**
+     * @var array
+     */
+    private $domains = array();
+
+    /**
+     * @param string $locale
+     * @param Cache  $cache
+     * @param string $prefix
+     */
+    public function __construct($locale, Cache $cache, $prefix = self::PREFIX)
+    {
+        parent::__construct($locale);
+        if (0 === strlen($prefix)) {
+            throw new \InvalidArgumentException('$prefix cannot be empty.');
+        }
+
+        $this->cache = $cache;
+        $this->prefix = $prefix.'_'.$locale.'_';
+
+        if ($cache->contains($domainsId = $this->prefix.self::CATALOGUE_DOMAINS)) {
+            $this->domains = $cache->fetch($domainsId);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDomains()
+    {
+        return $this->domains;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function all($domain = null)
+    {
+        if (!$this->cache instanceof MultiGetCache) {
+            return array();
+        }
+
+        $domains = $this->domains;
+        if (null !== $domain) {
+            $domains = array($domain);
+        }
+
+        $messages = array();
+        foreach ($domains as $domainMeta) {
+            $domainIdentity = $this->getDomainMetaDataId($domainMeta);
+            if ($this->cache->contains($domainIdentity)) {
+                $keys = $this->cache->fetch($domainIdentity);
+                $values = $this->cache->fetchMultiple(array_keys($keys));
+                foreach ($keys as $key => $id) {
+                    if (isset($values[$key])) {
+                        $messages[$domainMeta][$id] = $values[$key];
+                    }
+                }
+            }
+        }
+
+        if (null === $domain) {
+            return $messages;
+        }
+
+        return isset($messages[$domain]) ? $messages[$domain] : array();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function set($id, $translation, $domain = 'messages')
+    {
+        $this->add(array($id => $translation), $domain);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($id, $domain = 'messages')
+    {
+        if ($this->defines($id, $domain)) {
+            return true;
+        }
+
+        $fallbackCatalogue = $this->getFallbackCatalogue();
+        if (null !== $fallbackCatalogue) {
+            return $fallbackCatalogue->has($id, $domain);
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function defines($id, $domain = 'messages')
+    {
+        $key = $this->getCacheId($domain, $id);
+
+        return $this->cache->contains($key);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get($id, $domain = 'messages')
+    {
+        if ($this->defines($id, $domain)) {
+            return $this->cache->fetch($this->getCacheId($domain, $id));
+        }
+
+        $fallbackCatalogue = $this->getFallbackCatalogue();
+        if (null !== $fallbackCatalogue) {
+            return $fallbackCatalogue->get($id, $domain);
+        }
+
+        return $id;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function replace($messages, $domain = 'messages')
+    {
+        $domainMetaData = array();
+        $domainMetaKey = $this->getDomainMetaDataId($domain);
+        if ($this->cache->contains($domainMetaKey)) {
+            $domainMetaData = $this->cache->fetch($domainMetaKey);
+        }
+
+        foreach ($domainMetaData as $key => $id) {
+            if (!isset($messages[$id])) {
+                unset($domainMetaData[$key]);
+                $this->cache->delete($key);
+            }
+        }
+
+        $this->cache->save($domainMetaKey, $domainMetaData);
+        $this->add($messages, $domain);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function add($messages, $domain = 'messages')
+    {
+        if (!isset($this->domains[$domain])) {
+            $this->addDomain($domain);
+        }
+
+        $domainMetaData = array();
+        $domainMetaKey = $this->getDomainMetaDataId($domain);
+        if ($this->cache->contains($domainMetaKey)) {
+            $domainMetaData = $this->cache->fetch($domainMetaKey);
+        }
+
+        foreach ($messages as $id => $translation) {
+            $key = $this->getCacheId($domain, $id);
+            $domainMetaData[$key] = $id;
+            $this->cache->save($key, $translation);
+        }
+
+        $this->addDomainMetaData($domain, $domainMetaData);
+    }
+
+    private function addDomain($domain)
+    {
+        $this->domains[] = $domain;
+        $this->cache->save($this->prefix.self::CATALOGUE_DOMAINS, $this->domains);
+    }
+
+    private function addDomainMetaData($domain, $keys = array())
+    {
+        $domainIdentity = $this->getDomainMetaDataId($domain);
+        $this->cache->save($domainIdentity, $keys);
+    }
+
+    private function getCacheId($id, $domain = 'messages')
+    {
+        return $this->prefix.$domain.'_'.sha1($id);
+    }
+
+    private function getDomainMetaDataId($domain)
+    {
+        return $this->prefix.self::CATALOGUE_DOMAIN_METADATA.$domain;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Translation/DoctrineMessageCatalogueProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Translation/DoctrineMessageCatalogueProvider.php
@@ -1,0 +1,181 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Translation;
+
+use Doctrine\Common\Cache\Cache;
+use Symfony\Component\Translation\MessageCatalogueInterface;
+use Symfony\Component\Translation\MessageCatalogueProvider\MessageCatalogueProviderInterface;
+use Symfony\Component\Translation\MessageCatalogueProvider\ResourceMessageCatalogueProvider;
+
+/**
+ * @author Abdellatif Ait Boudad <a.aitboudad@gmail.com>
+ */
+class DoctrineMessageCatalogueProvider implements MessageCatalogueProviderInterface
+{
+    const CACHE_CATALOGUE_HASH = 'sf2_translation_catalogue';
+    const CACHE_DUMP_TIME = 'time';
+    const CACHE_META_DATA = 'meta';
+    const CATALOGUE_FALLBACK_LOCALE = 'fallback_locales';
+
+    /**
+     * @var MessageCatalogueProviderInterface
+     */
+    private $messageCatalogueProvider;
+
+    /**
+     * @var Cache
+     */
+    private $cache;
+
+    /**
+     * @var bool
+     */
+    private $debug;
+
+    /**
+     * @var MessageCatalogueInterface[]
+     */
+    private $catalogues;
+
+    /**
+     * @param MessageCatalogueProviderInterface $messageCatalogueProvider The message catalogue provider to use for loading the catalogue.
+     * @param Cache                             $cache
+     * @param bool                              $debug
+     */
+    public function __construct(MessageCatalogueProviderInterface $messageCatalogueProvider, Cache $cache, $debug = false)
+    {
+        $this->messageCatalogueProvider = $messageCatalogueProvider;
+        $this->cache = $cache;
+        $this->debug = $debug;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCatalogue($locale)
+    {
+        if (isset($this->catalogues[$locale]) && $this->isFresh($locale)) {
+            return $this->catalogues[$locale];
+        }
+
+        return $this->catalogues[$locale] = $this->dumpCatalogue($locale);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function dumpCatalogue($locale)
+    {
+        if ($this->isFresh($locale)) {
+            return $this->loadCatalogue($locale);
+        }
+
+        $messages = $this->messageCatalogueProvider->getCatalogue($locale);
+        $doctrineCatalogue = $this->createDoctrineCatalogueMessage($locale);
+        $doctrineCatalogue->addCatalogue($messages);
+
+        // dump catalogue metadata
+        $this->dumpCatalogueMetaData($locale, $doctrineCatalogue->getResources());
+
+        $fallbackLocales = array();
+        $messages = $messages->getFallbackCatalogue();
+        while ($messages) {
+            $fallbackLocale = $messages->getLocale();
+            $catalogue = $this->createDoctrineCatalogueMessage($fallbackLocale);
+            $catalogue->addCatalogue($messages);
+
+            // dump catalogue metadata
+            $this->dumpCatalogueMetaData($fallbackLocale, $messages->getResources());
+
+            $fallbackLocales[] = $fallbackLocale;
+            $doctrineCatalogue->addFallbackCatalogue($catalogue);
+            $messages = $messages->getFallbackCatalogue();
+        }
+
+        $this->cache->save($this->getFallbackLocaleKey($locale), serialize($fallbackLocales));
+
+        return $doctrineCatalogue;
+    }
+
+    private function loadCatalogue($locale)
+    {
+        $catalogue = $this->createDoctrineCatalogueMessage($locale);
+        $fallbackLocales = unserialize($this->cache->fetch($this->getFallbackLocaleKey($catalogue->getLocale())));
+        if ($fallbackLocales) {
+            foreach ($fallbackLocales as $fallbackLocale) {
+                $fallback = $this->createDoctrineCatalogueMessage($fallbackLocale);
+                $catalogue->addFallbackCatalogue($fallback);
+            }
+        }
+
+        return $catalogue;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    private function isFresh($locale)
+    {
+        if (!$this->cache->contains($this->getCatalogueHashKey($locale))) {
+            return false;
+        }
+
+        if ($this->debug) {
+            $time = $this->cache->fetch($this->getDumpTimeKey($locale));
+            $meta = unserialize($this->cache->fetch($this->getMetaDataKey($locale)));
+            foreach ($meta as $resource) {
+                if (!$resource->isFresh($time)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private function createDoctrineCatalogueMessage($locale)
+    {
+        return new DoctrineMessageCatalogue($locale, $this->cache, $this->getCatalogueHashKey($locale));
+    }
+
+    private function getCatalogueHashKey($locale)
+    {
+        return self::CACHE_CATALOGUE_HASH.'_'.$locale;
+    }
+
+    private function dumpCatalogueMetaData($locale, $metadata)
+    {
+        $this->cache->save($this->getCatalogueHashKey($locale), true);
+        $this->cache->save($this->getDumpTimeKey($locale), time());
+        $this->cache->save($this->getMetaDataKey($locale), serialize($metadata));
+    }
+
+    private function getDumpTimeKey($locale)
+    {
+        return $this->getCatalogueHashKey($locale).'_'.self::CACHE_DUMP_TIME;
+    }
+
+    private function getMetaDataKey($locale)
+    {
+        return $this->getCatalogueHashKey($locale).'_'.self::CACHE_META_DATA;
+    }
+
+    private function getFallbackLocaleKey($locale)
+    {
+        $key = self::CATALOGUE_FALLBACK_LOCALE;
+        if ($this->messageCatalogueProvider instanceof ResourceMessageCatalogueProvider) {
+            $key .= '_'.sha1(serialize($this->messageCatalogueProvider->getFallbackLocales()));
+        }
+
+        return $this->getCatalogueHashKey($locale).'_'.$key;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -33,7 +33,8 @@
         "symfony/translation": "~2.0,>=2.0.5|~3.0.0",
         "doctrine/data-fixtures": "1.0.*",
         "doctrine/dbal": "~2.4",
-        "doctrine/orm": "~2.4,>=2.4.5"
+        "doctrine/orm": "~2.4,>=2.4.5",
+        "doctrine/cache": "~1.0"
     },
     "suggest": {
         "symfony/form": "",
@@ -41,7 +42,8 @@
         "symfony/property-info": "",
         "doctrine/data-fixtures": "",
         "doctrine/dbal": "",
-        "doctrine/orm": ""
+        "doctrine/orm": "",
+        "doctrine/cache": ""
     },
     "autoload": {
         "psr-4": { "Symfony\\Bridge\\Doctrine\\": "" }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -617,6 +617,7 @@ class Configuration implements ConfigurationInterface
                         ->arrayNode('paths')
                             ->prototype('scalar')->end()
                         ->end()
+                        ->scalarNode('message_catalogue_provider')->defaultValue('translation.message_catalogue_provider.cache')->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -668,6 +668,15 @@ class FrameworkExtension extends Extension
 
         $container->setParameter('translator.logging', $config['logging']);
 
+        if (isset($config['message_catalogue_provider'])) {
+            $container->setParameter(
+                'translator.message_catalogue_provider.cache.prefix',
+                'translator_'.hash('sha256', $container->getParameter('kernel.root_dir'))
+            );
+
+            $container->setAlias('translation.message_catalogue_provider', $config['message_catalogue_provider']);
+        }
+
         // Discover translation directories
         $dirs = array();
         if (class_exists('Symfony\Component\Validator\Validation')) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -189,6 +189,7 @@
         <xsd:attribute name="enabled" type="xsd:boolean" />
         <xsd:attribute name="fallback" type="xsd:string" />
         <xsd:attribute name="logging" type="xsd:boolean" />
+        <xsd:attribute name="message_catalogue_provider" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="validation">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
@@ -33,6 +33,7 @@
         <parameter key="translation.loader.class">Symfony\Bundle\FrameworkBundle\Translation\TranslationLoader</parameter>
         <parameter key="translation.extractor.class">Symfony\Component\Translation\Extractor\ChainExtractor</parameter>
         <parameter key="translation.writer.class">Symfony\Component\Translation\Writer\TranslationWriter</parameter>
+        <parameter key="translator.message_catalogue_provider.cache.prefix" />
     </parameters>
 
     <services>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -158,6 +158,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 'fallbacks' => array('en'),
                 'logging' => true,
                 'paths' => array(),
+                'message_catalogue_provider' => 'translation.message_catalogue_provider.cache',
             ),
             'validation' => array(
                 'enabled' => false,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -251,6 +251,8 @@ abstract class FrameworkExtensionTest extends TestCase
 
         $calls = $container->getDefinition('translator.default')->getMethodCalls();
         $this->assertEquals(array('fr'), $calls[1][1][0]);
+        $this->assertEquals(array('fr'), $calls[0][1][0]);
+        $this->assertContains('translator_', $container->getParameter('translator.message_catalogue_provider.cache.prefix'));
     }
 
     public function testTranslatorMultipleFallbacks()

--- a/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
@@ -17,21 +17,21 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetLocale()
     {
-        $catalogue = new MessageCatalogue('en');
+        $catalogue = $this->getCatalogue('en');
 
         $this->assertEquals('en', $catalogue->getLocale());
     }
 
     public function testGetDomains()
     {
-        $catalogue = new MessageCatalogue('en', array('domain1' => array(), 'domain2' => array()));
+        $catalogue = $this->getCatalogue('en', array('domain1' => array(), 'domain2' => array()));
 
         $this->assertEquals(array('domain1', 'domain2'), $catalogue->getDomains());
     }
 
     public function testAll()
     {
-        $catalogue = new MessageCatalogue('en', $messages = array('domain1' => array('foo' => 'foo'), 'domain2' => array('bar' => 'bar')));
+        $catalogue = $this->getCatalogue('en', $messages = array('domain1' => array('foo' => 'foo'), 'domain2' => array('bar' => 'bar')));
 
         $this->assertEquals(array('foo' => 'foo'), $catalogue->all('domain1'));
         $this->assertEquals(array(), $catalogue->all('domain88'));
@@ -40,7 +40,7 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
 
     public function testHas()
     {
-        $catalogue = new MessageCatalogue('en', array('domain1' => array('foo' => 'foo'), 'domain2' => array('bar' => 'bar')));
+        $catalogue = $this->getCatalogue('en', array('domain1' => array('foo' => 'foo'), 'domain2' => array('bar' => 'bar')));
 
         $this->assertTrue($catalogue->has('foo', 'domain1'));
         $this->assertFalse($catalogue->has('bar', 'domain1'));
@@ -49,7 +49,7 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
 
     public function testGetSet()
     {
-        $catalogue = new MessageCatalogue('en', array('domain1' => array('foo' => 'foo'), 'domain2' => array('bar' => 'bar')));
+        $catalogue = $this->getCatalogue('en', array('domain1' => array('foo' => 'foo'), 'domain2' => array('bar' => 'bar')));
         $catalogue->set('foo1', 'foo1', 'domain1');
 
         $this->assertEquals('foo', $catalogue->get('foo', 'domain1'));
@@ -58,7 +58,7 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
 
     public function testAdd()
     {
-        $catalogue = new MessageCatalogue('en', array('domain1' => array('foo' => 'foo'), 'domain2' => array('bar' => 'bar')));
+        $catalogue = $this->getCatalogue('en', array('domain1' => array('foo' => 'foo'), 'domain2' => array('bar' => 'bar')));
         $catalogue->add(array('foo1' => 'foo1'), 'domain1');
 
         $this->assertEquals('foo', $catalogue->get('foo', 'domain1'));
@@ -74,7 +74,7 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
 
     public function testReplace()
     {
-        $catalogue = new MessageCatalogue('en', array('domain1' => array('foo' => 'foo'), 'domain2' => array('bar' => 'bar')));
+        $catalogue = $this->getCatalogue('en', array('domain1' => array('foo' => 'foo'), 'domain2' => array('bar' => 'bar')));
         $catalogue->replace($messages = array('foo1' => 'foo1'), 'domain1');
 
         $this->assertEquals($messages, $catalogue->all('domain1'));
@@ -88,10 +88,10 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
         $r1 = $this->getMock('Symfony\Component\Config\Resource\ResourceInterface');
         $r1->expects($this->any())->method('__toString')->will($this->returnValue('r1'));
 
-        $catalogue = new MessageCatalogue('en', array('domain1' => array('foo' => 'foo'), 'domain2' => array('bar' => 'bar')));
+        $catalogue = $this->getCatalogue('en', array('domain1' => array('foo' => 'foo'), 'domain2' => array('bar' => 'bar')));
         $catalogue->addResource($r);
 
-        $catalogue1 = new MessageCatalogue('en', array('domain1' => array('foo1' => 'foo1')));
+        $catalogue1 = $this->getCatalogue('en', array('domain1' => array('foo1' => 'foo1')));
         $catalogue1->addResource($r1);
 
         $catalogue->addCatalogue($catalogue1);
@@ -110,10 +110,10 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
         $r1 = $this->getMock('Symfony\Component\Config\Resource\ResourceInterface');
         $r1->expects($this->any())->method('__toString')->will($this->returnValue('r1'));
 
-        $catalogue = new MessageCatalogue('en_US', array('domain1' => array('foo' => 'foo'), 'domain2' => array('bar' => 'bar')));
+        $catalogue = $this->getCatalogue('en_US', array('domain1' => array('foo' => 'foo'), 'domain2' => array('bar' => 'bar')));
         $catalogue->addResource($r);
 
-        $catalogue1 = new MessageCatalogue('en', array('domain1' => array('foo' => 'bar', 'foo1' => 'foo1')));
+        $catalogue1 = $this->getCatalogue('en', array('domain1' => array('foo' => 'bar', 'foo1' => 'foo1')));
         $catalogue1->addResource($r1);
 
         $catalogue->addFallbackCatalogue($catalogue1);
@@ -129,8 +129,8 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
      */
     public function testAddFallbackCatalogueWithParentCircularReference()
     {
-        $main = new MessageCatalogue('en_US');
-        $fallback = new MessageCatalogue('fr_FR');
+        $main = $this->getCatalogue('en_US');
+        $fallback = $this->getCatalogue('fr_FR');
 
         $fallback->addFallbackCatalogue($main);
         $main->addFallbackCatalogue($fallback);
@@ -155,13 +155,13 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
      */
     public function testAddCatalogueWhenLocaleIsNotTheSameAsTheCurrentOne()
     {
-        $catalogue = new MessageCatalogue('en');
-        $catalogue->addCatalogue(new MessageCatalogue('fr', array()));
+        $catalogue = $this->getCatalogue('en');
+        $catalogue->addCatalogue($this->getCatalogue('fr', array()));
     }
 
     public function testGetAddResource()
     {
-        $catalogue = new MessageCatalogue('en');
+        $catalogue = $this->getCatalogue('en');
         $r = $this->getMock('Symfony\Component\Config\Resource\ResourceInterface');
         $r->expects($this->any())->method('__toString')->will($this->returnValue('r'));
         $catalogue->addResource($r);
@@ -175,7 +175,7 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
 
     public function testMetadataDelete()
     {
-        $catalogue = new MessageCatalogue('en');
+        $catalogue = $this->getCatalogue('en');
         $this->assertEquals(array(), $catalogue->getMetadata('', ''), 'Metadata is empty');
         $catalogue->deleteMetadata('key', 'messages');
         $catalogue->deleteMetadata('', 'messages');
@@ -184,7 +184,7 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
 
     public function testMetadataSetGetDelete()
     {
-        $catalogue = new MessageCatalogue('en');
+        $catalogue = $this->getCatalogue('en');
         $catalogue->setMetadata('key', 'value');
         $this->assertEquals('value', $catalogue->getMetadata('key', 'messages'), "Metadata 'key' = 'value'");
 
@@ -200,15 +200,20 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
 
     public function testMetadataMerge()
     {
-        $cat1 = new MessageCatalogue('en');
+        $cat1 = $this->getCatalogue('en');
         $cat1->setMetadata('a', 'b');
         $this->assertEquals(array('messages' => array('a' => 'b')), $cat1->getMetadata('', ''), 'Cat1 contains messages metadata.');
 
-        $cat2 = new MessageCatalogue('en');
+        $cat2 = $this->getCatalogue('en');
         $cat2->setMetadata('b', 'c', 'domain');
         $this->assertEquals(array('domain' => array('b' => 'c')), $cat2->getMetadata('', ''), 'Cat2 contains domain metadata.');
 
         $cat1->addCatalogue($cat2);
         $this->assertEquals(array('messages' => array('a' => 'b'), 'domain' => array('b' => 'c')), $cat1->getMetadata('', ''), 'Cat1 contains merged metadata.');
+    }
+
+    protected function getCatalogue($locale, $messages = array())
+    {
+        return new MessageCatalogue($locale, $messages);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | #13948, #2570, #13676 |
| Tests pass? | yes |
| License | MIT |

Hi,
This PR add `message_catalogue_provider` option to the configuration to specify a different MessageCatalogue provider and add DoctrineMessageCacheProvider to allow keep messages in a key-value-store type cache (https://github.com/symfony/symfony/pull/13986)

``` yaml
#config.yml
framework:
    translator:
        message_catalogue_provider: translation.message_catalogue_provider.doctrine_cache

doctrine_cache:
    providers:
        translation_cache:
            memcached:
                servers:
                    localhost: 11211
```

``` yaml
#services.yml
translation.message_catalogue_provider.doctrine_cache:
    class: Symfony\Bridge\Doctrine\Translation\DoctrineMessageCatalogueProvider
    arguments: [@translation.message_catalogue_provider.resource, @doctrine_cache.providers.translation_cache, %kernel.debug%]
```
