### PR TITLE
[FrameworkBundle] Add a new ClassCache cache warmer

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ClassCacheCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ClassCacheCacheWarmer.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\CacheWarmer;
+
+use Symfony\Component\ClassLoader\ClassCollectionLoader;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+
+/**
+ * Generates the Class Cache (classes.php) file.
+ *
+ * @author Tugdual Saunier <tucksaun@gmail.com>
+ */
+class ClassCacheCacheWarmer implements CacheWarmerInterface
+{
+    /**
+     * Warms up the cache.
+     *
+     * @param string $cacheDir The cache directory
+     */
+    public function warmUp($cacheDir)
+    {
+        $classmap = $cacheDir.'/classes.map';
+
+        if (!is_file($classmap)) {
+            return;
+        }
+
+        ClassCollectionLoader::load(include($classmap), $cacheDir, 'classes', false);
+    }
+
+    /**
+     * Checks whether this warmer is optional or not.
+     *
+     * @return bool always true
+     */
+    public function isOptional()
+    {
+        return true;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -34,6 +34,10 @@
             <argument type="collection" />
         </service>
 
+        <service id="kernel.class_cache.cache_warmer" class="Symfony\Bundle\FrameworkBundle\CacheWarmer\ClassCacheCacheWarmer">
+            <tag name="kernel.cache_warmer" />
+        </service>
+
         <service id="cache_clearer" class="%cache_clearer.class%">
             <argument type="collection" />
         </service>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This new cache warmer allows to remove the known slowness of the first hit of a Symfony application (even when cache has been warmed up). This also allows to make a Symfony application runnable on a read-only filesystem (like in a Docker container for example)
