### PR TITLE
[TEMPLATING] relative paths in template cache

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/TemplatePathsCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/TemplatePathsCacheWarmer.php
@@ -46,7 +46,7 @@ class TemplatePathsCacheWarmer extends CacheWarmer
         foreach ($this->finder->findAllTemplates() as $template) {
             $this->locator->locate($template);
         }
-        $this->writeCacheFile($cacheDir.'/templates.php', sprintf('<?php return %s;', var_export($this->locator->cache, true)));
+        $this->writeCacheFile($cacheDir.'/templates.php', sprintf('<?php return %s;', var_export($this->locator->getCache(), true)));
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/TemplatePathsCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/TemplatePathsCacheWarmer.php
@@ -43,13 +43,10 @@ class TemplatePathsCacheWarmer extends CacheWarmer
      */
     public function warmUp($cacheDir)
     {
-        $templates = array();
-
         foreach ($this->finder->findAllTemplates() as $template) {
-            $templates[$template->getLogicalName()] = $this->locator->locate($template);
+            $this->locator->locate($template);
         }
-
-        $this->writeCacheFile($cacheDir.'/templates.php', sprintf('<?php return %s;', var_export($templates, true)));
+        $this->writeCacheFile($cacheDir.'/templates.php', sprintf('<?php return %s;', var_export($this->locator->cache, true)));
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating.xml
@@ -32,7 +32,6 @@
 
         <service id="templating.locator" class="%templating.locator.class%" public="false">
             <argument type="service" id="file_locator" />
-            <argument>%kernel.root_dir%</argument>
             <argument>%kernel.cache_dir%</argument>
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating.xml
@@ -32,6 +32,7 @@
 
         <service id="templating.locator" class="%templating.locator.class%" public="false">
             <argument type="service" id="file_locator" />
+            <argument>%kernel.root_dir%</argument>
             <argument>%kernel.cache_dir%</argument>
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/TemplateLocator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/TemplateLocator.php
@@ -83,9 +83,9 @@ class TemplateLocator implements FileLocatorInterface
             throw new \InvalidArgumentException(sprintf('Unable to find template "%s" : "%s".', $template, $e->getMessage()), 0, $e);
         }
     }
-    
+
     /**
-     * Returns the current cache
+     * Returns the current cache.
      *
      * @return array
      */

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/TemplateLocator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/TemplateLocator.php
@@ -29,7 +29,7 @@ class TemplateLocator implements FileLocatorInterface
      * Constructor.
      *
      * @param FileLocatorInterface $locator  A FileLocatorInterface instance
-     * @param string               $rootDir The root path
+     * @param string               $rootDir  The root path
      * @param string               $cacheDir The cache path
      */
     public function __construct(FileLocatorInterface $locator, $rootDir, $cacheDir = null)

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/TemplateLocator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/TemplateLocator.php
@@ -22,20 +22,23 @@ use Symfony\Component\Templating\TemplateReferenceInterface;
 class TemplateLocator implements FileLocatorInterface
 {
     protected $locator;
-    protected $cache;
+    protected $rootDir;
+    public $cache;
 
     /**
      * Constructor.
      *
      * @param FileLocatorInterface $locator  A FileLocatorInterface instance
+     * @param string               $rootDir The root path
      * @param string               $cacheDir The cache path
      */
-    public function __construct(FileLocatorInterface $locator, $cacheDir = null)
+    public function __construct(FileLocatorInterface $locator, $rootDir, $cacheDir = null)
     {
         if (null !== $cacheDir && is_file($cache = $cacheDir.'/templates.php')) {
             $this->cache = require $cache;
         }
 
+        $this->rootDir = dirname($rootDir);
         $this->locator = $locator;
     }
 
@@ -72,11 +75,11 @@ class TemplateLocator implements FileLocatorInterface
         $key = $this->getCacheKey($template);
 
         if (isset($this->cache[$key])) {
-            return $this->cache[$key];
+            return $this->rootDir.$this->cache[$key];
         }
 
         try {
-            return $this->cache[$key] = $this->locator->locate($template->getPath(), $currentPath);
+            return $this->rootDir.($this->cache[$key] = substr($this->locator->locate($template->getPath(), $currentPath), strlen($this->rootDir)));
         } catch (\InvalidArgumentException $e) {
             throw new \InvalidArgumentException(sprintf('Unable to find template "%s" : "%s".', $template, $e->getMessage()), 0, $e);
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/TemplateLocator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/TemplateLocator.php
@@ -23,22 +23,21 @@ class TemplateLocator implements FileLocatorInterface
 {
     protected $locator;
     protected $rootDir;
-    public $cache;
+    protected $cache;
 
     /**
      * Constructor.
      *
      * @param FileLocatorInterface $locator  A FileLocatorInterface instance
-     * @param string               $rootDir  The root path
      * @param string               $cacheDir The cache path
      */
-    public function __construct(FileLocatorInterface $locator, $rootDir, $cacheDir = null)
+    public function __construct(FileLocatorInterface $locator, $cacheDir = null)
     {
         if (null !== $cacheDir && is_file($cache = $cacheDir.'/templates.php')) {
             $this->cache = require $cache;
         }
 
-        $this->rootDir = dirname($rootDir);
+        $this->rootDir = realpath(__dir__.'/../../../../../../../../../');
         $this->locator = $locator;
     }
 
@@ -83,5 +82,15 @@ class TemplateLocator implements FileLocatorInterface
         } catch (\InvalidArgumentException $e) {
             throw new \InvalidArgumentException(sprintf('Unable to find template "%s" : "%s".', $template, $e->getMessage()), 0, $e);
         }
+    }
+    
+    /**
+     * Returns the current cache
+     *
+     * @return array
+     */
+    public function getCache()
+    {
+        return $this->cache;
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | #3079 |
| License | MIT |
| Doc PR |  |
- [ ] run tests

Templates are saved with relative paths. Absolute path is added on locate. 
