### PR TITLE
[Console] Fix bug with format, when set max count, by start method in progress bar

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -44,6 +44,7 @@ class ProgressBar
     private $formatLineCount;
     private $messages;
     private $overwrite = true;
+    private $formatSetByUser = false;
 
     private static $formatters;
     private static $formats;
@@ -73,7 +74,7 @@ class ProgressBar
             }
         }
 
-        $this->setFormat($this->determineBestFormat());
+        $this->setFormatInternal($this->determineBestFormat());
 
         $this->startTime = time();
     }
@@ -311,16 +312,8 @@ class ProgressBar
      */
     public function setFormat($format)
     {
-        // try to use the _nomax variant if available
-        if (!$this->max && null !== self::getFormatDefinition($format.'_nomax')) {
-            $this->format = self::getFormatDefinition($format.'_nomax');
-        } elseif (null !== self::getFormatDefinition($format)) {
-            $this->format = self::getFormatDefinition($format);
-        } else {
-            $this->format = $format;
-        }
-
-        $this->formatLineCount = substr_count($this->format, "\n");
+        $this->formatSetByUser = true;
+        $this->setFormatInternal($format);
     }
 
     /**
@@ -346,6 +339,10 @@ class ProgressBar
 
         if (null !== $max) {
             $this->setMaxSteps($max);
+
+            if (!$this->formatSetByUser) {
+                $this->setFormatInternal($this->determineBestFormat());
+            }
         }
 
         $this->display();
@@ -477,6 +474,25 @@ class ProgressBar
         }
 
         $this->overwrite(str_repeat("\n", $this->formatLineCount));
+    }
+
+    /**
+     * Sets the progress bar format.
+     *
+     * @param string $format The format
+     */
+    private function setFormatInternal($format)
+    {
+        // try to use the _nomax variant if available
+        if (!$this->max && null !== self::getFormatDefinition($format.'_nomax')) {
+            $this->format = self::getFormatDefinition($format.'_nomax');
+        } elseif (null !== self::getFormatDefinition($format)) {
+            $this->format = self::getFormatDefinition($format);
+        } else {
+            $this->format = $format;
+        }
+
+        $this->formatLineCount = substr_count($this->format, "\n");
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -106,6 +106,27 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testFormatWhenMaxInConstructAndInStart()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream(), 10);
+        $bar->start();
+        $bar->advance(10);
+        $bar->finish();
+
+        rewind($output->getStream());
+        $maxInConstruct = stream_get_contents($output->getStream());
+
+        $bar = new ProgressBar($output = $this->getOutputStream());
+        $bar->start(10);
+        $bar->advance(10);
+        $bar->finish();
+
+        rewind($output->getStream());
+        $maxInStart = stream_get_contents($output->getStream());
+
+        $this->assertEquals($maxInStart, $maxInConstruct);
+    }
+
     public function testCustomizations()
     {
         $bar = new ProgressBar($output = $this->getOutputStream(), 10);


### PR DESCRIPTION
When I set max count, by call "ProgressBar::start()", I got invalid progress bar format.

Example code:

``` php
$bar = new ProgressBar($output, 100);
$bar->start();
$bar->advance(100);
$bar->finish();
```

Output:
 100/100 [============================] 100%

Example code:

``` php
$bar = new ProgressBar($output);
$bar->start(100);
$bar->advance(100);
$bar->finish();
```

Output:
 100 [============================]

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
