### PR TITLE
[VarDumper] Move $prev as 1st argument in ThrowingCasterException::__construct, removing $caster

### DIFF
--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -292,7 +292,7 @@ abstract class AbstractCloner implements ClonerInterface
                 $a = $cast;
             }
         } catch (\Exception $e) {
-            $a[(Stub::TYPE_OBJECT === $stub->type ? Caster::PREFIX_VIRTUAL : '').'⚠'] = new ThrowingCasterException($callback, $e);
+            $a[(Stub::TYPE_OBJECT === $stub->type ? Caster::PREFIX_VIRTUAL : '').'⚠'] = new ThrowingCasterException($e);
         }
 
         return $a;

--- a/src/Symfony/Component/VarDumper/Exception/ThrowingCasterException.php
+++ b/src/Symfony/Component/VarDumper/Exception/ThrowingCasterException.php
@@ -17,11 +17,15 @@ namespace Symfony\Component\VarDumper\Exception;
 class ThrowingCasterException extends \Exception
 {
     /**
-     * @param callable   $caster The failing caster
-     * @param \Exception $prev   The exception thrown from the caster
+     * @param \Exception $prev The exception thrown from the caster
      */
-    public function __construct($caster, \Exception $prev)
+    public function __construct($prev, \Exception $e = null)
     {
+        if (!$prev instanceof \Exception) {
+            @trigger_error('Providing $caster a 1st argument when instanciating a '.__CLASS__.' is deprecated since version 2.8 and will be removed in 3.0. Provide directly the $prev exception instead.', E_USER_DEPRECATED);
+
+            $prev = $e;
+        }
         parent::__construct('Unexpected '.get_class($prev).' thrown from a caster: '.$prev->getMessage(), 0, $prev);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
