### PR TITLE
Return default value if parameter does not exist

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -229,6 +229,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
     public function getInt($key, $default = 0, $deep = false)
     {
         $value = $this->get($key, $default, $deep);
+
         return $value === $default ? $value : (int) $value;
     }
 

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -228,7 +228,8 @@ class ParameterBag implements \IteratorAggregate, \Countable
      */
     public function getInt($key, $default = 0, $deep = false)
     {
-        return (int) $this->get($key, $default, $deep);
+        $value = $this->get($key, $default, $deep);
+        return $value === $default ? $value : (int) $value;
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets |  |
| Tests pass? | yes |
| License | MIT |
| Doc PR |  |

`public integer getInt(string $key, mixed $default, boolean $deep = false)`

Currently, getInt() returns the default value converted to an integer if parameter doesn't exist. With this patch, getInt() simply returns the default value (e.g. null) if parameter doesn't exist.
