### PR TITLE
compatibility with Security component split

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -553,7 +553,16 @@ class FrameworkExtension extends Extension
         if (class_exists('Symfony\Component\Security\Core\Exception\AuthenticationException')) {
             $r = new \ReflectionClass('Symfony\Component\Security\Core\Exception\AuthenticationException');
 
-            $dirs[] = dirname($r->getFilename()).'/../../Resources/translations';
+            $legacyTranslationsDir = dirname($r->getFilename()).'/../../Resources/translations';
+
+            if (file_exists($legacyTranslationsDir)) {
+                // in Symfony 2.3, translations are located in the symfony/security package
+                $dirs[] = $legacyTranslationsDir;
+            } else {
+                // with Symfony 2.4, the Security component was split into several subpackages
+                // and the translations have been moved to the symfony/security-core package
+                $dirs[] = dirname($r->getFilename()).'/../Resources/translations';
+            }
         }
         $overridePath = $container->getParameter('kernel.root_dir').'/Resources/%s/translations';
         foreach ($container->getParameter('kernel.bundles') as $bundle => $class) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The FrameworkBundle in version 2.3 can be used with recent versions of
the Security component. However, after the Security component has been
split with Symfony 2.4, translations resources have been moved to the
`symfony/security-core` package. Thus, the changed location must be
taken into account.
