### PR TITLE
[PropertyInfo] Remove all the mixed results from interfaces and implementations

### DIFF
--- a/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
+++ b/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
@@ -43,7 +43,7 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
         try {
             $metadata = $this->classMetadataFactory->getMetadataFor($class);
         } catch (MappingException $exception) {
-            return;
+            return array();
         }
 
         return array_merge($metadata->getFieldNames(), $metadata->getAssociationNames());
@@ -57,7 +57,7 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
         try {
             $metadata = $this->classMetadataFactory->getMetadataFor($class);
         } catch (MappingException $exception) {
-            return;
+            return array();
         }
 
         if ($metadata->hasAssociation($property)) {
@@ -107,6 +107,8 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
                     return array(new Type($this->getPhpType($typeOfField), $nullable));
             }
         }
+
+        return array();
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -85,7 +85,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
     {
         list($docBlock, $source, $prefix) = $this->getDocBlock($class, $property);
         if (!$docBlock) {
-            return;
+            return array();
         }
 
         switch ($source) {
@@ -123,11 +123,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
             }
         }
 
-        if (!isset($types[0])) {
-            return;
-        }
-
-        if (!in_array($prefix, ReflectionExtractor::$arrayMutatorPrefixes)) {
+        if (!isset($types[0]) || !in_array($prefix, ReflectionExtractor::$arrayMutatorPrefixes)) {
             return $types;
         }
 

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -52,7 +52,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         try {
             $reflectionClass = new \ReflectionClass($class);
         } catch (\ReflectionException $reflectionException) {
-            return;
+            return [];
         }
 
         $properties = array();
@@ -75,13 +75,11 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
      */
     public function getTypes($class, $property, array $context = array())
     {
-        if ($fromMutator = $this->extractFromMutator($class, $property)) {
-            return $fromMutator;
+        if (null === ($types = $this->extractFromMutator($class, $property))) {
+            $types = $this->extractFromAccessor($class, $property);
         }
 
-        if ($fromAccessor = $this->extractFromAccessor($class, $property)) {
-            return $fromAccessor;
-        }
+        return null !== $types ? $types : array();
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/Extractor/SerializerExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/SerializerExtractor.php
@@ -37,11 +37,11 @@ class SerializerExtractor implements PropertyListExtractorInterface
     public function getProperties($class, array $context = array())
     {
         if (!isset($context['serializer_groups']) || !is_array($context['serializer_groups'])) {
-            return;
+            return [];
         }
 
         if (!$this->classMetadataFactory->getMetadataFor($class)) {
-            return;
+            return [];
         }
 
         $properties = array();

--- a/src/Symfony/Component/PropertyInfo/PropertyAccessExtractorInterface.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyAccessExtractorInterface.php
@@ -25,7 +25,7 @@ interface PropertyAccessExtractorInterface
      * @param string $property
      * @param array  $context
      *
-     * @return bool|null
+     * @return bool
      */
     public function isReadable($class, $property, array $context = array());
 
@@ -36,7 +36,7 @@ interface PropertyAccessExtractorInterface
      * @param string $property
      * @param array  $context
      *
-     * @return bool|null
+     * @return bool
      */
     public function isWritable($class, $property, array $context = array());
 }

--- a/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php
@@ -57,7 +57,12 @@ class PropertyInfoExtractor implements PropertyInfoExtractorInterface
      */
     public function getProperties($class, array $context = array())
     {
-        return $this->extract($this->listExtractors, 'getProperties', array($class, $context));
+        $properties = $this->extract($this->listExtractors, 'getProperties', array($class, $context));
+        if (null === $properties) {
+            return array();
+        }
+
+        return $properties;
     }
 
     /**
@@ -81,7 +86,12 @@ class PropertyInfoExtractor implements PropertyInfoExtractorInterface
      */
     public function getTypes($class, $property, array $context = array())
     {
-        return $this->extract($this->typeExtractors, 'getTypes', array($class, $property, $context));
+        $types = $this->extract($this->typeExtractors, 'getTypes', array($class, $property, $context));
+        if (null === $types) {
+            return array();
+        }
+
+        return $types;
     }
 
     /**
@@ -89,7 +99,12 @@ class PropertyInfoExtractor implements PropertyInfoExtractorInterface
      */
     public function isReadable($class, $property, array $context = array())
     {
-        return $this->extract($this->accessExtractors, 'isReadable', array($class, $property, $context));
+        $readable = $this->extract($this->accessExtractors, 'isReadable', array($class, $property, $context));
+        if (null === $readable) {
+            return false;
+        }
+
+        return $readable;
     }
 
     /**
@@ -97,7 +112,12 @@ class PropertyInfoExtractor implements PropertyInfoExtractorInterface
      */
     public function isWritable($class, $property, array $context = array())
     {
-        return $this->extract($this->accessExtractors, 'isWritable', array($class, $property, $context));
+        $writable = $this->extract($this->accessExtractors, 'isWritable', array($class, $property, $context));
+        if (null === $writable) {
+            return false;
+        }
+
+        return $writable;
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/PropertyListExtractorInterface.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyListExtractorInterface.php
@@ -24,7 +24,7 @@ interface PropertyListExtractorInterface
      * @param string $class
      * @param array  $context
      *
-     * @return string[]|null
+     * @return string[]
      */
     public function getProperties($class, array $context = array());
 }

--- a/src/Symfony/Component/PropertyInfo/PropertyTypeExtractorInterface.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyTypeExtractorInterface.php
@@ -25,7 +25,7 @@ interface PropertyTypeExtractorInterface
      * @param string $property
      * @param array  $context
      *
-     * @return Type[]|null
+     * @return Type[]
      */
     public function getTypes($class, $property, array $context = array());
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractors/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractors/PhpDocExtractorTest.php
@@ -42,13 +42,13 @@ class PhpDocExtractorTest extends \PHPUnit_Framework_TestCase
     public function typesProvider()
     {
         return array(
-            array('foo', null, 'Short description.', 'Long description.'),
+            array('foo', array(), 'Short description.', 'Long description.'),
             array('bar', array(new Type(Type::BUILTIN_TYPE_STRING)), 'This is bar.', null),
             array('baz', array(new Type(Type::BUILTIN_TYPE_INT)), 'Should be used.', null),
             array('foo2', array(new Type(Type::BUILTIN_TYPE_FLOAT)), null, null),
             array('foo3', array(new Type(Type::BUILTIN_TYPE_CALLABLE)), null, null),
             array('foo4', array(new Type(Type::BUILTIN_TYPE_NULL)), null, null),
-            array('foo5', null, null, null),
+            array('foo5', array(), null, null),
             array(
                 'files',
                 array(

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractors/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractors/ReflectionExtractorTest.php
@@ -64,11 +64,11 @@ class ReflectionExtractorTest extends \PHPUnit_Framework_TestCase
     public function typesProvider()
     {
         return array(
-            array('a', null),
+            array('a', array()),
             array('b', array(new Type(Type::BUILTIN_TYPE_OBJECT, true, 'Symfony\Component\PropertyInfo\Tests\Fixtures\ParentDummy'))),
             array('c', array(new Type(Type::BUILTIN_TYPE_BOOL))),
             array('d', array(new Type(Type::BUILTIN_TYPE_BOOL))),
-            array('e', null),
+            array('e', array()),
             array('f', array(new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime')))),
         );
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

This PR replaces the mixed results of the `PropertyInfo` component by consistent ones. Basically, all the methods were able to return `null` and a boolean or an array. IMO, these mixed return types requires more work from a usage point of view and are not necessary at all.
