### PR TITLE
[Validator] Allow an empty path in a URL with only a fragment or a query

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/UrlValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UrlValidator.php
@@ -33,7 +33,7 @@ class UrlValidator extends ConstraintValidator
                 \]  # a IPv6 address
             )
             (:[0-9]+)?                              # a port (optional)
-            (/?|/\S+)                               # a /, nothing or a / with something
+            (/?|/\S+|\?|\#)                         # a /, nothing, a / with something, a query or a fragment
         $~ixu';
 
     /**

--- a/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
@@ -111,6 +111,8 @@ class UrlValidatorTest extends AbstractConstraintValidatorTest
             array('http://☎.com/'),
             array('http://username:password@symfony.com'),
             array('http://user-name@symfony.com'),
+            array('http://symfony.com?'),
+            array('http://symfony.com#'),
         );
     }
 
@@ -140,8 +142,6 @@ class UrlValidatorTest extends AbstractConstraintValidatorTest
             array('http://goog_le.com'),
             array('http://google.com::aa'),
             array('http://google.com:aa'),
-            array('http://symfony.com?'),
-            array('http://symfony.com#'),
             array('ftp://google.fr'),
             array('faked://google.fr'),
             array('http://127.0.0.1:aa/'),


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15891 |
| License | MIT |
| Doc PR | - |

URLs like `http://symfony.com?query=1` or `http://symfony.com#` should be valid.

According to the [RFC3986](https://tools.ietf.org/html/rfc3986#page-16):

> When authority is present, the path must either be empty or begin with a slash ("/") character.
> When authority is not present, the path cannot begin with two slash characters ("//").

Since the RFC describes URIs, the second sentence doesn't apply here as the authority is required in URLs .
