### PR TITLE
Use PHPUnit 5.0 for PHP 7

### DIFF
--- a/phpunit
+++ b/phpunit
@@ -3,8 +3,13 @@
 
 error_reporting(-1);
 
-$PHPUNIT_VERSION = 4.8;
+$PHPUNIT_VERSION = '4.8';
 $PHPUNIT_DIR = __DIR__.'/.phpunit';
+
+// PHPUnit 4.8 does not support PHP 7, while 5.0 requires PHP 5.6+
+if (PHP_VERSION_ID >= 70000) {
+    $PHPUNIT_DIR = '5.0';
+}
 
 if (!file_exists("$PHPUNIT_DIR/phpunit-$PHPUNIT_VERSION/phpunit")) {
     // Build a standalone phpunit without symfony/yaml


### PR DESCRIPTION
PHPUnit 4.8 is not fully compatible with PHP 7, and won't be fixed for full support. See https://github.com/sebastianbergmann/phpunit/issues/1882
