### PR TITLE
[VarDumper] consistent signature of getDump() in class + trait

### DIFF
--- a/src/Symfony/Component/VarDumper/Test/VarDumperTestCase.php
+++ b/src/Symfony/Component/VarDumper/Test/VarDumperTestCase.php
@@ -29,7 +29,7 @@ abstract class VarDumperTestCase extends \PHPUnit_Framework_TestCase
         $this->assertStringMatchesFormat(rtrim($dump), $this->getDump($data), $message);
     }
 
-    private function getDump($data)
+    protected function getDump($data)
     {
         $h = fopen('php://memory', 'r+b');
         $cloner = new VarCloner();

--- a/src/Symfony/Component/VarDumper/Test/VarDumperTestTrait.php
+++ b/src/Symfony/Component/VarDumper/Test/VarDumperTestTrait.php
@@ -29,7 +29,7 @@ trait VarDumperTestTrait
         $this->assertStringMatchesFormat(rtrim($dump), $this->getDump($data), $message);
     }
 
-    public function getDump($data)
+    protected function getDump($data)
     {
         $h = fopen('php://memory', 'r+b');
         $cloner = new VarCloner();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16126 |
| License | MIT |
| Doc PR |  |
