### PR TITLE
[EventDispatcher] added EventDispatcher::getListenerPriority()

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -294,27 +294,21 @@ class JsonDescriptor extends Descriptor
     {
         $data = array();
 
-        $registeredListeners = $eventDispatcher->getListeners($event, true);
+        $registeredListeners = $eventDispatcher->getListeners($event);
         if (null !== $event) {
-            krsort($registeredListeners);
-            foreach ($registeredListeners as $priority => $listeners) {
-                foreach ($listeners as $listener) {
-                    $listener = $this->getCallableData($listener);
-                    $listener['priority'] = $priority;
-                    $data[] = $listener;
-                }
+            foreach ($registeredListeners as $listener) {
+                $l = $this->getCallableData($listener);
+                $l['priority'] = $eventDispatcher->getListenerPriority($event, $listener);
+                $data[] = $l;
             }
         } else {
             ksort($registeredListeners);
 
             foreach ($registeredListeners as $eventListened => $eventListeners) {
-                krsort($eventListeners);
-                foreach ($eventListeners as $priority => $listeners) {
-                    foreach ($listeners as $listener) {
-                        $listener = $this->getCallableData($listener);
-                        $listener['priority'] = $priority;
-                        $data[$eventListened][] = $listener;
-                    }
+                foreach ($eventListeners as $eventListener) {
+                    $l = $this->getCallableData($eventListener);
+                    $l['priority'] = $eventDispatcher->getListenerPriority($eventListened, $eventListener);
+                    $data[$eventListened][] = $l;
                 }
             }
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -273,30 +273,23 @@ class MarkdownDescriptor extends Descriptor
 
         $this->write(sprintf('# %s', $title)."\n");
 
-        $registeredListeners = $eventDispatcher->getListeners($event, true);
+        $registeredListeners = $eventDispatcher->getListeners($event);
         if (null !== $event) {
-            krsort($registeredListeners);
-            $order = 1;
-            foreach ($registeredListeners as $priority => $listeners) {
-                foreach ($listeners as $listener) {
-                    $this->write("\n".sprintf('## Listener %d', $order++)."\n");
-                    $this->describeCallable($listener);
-                    $this->write(sprintf('- Priority: `%d`', $priority)."\n");
-                }
+            foreach ($registeredListeners as $order => $listener) {
+                $this->write("\n".sprintf('## Listener %d', $order + 1)."\n");
+                $this->describeCallable($listener);
+                $this->write(sprintf('- Priority: `%d`', $eventDispatcher->getListenerPriority($event, $listener))."\n");
             }
         } else {
             ksort($registeredListeners);
 
             foreach ($registeredListeners as $eventListened => $eventListeners) {
                 $this->write("\n".sprintf('## %s', $eventListened)."\n");
-                krsort($eventListeners);
-                $order = 1;
-                foreach ($eventListeners as $priority => $listeners) {
-                    foreach ($listeners as $listener) {
-                        $this->write("\n".sprintf('### Listener %d', $order++)."\n");
-                        $this->describeCallable($listener);
-                        $this->write(sprintf('- Priority: `%d`', $priority)."\n");
-                    }
+
+                foreach ($eventListeners as $order => $eventListener) {
+                    $this->write("\n".sprintf('### Listener %d', $order + 1)."\n");
+                    $this->describeCallable($eventListener);
+                    $this->write(sprintf('- Priority: `%d`', $eventDispatcher->getListenerPriority($eventListened, $eventListener))."\n");
                 }
             }
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -358,15 +358,14 @@ class TextDescriptor extends Descriptor
 
         $options['output']->title($title);
 
-        $registeredListeners = $eventDispatcher->getListeners($event, true);
-
+        $registeredListeners = $eventDispatcher->getListeners($event);
         if (null !== $event) {
-            $this->renderEventListenerTable($registeredListeners, $options['output']);
+            $this->renderEventListenerTable($eventDispatcher, $event, $registeredListeners, $options['output']);
         } else {
             ksort($registeredListeners);
             foreach ($registeredListeners as $eventListened => $eventListeners) {
                 $options['output']->section(sprintf('"%s" event', $eventListened));
-                $this->renderEventListenerTable($eventListeners, $options['output']);
+                $this->renderEventListenerTable($eventDispatcher, $eventListened, $eventListeners, $options['output']);
             }
         }
     }
@@ -382,17 +381,14 @@ class TextDescriptor extends Descriptor
     /**
      * @param array $array
      */
-    private function renderEventListenerTable(array $eventListeners, SymfonyStyle $renderer)
+    private function renderEventListenerTable(EventDispatcherInterface $eventDispatcher, $event, array $eventListeners, SymfonyStyle $renderer)
     {
         $tableHeaders = array('Order', 'Callable', 'Priority');
         $tableRows = array();
 
-        krsort($eventListeners);
         $order = 1;
-        foreach ($eventListeners as $priority => $listeners) {
-            foreach ($listeners as $listener) {
-                $tableRows[] = array(sprintf('#%d', $order++), $this->formatCallable($listener), $priority);
-            }
+        foreach ($eventListeners as $order => $listener) {
+            $tableRows[] = array(sprintf('#%d', $order + 1), $this->formatCallable($listener), $eventDispatcher->getListenerPriority($event, $listener));
         }
 
         $renderer->table($tableHeaders, $tableRows);

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -449,9 +449,9 @@ class XmlDescriptor extends Descriptor
         $dom = new \DOMDocument('1.0', 'UTF-8');
         $dom->appendChild($eventDispatcherXML = $dom->createElement('event-dispatcher'));
 
-        $registeredListeners = $eventDispatcher->getListeners($event, true);
+        $registeredListeners = $eventDispatcher->getListeners($event);
         if (null !== $event) {
-            $this->appendEventListenerDocument($eventDispatcherXML, $registeredListeners);
+            $this->appendEventListenerDocument($eventDispatcher, $event, $eventDispatcherXML, $registeredListeners);
         } else {
             ksort($registeredListeners);
 
@@ -459,7 +459,7 @@ class XmlDescriptor extends Descriptor
                 $eventDispatcherXML->appendChild($eventXML = $dom->createElement('event'));
                 $eventXML->setAttribute('name', $eventListened);
 
-                $this->appendEventListenerDocument($eventXML, $eventListeners);
+                $this->appendEventListenerDocument($eventDispatcher, $eventListened, $eventXML, $eventListeners);
             }
         }
 
@@ -470,16 +470,13 @@ class XmlDescriptor extends Descriptor
      * @param \DOMElement $element
      * @param array       $eventListeners
      */
-    private function appendEventListenerDocument(\DOMElement $element, array $eventListeners)
+    private function appendEventListenerDocument(EventDispatcherInterface $eventDispatcher, $event, \DOMElement $element, array $eventListeners)
     {
-        krsort($eventListeners);
-        foreach ($eventListeners as $priority => $listeners) {
-            foreach ($listeners as $listener) {
-                $callableXML = $this->getCallableDocument($listener);
-                $callableXML->childNodes->item(0)->setAttribute('priority', $priority);
+        foreach ($eventListeners as $listener) {
+            $callableXML = $this->getCallableDocument($listener);
+            $callableXML->childNodes->item(0)->setAttribute('priority', $eventDispatcher->getListenerPriority($event, $listener));
 
-                $element->appendChild($element->ownerDocument->importNode($callableXML->childNodes->item(0), true));
-            }
+            $element->appendChild($element->ownerDocument->importNode($callableXML->childNodes->item(0), true));
         }
     }
 

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.9",
+        "symfony/event-dispatcher": "~2.8|~3.0.0",
         "symfony/security": "~2.8|~3.0.0",
         "symfony/security-acl": "~2.7|~3.0.0",
         "symfony/http-kernel": "~2.2|~3.0.0"

--- a/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
@@ -118,7 +118,7 @@ class ContainerAwareEventDispatcher extends EventDispatcher
     /**
      * {@inheritdoc}
      */
-    public function getListeners($eventName = null, $withPriorities = false)
+    public function getListeners($eventName = null)
     {
         if (null === $eventName) {
             foreach ($this->listenerIds as $serviceEventName => $args) {
@@ -128,7 +128,17 @@ class ContainerAwareEventDispatcher extends EventDispatcher
             $this->lazyLoad($eventName);
         }
 
-        return parent::getListeners($eventName, $withPriorities);
+        return parent::getListeners($eventName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getListenerPriority($eventName, $listener)
+    {
+        $this->lazyLoad($eventName);
+
+        return parent::getListenerPriority($eventName, $listener);
     }
 
     /**

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -52,16 +52,8 @@ class EventDispatcher implements EventDispatcherInterface
     /**
      * {@inheritdoc}
      */
-    public function getListeners($eventName = null, $withPriorities = false)
+    public function getListeners($eventName = null)
     {
-        if (true === $withPriorities) {
-            if (null !== $eventName) {
-                return isset($this->listeners[$eventName]) ? $this->listeners[$eventName] : array();
-            }
-
-            return array_filter($this->listeners);
-        }
-
         if (null !== $eventName) {
             if (!isset($this->listeners[$eventName])) {
                 return array();
@@ -81,6 +73,29 @@ class EventDispatcher implements EventDispatcherInterface
         }
 
         return array_filter($this->sorted);
+    }
+
+    /**
+     * Gets the listener priority for a specific event.
+     *
+     * Returns null if the event or the listener does not exist.
+     *
+     * @param string   $eventName The name of the event
+     * @param callable $listener  The listener to remove
+     *
+     * @return int|null The event listener priority
+     */
+    public function getListenerPriority($eventName, $listener)
+    {
+        if (!isset($this->listeners[$eventName])) {
+            return;
+        }
+
+        foreach ($this->listeners[$eventName] as $priority => $listeners) {
+            if (false !== ($key = array_search($listener, $listeners, true))) {
+                return $priority;
+            }
+        }
     }
 
     /**
@@ -177,8 +192,6 @@ class EventDispatcher implements EventDispatcherInterface
      */
     private function sortListeners($eventName)
     {
-        $this->sorted[$eventName] = array();
-
         krsort($this->listeners[$eventName]);
         $this->sorted[$eventName] = call_user_func_array('array_merge', $this->listeners[$eventName]);
     }

--- a/src/Symfony/Component/EventDispatcher/ImmutableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/ImmutableEventDispatcher.php
@@ -78,9 +78,17 @@ class ImmutableEventDispatcher implements EventDispatcherInterface
     /**
      * {@inheritdoc}
      */
-    public function getListeners($eventName = null, $withPriorities = false)
+    public function getListeners($eventName = null)
     {
-        return $this->dispatcher->getListeners($eventName, $withPriorities);
+        return $this->dispatcher->getListeners($eventName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getListenerPriority($eventName, $listener)
+    {
+        return $this->dispatcher->getListenerPriority($eventName, $listener);
     }
 
     /**

--- a/src/Symfony/Component/EventDispatcher/Tests/AbstractEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/AbstractEventDispatcherTest.php
@@ -108,6 +108,20 @@ abstract class AbstractEventDispatcherTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expected, $this->dispatcher->getListeners());
     }
 
+    public function testGetListenerPriority()
+    {
+        $listener1 = new TestEventListener();
+        $listener2 = new TestEventListener();
+
+        $this->dispatcher->addListener('pre.foo', $listener1, -10);
+        $this->dispatcher->addListener('pre.foo', $listener2);
+
+        $this->assertSame(-10, $this->dispatcher->getListenerPriority('pre.foo', $listener1));
+        $this->assertSame(0, $this->dispatcher->getListenerPriority('pre.foo', $listener2));
+        $this->assertNull($this->dispatcher->getListenerPriority('pre.bar', $listener2));
+        $this->assertNull($this->dispatcher->getListenerPriority('pre.foo', function () {}));
+    }
+
     public function testDispatch()
     {
         $this->dispatcher->addListener('pre.foo', array($this->listener, 'preFoo'));

--- a/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
@@ -25,7 +25,7 @@ class TraceableEventDispatcherTest extends \PHPUnit_Framework_TestCase
         $dispatcher = new EventDispatcher();
         $tdispatcher = new TraceableEventDispatcher($dispatcher, new Stopwatch());
 
-        $tdispatcher->addListener('foo', $listener = function () {; });
+        $tdispatcher->addListener('foo', $listener = function () {});
         $listeners = $dispatcher->getListeners('foo');
         $this->assertCount(1, $listeners);
         $this->assertSame($listener, $listeners[0]);
@@ -39,7 +39,7 @@ class TraceableEventDispatcherTest extends \PHPUnit_Framework_TestCase
         $dispatcher = new EventDispatcher();
         $tdispatcher = new TraceableEventDispatcher($dispatcher, new Stopwatch());
 
-        $tdispatcher->addListener('foo', $listener = function () {; });
+        $tdispatcher->addListener('foo', $listener = function () {});
         $this->assertSame($dispatcher->getListeners('foo'), $tdispatcher->getListeners('foo'));
     }
 
@@ -51,7 +51,7 @@ class TraceableEventDispatcherTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($dispatcher->hasListeners('foo'));
         $this->assertFalse($tdispatcher->hasListeners('foo'));
 
-        $tdispatcher->addListener('foo', $listener = function () {; });
+        $tdispatcher->addListener('foo', $listener = function () {});
         $this->assertTrue($dispatcher->hasListeners('foo'));
         $this->assertTrue($tdispatcher->hasListeners('foo'));
     }
@@ -76,7 +76,7 @@ class TraceableEventDispatcherTest extends \PHPUnit_Framework_TestCase
     {
         $dispatcher = new EventDispatcher();
         $tdispatcher = new TraceableEventDispatcher($dispatcher, new Stopwatch());
-        $tdispatcher->addListener('foo', $listener = function () {; });
+        $tdispatcher->addListener('foo', $listener = function () {});
 
         $this->assertEquals(array(), $tdispatcher->getCalledListeners());
         $this->assertEquals(array('foo.closure' => array('event' => 'foo', 'type' => 'Closure', 'pretty' => 'closure', 'priority' => 0)), $tdispatcher->getNotCalledListeners());
@@ -107,8 +107,8 @@ class TraceableEventDispatcherTest extends \PHPUnit_Framework_TestCase
 
         $dispatcher = new EventDispatcher();
         $tdispatcher = new TraceableEventDispatcher($dispatcher, new Stopwatch(), $logger);
-        $tdispatcher->addListener('foo', $listener1 = function () {; });
-        $tdispatcher->addListener('foo', $listener2 = function () {; });
+        $tdispatcher->addListener('foo', $listener1 = function () {});
+        $tdispatcher->addListener('foo', $listener2 = function () {});
 
         $logger->expects($this->at(0))->method('debug')->with('Notified event "foo" to listener "closure".');
         $logger->expects($this->at(1))->method('debug')->with('Notified event "foo" to listener "closure".');
@@ -123,7 +123,7 @@ class TraceableEventDispatcherTest extends \PHPUnit_Framework_TestCase
         $dispatcher = new EventDispatcher();
         $tdispatcher = new TraceableEventDispatcher($dispatcher, new Stopwatch(), $logger);
         $tdispatcher->addListener('foo', $listener1 = function (Event $event) { $event->stopPropagation(); });
-        $tdispatcher->addListener('foo', $listener2 = function () {; });
+        $tdispatcher->addListener('foo', $listener2 = function () {});
 
         $logger->expects($this->at(0))->method('debug')->with('Notified event "foo" to listener "closure".');
         $logger->expects($this->at(1))->method('debug')->with('Listener "closure" stopped propagation of the event "foo".');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14563, #15825 |
| License | MIT |
| Doc PR | n/a |

In #14563, we added a way to get the priorities of listeners, but as noted by @Tobion in #15825, the implementation is sub-optimal because of two main reasons: the change is not part of the interface but more importantly, the added boolean changes the return value of `getListeners()`.

This PR reverts most of #14563 to add a `getListenerPriority()` method. This method is quite slow, but as it should only be used for debugging purposes (on the CLI or the WDT), I think it's not really a problem.

In 3.0, this method should probably be added to `EventDispatcherInterface`.

ping @Tobion 
