### PR TITLE
temporarily allow PHP 7 builds to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ matrix:
           env: deps=high
         - php: 7
           env: deps=low
+    allow_failures:
+        - php: 7
     fast_finish: true
 
 services: mongodb


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

It's a pain to review pull requests that always fail as the build job
for PHP 7 is broken. We have to use PHPUnit 5 for this job as it is the
only version supporting PHP 7 which suffers from broken behavior in the
mock library (see sebastianbergmann/phpunit-mock-objects#259).

Therefore, I suggest to allow failures of the PHP 7 build job until
above mentioned issue has been fixed to make it easier for reviewers to
spot really broken tests.
