### PR TITLE
Replace is_callable checks with type hints

### DIFF
--- a/src/Symfony/Bridge/Twig/Command/DebugCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/DebugCommand.php
@@ -149,7 +149,7 @@ EOF
                     return;
                 }
                 $refl = new \ReflectionMethod($cb[0], $cb[1]);
-            } elseif (is_object($cb) && is_callable($cb)) {
+            } elseif (is_object($cb) && method_exists($cb, '__invoke')) {
                 $refl = new \ReflectionMethod($cb, '__invoke');
             } elseif (function_exists($cb)) {
                 $refl = new \ReflectionFunction($cb);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug_prod.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug_prod.xml
@@ -12,7 +12,7 @@
         <service id="debug.debug_handlers_listener" class="Symfony\Component\HttpKernel\EventListener\DebugHandlersListener">
             <tag name="kernel.event_subscriber" />
             <tag name="monolog.logger" channel="php" />
-            <argument /><!-- Exception handler -->
+            <argument>null</argument><!-- Exception handler -->
             <argument type="service" id="logger" on-invalid="null" />
             <argument>null</argument><!-- Log levels map for enabled error levels -->
             <argument>null</argument>

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -273,12 +273,8 @@ class Command
      *
      * @see execute()
      */
-    public function setCode($code)
+    public function setCode(callable $code)
     {
-        if (!is_callable($code)) {
-            throw new InvalidArgumentException('Invalid callable provided to Command::setCode.');
-        }
-
         if ($code instanceof \Closure) {
             $r = new \ReflectionFunction($code);
             if (null === $r->getClosureThis()) {

--- a/src/Symfony/Component/Console/Helper/ProcessHelper.php
+++ b/src/Symfony/Component/Console/Helper/ProcessHelper.php
@@ -36,7 +36,7 @@ class ProcessHelper extends Helper
      *
      * @return Process The process that ran
      */
-    public function run(OutputInterface $output, $cmd, $error = null, $callback = null, $verbosity = OutputInterface::VERBOSITY_VERY_VERBOSE)
+    public function run(OutputInterface $output, $cmd, $error = null, callable $callback = null, $verbosity = OutputInterface::VERBOSITY_VERY_VERBOSE)
     {
         if ($output instanceof ConsoleOutputInterface) {
             $output = $output->getErrorOutput();
@@ -92,7 +92,7 @@ class ProcessHelper extends Helper
      *
      * @see run()
      */
-    public function mustRun(OutputInterface $output, $cmd, $error = null, $callback = null)
+    public function mustRun(OutputInterface $output, $cmd, $error = null, callable $callback = null)
     {
         $process = $this->run($output, $cmd, $error, $callback);
 
@@ -112,7 +112,7 @@ class ProcessHelper extends Helper
      *
      * @return callable
      */
-    public function wrapCallback(OutputInterface $output, Process $process, $callback = null)
+    public function wrapCallback(OutputInterface $output, Process $process, callable $callback = null)
     {
         if ($output instanceof ConsoleOutputInterface) {
             $output = $output->getErrorOutput();

--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -86,7 +86,7 @@ class ProgressBar
      * @param string   $name     The placeholder name (including the delimiter char like %)
      * @param callable $callable A PHP callable
      */
-    public static function setPlaceholderFormatterDefinition($name, $callable)
+    public static function setPlaceholderFormatterDefinition($name, callable $callable)
     {
         if (!self::$formatters) {
             self::$formatters = self::initPlaceholderFormatters();

--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -377,7 +377,7 @@ class QuestionHelper extends Helper
      *
      * @throws \Exception In case the max number of attempts has been reached and no valid response has been given
      */
-    private function validateAttempts($interviewer, OutputInterface $output, Question $question)
+    private function validateAttempts(callable $interviewer, OutputInterface $output, Question $question)
     {
         $error = null;
         $attempts = $question->getMaxAttempts();

--- a/src/Symfony/Component/Console/Question/Question.php
+++ b/src/Symfony/Component/Console/Question/Question.php
@@ -164,7 +164,7 @@ class Question
      *
      * @return Question The current instance
      */
-    public function setValidator($validator)
+    public function setValidator(callable $validator = null)
     {
         $this->validator = $validator;
 
@@ -220,11 +220,11 @@ class Question
      *
      * The normalizer can be a callable (a string), a closure or a class implementing __invoke.
      *
-     * @param string|\Closure $normalizer
+     * @param callable $normalizer
      *
      * @return Question The current instance
      */
-    public function setNormalizer($normalizer)
+    public function setNormalizer(callable $normalizer)
     {
         $this->normalizer = $normalizer;
 
@@ -236,7 +236,7 @@ class Question
      *
      * The normalizer can ba a callable (a string), a closure or a class implementing __invoke.
      *
-     * @return string|\Closure
+     * @return callable
      */
     public function getNormalizer()
     {

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -332,16 +332,6 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('interact called'.PHP_EOL.'from the code...'.PHP_EOL, $tester->getDisplay());
     }
 
-    /**
-     * @expectedException        \InvalidArgumentException
-     * @expectedExceptionMessage Invalid callable provided to Command::setCode.
-     */
-    public function testSetCodeWithNonCallable()
-    {
-        $command = new \TestCommand();
-        $command->setCode(array($this, 'nonExistentMethod'));
-    }
-
     public function callableMethodCommand(InputInterface $input, OutputInterface $output)
     {
         $output->writeln('from the code...');

--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -235,14 +235,9 @@ class ErrorHandler
      * @param callable $handler A handler that will be called on Exception
      *
      * @return callable|null The previous exception handler
-     *
-     * @throws \InvalidArgumentException
      */
-    public function setExceptionHandler($handler)
+    public function setExceptionHandler(callable $handler = null)
     {
-        if (null !== $handler && !is_callable($handler)) {
-            throw new \LogicException('The exception handler must be a valid PHP callable.');
-        }
         $prev = $this->exceptionHandler;
         $this->exceptionHandler = $handler;
 

--- a/src/Symfony/Component/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/Debug/ExceptionHandler.php
@@ -72,11 +72,8 @@ class ExceptionHandler
      *
      * @return callable|null The previous exception handler if any
      */
-    public function setHandler($handler)
+    public function setHandler(callable $handler = null)
     {
-        if (null !== $handler && !is_callable($handler)) {
-            throw new \LogicException('The exception handler must be a valid PHP callable.');
-        }
         $old = $this->handler;
         $this->handler = $handler;
 

--- a/src/Symfony/Component/ExpressionLanguage/ExpressionFunction.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionFunction.php
@@ -41,7 +41,7 @@ class ExpressionFunction
      * @param callable $compiler  A callable able to compile the function
      * @param callable $evaluator A callable able to evaluate the function
      */
-    public function __construct($name, $compiler, $evaluator)
+    public function __construct($name, callable $compiler, callable $evaluator)
     {
         $this->name = $name;
         $this->compiler = $compiler;

--- a/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
@@ -112,7 +112,7 @@ class ExpressionLanguage
      *
      * @see ExpressionFunction
      */
-    public function register($name, $compiler, $evaluator)
+    public function register($name, callable $compiler, callable $evaluator)
     {
         $this->functions[$name] = array('compiler' => $compiler, 'evaluator' => $evaluator);
     }

--- a/src/Symfony/Component/Finder/Iterator/CustomFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/CustomFilterIterator.php
@@ -26,8 +26,8 @@ class CustomFilterIterator extends FilterIterator
     /**
      * Constructor.
      *
-     * @param \Iterator $iterator The Iterator to filter
-     * @param array     $filters  An array of PHP callbacks
+     * @param \Iterator  $iterator The Iterator to filter
+     * @param callable[] $filters  An array of PHP callbacks
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Symfony/Component/Form/CallbackTransformer.php
+++ b/src/Symfony/Component/Form/CallbackTransformer.php
@@ -35,18 +35,9 @@ class CallbackTransformer implements DataTransformerInterface
      *
      * @param callable $transform        The forward transform callback
      * @param callable $reverseTransform The reverse transform callback
-     *
-     * @throws \InvalidArgumentException when the given callbacks is invalid
      */
-    public function __construct($transform, $reverseTransform)
+    public function __construct(callable $transform, callable $reverseTransform)
     {
-        if (!is_callable($transform)) {
-            throw new \InvalidArgumentException('Argument 1 should be a callable');
-        }
-        if (!is_callable($reverseTransform)) {
-            throw new \InvalidArgumentException('Argument 2 should be a callable');
-        }
-
         $this->transform = $transform;
         $this->reverseTransform = $reverseTransform;
     }

--- a/src/Symfony/Component/Form/ChoiceList/ArrayChoiceList.php
+++ b/src/Symfony/Component/Form/ChoiceList/ArrayChoiceList.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Form\ChoiceList;
 
-use Symfony\Component\Form\Exception\UnexpectedTypeException;
-
 /**
  * A list of choices with arbitrary data types.
  *
@@ -64,12 +62,8 @@ class ArrayChoiceList implements ChoiceListInterface
      *                                    incrementing integers are used as
      *                                    values
      */
-    public function __construct($choices, $value = null)
+    public function __construct($choices, callable $value = null)
     {
-        if (null !== $value && !is_callable($value)) {
-            throw new UnexpectedTypeException($value, 'null or callable');
-        }
-
         if ($choices instanceof \Traversable) {
             $choices = iterator_to_array($choices);
         }

--- a/src/Symfony/Component/Form/ChoiceList/ArrayKeyChoiceList.php
+++ b/src/Symfony/Component/Form/ChoiceList/ArrayKeyChoiceList.php
@@ -101,7 +101,7 @@ class ArrayKeyChoiceList extends ArrayChoiceList
      *                                  the keys of the values or if any of the
      *                                  choices is not scalar
      */
-    public function __construct($choices, $value = null)
+    public function __construct($choices, callable $value = null)
     {
         // If no values are given, use the choices as values
         // Since the choices are stored in the collection keys, i.e. they are

--- a/src/Symfony/Component/Form/ChoiceList/LazyChoiceList.php
+++ b/src/Symfony/Component/Form/ChoiceList/LazyChoiceList.php
@@ -59,7 +59,7 @@ class LazyChoiceList implements ChoiceListInterface
      * @param null|callable         $value  The callable generating the choice
      *                                      values
      */
-    public function __construct(ChoiceLoaderInterface $loader, $value = null)
+    public function __construct(ChoiceLoaderInterface $loader, callable $value = null)
     {
         $this->loader = $loader;
         $this->value = $value;

--- a/src/Symfony/Component/Form/Tests/CallbackTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/CallbackTransformerTest.php
@@ -25,22 +25,4 @@ class CallbackTransformerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo has been transformed', $transformer->transform('foo'));
         $this->assertEquals('bar has reversely been transformed', $transformer->reverseTransform('bar'));
     }
-
-    /**
-     * @dataProvider invalidCallbacksProvider
-     *
-     * @expectedException \InvalidArgumentException
-     */
-    public function testConstructorWithInvalidCallbacks($transformCallback, $reverseTransformCallback)
-    {
-        new CallbackTransformer($transformCallback, $reverseTransformCallback);
-    }
-
-    public function invalidCallbacksProvider()
-    {
-        return array(
-            array(null, function () {}),
-            array(function () {}, null),
-        );
-    }
 }

--- a/src/Symfony/Component/Form/Tests/ChoiceList/ArrayChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/ArrayChoiceListTest.php
@@ -42,14 +42,6 @@ class ArrayChoiceListTest extends AbstractChoiceListTest
         return array('0', '1', '2', '3', '4', '5', '6');
     }
 
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\InvalidArgumentException
-     */
-    public function testFailIfKeyMismatch()
-    {
-        new ArrayChoiceList(array(0 => 'a', 1 => 'b'), array(1 => 'a', 2 => 'b'));
-    }
-
     public function testCreateChoiceListWithValueCallback()
     {
         $callback = function ($choice) {

--- a/src/Symfony/Component/HttpFoundation/StreamedResponse.php
+++ b/src/Symfony/Component/HttpFoundation/StreamedResponse.php
@@ -64,14 +64,9 @@ class StreamedResponse extends Response
      * Sets the PHP callback associated with this Response.
      *
      * @param callable $callback A valid PHP callback
-     *
-     * @throws \LogicException
      */
-    public function setCallback($callback)
+    public function setCallback(callable $callback)
     {
-        if (!is_callable($callback)) {
-            throw new \LogicException('The Response callback must be a valid PHP callable.');
-        }
         $this->callback = $callback;
     }
 

--- a/src/Symfony/Component/HttpFoundation/StreamedResponse.php
+++ b/src/Symfony/Component/HttpFoundation/StreamedResponse.php
@@ -36,7 +36,7 @@ class StreamedResponse extends Response
      * @param int           $status   The response status code
      * @param array         $headers  An array of response headers
      */
-    public function __construct($callback = null, $status = 200, $headers = array())
+    public function __construct(callable $callback = null, $status = 200, $headers = array())
     {
         parent::__construct(null, $status, $headers);
 

--- a/src/Symfony/Component/HttpFoundation/Tests/StreamedResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/StreamedResponseTest.php
@@ -90,15 +90,6 @@ class StreamedResponseTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \LogicException
      */
-    public function testSetCallbackNonCallable()
-    {
-        $response = new StreamedResponse(null);
-        $response->setCallback(null);
-    }
-
-    /**
-     * @expectedException \LogicException
-     */
     public function testSetContent()
     {
         $response = new StreamedResponse(function () { echo 'foo'; });

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -131,7 +131,7 @@ class ControllerResolver implements ControllerResolverInterface
      *
      * @param string $controller A Controller string
      *
-     * @return mixed A PHP callable
+     * @return callable A PHP callable
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Symfony/Component/HttpKernel/Event/FilterControllerEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/FilterControllerEvent.php
@@ -29,12 +29,10 @@ class FilterControllerEvent extends KernelEvent
 {
     /**
      * The current controller.
-     *
-     * @var callable
      */
     private $controller;
 
-    public function __construct(HttpKernelInterface $kernel, $controller, Request $request, $requestType)
+    public function __construct(HttpKernelInterface $kernel, callable $controller, Request $request, $requestType)
     {
         parent::__construct($kernel, $request, $requestType);
 

--- a/src/Symfony/Component/HttpKernel/Event/FilterControllerEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/FilterControllerEvent.php
@@ -58,47 +58,8 @@ class FilterControllerEvent extends KernelEvent
      *
      * @throws \LogicException
      */
-    public function setController($controller)
+    public function setController(callable $controller)
     {
-        // controller must be a callable
-        if (!is_callable($controller)) {
-            throw new \LogicException(sprintf('The controller must be a callable (%s given).', $this->varToString($controller)));
-        }
-
         $this->controller = $controller;
-    }
-
-    private function varToString($var)
-    {
-        if (is_object($var)) {
-            return sprintf('Object(%s)', get_class($var));
-        }
-
-        if (is_array($var)) {
-            $a = array();
-            foreach ($var as $k => $v) {
-                $a[] = sprintf('%s => %s', $k, $this->varToString($v));
-            }
-
-            return sprintf('Array(%s)', implode(', ', $a));
-        }
-
-        if (is_resource($var)) {
-            return sprintf('Resource(%s)', get_resource_type($var));
-        }
-
-        if (null === $var) {
-            return 'null';
-        }
-
-        if (false === $var) {
-            return 'false';
-        }
-
-        if (true === $var) {
-            return 'true';
-        }
-
-        return (string) $var;
     }
 }

--- a/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
@@ -45,7 +45,7 @@ class DebugHandlersListener implements EventSubscriberInterface
      * @param bool                 $scream           Enables/disables screaming mode, where even silenced errors are logged
      * @param string               $fileLinkFormat   The format for links to source files
      */
-    public function __construct($exceptionHandler, LoggerInterface $logger = null, $levels = null, $throwAt = -1, $scream = true, $fileLinkFormat = null)
+    public function __construct(callable $exceptionHandler = null, LoggerInterface $logger = null, $levels = null, $throwAt = -1, $scream = true, $fileLinkFormat = null)
     {
         $this->exceptionHandler = $exceptionHandler;
         $this->logger = $logger;

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -154,17 +154,6 @@ class HttpKernelTest extends \PHPUnit_Framework_TestCase
         $kernel->handle(new Request());
     }
 
-    /**
-     * @expectedException \LogicException
-     */
-    public function testHandleWhenTheControllerIsNotACallable()
-    {
-        $dispatcher = new EventDispatcher();
-        $kernel = new HttpKernel($dispatcher, $this->getResolver('foobar'));
-
-        $kernel->handle(new Request());
-    }
-
     public function testHandleWhenTheControllerIsAClosure()
     {
         $response = new Response('foo');

--- a/src/Symfony/Component/Process/PhpProcess.php
+++ b/src/Symfony/Component/Process/PhpProcess.php
@@ -54,7 +54,7 @@ class PhpProcess extends Process
     /**
      * {@inheritdoc}
      */
-    public function start($callback = null)
+    public function start(callable $callback = null)
     {
         if (null === $this->getCommandLine()) {
             throw new RuntimeException('Unable to find the PHP executable.');

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -217,7 +217,7 @@ class Process
      * @throws RuntimeException       if PHP was compiled with --enable-sigchild and the enhanced sigchild compatibility mode is not enabled
      * @throws ProcessFailedException if the process didn't terminate successfully
      */
-    public function mustRun($callback = null)
+    public function mustRun(callable $callback = null)
     {
         if ($this->isSigchildEnabled() && !$this->enhanceSigchildCompatibility) {
             throw new RuntimeException('This PHP has been compiled with --enable-sigchild. You must use setEnhanceSigchildCompatibility() to use this method.');
@@ -252,7 +252,7 @@ class Process
      * @throws RuntimeException When process is already running
      * @throws LogicException   In case a callback is provided and output has been disabled
      */
-    public function start($callback = null)
+    public function start(callable $callback = null)
     {
         if ($this->isRunning()) {
             throw new RuntimeException('Process is already running');
@@ -310,7 +310,7 @@ class Process
      *
      * @see start()
      */
-    public function restart($callback = null)
+    public function restart(callable $callback = null)
     {
         if ($this->isRunning()) {
             throw new RuntimeException('Process is already running');
@@ -337,7 +337,7 @@ class Process
      * @throws RuntimeException When process stopped after receiving signal
      * @throws LogicException   When process is not yet started
      */
-    public function wait($callback = null)
+    public function wait(callable $callback = null)
     {
         $this->requireProcessIsStarted(__FUNCTION__);
 
@@ -1232,7 +1232,7 @@ class Process
      *
      * @param callable|null $callback The user defined PHP callback
      *
-     * @return callable A PHP callable
+     * @return \Closure A PHP closure
      */
     protected function buildCallback($callback)
     {

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -86,15 +86,9 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
      * @param callable $circularReferenceHandler
      *
      * @return self
-     *
-     * @throws InvalidArgumentException
      */
-    public function setCircularReferenceHandler($circularReferenceHandler)
+    public function setCircularReferenceHandler(callable $circularReferenceHandler)
     {
-        if (!is_callable($circularReferenceHandler)) {
-            throw new InvalidArgumentException('The given circular reference handler is not callable.');
-        }
-
         $this->circularReferenceHandler = $circularReferenceHandler;
 
         return $this;

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -97,7 +97,7 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
     /**
      * Set normalization callbacks.
      *
-     * @param array $callbacks help normalize the result
+     * @param callable[] $callbacks help normalize the result
      *
      * @return self
      *

--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -350,10 +350,10 @@ class PhpEngine implements EngineInterface, \ArrayAccess
     /**
      * Adds an escaper for the given context.
      *
-     * @param string $context The escaper context (html, js, ...)
-     * @param mixed  $escaper A PHP callable
+     * @param string   $context The escaper context (html, js, ...)
+     * @param callable $escaper A PHP callable
      */
-    public function setEscaper($context, $escaper)
+    public function setEscaper($context, callable $escaper)
     {
         $this->escapers[$context] = $escaper;
         self::$escaperCache[$context] = array();
@@ -364,7 +364,7 @@ class PhpEngine implements EngineInterface, \ArrayAccess
      *
      * @param string $context The context name
      *
-     * @return mixed $escaper A PHP callable
+     * @return callable $escaper A PHP callable
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Symfony/Component/Translation/PluralizationRules.php
+++ b/src/Symfony/Component/Translation/PluralizationRules.php
@@ -189,12 +189,10 @@ class PluralizationRules
     /**
      * Overrides the default plural rule for a given locale.
      *
-     * @param string $rule   A PHP callable
-     * @param string $locale The locale
-     *
-     * @throws \LogicException
+     * @param callable $rule   A PHP callable
+     * @param string   $locale The locale
      */
-    public static function set($rule, $locale)
+    public static function set(callable $rule, $locale)
     {
         if ('pt_BR' === $locale) {
             // temporary set a locale for brazilian
@@ -203,10 +201,6 @@ class PluralizationRules
 
         if (strlen($locale) > 3) {
             $locale = substr($locale, 0, -strlen(strrchr($locale, '_')));
-        }
-
-        if (!is_callable($rule)) {
-            throw new \LogicException('The given rule can not be called');
         }
 
         self::$rules[$locale] = $rule;

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -304,7 +304,7 @@ abstract class AbstractCloner implements ClonerInterface
                 $a = $cast;
             }
         } catch (\Exception $e) {
-            $a[(Stub::TYPE_OBJECT === $stub->type ? Caster::PREFIX_VIRTUAL : '').'⚠'] = new ThrowingCasterException($callback, $e);
+            $a[(Stub::TYPE_OBJECT === $stub->type ? Caster::PREFIX_VIRTUAL : '').'⚠'] = new ThrowingCasterException($e);
         }
 
         return $a;

--- a/src/Symfony/Component/VarDumper/Exception/ThrowingCasterException.php
+++ b/src/Symfony/Component/VarDumper/Exception/ThrowingCasterException.php
@@ -17,10 +17,9 @@ namespace Symfony\Component\VarDumper\Exception;
 class ThrowingCasterException extends \Exception
 {
     /**
-     * @param callable   $caster The failing caster
-     * @param \Exception $prev   The exception thrown from the caster
+     * @param \Exception $prev The exception thrown from the caster
      */
-    public function __construct($caster, \Exception $prev)
+    public function __construct(\Exception $prev)
     {
         parent::__construct('Unexpected '.get_class($prev).' thrown from a caster: '.$prev->getMessage(), 0, $prev);
     }

--- a/src/Symfony/Component/VarDumper/VarDumper.php
+++ b/src/Symfony/Component/VarDumper/VarDumper.php
@@ -38,12 +38,8 @@ class VarDumper
         return call_user_func(self::$handler, $var);
     }
 
-    public static function setHandler($callable)
+    public static function setHandler(callable $callable = null)
     {
-        if (null !== $callable && !is_callable($callable, true)) {
-            throw new \InvalidArgumentException('Invalid PHP callback.');
-        }
-
         $prevHandler = self::$handler;
         self::$handler = $callable;
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14330 |
| License | MIT |
| Doc PR | - |

Also removes tests checking the exceptions thrown from
the removed is_callable checks.
