### PR TITLE
[Routing] use constants in tests

### DIFF
--- a/src/Symfony/Component/Routing/Tests/Generator/Dumper/PhpGeneratorDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/Dumper/PhpGeneratorDumperTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Routing\Tests\Generator\Dumper;
 
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\Generator\Dumper\PhpGeneratorDumper;
@@ -64,10 +65,10 @@ class PhpGeneratorDumperTest extends \PHPUnit_Framework_TestCase
 
         $projectUrlGenerator = new \ProjectUrlGenerator(new RequestContext('/app.php'));
 
-        $absoluteUrlWithParameter = $projectUrlGenerator->generate('Test', array('foo' => 'bar'), true);
-        $absoluteUrlWithoutParameter = $projectUrlGenerator->generate('Test2', array(), true);
-        $relativeUrlWithParameter = $projectUrlGenerator->generate('Test', array('foo' => 'bar'), false);
-        $relativeUrlWithoutParameter = $projectUrlGenerator->generate('Test2', array(), false);
+        $absoluteUrlWithParameter = $projectUrlGenerator->generate('Test', array('foo' => 'bar'), UrlGeneratorInterface::ABSOLUTE_URL);
+        $absoluteUrlWithoutParameter = $projectUrlGenerator->generate('Test2', array(), UrlGeneratorInterface::ABSOLUTE_URL);
+        $relativeUrlWithParameter = $projectUrlGenerator->generate('Test', array('foo' => 'bar'), UrlGeneratorInterface::ABSOLUTE_PATH);
+        $relativeUrlWithoutParameter = $projectUrlGenerator->generate('Test2', array(), UrlGeneratorInterface::ABSOLUTE_PATH);
 
         $this->assertEquals($absoluteUrlWithParameter, 'http://localhost/app.php/testing/bar');
         $this->assertEquals($absoluteUrlWithoutParameter, 'http://localhost/app.php/testing2');

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -22,7 +22,7 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testAbsoluteUrlWithPort80()
     {
         $routes = $this->getRoutes('test', new Route('/testing'));
-        $url = $this->getGenerator($routes)->generate('test', array(), true);
+        $url = $this->getGenerator($routes)->generate('test', array(), UrlGeneratorInterface::ABSOLUTE_URL);
 
         $this->assertEquals('http://localhost/app.php/testing', $url);
     }
@@ -30,7 +30,7 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testAbsoluteSecureUrlWithPort443()
     {
         $routes = $this->getRoutes('test', new Route('/testing'));
-        $url = $this->getGenerator($routes, array('scheme' => 'https'))->generate('test', array(), true);
+        $url = $this->getGenerator($routes, array('scheme' => 'https'))->generate('test', array(), UrlGeneratorInterface::ABSOLUTE_URL);
 
         $this->assertEquals('https://localhost/app.php/testing', $url);
     }
@@ -38,7 +38,7 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testAbsoluteUrlWithNonStandardPort()
     {
         $routes = $this->getRoutes('test', new Route('/testing'));
-        $url = $this->getGenerator($routes, array('httpPort' => 8080))->generate('test', array(), true);
+        $url = $this->getGenerator($routes, array('httpPort' => 8080))->generate('test', array(), UrlGeneratorInterface::ABSOLUTE_URL);
 
         $this->assertEquals('http://localhost:8080/app.php/testing', $url);
     }
@@ -46,7 +46,7 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testAbsoluteSecureUrlWithNonStandardPort()
     {
         $routes = $this->getRoutes('test', new Route('/testing'));
-        $url = $this->getGenerator($routes, array('httpsPort' => 8080, 'scheme' => 'https'))->generate('test', array(), true);
+        $url = $this->getGenerator($routes, array('httpsPort' => 8080, 'scheme' => 'https'))->generate('test', array(), UrlGeneratorInterface::ABSOLUTE_URL);
 
         $this->assertEquals('https://localhost:8080/app.php/testing', $url);
     }
@@ -54,7 +54,7 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testRelativeUrlWithoutParameters()
     {
         $routes = $this->getRoutes('test', new Route('/testing'));
-        $url = $this->getGenerator($routes)->generate('test', array(), false);
+        $url = $this->getGenerator($routes)->generate('test', array(), UrlGeneratorInterface::ABSOLUTE_PATH);
 
         $this->assertEquals('/app.php/testing', $url);
     }
@@ -62,7 +62,7 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testRelativeUrlWithParameter()
     {
         $routes = $this->getRoutes('test', new Route('/testing/{foo}'));
-        $url = $this->getGenerator($routes)->generate('test', array('foo' => 'bar'), false);
+        $url = $this->getGenerator($routes)->generate('test', array('foo' => 'bar'), UrlGeneratorInterface::ABSOLUTE_PATH);
 
         $this->assertEquals('/app.php/testing/bar', $url);
     }
@@ -70,7 +70,7 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testRelativeUrlWithNullParameter()
     {
         $routes = $this->getRoutes('test', new Route('/testing.{format}', array('format' => null)));
-        $url = $this->getGenerator($routes)->generate('test', array(), false);
+        $url = $this->getGenerator($routes)->generate('test', array(), UrlGeneratorInterface::ABSOLUTE_PATH);
 
         $this->assertEquals('/app.php/testing', $url);
     }
@@ -83,13 +83,13 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $routes = $this->getRoutes('test', new Route('/testing/{foo}/bar', array('foo' => null)));
         // This must raise an exception because the default requirement for "foo" is "[^/]+" which is not met with these params.
         // Generating path "/testing//bar" would be wrong as matching this route would fail.
-        $this->getGenerator($routes)->generate('test', array(), false);
+        $this->getGenerator($routes)->generate('test', array(), UrlGeneratorInterface::ABSOLUTE_PATH);
     }
 
     public function testRelativeUrlWithOptionalZeroParameter()
     {
         $routes = $this->getRoutes('test', new Route('/testing/{page}'));
-        $url = $this->getGenerator($routes)->generate('test', array('page' => 0), false);
+        $url = $this->getGenerator($routes)->generate('test', array('page' => 0), UrlGeneratorInterface::ABSOLUTE_PATH);
 
         $this->assertEquals('/app.php/testing/0', $url);
     }
@@ -104,7 +104,7 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testRelativeUrlWithExtraParameters()
     {
         $routes = $this->getRoutes('test', new Route('/testing'));
-        $url = $this->getGenerator($routes)->generate('test', array('foo' => 'bar'), false);
+        $url = $this->getGenerator($routes)->generate('test', array('foo' => 'bar'), UrlGeneratorInterface::ABSOLUTE_PATH);
 
         $this->assertEquals('/app.php/testing?foo=bar', $url);
     }
@@ -112,7 +112,7 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testAbsoluteUrlWithExtraParameters()
     {
         $routes = $this->getRoutes('test', new Route('/testing'));
-        $url = $this->getGenerator($routes)->generate('test', array('foo' => 'bar'), true);
+        $url = $this->getGenerator($routes)->generate('test', array('foo' => 'bar'), UrlGeneratorInterface::ABSOLUTE_URL);
 
         $this->assertEquals('http://localhost/app.php/testing?foo=bar', $url);
     }
@@ -120,7 +120,7 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testUrlWithNullExtraParameters()
     {
         $routes = $this->getRoutes('test', new Route('/testing'));
-        $url = $this->getGenerator($routes)->generate('test', array('foo' => null), true);
+        $url = $this->getGenerator($routes)->generate('test', array('foo' => null), UrlGeneratorInterface::ABSOLUTE_URL);
 
         $this->assertEquals('http://localhost/app.php/testing', $url);
     }
@@ -167,7 +167,7 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testGenerateWithoutRoutes()
     {
         $routes = $this->getRoutes('foo', new Route('/testing/{foo}'));
-        $this->getGenerator($routes)->generate('test', array(), true);
+        $this->getGenerator($routes)->generate('test', array(), UrlGeneratorInterface::ABSOLUTE_URL);
     }
 
     /**
@@ -176,7 +176,7 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testGenerateForRouteWithoutMandatoryParameter()
     {
         $routes = $this->getRoutes('test', new Route('/testing/{foo}'));
-        $this->getGenerator($routes)->generate('test', array(), true);
+        $this->getGenerator($routes)->generate('test', array(), UrlGeneratorInterface::ABSOLUTE_URL);
     }
 
     /**
@@ -185,7 +185,7 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testGenerateForRouteWithInvalidOptionalParameter()
     {
         $routes = $this->getRoutes('test', new Route('/testing/{foo}', array('foo' => '1'), array('foo' => 'd+')));
-        $this->getGenerator($routes)->generate('test', array('foo' => 'bar'), true);
+        $this->getGenerator($routes)->generate('test', array('foo' => 'bar'), UrlGeneratorInterface::ABSOLUTE_URL);
     }
 
     /**
@@ -194,7 +194,7 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testGenerateForRouteWithInvalidParameter()
     {
         $routes = $this->getRoutes('test', new Route('/testing/{foo}', array(), array('foo' => '1|2')));
-        $this->getGenerator($routes)->generate('test', array('foo' => '0'), true);
+        $this->getGenerator($routes)->generate('test', array('foo' => '0'), UrlGeneratorInterface::ABSOLUTE_URL);
     }
 
     public function testGenerateForRouteWithInvalidOptionalParameterNonStrict()
@@ -202,7 +202,7 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $routes = $this->getRoutes('test', new Route('/testing/{foo}', array('foo' => '1'), array('foo' => 'd+')));
         $generator = $this->getGenerator($routes);
         $generator->setStrictRequirements(false);
-        $this->assertNull($generator->generate('test', array('foo' => 'bar'), true));
+        $this->assertNull($generator->generate('test', array('foo' => 'bar'), UrlGeneratorInterface::ABSOLUTE_URL));
     }
 
     public function testGenerateForRouteWithInvalidOptionalParameterNonStrictWithLogger()
@@ -213,7 +213,7 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
             ->method('error');
         $generator = $this->getGenerator($routes, array(), $logger);
         $generator->setStrictRequirements(false);
-        $this->assertNull($generator->generate('test', array('foo' => 'bar'), true));
+        $this->assertNull($generator->generate('test', array('foo' => 'bar'), UrlGeneratorInterface::ABSOLUTE_URL));
     }
 
     public function testGenerateForRouteWithInvalidParameterButDisabledRequirementsCheck()
@@ -230,7 +230,7 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testGenerateForRouteWithInvalidMandatoryParameter()
     {
         $routes = $this->getRoutes('test', new Route('/testing/{foo}', array(), array('foo' => 'd+')));
-        $this->getGenerator($routes)->generate('test', array('foo' => 'bar'), true);
+        $this->getGenerator($routes)->generate('test', array('foo' => 'bar'), UrlGeneratorInterface::ABSOLUTE_URL);
     }
 
     /**
@@ -405,7 +405,7 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $routes = $this->getRoutes('test', new Route('/{name}', array(), array(), array(), '{locale}.example.com'));
 
-        $this->assertEquals('http://fr.example.com/app.php/Fabien', $this->getGenerator($routes, array('host' => 'fr.example.com'))->generate('test', array('name' => 'Fabien', 'locale' => 'fr'), true));
+        $this->assertEquals('http://fr.example.com/app.php/Fabien', $this->getGenerator($routes, array('host' => 'fr.example.com'))->generate('test', array('name' => 'Fabien', 'locale' => 'fr'), UrlGeneratorInterface::ABSOLUTE_URL));
     }
 
     /**
@@ -414,7 +414,7 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testUrlWithInvalidParameterInHost()
     {
         $routes = $this->getRoutes('test', new Route('/', array(), array('foo' => 'bar'), array(), '{foo}.example.com'));
-        $this->getGenerator($routes)->generate('test', array('foo' => 'baz'), false);
+        $this->getGenerator($routes)->generate('test', array('foo' => 'baz'), UrlGeneratorInterface::ABSOLUTE_PATH);
     }
 
     /**
@@ -423,7 +423,7 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testUrlWithInvalidParameterInHostWhenParamHasADefaultValue()
     {
         $routes = $this->getRoutes('test', new Route('/', array('foo' => 'bar'), array('foo' => 'bar'), array(), '{foo}.example.com'));
-        $this->getGenerator($routes)->generate('test', array('foo' => 'baz'), false);
+        $this->getGenerator($routes)->generate('test', array('foo' => 'baz'), UrlGeneratorInterface::ABSOLUTE_PATH);
     }
 
     /**
@@ -432,7 +432,7 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testUrlWithInvalidParameterEqualsDefaultValueInHost()
     {
         $routes = $this->getRoutes('test', new Route('/', array('foo' => 'baz'), array('foo' => 'bar'), array(), '{foo}.example.com'));
-        $this->getGenerator($routes)->generate('test', array('foo' => 'baz'), false);
+        $this->getGenerator($routes)->generate('test', array('foo' => 'baz'), UrlGeneratorInterface::ABSOLUTE_PATH);
     }
 
     public function testUrlWithInvalidParameterInHostInNonStrictMode()
@@ -440,7 +440,7 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $routes = $this->getRoutes('test', new Route('/', array(), array('foo' => 'bar'), array(), '{foo}.example.com'));
         $generator = $this->getGenerator($routes);
         $generator->setStrictRequirements(false);
-        $this->assertNull($generator->generate('test', array('foo' => 'baz'), false));
+        $this->assertNull($generator->generate('test', array('foo' => 'baz'), UrlGeneratorInterface::ABSOLUTE_PATH));
     }
 
     public function testHostIsCaseInsensitive()

--- a/src/Symfony/Component/Security/Tests/Http/HttpUtilsTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/HttpUtilsTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Security\Tests\Http;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Http\HttpUtils;
 
@@ -43,7 +44,7 @@ class HttpUtilsTest extends \PHPUnit_Framework_TestCase
         $urlGenerator
             ->expects($this->any())
             ->method('generate')
-            ->with('foobar', array(), true)
+            ->with('foobar', array(), UrlGeneratorInterface::ABSOLUTE_URL)
             ->will($this->returnValue('http://localhost/foo/bar'))
         ;
         $urlGenerator


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Use constants in tests instead of hardcoded values in preparation for #16276
