### PR TITLE
[HttpKernel] Lookup the response even if the lock was released after two second wait

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -544,7 +544,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
                 $wait += 50000;
             }
 
-            if ($wait < 2000000) {
+            if ($wait < 5000000) {
                 // replace the current entry with the fresh one
                 $new = $this->lookup($request);
                 $entry->headers = $new->headers;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

While looking into #15813 I noticed that we [wait for the lock to be released for five seconds, but then only do a lookup if the lock was released in two seconds](https://github.com/symfony/symfony/blob/fa604d3c6f16f264863a42c200391ab996640296/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php#L540-L562), no more.

I think it's worth to make both values the same (so either two or five seconds). I see no reason why we should wait for the lock for five seconds, but then only do a lookup if we waited for two. One way the wait either takes too long, the other way we loose the opportunity to actually return a response.
