### PR TITLE
[PropertyInfo] Test behavior when an extractor returns null

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/NullExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/NullExtractor.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+use Symfony\Component\PropertyInfo\PropertyAccessExtractorInterface;
+use Symfony\Component\PropertyInfo\PropertyDescriptionExtractorInterface;
+use Symfony\Component\PropertyInfo\PropertyListExtractorInterface;
+use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * Not able to guess anything.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class NullExtractor implements PropertyListExtractorInterface, PropertyDescriptionExtractorInterface, PropertyTypeExtractorInterface, PropertyAccessExtractorInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getShortDescription($class, $property, array $context = array())
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLongDescription($class, $property, array $context = array())
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTypes($class, $property, array $context = array())
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isReadable($class, $property, array $context = array())
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isWritable($class, $property, array $context = array())
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getProperties($class, array $context = array())
+    {
+    }
+}

--- a/src/Symfony/Component/PropertyInfo/Tests/PropertyInfoExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/PropertyInfoExtractorTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\PropertyInfo\PropertyInfo\Tests;
 
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyExtractor;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\NullExtractor;
 use Symfony\Component\PropertyInfo\Type;
 
 /**
@@ -27,7 +28,7 @@ class PropertyInfoExtractorTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $extractors = array(new DummyExtractor());
+        $extractors = array(new NullExtractor(), new DummyExtractor());
         $this->propertyInfo = new PropertyInfoExtractor($extractors, $extractors, $extractors, $extractors);
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16064 |
| License | MIT |
| Doc PR | n/a |

Add a test as suggested by @stof in https://github.com/symfony/symfony/pull/16064#issuecomment-144975004
