### PR TITLE
[VarDumper] Add $this->getDump($var) when using VarDumperTestTrait

### DIFF
--- a/src/Symfony/Component/VarDumper/Test/VarDumperTestTrait.php
+++ b/src/Symfony/Component/VarDumper/Test/VarDumperTestTrait.php
@@ -21,15 +21,15 @@ trait VarDumperTestTrait
 {
     public function assertDumpEquals($dump, $data, $message = '')
     {
-        $this->assertSame(rtrim($dump), $this->getVarDumperDump($data), $message);
+        $this->assertSame(rtrim($dump), $this->getDump($data), $message);
     }
 
     public function assertDumpMatchesFormat($dump, $data, $message = '')
     {
-        $this->assertStringMatchesFormat(rtrim($dump), $this->getVarDumperDump($data), $message);
+        $this->assertStringMatchesFormat(rtrim($dump), $this->getDump($data), $message);
     }
 
-    private function getVarDumperDump($data)
+    public function getDump($data)
     {
         $h = fopen('php://memory', 'r+b');
         $cloner = new VarCloner();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

So useful when writing/updating dump fixtures!
