### PR TITLE
Command list ordering fix

### DIFF
--- a/src/Symfony/Component/Console/Descriptor/ApplicationDescription.php
+++ b/src/Symfony/Component/Console/Descriptor/ApplicationDescription.php
@@ -134,15 +134,17 @@ class ApplicationDescription
     private function sortCommands(array $commands)
     {
         $namespacedCommands = array();
+        $globalCommands = array();
         foreach ($commands as $name => $command) {
             $key = $this->application->extractNamespace($name, 1);
             if (!$key) {
-                $key = '_global';
+                $globalCommands['_global'][$name] = $command;
+            } else {
+                $namespacedCommands[$key][$name] = $command;
             }
-
-            $namespacedCommands[$key][$name] = $command;
         }
         ksort($namespacedCommands);
+        $namespacedCommands = array_merge($globalCommands, $namespacedCommands);
 
         foreach ($namespacedCommands as &$commandsSet) {
             ksort($commandsSet);

--- a/src/Symfony/Component/Console/Tests/Command/ListCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/ListCommandTest.php
@@ -61,4 +61,36 @@ EOF;
 
         $this->assertEquals($output, $commandTester->getDisplay(true));
     }
+
+    public function testExecuteListsCommandsNameAndNamespaceRaw()
+    {
+        require_once realpath(__DIR__.'/../Fixtures/Foo6Command.php');
+        $application = new Application();
+        $application->add(new \Foo6Command());
+        $commandTester = new CommandTester($command = $application->get('list'));
+        $commandTester->execute(array('command' => $command->getName()));
+        $output = <<<EOF
+Console Tool
+
+Usage:
+ [options] command [arguments]
+
+Options:
+ --help (-h)           Display this help message.
+ --quiet (-q)          Do not output any message.
+ --verbose (-v|vv|vvv) Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug.
+ --version (-V)        Display this application version.
+ --ansi                Force ANSI output.
+ --no-ansi             Disable ANSI output.
+ --no-interaction (-n) Do not ask any interactive question.
+
+Available commands:
+ help                         Displays help for a command
+ list                         Lists commands
+<fg=blue>foo
+ <fg=blue>foo:bar</fg=blue>
+EOF;
+
+        $this->assertEquals($output, trim($commandTester->getDisplay(true)));
+    }
 }

--- a/src/Symfony/Component/Console/Tests/Command/ListCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/ListCommandTest.php
@@ -62,33 +62,49 @@ EOF;
         $this->assertEquals($output, $commandTester->getDisplay(true));
     }
 
-    public function testExecuteListsCommandsNameAndNamespaceRaw()
+    public function testExecuteListsCommandsOrder()
     {
         require_once realpath(__DIR__.'/../Fixtures/Foo6Command.php');
         $application = new Application();
         $application->add(new \Foo6Command());
         $commandTester = new CommandTester($command = $application->get('list'));
-        $commandTester->execute(array('command' => $command->getName()));
+        $commandTester->execute(array('command' => $command->getName()), array('decorated' => false));
         $output = <<<EOF
 Console Tool
 
 Usage:
- [options] command [arguments]
+  command [options] [arguments]
 
 Options:
- --help (-h)           Display this help message.
- --quiet (-q)          Do not output any message.
- --verbose (-v|vv|vvv) Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug.
- --version (-V)        Display this application version.
- --ansi                Force ANSI output.
- --no-ansi             Disable ANSI output.
- --no-interaction (-n) Do not ask any interactive question.
+  --help           -h Display this help message
+  --quiet          -q Do not output any message
+  --verbose        -v|vv|vvv Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+  --version        -V Display this application version
+  --ansi              Force ANSI output
+  --no-ansi           Disable ANSI output
+  --no-interaction -n Do not ask any interactive question
 
 Available commands:
- help                         Displays help for a command
- list                         Lists commands
-<fg=blue>foo
- <fg=blue>foo:bar</fg=blue>
+  help       Displays help for a command
+  list       Lists commands
+0foo
+  0foo:bar   0foo:bar command
+EOF;
+
+        $this->assertEquals($output, trim($commandTester->getDisplay(true)));
+    }
+
+    public function testExecuteListsCommandsOrderRaw()
+    {
+        require_once realpath(__DIR__.'/../Fixtures/Foo6Command.php');
+        $application = new Application();
+        $application->add(new \Foo6Command());
+        $commandTester = new CommandTester($command = $application->get('list'));
+        $commandTester->execute(array('command' => $command->getName(), '--raw' => true));
+        $output = <<<EOF
+help       Displays help for a command
+list       Lists commands
+0foo:bar   0foo:bar command
 EOF;
 
         $this->assertEquals($output, trim($commandTester->getDisplay(true)));

--- a/src/Symfony/Component/Console/Tests/Fixtures/Foo6Command.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Foo6Command.php
@@ -1,0 +1,13 @@
+<?php
+
+
+use Symfony\Component\Console\Command\Command;
+
+class Foo6Command extends Command
+{
+    protected function configure()
+    {
+        $this->setName('<fg=blue>foo:bar</fg=blue>');
+    }
+
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/Foo6Command.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Foo6Command.php
@@ -7,7 +7,6 @@ class Foo6Command extends Command
 {
     protected function configure()
     {
-        $this->setName('<fg=blue>foo:bar</fg=blue>');
+        $this->setName('0foo:bar')->setDescription('0foo:bar command');
     }
-
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |

Makes sure that global commands are always first.
