### PR TITLE
[FrameworkBundle] Deprecate the security.secure_random service

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/security.xml
@@ -14,6 +14,7 @@
             <tag name="monolog.logger" channel="security" />
             <argument>%kernel.cache_dir%/secure_random.seed</argument>
             <argument type="service" id="logger" on-invalid="ignore" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 2.8 and will be removed in 3.0. Use the random_bytes() function instead.</deprecated>
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -69,6 +69,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertTrue($container->hasDefinition('security.csrf.token_manager'));
     }
 
+    /** @group legacy */
     public function testSecureRandomIsAvailableIfCsrfIsDisabled()
     {
         $container = $this->createContainerFromFile('csrf_disabled');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Since the SecureRandom class and interface are already deprecated, so should be the service.
