### PR TITLE
[translator] Consider numeric messages as same as fallback

### DIFF
--- a/src/Symfony/Component/Translation/DataCollectorTranslator.php
+++ b/src/Symfony/Component/Translation/DataCollectorTranslator.php
@@ -121,7 +121,7 @@ class DataCollectorTranslator implements TranslatorInterface, TranslatorBagInter
         $locale = $catalogue->getLocale();
         if ($catalogue->defines($id, $domain)) {
             $state = self::MESSAGE_DEFINED;
-        } elseif ($catalogue->has($id, $domain)) {
+        } elseif ($catalogue->has($id, $domain) || is_numeric($translation)) {
             $state = self::MESSAGE_EQUALS_FALLBACK;
 
             $fallbackCatalogue = $catalogue->getFallBackCatalogue();


### PR DESCRIPTION
It does not make sense to warn the user because "2015" or "10" are not translated.
Maybe numeric values should not be counted at all

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
