### PR TITLE
[PropertyAccess] Fail the test if the exception was not thrown on accessing an invalid element

### DIFF
--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -148,6 +148,8 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
 
         try {
             $propertyAccessor->getValue($object, 'firstName[1]');
+
+            $this->fail('Expected an exception to be thrown when accessing an invalid element.');
         } catch (NoSuchIndexException $e) {
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This is a followup to [Tobion's comment](https://github.com/symfony/symfony/pull/16155#discussion_r41394562) on  #16155 .
