### PR TITLE
[TwigBundle] added a Twig templates warmer when templating is disabled

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/TemplateFinder.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/TemplateFinder.php
@@ -45,7 +45,7 @@ class TemplateFinder implements TemplateFinderInterface
     /**
      * Find all the templates in the bundle and in the kernel Resources folder.
      *
-     * @return array An array of templates of type TemplateReferenceInterface
+     * @return TemplateReferenceInterface[]
      */
     public function findAllTemplates()
     {
@@ -69,7 +69,7 @@ class TemplateFinder implements TemplateFinderInterface
      *
      * @param string $dir The folder where to look for templates
      *
-     * @return array An array of templates of type TemplateReferenceInterface
+     * @return TemplateReferenceInterface[]
      */
     private function findTemplatesInFolder($dir)
     {
@@ -93,7 +93,7 @@ class TemplateFinder implements TemplateFinderInterface
      *
      * @param BundleInterface $bundle The bundle where to look for templates
      *
-     * @return array An array of templates of type TemplateReferenceInterface
+     * @return TemplateReferenceInterface[]
      */
     private function findTemplatesInBundle(BundleInterface $bundle)
     {

--- a/src/Symfony/Bundle/TwigBundle/CacheWarmer/TemplateCacheWarmer.php
+++ b/src/Symfony/Bundle/TwigBundle/CacheWarmer/TemplateCacheWarmer.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\TwigBundle\CacheWarmer;
+
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+
+/**
+ * Generates the Twig cache for all templates.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class TemplateCacheWarmer implements CacheWarmerInterface
+{
+    private $twig;
+    private $iterator;
+
+    public function __construct(\Twig_Environment $twig, \Traversable $iterator)
+    {
+        $this->twig = $twig;
+        $this->iterator = $iterator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function warmUp($cacheDir)
+    {
+        foreach ($this->iterator as $template) {
+            try {
+                $this->twig->loadTemplate($template);
+            } catch (\Twig_Error $e) {
+                // problem during compilation, give up
+                // might be a syntax error or a non-Twig template
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isOptional()
+    {
+        return true;
+    }
+}

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -78,6 +78,7 @@ class TwigExtension extends Extension
         }
 
         $container->getDefinition('twig.cache_warmer')->replaceArgument(2, $config['paths']);
+        $container->getDefinition('twig.template_iterator')->replaceArgument(2, $config['paths']);
 
         // register bundles as Twig namespaces
         foreach ($container->getParameter('kernel.bundles') as $bundle => $class) {

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -52,6 +52,18 @@
             <argument type="collection" /> <!-- Twig paths -->
         </service>
 
+        <service id="twig.template_iterator" class="Symfony\Bundle\TwigBundle\TemplateIterator" public="false">
+            <argument type="service" id="kernel" />
+            <argument>%kernel.root_dir%</argument>
+            <argument type="collection" /> <!-- Twig paths -->
+        </service>
+
+        <service id="twig.template_cache_warmer" class="Symfony\Bundle\TwigBundle\CacheWarmer\TemplateCacheWarmer" public="false">
+            <tag name="kernel.cache_warmer" />
+            <argument type="service" id="twig" />
+            <argument type="service" id="twig.template_iterator" />
+        </service>
+
         <service id="twig.loader.native_filesystem" class="Twig_Loader_Filesystem" public="false">
             <argument type="collection" />
         </service>

--- a/src/Symfony/Bundle/TwigBundle/TemplateIterator.php
+++ b/src/Symfony/Bundle/TwigBundle/TemplateIterator.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\TwigBundle;
+
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Iterator for all templates in bundles and in the application Resources directory.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class TemplateIterator implements \IteratorAggregate
+{
+    private $kernel;
+    private $rootDir;
+    private $templates;
+    private $paths;
+
+    /**
+     * @param KernelInterface $kernel  A KernelInterface instance
+     * @param string          $rootDir The directory where global templates can be stored
+     * @param array           $paths   Additional Twig paths to warm
+     */
+    public function __construct(KernelInterface $kernel, $rootDir, array $paths = array())
+    {
+        $this->kernel = $kernel;
+        $this->rootDir = $rootDir;
+        $this->paths = $paths;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator()
+    {
+        if (null !== $this->templates) {
+            return $this->templates;
+        }
+
+        $this->templates = $this->findTemplatesInDirectory($this->rootDir.'/Resources/views');
+        foreach ($this->kernel->getBundles() as $bundle) {
+            $name = $bundle->getName();
+            if ('Bundle' === substr($name, -6)) {
+                $name = substr($name, 0, -6);
+            }
+
+            $this->templates = array_merge(
+                $this->templates,
+                $this->findTemplatesInDirectory($bundle->getPath().'/Resources/views', $name),
+                $this->findTemplatesInDirectory($this->rootDir.'/'.$bundle->getName().'/views', $name)
+            );
+        }
+
+        foreach ($this->paths as $dir => $namespace) {
+            $this->templates = array_merge($this->templates, $this->findTemplatesInDirectory($dir, $namespace));
+        }
+
+        return $this->templates = new \ArrayIterator(array_unique($this->templates));
+    }
+
+    /**
+     * Find templates in the given directory.
+     *
+     * @param string      $dir       The directory where to look for templates
+     * @param string|null $namespace The template namespace
+     *
+     * @return array
+     */
+    private function findTemplatesInDirectory($dir, $namespace = null)
+    {
+        if (!is_dir($dir)) {
+            return array();
+        }
+
+        $templates = array();
+        foreach (Finder::create()->files()->followLinks()->in($dir) as $file) {
+            $templates[] = (null !== $namespace ? '@'.$namespace.'/' : '').str_replace('\\', '/', $file->getRelativePathname());
+        }
+
+        return $templates;
+    }
+}

--- a/src/Symfony/Bundle/TwigBundle/Tests/Fixtures/templates/BarBundle/Resources/views/index.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Fixtures/templates/BarBundle/Resources/views/index.html.twig
@@ -1,0 +1,1 @@
+{# Twig template #}

--- a/src/Symfony/Bundle/TwigBundle/Tests/Fixtures/templates/Foo/index.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Fixtures/templates/Foo/index.html.twig
@@ -1,0 +1,1 @@
+{# Twig template #}

--- a/src/Symfony/Bundle/TwigBundle/Tests/Fixtures/templates/Resources/views/layout.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Fixtures/templates/Resources/views/layout.html.twig
@@ -1,0 +1,1 @@
+{# Twig template #}

--- a/src/Symfony/Bundle/TwigBundle/Tests/Fixtures/templates/Resources/views/sub/sub.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Fixtures/templates/Resources/views/sub/sub.html.twig
@@ -1,0 +1,1 @@
+{# Twig template #}

--- a/src/Symfony/Bundle/TwigBundle/Tests/TemplateIteratorTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/TemplateIteratorTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\TwigBundle\Tests;
+
+use Symfony\Bundle\TwigBundle\TemplateIterator;
+
+class TemplateIteratorTest extends TestCase
+{
+    public function testGetIterator()
+    {
+        $bundle = $this->getMock('Symfony\Component\HttpKernel\Bundle\BundleInterface');
+        $bundle->expects($this->any())->method('getName')->will($this->returnValue('BarBundle'));
+        $bundle->expects($this->any())->method('getPath')->will($this->returnValue(__DIR__.'/Fixtures/templates/BarBundle'));
+
+        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Kernel')->disableOriginalConstructor()->getMock();
+        $kernel->expects($this->any())->method('getBundles')->will($this->returnValue(array(
+            $bundle,
+        )));
+        $iterator = new TemplateIterator($kernel, __DIR__.'/Fixtures/templates', array(__DIR__.'/Fixtures/templates/Foo' => 'Foo'));
+
+        $sorted = iterator_to_array($iterator);
+        sort($sorted);
+        $this->assertEquals(
+            array(
+                '@Bar/index.html.twig',
+                '@Foo/index.html.twig',
+                'layout.html.twig',
+                'sub/sub.html.twig',
+            ),
+            $sorted
+        );
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

When disabling the templating component, Twig templates are not warmed up as the warmer depends on the template finder which needs the templating component. This PR adds a new cache warmer that covers this case.

see #16262
