### PR TITLE
[FrameworkBundle] support array in route requirement parameters

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -161,7 +161,7 @@ class Router extends BaseRouter implements WarmableInterface
                 'must be a %s, but it is of type %s.',
                 $match[1],
                 $value,
-                'string or numeric' . ($acceptArrayParameters ? ' or an array' : ''),
+                'string or numeric'.($acceptArrayParameters ? ' or an array' : ''),
                 gettype($resolved)
                 )
             );

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -92,7 +92,7 @@ class Router extends BaseRouter implements WarmableInterface
             }
 
             foreach ($route->getRequirements() as $name => $value) {
-                $route->setRequirement($name, $this->resolve($value));
+                $route->setRequirement($name, $this->resolve($value, true));
             }
 
             $route->setPath($this->resolve($route->getPath()));
@@ -116,7 +116,8 @@ class Router extends BaseRouter implements WarmableInterface
     /**
      * Recursively replaces placeholders with the service container parameters.
      *
-     * @param mixed $value The source which might contain "%placeholders%"
+     * @param mixed $value                 The source which might contain "%placeholders%"
+     * @param bool  $acceptArrayParameters Allow the parameter array support (mean one element of the array)
      *
      * @return mixed The source with the placeholders replaced by the container
      *               parameters. Arrays are resolved recursively.
@@ -124,7 +125,7 @@ class Router extends BaseRouter implements WarmableInterface
      * @throws ParameterNotFoundException When a placeholder does not exist as a container parameter
      * @throws RuntimeException           When a container value is not a string or a numeric value
      */
-    private function resolve($value)
+    private function resolve($value, $acceptArrayParameters = false)
     {
         if (is_array($value)) {
             foreach ($value as $key => $val) {
@@ -140,7 +141,7 @@ class Router extends BaseRouter implements WarmableInterface
 
         $container = $this->container;
 
-        $escapedValue = preg_replace_callback('/%%|%([^%\s]++)%/', function ($match) use ($container, $value) {
+        $escapedValue = preg_replace_callback('/%%|%([^%\s]++)%/', function ($match) use ($container, $value, $acceptArrayParameters) {
             // skip %%
             if (!isset($match[1])) {
                 return '%%';
@@ -151,12 +152,16 @@ class Router extends BaseRouter implements WarmableInterface
             if (is_string($resolved) || is_numeric($resolved)) {
                 return (string) $resolved;
             }
+            if ($acceptArrayParameters && is_array($resolved)) {
+                return implode('|', $resolved);
+            }
 
             throw new RuntimeException(sprintf(
                 'The container parameter "%s", used in the route configuration value "%s", '.
-                'must be a string or numeric, but it is of type %s.',
+                'must be a %s, but it is of type %s.',
                 $match[1],
                 $value,
+                'string or numeric' . ($acceptArrayParameters ? ' or an array' : ''),
                 gettype($resolved)
                 )
             );

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
@@ -42,6 +42,30 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('"bar" == "bar"', $router->getRouteCollection()->get('foo')->getCondition());
     }
 
+    public function testGenerateWithArrayParam()
+    {
+        $routes = new RouteCollection();
+
+        $routes->add('foo', new Route(
+            ' /{_locale}',
+            array(
+                '_locale' => '%locale%',
+            ),
+            array(
+                '_locale' => '%active_locales%',
+            )
+        ));
+
+        $sc = $this->getServiceContainer($routes);
+        $sc->setParameter('locale', 'es');
+        $sc->setParameter('active_locales', array('es', 'en'));
+
+        $router = new Router($sc, 'foo');
+
+        $this->assertSame('/en', $router->generate('foo', array('_locale' => 'en')));
+        $this->assertSame('/', $router->generate('foo', array('_locale' => 'es')));
+    }
+
     public function testDefaultsPlaceholders()
     {
         $routes = new RouteCollection();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Sometimes it can be usefull to restrict the parameters of a route to one value of a list defined in the application parameters. 

For example, if I take the example provided here:
http://symfony.com/doc/current/book/translation.html#book-translation-locale-url

If I have an `active_languages: [fr, en]` parameter defined in my parameters, it would be useful to be able to provide it directly in a route requirements, like this, to avoid to create another parameter as a string `active_languages_str: "fr|en"`:

``` php
/**
 * @Route("/list/{_locale}", name="list", requirements={"_locale" = "%active_languages%"})
```

I think this case can be applied for other common cases.
