### PR TITLE
[filesystem] makeRelativePath does not work correctly from root

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -331,7 +331,7 @@ class Filesystem
         $depth = count($startPathArr) - $index;
 
         // When we need to traverse from the start, and we are starting from a root path, don't add '../'
-        if ($startPath[0] == '/' && $index == 0 && $depth == 1) {
+        if ('/' === $startPath[0] && 0 === $index && 1 === $depth) {
             $traverser = '';
         } else {
             // Repeated "../" for each level need to reach the common path

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -330,8 +330,13 @@ class Filesystem
         // Determine how deep the start path is relative to the common path (ie, "web/bundles" = 2 levels)
         $depth = count($startPathArr) - $index;
 
-        // Repeated "../" for each level need to reach the common path
-        $traverser = str_repeat('../', $depth);
+        // When we need to traverse from the start, and we are starting from a root path, don't add '../'
+        if ($startPath[0] == '/' && $index == 0 && $depth == 1) {
+            $traverser = '';
+        } else {
+            // Repeated "../" for each level need to reach the common path
+            $traverser = str_repeat('../', $depth);
+        }
 
         $endPathRemainder = implode('/', array_slice($endPathArr, $index));
 

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -781,6 +781,8 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
             array('/a/aab/bb', '/a/aa/', '../aab/bb/'),
             array('/a/aab/bb/', '/a/aa', '../aab/bb/'),
             array('/a/aab/bb/', '/a/aa/', '../aab/bb/'),
+            array('/a/aab/bb/', '/', 'a/aab/bb/'),
+            array('/a/aab/bb/', '/b/aab', '../../a/aab/bb/'),
         );
 
         if ('\\' === DIRECTORY_SEPARATOR) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes/no |
| New feature? | yes/no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14066, #14067 |
| License | MIT |
| Doc PR | n/a |

When using `makeRelativePath`, it returns an incorrect path when trying to fetch an entry from the root:

```
  $fs->makePathRelative('/foo/bar/baz', '/');
```

Actual result:

```
  ../foo/bar/baz
```

Expected result:

```
  foo/bar/baz
```

As we have specified an absolute path, there is no point on having an `..` added. It works, because a root directory has a `..` which points to itself, but it could result in issues when the relative path is actually prefixed or concatted.
