### PR TITLE
[Process] Workaround buggy PHP warning

### DIFF
--- a/src/Symfony/Component/Process/ExecutableFinder.php
+++ b/src/Symfony/Component/Process/ExecutableFinder.php
@@ -56,6 +56,7 @@ class ExecutableFinder
             $searchPath = explode(PATH_SEPARATOR, ini_get('open_basedir'));
             $dirs = array();
             foreach ($searchPath as $path) {
+                // Silencing against https://bugs.php.net/69240
                 if (@is_dir($path)) {
                     $dirs[] = $path;
                 } else {

--- a/src/Symfony/Component/Process/ExecutableFinder.php
+++ b/src/Symfony/Component/Process/ExecutableFinder.php
@@ -56,19 +56,12 @@ class ExecutableFinder
             $searchPath = explode(PATH_SEPARATOR, ini_get('open_basedir'));
             $dirs = array();
             foreach ($searchPath as $path) {
-                try {
-                    if (is_dir($path)) {
-                        $dirs[] = $path;
-                    } else {
-                        if (basename($path) == $name && is_executable($path)) {
-                            return $path;
-                        }
+                if (@is_dir($path)) {
+                    $dirs[] = $path;
+                } else {
+                    if (basename($path) == $name && is_executable($path)) {
+                        return $path;
                     }
-                }
-                catch (\ErrorException $e) {
-                    //There is a bug in PHP that causes an exception to be
-                    //thrown when the directory does not exist.
-                    //See: https://bugs.php.net/bug.php?id=69240
                 }
             }
         } else {

--- a/src/Symfony/Component/Process/ExecutableFinder.php
+++ b/src/Symfony/Component/Process/ExecutableFinder.php
@@ -56,12 +56,19 @@ class ExecutableFinder
             $searchPath = explode(PATH_SEPARATOR, ini_get('open_basedir'));
             $dirs = array();
             foreach ($searchPath as $path) {
-                if (is_dir($path)) {
-                    $dirs[] = $path;
-                } else {
-                    if (basename($path) == $name && is_executable($path)) {
-                        return $path;
+                try {
+                    if (is_dir($path)) {
+                        $dirs[] = $path;
+                    } else {
+                        if (basename($path) == $name && is_executable($path)) {
+                            return $path;
+                        }
                     }
+                }
+                catch (\ErrorException $e) {
+                    //There is a bug in PHP that causes an exception to be
+                    //thrown when the directory does not exist.
+                    //See: https://bugs.php.net/bug.php?id=69240
                 }
             }
         } else {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This temporary workaround is intended to address an uncaught exception that may occur, until https://bugs.php.net/bug.php?id=69240 is fixed.

Obviously the `@` operator is another option, but I'm erring towards the notion that the Symfony authors/maintainers may wish to implement more elegant exception-handling logic than simply using `@`.
