### PR TITLE
[WebProfilerBundle] Disable the search toggle button on result page

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -381,8 +381,10 @@
                     Sfjs.addClass(element, 'sf-toggle-content');
 
                     if (toggles[i].hasAttribute('data-toggle-initial') && toggles[i].getAttribute('data-toggle-initial') == 'display') {
+                        Sfjs.removeClass(element, 'sf-toggle-hidden');
                         Sfjs.addClass(element, 'sf-toggle-visible');
                     } else {
+                        Sfjs.removeClass(element, 'sf-toggle-visible');
                         Sfjs.addClass(element, 'sf-toggle-hidden');
                     }
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
@@ -60,9 +60,11 @@
                         <a class="btn btn-sm" href="{{ path('_profiler_search', { limit: 10 }) }}">Last 10</a>
                         <a class="btn btn-sm" href="{{ path('_profiler', { token: 'latest' }|merge(request.query.all)) }}">Latest</a>
 
-                        <a class="sf-toggle btn btn-sm" data-toggle-selector="#sidebar-search" {% if tokens is defined or about is defined %}data-toggle-initial="display"{% endif %}>
-                            {{ include('@WebProfiler/Icon/search.svg') }} <span class="hidden-small">Search</span>
-                        </a>
+                        {% if tokens is not defined and about is not defined %}
+                            <a class="sf-toggle btn btn-sm" data-toggle-selector="#sidebar-search" data-toggle-initial="hidden">
+                                {{ include('@WebProfiler/Icon/search.svg') }} <span class="hidden-small">Search</span>
+                            </a>
+                        {% endif %}
 
                         {{ render(path('_profiler_search_bar')) }}
                     </div>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/search.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/search.html.twig
@@ -1,4 +1,4 @@
-<div id="sidebar-search">
+<div id="sidebar-search" class="sf-toggle-content sf-toggle-visible">
     <form action="{{ path('_profiler_search') }}" method="get">
         <div class="form-group">
             <label for="ip">IP</label>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15823 |
| License | MIT |
| Doc PR |  |

Before:
The search form is hidden. I think that this functionality is unnecessary and confusing.

![before](https://cloud.githubusercontent.com/assets/288535/10248581/bd8c3ba0-6920-11e5-9485-ef30eaf4afe3.png)

After:

![after](https://cloud.githubusercontent.com/assets/288535/10248589/c330906a-6920-11e5-99d6-3c6e2e85eae6.png)
