### PR TITLE
[Yaml] removed YAML parser \ escaping in double-quotes

### DIFF
--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+3.0.0
+-----
+
+ * Yaml::parse() now throws an exception when a blackslash is not escaped
+   in double-quoted strings
+
 2.8.0
 -----
 

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -71,12 +71,12 @@ class InlineTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @group legacy
-     * throws \Symfony\Component\Yaml\Exception\ParseException in 3.0
+     * @expectedException        \Symfony\Component\Yaml\Exception\ParseException
+     * @expectedExceptionMessage Found unknown escape character "\V".
      */
     public function testParseScalarWithNonEscapedBlackslashShouldThrowException()
     {
-        $this->assertSame('Foo\Var', Inline::parse('"Foo\Var"'));
+        Inline::parse('"Foo\Var"');
     }
 
     /**

--- a/src/Symfony/Component/Yaml/Unescaper.php
+++ b/src/Symfony/Component/Yaml/Unescaper.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Yaml;
 
+use Symfony\Component\Yaml\Exception\ParseException;
+
 /**
  * Unescaper encapsulates unescaping rules for single and double-quoted
  * YAML strings.
@@ -59,11 +61,8 @@ class Unescaper
      * @param string $value An escaped character
      *
      * @return string The unescaped character
-     *
-     * @internal This method is public to be usable as callback. It should not
-     *           be used in user code. Should be changed in 3.0.
      */
-    public function unescapeCharacter($value)
+    private function unescapeCharacter($value)
     {
         switch ($value[1]) {
             case '0':
@@ -113,9 +112,7 @@ class Unescaper
             case 'U':
                 return self::utf8chr(hexdec(substr($value, 2, 8)));
             default:
-                @trigger_error('Not escaping a backslash in a double-quoted string is deprecated since Symfony 2.8 and will throw a ParseException in 3.0.', E_USER_DEPRECATED);
-
-                return $value;
+                throw new ParseException(sprintf('Found unknown escape character "%s".', $value));
         }
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Should be rebased when #16201 is merged.
