### PR TITLE
[Console] Fix progress bar formatting when max is set on start() and some other edge cases

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -43,6 +43,7 @@ class ProgressBar
     private $formatLineCount;
     private $messages;
     private $overwrite = true;
+    private $formatSetByUser = false;
 
     private static $formatters;
     private static $formats;
@@ -72,7 +73,7 @@ class ProgressBar
             }
         }
 
-        $this->setFormat($this->determineBestFormat());
+        $this->setFormatInternal($this->determineBestFormat());
 
         $this->startTime = time();
     }
@@ -310,16 +311,8 @@ class ProgressBar
      */
     public function setFormat($format)
     {
-        // try to use the _nomax variant if available
-        if (!$this->max && null !== self::getFormatDefinition($format.'_nomax')) {
-            $this->format = self::getFormatDefinition($format.'_nomax');
-        } elseif (null !== self::getFormatDefinition($format)) {
-            $this->format = self::getFormatDefinition($format);
-        } else {
-            $this->format = $format;
-        }
-
-        $this->formatLineCount = substr_count($this->format, "\n");
+        $this->formatSetByUser = true;
+        $this->setFormatInternal($format);
     }
 
     /**
@@ -345,6 +338,10 @@ class ProgressBar
 
         if (null !== $max) {
             $this->setMaxSteps($max);
+
+            if (!$this->formatSetByUser) {
+                $this->setFormatInternal($this->determineBestFormat());
+            }
         }
 
         $this->display();
@@ -476,6 +473,25 @@ class ProgressBar
         }
 
         $this->overwrite(str_repeat("\n", $this->formatLineCount));
+    }
+
+    /**
+     * Sets the progress bar format.
+     *
+     * @param string $format The format
+     */
+    private function setFormatInternal($format)
+    {
+        // try to use the _nomax variant if available
+        if (!$this->max && null !== self::getFormatDefinition($format.'_nomax')) {
+            $this->format = self::getFormatDefinition($format.'_nomax');
+        } elseif (null !== self::getFormatDefinition($format)) {
+            $this->format = self::getFormatDefinition($format);
+        } else {
+            $this->format = $format;
+        }
+
+        $this->formatLineCount = substr_count($this->format, "\n");
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -106,6 +106,27 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testFormatWhenMaxInConstructAndInStart()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream(), 10);
+        $bar->start();
+        $bar->advance(10);
+        $bar->finish();
+
+        rewind($output->getStream());
+        $maxInConstruct = stream_get_contents($output->getStream());
+
+        $bar = new ProgressBar($output = $this->getOutputStream());
+        $bar->start(10);
+        $bar->advance(10);
+        $bar->finish();
+
+        rewind($output->getStream());
+        $maxInStart = stream_get_contents($output->getStream());
+
+        $this->assertEquals($maxInStart, $maxInConstruct);
+    }
+
     public function testCustomizations()
     {
         $bar = new ProgressBar($output = $this->getOutputStream(), 10);

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -106,25 +106,51 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testFormatWhenMaxInConstructAndInStart()
+    public function testFormat()
     {
+        $expected =
+            $this->generateOutput('  0/10 [>---------------------------]   0%').
+            $this->generateOutput(' 10/10 [============================] 100%').
+            $this->generateOutput(' 10/10 [============================] 100%')
+        ;
+
+        // max in construct, no format
         $bar = new ProgressBar($output = $this->getOutputStream(), 10);
         $bar->start();
         $bar->advance(10);
         $bar->finish();
 
         rewind($output->getStream());
-        $maxInConstruct = stream_get_contents($output->getStream());
+        $this->assertEquals($expected, stream_get_contents($output->getStream()));
 
+        // max in start, no format
         $bar = new ProgressBar($output = $this->getOutputStream());
         $bar->start(10);
         $bar->advance(10);
         $bar->finish();
 
         rewind($output->getStream());
-        $maxInStart = stream_get_contents($output->getStream());
+        $this->assertEquals($expected, stream_get_contents($output->getStream()));
 
-        $this->assertEquals($maxInStart, $maxInConstruct);
+        // max in construct, explicit format before
+        $bar = new ProgressBar($output = $this->getOutputStream(), 10);
+        $bar->setFormat('normal');
+        $bar->start();
+        $bar->advance(10);
+        $bar->finish();
+
+        rewind($output->getStream());
+        $this->assertEquals($expected, stream_get_contents($output->getStream()));
+
+        // max in start, explicit format before
+        $bar = new ProgressBar($output = $this->getOutputStream());
+        $bar->setFormat('normal');
+        $bar->start(10);
+        $bar->advance(10);
+        $bar->finish();
+
+        rewind($output->getStream());
+        $this->assertEquals($expected, stream_get_contents($output->getStream()));
     }
 
     public function testCustomizations()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Besides what #16149 fixed, it also fixes the case where `setFormat()` is called before `start()`.

From #16149

When I set max count, by call "ProgressBar::start()", I got invalid progress bar format.

Example code:

``` php
$bar = new ProgressBar($output, 100);
$bar->start();
$bar->advance(100);
$bar->finish();
```

Output:
 100/100 [============================] 100%

Example code:

``` php
$bar = new ProgressBar($output);
$bar->start(100);
$bar->advance(100);
$bar->finish();
```

Output:
 100 [============================]
