### PR TITLE
[FrameworkBundle] [Routing] DelegatingLoader: remove unused logger

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -477,6 +477,8 @@ UPGRADE FROM 2.x to 3.0
    interface.
    The `security.csrf.token_manager` should be used instead.
 
+ * The `LoggerInterface` argument was removed from the `Symfony\Bundle\FrameworkBundle\Routing\DelegatingLoader` constructor.
+
 ### HttpKernel
 
  * The `Symfony\Component\HttpKernel\Log\LoggerInterface` has been removed in


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6298 |
| License | MIT |
| Doc PR | - |

There is no harm into keeping it, but I think 3.0 is the occasion to remove such things.
Also proposed in https://github.com/symfony/symfony/issues/11742
