### PR TITLE
Show the installed bundle versions in the web profiler

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -227,13 +227,15 @@
                 <tr>
                     <th class="key">Name</th>
                     <th>Path</th>
+                    <th>Version</th>
                 </tr>
             </thead>
             <tbody>
-                {% for name in collector.bundles|keys|sort %}
+                {% for bundle in collector.bundles %}
                 <tr>
-                    <th scope="row" class="font-normal">{{ name }}</th>
-                    <td class="font-normal">{{ collector.bundles[name] }}</td>
+                    <th scope="row" class="font-normal">{{ bundle.name }}</th>
+                    <td class="font-normal">{{ bundle.path }}</td>
+                    <td>{{ bundle.version|default('-') }}</td>
                 </tr>
                 {% endfor %}
             </tbody>

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -358,7 +358,7 @@ class ConfigDataCollector extends DataCollector
         $longestCommonPrefix = array_reduce($paths, function ($prefix, $path) {
             $length = min(strlen($prefix), strlen($path));
             while (substr($prefix, 0, $length) !== substr($path, 0, $length)) {
-                $length--;
+                --$length;
             }
 
             return substr($prefix, 0, $length);

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -311,7 +311,7 @@ class ConfigDataCollector extends DataCollector
 
             $bundleVersion = null;
             foreach ($installedPackages as $packageName => $packageVersion) {
-                if (preg_match(sprintf('~.*/vendor/%s~', preg_quote($packageName)), $bundlePath)) {
+                if (strpos($bundlePath, '/vendor/'.$packageName)) {
                     $bundleVersion = $packageVersion;
 
                     break;

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -296,22 +296,21 @@ class ConfigDataCollector extends DataCollector
     {
         $bundles = array();
 
-        try {
-            $composerLockPath = $this->kernel->getRootDir().'/../composer.lock';
+        $composerLockPath = $this->kernel->getRootDir().'/../composer.lock';
+        if (!file_exists($composerLockPath)) {
+            $installedPackages = array();
+        } else {
             $composerLock = json_decode(file_get_contents($composerLockPath), true);
-
-            foreach (array_merge($composerLock['packages'], $composerLock['packages-dev']) as $dependency) {
-                $installedDependencies[$dependency['name']] = $dependency['version'];
+            foreach (array_merge($composerLock['packages'], $composerLock['packages-dev']) as $package) {
+                $installedPackages[$package['name']] = $package['version'];
             }
-        } catch (\Exception $e) {
-            $installedDependencies = array();
         }
 
         foreach ($this->kernel->getBundles() as $name => $bundle) {
             $bundlePath = $bundle->getPath();
 
             $bundleVersion = null;
-            foreach ($installedDependencies as $packageName => $packageVersion) {
+            foreach ($installedPackages as $packageName => $packageVersion) {
                 if (preg_match(sprintf('~.*/vendor/%s~', $packageName), $bundlePath)) {
                     $bundleVersion = $packageVersion;
 

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -292,15 +292,13 @@ class ConfigDataCollector extends DataCollector
      *
      * @return array
      */
-    private function getBundleData()
+    public function getBundleData()
     {
         $bundles = array();
         $installedPackages = $this->getInstalledPackages();
+        $enabledBundles = $this->getEnabledBundles();
 
-        foreach ($this->kernel->getBundles() as $name => $bundle) {
-            $bundlePath = $bundle->getPath();
-            $bundleVersion = null;
-
+        foreach ($this->getEnabledBundles() as $bundleName => $bundlePath) {
             foreach ($installedPackages as $packageName => $packageVersion) {
                 if (strpos($bundlePath.'/', '/vendor/'.$packageName.'/')) {
                     $bundleVersion = $packageVersion;
@@ -312,9 +310,11 @@ class ConfigDataCollector extends DataCollector
 
                     break;
                 }
+
+                $bundleVersion = null;
             }
 
-            $bundles[$name] = array('name' => $name, 'path' => $bundlePath, 'version' => $bundleVersion);
+            $bundles[$bundleName] = array('name' => $bundleName, 'path' => $bundlePath, 'version' => $bundleVersion);
         }
 
         ksort($bundles);
@@ -388,5 +388,21 @@ class ConfigDataCollector extends DataCollector
         }
 
         return $installedPackages;
+    }
+
+    /**
+     * Returns the names and paths of the bundles enabled in the current kernel.
+     *
+     * @return array
+     */
+    private function getEnabledBundles()
+    {
+        $enabledBundles = array();
+
+        foreach ($this->kernel->getBundles() as $name => $bundle) {
+            $enabledBundles[$name] = $bundle->getPath();
+        }
+
+        return $enabledBundles;
     }
 }

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -300,11 +300,11 @@ class ConfigDataCollector extends DataCollector
 
         foreach ($this->getEnabledBundles() as $bundleName => $bundlePath) {
             foreach ($installedPackages as $packageName => $packageVersion) {
-                if (strpos($bundlePath.'/', '/vendor/'.$packageName.'/')) {
+                if (strpos($bundlePath.DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR.'vendor'.DIRECTORY_SEPARATOR.$packageName.DIRECTORY_SEPARATOR)) {
                     $bundleVersion = $packageVersion;
 
                     break;
-                } elseif (strpos($bundlePath, 'symfony/symfony/src/Symfony/Bundle')) {
+                } elseif (strpos($bundlePath, 'symfony'.DIRECTORY_SEPARATOR.'symfony'.DIRECTORY_SEPARATOR.'src'.DIRECTORY_SEPARATOR.'Symfony'.DIRECTORY_SEPARATOR.'Bundle')) {
                     // this is a built-in Symfony bundle; its version is the same as Symfony
                     $bundleVersion = Kernel::VERSION;
 

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -334,11 +334,11 @@ class ConfigDataCollector extends DataCollector
         $projectRootDirectory = $this->findProjectRootDirectory();
 
         while ($path !== $projectRootDirectory) {
-            if (file_exists($composerLockPath = $path.'/composer.lock')) {
+            if (file_exists($composerLockPath = $path.DIRECTORY_SEPARATOR.'composer.lock')) {
                 return $composerLockPath;
             }
 
-            $path = realpath($path.'/..');
+            $path = realpath($path.DIRECTORY_SEPARATOR.'..');
         }
     }
 

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -311,11 +311,11 @@ class ConfigDataCollector extends DataCollector
 
             $bundleVersion = null;
             foreach ($installedPackages as $packageName => $packageVersion) {
-                if (preg_match(sprintf('~.*/vendor/%s~', $packageName), $bundlePath)) {
+                if (preg_match(sprintf('~.*/vendor/%s~', preg_quote($packageName)), $bundlePath)) {
                     $bundleVersion = $packageVersion;
 
                     break;
-                } elseif (preg_match('~.*/src/Symfony/Bundle/.*~', $bundlePath)) {
+                } elseif (strpos($bundlePath, 'symfony/symfony/src/Symfony/Bundle')) {
                     // this is a built-in Symfony bundle; its version is the same as Symfony
                     $bundleVersion = Kernel::VERSION;
 
@@ -323,11 +323,7 @@ class ConfigDataCollector extends DataCollector
                 }
             }
 
-            $bundles[$name] = array(
-                'name' => $name,
-                'path' => $bundlePath,
-                'version' => $bundleVersion,
-            );
+            $bundles[$name] = array('name' => $name, 'path' => $bundlePath, 'version' => $bundleVersion);
         }
 
         ksort($bundles);

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
@@ -57,6 +57,86 @@ class ConfigDataCollectorTest extends \PHPUnit_Framework_TestCase
             $this->assertFalse($c->hasAccelerator());
         }
     }
+
+    /**
+     * @dataProvider getBundleData()
+     */
+    public function testBundleData($installedPackages, $enabledBundles, $expectedResult)
+    {
+        $collector = $this->getMockBuilder('Symfony\Component\HttpKernel\DataCollector\ConfigDataCollector')
+            ->setMethods(array('getInstalledPackages', 'getEnabledBundles'))
+            ->getMock()
+        ;
+
+        $collector
+            ->expects($this->once())
+            ->method('getInstalledPackages')
+            ->with($this->anything())
+            ->will($this->returnValue($installedPackages))
+        ;
+        $collector
+            ->expects($this->once())
+            ->method('getEnabledBundles')
+            ->with($this->anything())
+            ->will($this->returnValue($enabledBundles))
+        ;
+
+        $this->assertEquals($expectedResult, $collector->getBundleData());
+    }
+
+    public function getBundleData()
+    {
+        return array(
+            array(
+                array(
+                    "doctrine/doctrine-fixtures-bundle" => "v2.2.0",
+                    "sensio/framework-extra-bundle" => "v3.0.10",
+                    "symfony/monolog-bundle" => "v2.7.1",
+                    "sensio/generator-bundle" => "v2.5.3",
+                ),
+                array(
+                    "SecurityBundle" => "/Users/fabien/project/vendor/symfony/symfony/src/Symfony/Bundle/SecurityBundle",
+                    "MonologBundle" => "/Users/fabien/project/vendor/symfony/monolog-bundle",
+                    "SensioFrameworkExtraBundle" => "/Users/fabien/project/vendor/sensio/framework-extra-bundle",
+                    "DoctrineFixturesBundle" => "/Users/fabien/project/vendor/doctrine/doctrine-fixtures-bundle/Doctrine/Bundle/FixturesBundle",
+                    "AppBundle" => "/Users/fabien/project/src/AppBundle",
+                    "SensioGeneratorBundle" => "/Users/fabien/project/vendor/sensio/generator-bundle/Sensio/Bundle/GeneratorBundle",
+                ),
+                array(
+                    "AppBundle" => array(
+                        "name" => "AppBundle",
+                        "path" => "/Users/fabien/project/src/AppBundle",
+                        "version" => null,
+                    ),
+                    "DoctrineFixturesBundle" => array(
+                        "name" => "AppBundle",
+                        "path" => "/Users/fabien/project/vendor/doctrine/doctrine-fixtures-bundle/Doctrine/Bundle/FixturesBundle",
+                        "version" => "v2.2.0",
+                    ),
+                    "MonologBundle" => array(
+                        "name" => "AppBundle",
+                        "path" => "/Users/fabien/project/vendor/symfony/monolog-bundle",
+                        "version" => "v2.7.1",
+                    ),
+                    "SecurityBundle" => array(
+                        "name" => "AppBundle",
+                        "path" => "/Users/fabien/project/vendor/symfony/symfony/src/Symfony/Bundle/SecurityBundle",
+                        "version" => "2.8.0-DEV",
+                    ),
+                    "SensioFrameworkExtraBundle" => array(
+                        "name" => "AppBundle",
+                        "path" => "/Users/fabien/project/vendor/sensio/framework-extra-bundle",
+                        "version" => "v3.0.10",
+                    ),
+                    "SensioGeneratorBundle" => array(
+                        "name" => "AppBundle",
+                        "path" => "/Users/fabien/project/vendor/sensio/generator-bundle/Sensio/Bundle/GeneratorBundle",
+                        "version" => "v2.5.3",
+                    ),
+                )
+            )
+        );
+    }
 }
 
 class KernelForTest extends Kernel

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
@@ -89,52 +89,52 @@ class ConfigDataCollectorTest extends \PHPUnit_Framework_TestCase
         return array(
             array(
                 array(
-                    "doctrine/doctrine-fixtures-bundle" => "v2.2.0",
-                    "sensio/framework-extra-bundle" => "v3.0.10",
-                    "symfony/monolog-bundle" => "v2.7.1",
-                    "sensio/generator-bundle" => "v2.5.3",
+                    'doctrine/doctrine-fixtures-bundle' => 'v2.2.0',
+                    'sensio/framework-extra-bundle' => 'v3.0.10',
+                    'symfony/monolog-bundle' => 'v2.7.1',
+                    'sensio/generator-bundle' => 'v2.5.3',
                 ),
                 array(
-                    "SecurityBundle" => "/Users/fabien/project/vendor/symfony/symfony/src/Symfony/Bundle/SecurityBundle",
-                    "MonologBundle" => "/Users/fabien/project/vendor/symfony/monolog-bundle",
-                    "SensioFrameworkExtraBundle" => "/Users/fabien/project/vendor/sensio/framework-extra-bundle",
-                    "DoctrineFixturesBundle" => "/Users/fabien/project/vendor/doctrine/doctrine-fixtures-bundle/Doctrine/Bundle/FixturesBundle",
-                    "AppBundle" => "/Users/fabien/project/src/AppBundle",
-                    "SensioGeneratorBundle" => "/Users/fabien/project/vendor/sensio/generator-bundle/Sensio/Bundle/GeneratorBundle",
+                    'SecurityBundle' => '/Users/fabien/project/vendor/symfony/symfony/src/Symfony/Bundle/SecurityBundle',
+                    'MonologBundle' => '/Users/fabien/project/vendor/symfony/monolog-bundle',
+                    'SensioFrameworkExtraBundle' => '/Users/fabien/project/vendor/sensio/framework-extra-bundle',
+                    'DoctrineFixturesBundle' => '/Users/fabien/project/vendor/doctrine/doctrine-fixtures-bundle/Doctrine/Bundle/FixturesBundle',
+                    'AppBundle' => '/Users/fabien/project/src/AppBundle',
+                    'SensioGeneratorBundle' => '/Users/fabien/project/vendor/sensio/generator-bundle/Sensio/Bundle/GeneratorBundle',
                 ),
                 array(
-                    "AppBundle" => array(
-                        "name" => "AppBundle",
-                        "path" => "/Users/fabien/project/src/AppBundle",
-                        "version" => null,
+                    'AppBundle' => array(
+                        'name' => 'AppBundle',
+                        'path' => '/Users/fabien/project/src/AppBundle',
+                        'version' => null,
                     ),
-                    "DoctrineFixturesBundle" => array(
-                        "name" => "AppBundle",
-                        "path" => "/Users/fabien/project/vendor/doctrine/doctrine-fixtures-bundle/Doctrine/Bundle/FixturesBundle",
-                        "version" => "v2.2.0",
+                    'DoctrineFixturesBundle' => array(
+                        'name' => 'AppBundle',
+                        'path' => '/Users/fabien/project/vendor/doctrine/doctrine-fixtures-bundle/Doctrine/Bundle/FixturesBundle',
+                        'version' => 'v2.2.0',
                     ),
-                    "MonologBundle" => array(
-                        "name" => "AppBundle",
-                        "path" => "/Users/fabien/project/vendor/symfony/monolog-bundle",
-                        "version" => "v2.7.1",
+                    'MonologBundle' => array(
+                        'name' => 'AppBundle',
+                        'path' => '/Users/fabien/project/vendor/symfony/monolog-bundle',
+                        'version' => 'v2.7.1',
                     ),
-                    "SecurityBundle" => array(
-                        "name" => "AppBundle",
-                        "path" => "/Users/fabien/project/vendor/symfony/symfony/src/Symfony/Bundle/SecurityBundle",
-                        "version" => "2.8.0-DEV",
+                    'SecurityBundle' => array(
+                        'name' => 'AppBundle',
+                        'path' => '/Users/fabien/project/vendor/symfony/symfony/src/Symfony/Bundle/SecurityBundle',
+                        'version' => '2.8.0-DEV',
                     ),
-                    "SensioFrameworkExtraBundle" => array(
-                        "name" => "AppBundle",
-                        "path" => "/Users/fabien/project/vendor/sensio/framework-extra-bundle",
-                        "version" => "v3.0.10",
+                    'SensioFrameworkExtraBundle' => array(
+                        'name' => 'AppBundle',
+                        'path' => '/Users/fabien/project/vendor/sensio/framework-extra-bundle',
+                        'version' => 'v3.0.10',
                     ),
-                    "SensioGeneratorBundle" => array(
-                        "name" => "AppBundle",
-                        "path" => "/Users/fabien/project/vendor/sensio/generator-bundle/Sensio/Bundle/GeneratorBundle",
-                        "version" => "v2.5.3",
+                    'SensioGeneratorBundle' => array(
+                        'name' => 'AppBundle',
+                        'path' => '/Users/fabien/project/vendor/sensio/generator-bundle/Sensio/Bundle/GeneratorBundle',
+                        'version' => 'v2.5.3',
                     ),
-                )
-            )
+                ),
+            ),
         );
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Now that I'm upgrading some apps to Symfony 2.8, sometimes I need to know the exact version installed for some bundles. I think that the web profiler is the right place to show that information.

This feature is also useful to provide support for bundles' users because it's common to ask them: "which version of the bundle are you using?"
### Before

![before](https://cloud.githubusercontent.com/assets/73419/10512204/0085fba8-733f-11e5-8352-ee53d350f8e1.png)
### After

![after](https://cloud.githubusercontent.com/assets/73419/10512206/033ec172-733f-11e5-8bac-53a36d1a1518.png)
