### PR TITLE
[HttpFoundation] Fixes IpUtils::checkIp4 on /0 subnets

### DIFF
--- a/src/Symfony/Component/HttpFoundation/IpUtils.php
+++ b/src/Symfony/Component/HttpFoundation/IpUtils.php
@@ -62,11 +62,11 @@ class IpUtils
     public static function checkIp4($requestIp, $ip)
     {
         if (false !== strpos($ip, '/')) {
-            if ('0.0.0.0/0' === $ip) {
+            list($address, $netmask) = explode('/', $ip, 2);
+
+            if ('0' === $netmask) {
                 return true;
             }
-
-            list($address, $netmask) = explode('/', $ip, 2);
 
             if ($netmask < 1 || $netmask > 32) {
                 return false;

--- a/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
@@ -35,8 +35,7 @@ class IpUtilsTest extends \PHPUnit_Framework_TestCase
             array(true, '192.168.1.1', array('192.168.1.0/24', '1.2.3.4/1')),
             array(false, '192.168.1.1', array('1.2.3.4/1', '4.3.2.1/1')),
             array(true, '1.2.3.4', '0.0.0.0/0'),
-            array(false, '1.2.3.4', '256.256.256/0'),
-            array(false, '1.2.3.4', '192.168.1.0/0'),
+            array(true, '1.2.3.4', '192.168.1.0/0'),
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16055 |
| License | MIT |
| Doc PR | Not needed |

This fixes the bug reported by @ultrafez in #16055 
