### PR TITLE
[WebProfilerBundle] [toolbar] Changed profiler toolbar green color to comply with WCAG 2.0AA

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -165,7 +165,7 @@
 }
 
 .sf-toolbar-block .sf-toolbar-status-green {
-    background-color: #759e1a;
+    background-color: #5e8014;
 }
 
 .sf-toolbar-block .sf-toolbar-status-red {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

[WebProfilerBundle] Modified green icon colors for min contrast of 4.5
(resubmitting this on the 2.3 branch. Previous PR was #15827)
