### PR TITLE
Fixing typo in variable name

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
@@ -49,7 +49,7 @@ class AnnotationLoader implements LoaderInterface
         $attributesMetadata = $classMetadata->getAttributesMetadata();
 
         foreach ($reflectionClass->getProperties() as $property) {
-            if (!isset($attributeMetadata[$property->name])) {
+            if (!isset($attributesMetadata[$property->name])) {
                 $attributesMetadata[$property->name] = new AttributeMetadata($property->name);
                 $classMetadata->addAttributeMetadata($attributesMetadata[$property->name]);
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |

``` php
foreach ($reflectionClass->getProperties() as $property) {
    if (!isset($attributeMetadata[$property->name])) { // <--- looks here
        $attributesMetadata[$property->name] = new AttributeMetadata($property->name);
        $classMetadata->addAttributeMetadata($attributesMetadata[$property->name]);
    }

    if ($property->getDeclaringClass()->name === $className) {
        foreach ($this->reader->getPropertyAnnotations($property) as $groups) {
            if ($groups instanceof Groups) {
                foreach ($groups->getGroups() as $group) {
                    $attributesMetadata[$property->name]->addGroup($group);
                }
            }

            $loaded = true;
        }
    }
}
```

This `$attributeMetadata` does not exists in this `foreach` context and the goal of this condition could be unexpected.
