### PR TITLE
[UPGRADE-2.8][FrameworkBundle] Add missing deprecation

### DIFF
--- a/UPGRADE-2.8.md
+++ b/UPGRADE-2.8.md
@@ -438,6 +438,9 @@ FrameworkBundle
        session:
            cookie_httponly: false
    ```
+ 
+ * The ability to pass a `LoggerInterface` instance as the second argument of the `DelegatingLoader` 
+   constructor was deprecated and will be removed in Symfony 3.0.
 
 Security
 --------


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets | - |
| License | MIT |

Add missing deprecation about the `DelegatingLoader` from #16135 in the `UPGRADE-2.8` file.
#16117 now only updates the `UPGRADE-3.0` file, so it might be closed if not needed.
