### PR TITLE
[HttpFoundation] Fixes /0 subnet handling in IpUtils

### DIFF
--- a/src/Symfony/Component/HttpFoundation/IpUtils.php
+++ b/src/Symfony/Component/HttpFoundation/IpUtils.php
@@ -57,18 +57,19 @@ class IpUtils
      * @param string $requestIp IPv4 address to check
      * @param string $ip        IPv4 address or subnet in CIDR notation
      *
-     * @return bool Whether the IP is valid
+     * @return bool Whether the request IP matches the IP, or whether the request IP is within the CIDR subnet.
      */
     public static function checkIp4($requestIp, $ip)
     {
         if (false !== strpos($ip, '/')) {
-            if ('0.0.0.0/0' === $ip) {
-                return true;
-            }
-
             list($address, $netmask) = explode('/', $ip, 2);
 
-            if ($netmask < 1 || $netmask > 32) {
+            if ($netmask === '0') {
+                // Ensure IP is valid - using ip2long below implicitly validates, but we need to do it manually here
+                return filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4);
+            }
+
+            if ($netmask < 0 || $netmask > 32) {
                 return false;
             }
         } else {

--- a/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
@@ -30,13 +30,12 @@ class IpUtilsTest extends \PHPUnit_Framework_TestCase
             array(true, '192.168.1.1', '192.168.1.1/1'),
             array(true, '192.168.1.1', '192.168.1.0/24'),
             array(false, '192.168.1.1', '1.2.3.4/1'),
-            array(false, '192.168.1.1', '192.168.1/33'),
+            array(false, '192.168.1.1', '192.168.1.1/33'), // invalid subnet
             array(true, '192.168.1.1', array('1.2.3.4/1', '192.168.1.0/24')),
             array(true, '192.168.1.1', array('192.168.1.0/24', '1.2.3.4/1')),
             array(false, '192.168.1.1', array('1.2.3.4/1', '4.3.2.1/1')),
-            array(true, '1.2.3.4', '0.0.0.0/0'),
-            array(false, '1.2.3.4', '256.256.256/0'),
-            array(false, '1.2.3.4', '192.168.1.0/0'),
+            array(false, '1.2.3.4', '256.256.256/0'), // invalid CIDR notation
+            array(true, '1.2.3.4', '192.168.1.0/0'),
         );
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
@@ -34,8 +34,9 @@ class IpUtilsTest extends \PHPUnit_Framework_TestCase
             array(true, '192.168.1.1', array('1.2.3.4/1', '192.168.1.0/24')),
             array(true, '192.168.1.1', array('192.168.1.0/24', '1.2.3.4/1')),
             array(false, '192.168.1.1', array('1.2.3.4/1', '4.3.2.1/1')),
-            array(false, '1.2.3.4', '256.256.256/0'), // invalid CIDR notation
+            array(true, '1.2.3.4', '0.0.0.0/0'),
             array(true, '1.2.3.4', '192.168.1.0/0'),
+            array(false, '1.2.3.4', '256.256.256/0'), // invalid CIDR notation
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16055 |
| License | MIT |
| Doc PR | Not needed |

Fixes bug #16055. For IP addresses with CIDR subnet length 0, the IP address must be valid - IPs with subnet masks greater than zero are implicitly validated due to the use of `ip2long` and `substr_compare` (although it's not particularly robust - there could be some future work to improve this here).
