### PR TITLE
Fix the BC layer for the key->secret renaming for remember_me

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
@@ -134,6 +134,8 @@ class RememberMeFactory implements SecurityFactoryInterface
                     $v['secret'] = $v['key'];
 
                     unset($v['key']);
+
+                    return $v;
                 })
                 ->end()
             ->children();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony-docs/issues/5765 |
| License | MIT |
| Doc PR | n/a |

There was a mistake in https://github.com/symfony/symfony/pull/15141 removing the configuration entirely.
