### PR TITLE
Fixed dumpArray when passing an empty array

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
@@ -15,7 +15,7 @@ services:
         properties: { foo: bar, moo: '@foo.baz', qux: { '%foo%': 'foo is %foo%', foobar: '%foo%' } }
         calls:
             - [setBar, ['@bar']]
-            - [initialize, {  }]
+            - [initialize, []]
 
         configurator: sc_configure
     bar:

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
-        "symfony/yaml": "~2.1",
+        "symfony/yaml": "~2.3",
         "symfony/config": "~2.2"
     },
     "suggest": {

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -156,9 +156,14 @@ class Inline
      */
     private static function dumpArray($value, $exceptionOnInvalidType, $objectSupport)
     {
-        // array
         $keys = array_keys($value);
         $keysCount = count($keys);
+
+        if (0 === $keysCount) {
+            return '[]';
+        }
+
+        // sequence   
         if ((1 === $keysCount && '0' == $keys[0])
             || ($keysCount > 1 && array_reduce($keys, function ($v, $w) { return (int) $v + $w; }, 0) === $keysCount * ($keysCount - 1) / 2)
         ) {

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -57,7 +57,7 @@ class DumperTest extends \PHPUnit_Framework_TestCase
         $expected = <<<EOF
 '': bar
 foo: '#bar'
-'foo''bar': {  }
+'foo''bar': []
 bar:
        - 1
        - foo
@@ -102,28 +102,38 @@ EOF;
         }
     }
 
-    public function testInlineLevel()
+    /**
+     * @dataProvider getInlineLevelTests
+     */
+    public function testInlineLevel($expected, $levels)
     {
-        $expected = <<<EOF
-{ '': bar, foo: '#bar', 'foo''bar': {  }, bar: [1, foo], foobar: { foo: bar, bar: [1, foo], foobar: { foo: bar, bar: [1, foo] } } }
-EOF;
-        $this->assertEquals($expected, $this->dumper->dump($this->array, -10), '->dump() takes an inline level argument');
-        $this->assertEquals($expected, $this->dumper->dump($this->array, 0), '->dump() takes an inline level argument');
+        $levels = (array) $levels;
 
-        $expected = <<<EOF
+        foreach ($levels as $level) {
+            $this->assertEquals($expected, $this->dumper->dump($this->array, $level), '->dump() takes an inline level argument');
+        }
+    }
+
+    public function getInlineLevelTests()
+    {
+        return array(
+            array(<<<EOF
+{ '': bar, foo: '#bar', 'foo''bar': [], bar: [1, foo], foobar: { foo: bar, bar: [1, foo], foobar: { foo: bar, bar: [1, foo] } } }
+EOF
+            , array(-10, 0)),
+            array(<<<EOF
 '': bar
 foo: '#bar'
-'foo''bar': {  }
+'foo''bar': []
 bar: [1, foo]
 foobar: { foo: bar, bar: [1, foo], foobar: { foo: bar, bar: [1, foo] } }
 
-EOF;
-        $this->assertEquals($expected, $this->dumper->dump($this->array, 1), '->dump() takes an inline level argument');
-
-        $expected = <<<EOF
+EOF
+            , 1),
+            array(<<<EOF
 '': bar
 foo: '#bar'
-'foo''bar': {  }
+'foo''bar': []
 bar:
     - 1
     - foo
@@ -132,13 +142,12 @@ foobar:
     bar: [1, foo]
     foobar: { foo: bar, bar: [1, foo] }
 
-EOF;
-        $this->assertEquals($expected, $this->dumper->dump($this->array, 2), '->dump() takes an inline level argument');
-
-        $expected = <<<EOF
+EOF
+            , 2),
+            array(<<<EOF
 '': bar
 foo: '#bar'
-'foo''bar': {  }
+'foo''bar': []
 bar:
     - 1
     - foo
@@ -151,13 +160,12 @@ foobar:
         foo: bar
         bar: [1, foo]
 
-EOF;
-        $this->assertEquals($expected, $this->dumper->dump($this->array, 3), '->dump() takes an inline level argument');
-
-        $expected = <<<EOF
+EOF
+            , 3),
+            array(<<<EOF
 '': bar
 foo: '#bar'
-'foo''bar': {  }
+'foo''bar': []
 bar:
     - 1
     - foo
@@ -172,9 +180,9 @@ foobar:
             - 1
             - foo
 
-EOF;
-        $this->assertEquals($expected, $this->dumper->dump($this->array, 4), '->dump() takes an inline level argument');
-        $this->assertEquals($expected, $this->dumper->dump($this->array, 10), '->dump() takes an inline level argument');
+EOF
+            , array(4, 10)),
+        );
     }
 
     public function testObjectSupportEnabled()

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -278,6 +278,7 @@ class InlineTest extends \PHPUnit_Framework_TestCase
             "'off'" => 'off',
 
             // sequences
+            '[]' => array(),
             '[foo, bar, false, null, 12]' => array('foo', 'bar', false, null, 12),
             '[\'foo,bar\', \'foo bar\']' => array('foo,bar', 'foo bar'),
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16266 |
| License | MIT |
| Doc PR | - |
