### PR TITLE
[Form] remove deprecated `options` and `type` from CollectionType

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -81,34 +81,6 @@ class CollectionType extends AbstractType
 
             return $value;
         };
-        $optionsNormalizer = function (Options $options, $value) use ($entryOptionsNormalizer) {
-            if (null !== $value) {
-                @trigger_error('The form option "options" is deprecated since version 2.8 and will be removed in 3.0. Use "entry_options" instead.', E_USER_DEPRECATED);
-            }
-
-            return $entryOptionsNormalizer($options, $value);
-        };
-        $typeNormalizer = function (Options $options, $value) {
-            if (null !== $value) {
-                @trigger_error('The form option "type" is deprecated since version 2.8 and will be removed in 3.0. Use "entry_type" instead.', E_USER_DEPRECATED);
-            }
-
-            return $value;
-        };
-        $entryType = function (Options $options) {
-            if (null !== $options['type']) {
-                return $options['type'];
-            }
-
-            return __NAMESPACE__.'\TextType';
-        };
-        $entryOptions = function (Options $options) {
-            if (1 === count($options['options']) && isset($options['block_name'])) {
-                return array();
-            }
-
-            return $options['options'];
-        };
 
         $resolver->setDefaults(array(
             'allow_add' => false,
@@ -116,17 +88,11 @@ class CollectionType extends AbstractType
             'prototype' => true,
             'prototype_data' => null,
             'prototype_name' => '__name__',
-            // deprecated as of Symfony 2.8, to be removed in Symfony 3.0. Use entry_type instead
-            'type' => null,
-            // deprecated as of Symfony 2.8, to be removed in Symfony 3.0. Use entry_options instead
-            'options' => null,
-            'entry_type' => $entryType,
-            'entry_options' => $entryOptions,
+            'entry_type' => __NAMESPACE__.'\TextType',
+            'entry_options' => array(),
             'delete_empty' => false,
         ));
 
-        $resolver->setNormalizer('type', $typeNormalizer);
-        $resolver->setNormalizer('options', $optionsNormalizer);
         $resolver->setNormalizer('entry_options', $entryOptionsNormalizer);
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -262,22 +262,6 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertSame('__test__', $form->getConfig()->getAttribute('prototype')->getName());
     }
 
-    /**
-     * @group legacy
-     */
-    public function testLegacyEntryOptions()
-    {
-        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', array(), array(
-            'type' => 'Symfony\Component\Form\Extension\Core\Type\NumberType',
-            'options' => array('attr' => array('maxlength' => '10')),
-        ));
-
-        $resolvedOptions = $form->getConfig()->getOptions();
-
-        $this->assertEquals('Symfony\Component\Form\Extension\Core\Type\NumberType', $resolvedOptions['entry_type']);
-        $this->assertEquals(array('attr' => array('maxlength' => '10'), 'block_name' => 'entry'), $resolvedOptions['entry_options']);
-    }
-
     public function testPrototypeDefaultLabel()
     {
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', array(), array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
