### PR TITLE
[WebProfilerBundle] Disabled profiler loading if twig is not enabled

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/WebProfilerExtension.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/WebProfilerExtension.php
@@ -42,6 +42,10 @@ class WebProfilerExtension extends Extension
         $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
 
+        if (!$container->has('twig')) {
+            return;
+        }
+
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('profiler.xml');
         $container->setParameter('web_profiler.debug_toolbar.position', $config['position']);

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
@@ -103,6 +103,16 @@ class WebProfilerExtensionTest extends TestCase
         $this->assertSaneContainer($this->getDumpedContainer());
     }
 
+    public function testLoadWithoutTwig()
+    {
+        $this->container->removeDefinition('twig');
+
+        $extension = new WebProfilerExtension();
+        $extension->load(array(array()), $this->container);
+
+        $this->assertFalse($this->container->hasDefinition('web_profiler.controller.profiler'));
+    }
+
     public function getDebugModes()
     {
         return array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

If twig is not enabled, this will cause an error as services defined in profiler.xml and toolbar.xml require a `twig` service.
