### PR TITLE
[Security] Add test to ensure translation files are synced

### DIFF
--- a/src/Symfony/Component/Security/Core/Resources/translations/security.tr.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.tr.xlf
@@ -8,7 +8,7 @@
             </trans-unit>
             <trans-unit id="2">
                 <source>Authentication credentials could not be found.</source>
-                <target>Yetkilendirme girdileri bulunamadı.</target>
+                <target>Kimlik bilgileri bulunamadı.</target>
             </trans-unit>
             <trans-unit id="3">
                 <source>Authentication request could not be processed due to a system problem.</source>
@@ -16,7 +16,7 @@
             </trans-unit>
             <trans-unit id="4">
                 <source>Invalid credentials.</source>
-                <target>Geçersiz girdiler.</target>
+                <target>Geçersiz kimlik bilgileri.</target>
             </trans-unit>
             <trans-unit id="5">
                 <source>Cookie has already been used by someone else.</source>
@@ -32,7 +32,7 @@
             </trans-unit>
             <trans-unit id="8">
                 <source>Digest nonce has expired.</source>
-                <target>Derleme zaman aşımı gerçekleşti.</target>
+                <target>Derleme zaman aşımına uğradı.</target>
             </trans-unit>
             <trans-unit id="9">
                 <source>No authentication provider found to support the authentication token.</source>
@@ -44,7 +44,7 @@
             </trans-unit>
             <trans-unit id="11">
                 <source>No token could be found.</source>
-                <target>Bilet bulunamadı.</target>
+                <target>Fiş bulunamadı.</target>
             </trans-unit>
             <trans-unit id="12">
                 <source>Username could not be found.</source>
@@ -56,11 +56,11 @@
             </trans-unit>
             <trans-unit id="14">
                 <source>Credentials have expired.</source>
-                <target>Girdiler zaman aşımına uğradı.</target>
+                <target>Kimlik bilgileri zaman aşımına uğradı.</target>
             </trans-unit>
             <trans-unit id="15">
                 <source>Account is disabled.</source>
-                <target>Hesap devre dışı bırakılmış.</target>
+                <target>Hesap engellenmiş.</target>
             </trans-unit>
             <trans-unit id="16">
                 <source>Account is locked.</source>

--- a/src/Symfony/Component/Security/Tests/Core/Translation/SyncedTranslationsTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Translation/SyncedTranslationsTest.php
@@ -1,0 +1,60 @@
+<?php
+
+class SyncedTranslationsTest extends PHPUnit_Framework_TestCase
+{
+    private $securityRootDir;
+    private $securityTransDir;
+    private $securityCoreTransDir;
+
+    public function __construct($name = null, array $data = array(), $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+        $this->securityRootDir = __DIR__.'/../../../';
+        $this->securityTransDir = $this->securityRootDir.'Resources/translations/';
+        $this->securityCoreTransDir = $this->securityRootDir.'Core/Resources/translations/';
+    }
+
+    public function testTranslationsFoldersAreSynced()
+    {
+        $this->assertSame(
+            $this->getTranslationFilesForDir($this->securityTransDir),
+            $this->getTranslationFilesForDir($this->securityCoreTransDir)
+        );
+    }
+
+    /**
+     * @dataProvider translationFilePathsProvider
+     */
+    public function testTranslationsFilesAreSynced($filePath)
+    {
+        $originPath = $this->securityCoreTransDir.$filePath;
+        $expectedPath = $this->securityTransDir.$filePath;
+
+        $this->assertFileEquals($originPath, $expectedPath, sprintf('"%s" and "%s" translation files should not be out of sync.', $originPath, $expectedPath));
+    }
+
+    public function translationFilePathsProvider()
+    {
+        return array_map(function ($path) {
+            return array($path);
+        }, $this->getTranslationFilesForDir($this->securityTransDir));
+    }
+
+    private function getTranslationFilesForDir($dir)
+    {
+        $filePaths = array();
+        foreach (scandir($dir) as $path) {
+            $file = new \SplFileInfo($path);
+            if ($file->isDir()) {
+                continue;
+            }
+            if (2 !== substr_count($file->getBasename(), '.') || 0 === preg_match('/\.\w+$/', $file->getBasename())) {
+                continue;
+            };
+
+            $filePaths[] = $path;
+        }
+
+        return $filePaths;
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/pull/16141#issuecomment-145838751 |
| License | MIT |
| Doc PR | - |

This new test ensure both `Symfony/Component/Security/Resources/translations` and `Symfony/Component/Security/Core/Resources/translations` translation files are synced.
