### PR TITLE
Fix PropertyAccessor modifying array in object when array key does no…

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -118,7 +118,9 @@ class PropertyAccessor implements PropertyAccessorInterface
                     (is_array($objectOrArray) && !array_key_exists($property, $objectOrArray))
                 )
             ) {
-                $objectOrArray[$property] = $i + 1 < $propertyPath->getLength() ? array() : null;
+                if ($i + 1 < $propertyPath->getLength()) {
+                    $objectOrArray[$property] = array();
+                }
             }
 
             if ($isIndex) {

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -103,6 +103,15 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Bernhard', $this->propertyAccessor->getValue($object, 'firstName'));
     }
 
+    public function testGetValueNotModifyObject()
+    {
+        $object = new Author();
+        $object->firstName = array('Bernhard');
+
+        $this->assertNull($this->propertyAccessor->getValue($object, 'firstName[1]'));
+        $this->assertSame(array('Bernhard'), $object->firstName);
+    }
+
     public function testGetValueIgnoresSingular()
     {
         $this->markTestSkipped('This feature is temporarily disabled as of 2.1');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16056 |
| License | MIT |
| Doc PR |  |
