### PR TITLE
Specify root namespace for RuntimeException

### DIFF
--- a/src/Symfony/Component/Process/README.md
+++ b/src/Symfony/Component/Process/README.md
@@ -12,7 +12,7 @@ $process = new Process('ls -lsa');
 $process->setTimeout(3600);
 $process->run();
 if (!$process->isSuccessful()) {
-    throw new RuntimeException($process->getErrorOutput());
+    throw new \RuntimeException($process->getErrorOutput());
 }
 
 print $process->getOutput();


### PR DESCRIPTION
The main example in the README will fail if the user is pasting the code into a file that has a namespace defined.
