### PR TITLE
[Form] Forward Form::submit(Request) to Form::HandleRequest

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -21,6 +21,7 @@ use Symfony\Component\Form\Util\FormUtil;
 use Symfony\Component\Form\Util\InheritDataAwareIterator;
 use Symfony\Component\Form\Util\OrderedHashMap;
 use Symfony\Component\PropertyAccess\PropertyPath;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Form represents a form.
@@ -507,6 +508,10 @@ class Form implements \IteratorAggregate, FormInterface
      */
     public function submit($submittedData, $clearMissing = true)
     {
+        if ($submittedData instanceof Request) {
+            return $this->handleRequest($submittedData);
+        }
+
         if ($this->submitted) {
             throw new AlreadySubmittedException('A form can only be submitted once');
         }

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -508,12 +508,12 @@ class Form implements \IteratorAggregate, FormInterface
      */
     public function submit($submittedData, $clearMissing = true)
     {
-        if ($submittedData instanceof Request) {
-            return $this->handleRequest($submittedData);
-        }
-
         if ($this->submitted) {
             throw new AlreadySubmittedException('A form can only be submitted once');
+        }
+
+        if ($submittedData instanceof Request) {
+            return $this->handleRequest($submittedData);
         }
 
         // Initialize errors in the very beginning so that we don't lose any

--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -909,6 +909,25 @@ class SimpleFormTest extends AbstractFormTest
         $this->assertSame($form, $form->handleRequest('REQUEST'));
     }
 
+    /**
+     * Shall be removed in 3.0
+     */
+    public function testSubmitForwardsToRequestHandlerUsingRequestArgument()
+    {
+        $handler = $this->getMock('Symfony\Component\Form\RequestHandlerInterface');
+
+        $form = $this->getBuilder()
+            ->setRequestHandler($handler)
+            ->getForm();
+
+        $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
+
+        $handler->expects($this->once())
+            ->method('handleRequest')
+            ->with($this->identicalTo($form), $request);
+        $this->assertSame($form, $form->submit($request));
+    }
+
     public function testFormInheritsParentData()
     {
         $child = $this->getBuilder('child')

--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -928,6 +928,25 @@ class SimpleFormTest extends AbstractFormTest
         $this->assertSame($form, $form->submit($request));
     }
 
+    /**
+     * Shall be removed in 3.0.
+     */
+    public function testBindForwardsToRequestHandler()
+    {
+        $handler = $this->getMock('Symfony\Component\Form\RequestHandlerInterface');
+
+        $form = $this->getBuilder()
+        ->setRequestHandler($handler)
+        ->getForm();
+
+        $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
+
+        $handler->expects($this->once())
+        ->method('handleRequest')
+        ->with($this->identicalTo($form), $request);
+        $this->assertSame($form, $form->bind($request));
+    }
+
     public function testFormInheritsParentData()
     {
         $child = $this->getBuilder('child')

--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -910,7 +910,7 @@ class SimpleFormTest extends AbstractFormTest
     }
 
     /**
-     * Shall be removed in 3.0
+     * Shall be removed in 3.0.
      */
     public function testSubmitForwardsToRequestHandlerUsingRequestArgument()
     {


### PR DESCRIPTION
When the argument of Form::submit is a Request object it forwards to Form::HandleRequest.
Fixes the issue with uploaded files exceeding post_max_size,
and form marked as valid with empty fields.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #13291 |
| License | MIT |
| Doc PR |  |
