### PR TITLE
[PhpUnit] Auto-register SymfonyTestsListener

### DIFF
--- a/phpunit
+++ b/phpunit
@@ -47,6 +47,15 @@ if (!file_exists("$PHPUNIT_DIR/phpunit-$PHPUNIT_VERSION/phpunit") || md5_file(__
     passthru("$COMPOSER remove --no-update symfony/yaml");
     passthru("$COMPOSER require --dev --no-update symfony/phpunit-bridge \">=2.8@dev\"");
     passthru("$COMPOSER install --prefer-source --no-progress --ansi");
+    file_put_contents('phpunit', <<<EOPHP
+<?php
+
+define('PHPUNIT_COMPOSER_INSTALL', __DIR__.'/vendor/autoload.php');
+require PHPUNIT_COMPOSER_INSTALL;
+Symfony\Bridge\PhpUnit\TextUI\Command::main();
+
+EOPHP
+    );
     chdir('..');
     if (file_exists('../src/Symfony/Bridge/PhpUnit') && `git diff --name-only HEAD^ -- ../src/Symfony/Bridge/PhpUnit`) {
         passthru(sprintf('\\' === DIRECTORY_SEPARATOR ? 'del /S /F /Q %s & rmdir %1$s >nul 2>&1': 'rm -rf %s', str_replace('/', DIRECTORY_SEPARATOR, "phpunit-$PHPUNIT_VERSION/vendor/symfony/phpunit-bridge")));

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -43,8 +43,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Bridge/Doctrine/phpunit.xml.dist
+++ b/src/Symfony/Bridge/Doctrine/phpunit.xml.dist
@@ -25,8 +25,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Bridge/Monolog/phpunit.xml.dist
+++ b/src/Symfony/Bridge/Monolog/phpunit.xml.dist
@@ -25,8 +25,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Bridge/PhpUnit/SymfonyTestsListener.php
+++ b/src/Symfony/Bridge/PhpUnit/SymfonyTestsListener.php
@@ -18,7 +18,7 @@ use Doctrine\Common\Annotations\AnnotationRegistry;
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class SkippedTestsListener extends \PHPUnit_Framework_BaseTestListener
+class SymfonyTestsListener extends \PHPUnit_Framework_BaseTestListener
 {
     private $state = -1;
     private $skippedFile = false;

--- a/src/Symfony/Bridge/PhpUnit/TextUI/Command.php
+++ b/src/Symfony/Bridge/PhpUnit/TextUI/Command.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\TextUI;
+
+/**
+ * {@inheritdoc}
+ */
+class Command extends \PHPUnit_TextUI_Command
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function createRunner()
+    {
+        return new TestRunner($this->arguments['loader']);
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/TextUI/TestRunner.php
+++ b/src/Symfony/Bridge/PhpUnit/TextUI/TestRunner.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\TextUI;
+
+use Symfony\Bridge\PhpUnit\SymfonyTestsListener;
+
+/**
+ * {@inheritdoc}
+ */
+class TestRunner extends \PHPUnit_TextUI_TestRunner
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function handleConfiguration(array &$arguments)
+    {
+        $arguments['listeners'] = isset($arguments['listeners']) ? $arguments['listeners'] : array();
+        $arguments['listeners'][] = new SymfonyTestsListener();
+
+        return parent::handleConfiguration($arguments);
+    }
+}

--- a/src/Symfony/Bridge/ProxyManager/phpunit.xml.dist
+++ b/src/Symfony/Bridge/ProxyManager/phpunit.xml.dist
@@ -26,8 +26,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Bridge/Twig/phpunit.xml.dist
+++ b/src/Symfony/Bridge/Twig/phpunit.xml.dist
@@ -26,8 +26,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Bundle/DebugBundle/phpunit.xml.dist
+++ b/src/Symfony/Bundle/DebugBundle/phpunit.xml.dist
@@ -26,8 +26,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Bundle/FrameworkBundle/phpunit.xml.dist
+++ b/src/Symfony/Bundle/FrameworkBundle/phpunit.xml.dist
@@ -26,8 +26,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Bundle/SecurityBundle/phpunit.xml.dist
+++ b/src/Symfony/Bundle/SecurityBundle/phpunit.xml.dist
@@ -26,8 +26,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Bundle/TwigBundle/phpunit.xml.dist
+++ b/src/Symfony/Bundle/TwigBundle/phpunit.xml.dist
@@ -26,8 +26,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Bundle/WebProfilerBundle/phpunit.xml.dist
+++ b/src/Symfony/Bundle/WebProfilerBundle/phpunit.xml.dist
@@ -26,8 +26,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/Asset/phpunit.xml.dist
+++ b/src/Symfony/Component/Asset/phpunit.xml.dist
@@ -25,8 +25,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/BrowserKit/phpunit.xml.dist
+++ b/src/Symfony/Component/BrowserKit/phpunit.xml.dist
@@ -26,8 +26,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/ClassLoader/phpunit.xml.dist
+++ b/src/Symfony/Component/ClassLoader/phpunit.xml.dist
@@ -26,8 +26,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/Config/phpunit.xml.dist
+++ b/src/Symfony/Component/Config/phpunit.xml.dist
@@ -26,8 +26,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/Console/phpunit.xml.dist
+++ b/src/Symfony/Component/Console/phpunit.xml.dist
@@ -26,8 +26,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/CssSelector/phpunit.xml.dist
+++ b/src/Symfony/Component/CssSelector/phpunit.xml.dist
@@ -26,8 +26,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/Debug/phpunit.xml.dist
+++ b/src/Symfony/Component/Debug/phpunit.xml.dist
@@ -28,8 +28,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/DependencyInjection/phpunit.xml.dist
+++ b/src/Symfony/Component/DependencyInjection/phpunit.xml.dist
@@ -26,8 +26,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/DomCrawler/phpunit.xml.dist
+++ b/src/Symfony/Component/DomCrawler/phpunit.xml.dist
@@ -26,8 +26,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/EventDispatcher/phpunit.xml.dist
+++ b/src/Symfony/Component/EventDispatcher/phpunit.xml.dist
@@ -26,8 +26,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/ExpressionLanguage/phpunit.xml.dist
+++ b/src/Symfony/Component/ExpressionLanguage/phpunit.xml.dist
@@ -30,8 +30,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/Filesystem/phpunit.xml.dist
+++ b/src/Symfony/Component/Filesystem/phpunit.xml.dist
@@ -24,8 +24,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/Finder/phpunit.xml.dist
+++ b/src/Symfony/Component/Finder/phpunit.xml.dist
@@ -25,8 +25,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/Form/phpunit.xml.dist
+++ b/src/Symfony/Component/Form/phpunit.xml.dist
@@ -25,8 +25,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/HttpFoundation/phpunit.xml.dist
+++ b/src/Symfony/Component/HttpFoundation/phpunit.xml.dist
@@ -26,8 +26,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/HttpKernel/phpunit.xml.dist
+++ b/src/Symfony/Component/HttpKernel/phpunit.xml.dist
@@ -25,8 +25,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/Intl/phpunit.xml.dist
+++ b/src/Symfony/Component/Intl/phpunit.xml.dist
@@ -31,8 +31,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/Ldap/phpunit.xml.dist
+++ b/src/Symfony/Component/Ldap/phpunit.xml.dist
@@ -25,8 +25,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/Locale/phpunit.xml.dist
+++ b/src/Symfony/Component/Locale/phpunit.xml.dist
@@ -26,8 +26,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/OptionsResolver/phpunit.xml.dist
+++ b/src/Symfony/Component/OptionsResolver/phpunit.xml.dist
@@ -25,8 +25,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/Process/phpunit.xml.dist
+++ b/src/Symfony/Component/Process/phpunit.xml.dist
@@ -24,8 +24,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/PropertyAccess/phpunit.xml.dist
+++ b/src/Symfony/Component/PropertyAccess/phpunit.xml.dist
@@ -25,8 +25,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/PropertyInfo/phpunit.xml.dist
+++ b/src/Symfony/Component/PropertyInfo/phpunit.xml.dist
@@ -26,8 +26,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/Routing/phpunit.xml.dist
+++ b/src/Symfony/Component/Routing/phpunit.xml.dist
@@ -25,8 +25,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/Security/Core/phpunit.xml.dist
+++ b/src/Symfony/Component/Security/Core/phpunit.xml.dist
@@ -30,8 +30,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/Security/Csrf/phpunit.xml.dist
+++ b/src/Symfony/Component/Security/Csrf/phpunit.xml.dist
@@ -30,8 +30,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/Security/Guard/phpunit.xml.dist
+++ b/src/Symfony/Component/Security/Guard/phpunit.xml.dist
@@ -30,8 +30,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/Security/Http/phpunit.xml.dist
+++ b/src/Symfony/Component/Security/Http/phpunit.xml.dist
@@ -30,8 +30,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/Security/phpunit.xml.dist
+++ b/src/Symfony/Component/Security/phpunit.xml.dist
@@ -32,8 +32,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/Serializer/phpunit.xml.dist
+++ b/src/Symfony/Component/Serializer/phpunit.xml.dist
@@ -25,8 +25,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/Stopwatch/phpunit.xml.dist
+++ b/src/Symfony/Component/Stopwatch/phpunit.xml.dist
@@ -25,8 +25,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/Templating/phpunit.xml.dist
+++ b/src/Symfony/Component/Templating/phpunit.xml.dist
@@ -25,8 +25,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/Translation/phpunit.xml.dist
+++ b/src/Symfony/Component/Translation/phpunit.xml.dist
@@ -25,8 +25,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/Validator/phpunit.xml.dist
+++ b/src/Symfony/Component/Validator/phpunit.xml.dist
@@ -25,8 +25,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/VarDumper/phpunit.xml.dist
+++ b/src/Symfony/Component/VarDumper/phpunit.xml.dist
@@ -26,8 +26,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>

--- a/src/Symfony/Component/Yaml/phpunit.xml.dist
+++ b/src/Symfony/Component/Yaml/phpunit.xml.dist
@@ -25,8 +25,4 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SkippedTestsListener" />
-    </listeners>
 </phpunit>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This allows removing the copy/pasted `<listeners>` tags in our phpunit.xml.dist files and opens for future enhancements (like #16194)
