### PR TITLE
[Form] add missing deprecation triggers

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/EventListener/ValidationListener.php
+++ b/src/Symfony/Component/Form/Extension/Validator/EventListener/ValidationListener.php
@@ -46,6 +46,10 @@ class ValidationListener implements EventSubscriberInterface
             throw new \InvalidArgumentException('Validator must be instance of Symfony\Component\Validator\Validator\ValidatorInterface or Symfony\Component\Validator\ValidatorInterface');
         }
 
+        if ($validator instanceof LegacyValidatorInterface) {
+            @trigger_error('Passing an instance of Symfony\Component\Validator\ValidatorInterface as argument to the '.__METHOD__.' method is deprecated since version 2.8 and will be removed in 3.0. Use an implementation of Symfony\Component\Validator\Validator\ValidatorInterface instead', E_USER_DEPRECATED);
+        }
+
         $this->validator = $validator;
         $this->violationMapper = $violationMapper;
     }

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
@@ -40,6 +40,7 @@ class ValidatorExtension extends AbstractExtension
             $metadata = $validator->getMetadataFor('Symfony\Component\Form\Form');
         // 2.4 API
         } elseif ($validator instanceof LegacyValidatorInterface) {
+            @trigger_error('Passing an instance of Symfony\Component\Validator\ValidatorInterface as argument to the '.__METHOD__.' method is deprecated since version 2.8 and will be removed in 3.0. Use an implementation of Symfony\Component\Validator\Validator\ValidatorInterface instead', E_USER_DEPRECATED);
             $metadata = $validator->getMetadataFactory()->getMetadataFor('Symfony\Component\Form\Form');
         } else {
             throw new UnexpectedTypeException($validator, 'Symfony\Component\Validator\Validator\ValidatorInterface or Symfony\Component\Validator\ValidatorInterface');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #15767 |
| License | MIT |
| Doc PR |  |

Passing implementations of the pre 2.5 validator API to the constructors
of the `ValidatorExtension` and the `ValidationListener` must trigger a
deprecation.
