### PR TITLE
[DomCrawler] fix deprecation triggers

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -832,7 +832,7 @@ class Crawler extends \SplObjectStorage
      */
     public function attach($object, $data = null)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated as of 2.8 and will be removed in 3.0.', E_USER_DEPRECATED);
+        $this->triggerDeprecation(__METHOD__);
 
         parent::attach($object, $data);
     }
@@ -842,7 +842,7 @@ class Crawler extends \SplObjectStorage
      */
     public function detach($object)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated as of 2.8 and will be removed in 3.0.', E_USER_DEPRECATED);
+        $this->triggerDeprecation(__METHOD__);
 
         parent::detach($object);
     }
@@ -852,7 +852,7 @@ class Crawler extends \SplObjectStorage
      */
     public function contains($object)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated as of 2.8 and will be removed in 3.0.', E_USER_DEPRECATED);
+        $this->triggerDeprecation(__METHOD__);
 
         return parent::contains($object);
     }
@@ -862,7 +862,7 @@ class Crawler extends \SplObjectStorage
      */
     public function addAll($storage)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated as of 2.8 and will be removed in 3.0.', E_USER_DEPRECATED);
+        $this->triggerDeprecation(__METHOD__);
 
         parent::addAll($storage);
     }
@@ -872,7 +872,7 @@ class Crawler extends \SplObjectStorage
      */
     public function removeAll($storage)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated as of 2.8 and will be removed in 3.0.', E_USER_DEPRECATED);
+        $this->triggerDeprecation(__METHOD__);
 
         parent::removeAll($storage);
     }
@@ -882,7 +882,7 @@ class Crawler extends \SplObjectStorage
      */
     public function removeAllExcept($storage)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated as of 2.8 and will be removed in 3.0.', E_USER_DEPRECATED);
+        $this->triggerDeprecation(__METHOD__);
 
         parent::removeAllExcept($storage);
     }
@@ -892,7 +892,7 @@ class Crawler extends \SplObjectStorage
      */
     public function getInfo()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated as of 2.8 and will be removed in 3.0.', E_USER_DEPRECATED);
+        $this->triggerDeprecation(__METHOD__);
 
         return parent::getInfo();
     }
@@ -902,7 +902,7 @@ class Crawler extends \SplObjectStorage
      */
     public function setInfo($data)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated as of 2.8 and will be removed in 3.0.', E_USER_DEPRECATED);
+        $this->triggerDeprecation(__METHOD__);
 
         parent::setInfo($data);
     }
@@ -912,7 +912,7 @@ class Crawler extends \SplObjectStorage
      */
     public function offsetExists($object)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated as of 2.8 and will be removed in 3.0.', E_USER_DEPRECATED);
+        $this->triggerDeprecation(__METHOD__);
 
         return parent::offsetExists($object);
     }
@@ -922,7 +922,7 @@ class Crawler extends \SplObjectStorage
      */
     public function offsetSet($object, $data = null)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated as of 2.8 and will be removed in 3.0.', E_USER_DEPRECATED);
+        $this->triggerDeprecation(__METHOD__);
 
         parent::offsetSet($object, $data);
     }
@@ -932,7 +932,7 @@ class Crawler extends \SplObjectStorage
      */
     public function offsetUnset($object)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated as of 2.8 and will be removed in 3.0.', E_USER_DEPRECATED);
+        $this->triggerDeprecation(__METHOD__);
 
         parent::offsetUnset($object);
     }
@@ -942,7 +942,7 @@ class Crawler extends \SplObjectStorage
      */
     public function offsetGet($object)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated as of 2.8 and will be removed in 3.0.', E_USER_DEPRECATED);
+        $this->triggerDeprecation(__METHOD__);
 
         return parent::offsetGet($object);
     }
@@ -952,7 +952,7 @@ class Crawler extends \SplObjectStorage
      */
     public function getHash($object)
     {
-        // Cannot trigger a deprecation warning here because SplObjectStorage calls this method when attaching an object.
+        $this->triggerDeprecation(__METHOD__, true);
 
         return parent::getHash($object);
     }
@@ -1154,5 +1154,24 @@ class Crawler extends \SplObjectStorage
         $crawler->isHtml = $this->isHtml;
 
         return $crawler;
+    }
+
+    private function triggerDeprecation($methodName, $useTrace = false)
+    {
+        $traces = array();
+        $caller = array();
+
+        if ($useTrace || defined('HHVM_VERSION')) {
+            $traces = debug_backtrace();
+            $caller = $traces[2];
+        }
+
+        // The SplObjectStorage class performs calls to its own methods. These
+        // method calls must not lead to triggered deprecation notices.
+        if (isset($caller['class']) && 'SplObjectStorage' === $caller['class']) {
+            return;
+        }
+
+        @trigger_error('The '.$methodName.' method is deprecated as of 2.8 and will be removed in 3.0.', E_USER_DEPRECATED);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

On HHVM, the SplObjectStorage class performs calls to its method
internally. These method calls must not lead to triggered deprecation
notices.
