### PR TITLE
[HttpFoundation] prevent finfo() construct error 'expected path'

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/MimeType/FileinfoMimeTypeGuesser.php
+++ b/src/Symfony/Component/HttpFoundation/File/MimeType/FileinfoMimeTypeGuesser.php
@@ -62,7 +62,7 @@ class FileinfoMimeTypeGuesser implements MimeTypeGuesserInterface
             return;
         }
 
-        if (!empty($this->magicFile)) {
+        if (null !== $this->magicFile) {
             $finfo = new \finfo(FILEINFO_MIME_TYPE, $this->magicFile);
         } else {
             $finfo = new \finfo(FILEINFO_MIME_TYPE);

--- a/src/Symfony/Component/HttpFoundation/File/MimeType/FileinfoMimeTypeGuesser.php
+++ b/src/Symfony/Component/HttpFoundation/File/MimeType/FileinfoMimeTypeGuesser.php
@@ -62,7 +62,13 @@ class FileinfoMimeTypeGuesser implements MimeTypeGuesserInterface
             return;
         }
 
-        if (!$finfo = new \finfo(FILEINFO_MIME_TYPE, $this->magicFile)) {
+        if (!empty($this->magicFile)) {
+            $finfo = new \finfo(FILEINFO_MIME_TYPE, $this->magicFile);
+        } else {
+            $finfo = new \finfo(FILEINFO_MIME_TYPE);
+        }
+
+        if (!$finfo) {
             return;
         }
 


### PR DESCRIPTION
for some reason, on some systems (nginx, hhvm?) finfo() constructor will not accept null or '' as the second parameter. The second parameter must be omitted (if empty) to avoid this error.

Related to issue:

https://github.com/symfony/symfony/issues/16039
