### PR TITLE
Fix the detection of the deprecated usage of the ValidationListener

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/EventListener/ValidationListener.php
+++ b/src/Symfony/Component/Form/Extension/Validator/EventListener/ValidationListener.php
@@ -46,7 +46,7 @@ class ValidationListener implements EventSubscriberInterface
             throw new \InvalidArgumentException('Validator must be instance of Symfony\Component\Validator\Validator\ValidatorInterface or Symfony\Component\Validator\ValidatorInterface');
         }
 
-        if ($validator instanceof LegacyValidatorInterface) {
+        if (!$validator instanceof ValidatorInterface) {
             @trigger_error('Passing an instance of Symfony\Component\Validator\ValidatorInterface as argument to the '.__METHOD__.' method is deprecated since version 2.8 and will be removed in 3.0. Use an implementation of Symfony\Component\Validator\Validator\ValidatorInterface instead', E_USER_DEPRECATED);
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16248 |
| License | MIT |
| Doc PR | n/a |

the deprecation trigger should be triggered only when the valdiator does not implement the new interface. but implementing both the old and new interface is fine (and this is what is done in Symfony by default, as we provide a BC layer)
