### PR TITLE
[Validator] added Japanese translation

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.ja.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ja.xlf
@@ -310,6 +310,10 @@
                 <source>This value does not match the expected {{ charset }} charset.</source>
                 <target>この値は予期される文字コード（{{ charset }}）と異なります。</target>
             </trans-unit>
+            <trans-unit id="81">
+                <source>This is not a valid Business Identifier Code (BIC).</source>
+                <target>有効なSWIFTコードではありません。</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | - |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

I'm not sure what most apposite word is, in Japanese.
But I decided to use "SWIFTコード" because Japanese wikipedia says so: 
https://ja.wikipedia.org/wiki/ISO_9362
https://ja.wikipedia.org/wiki/%E6%97%A5%E6%9C%AC%E3%81%AE%E9%87%91%E8%9E%8D%E6%A9%9F%E9%96%A2%E3%81%AESWIFT%E3%82%B3%E3%83%BC%E3%83%89%E4%B8%80%E8%A6%A7
