### PR TITLE
[HttpKernel] Make the behaviour of surrogate renderers consistent in all environments

### DIFF
--- a/src/Symfony/Component/HttpKernel/Fragment/AbstractSurrogateFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/AbstractSurrogateFragmentRenderer.php
@@ -64,6 +64,10 @@ abstract class AbstractSurrogateFragmentRenderer extends RoutableFragmentRendere
     public function render($uri, Request $request, array $options = array())
     {
         if (!$this->surrogate || !$this->surrogate->hasSurrogateCapability($request)) {
+            if ($uri instanceof ControllerReference) {
+                $this->checkNonScalar($uri->attributes);
+            }
+
             return $this->inlineStrategy->render($uri, $request, $options);
         }
 

--- a/src/Symfony/Component/HttpKernel/Fragment/RoutableFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/RoutableFragmentRenderer.php
@@ -77,7 +77,10 @@ abstract class RoutableFragmentRenderer implements FragmentRendererInterface
         return $request->getBaseUrl().$path;
     }
 
-    private function checkNonScalar($values)
+    /**
+     * @internal
+     */
+    protected function checkNonScalar(array $values)
     {
         foreach ($values as $key => $value) {
             if (is_array($value)) {

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/EsiFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/EsiFragmentRendererTest.php
@@ -90,6 +90,20 @@ class EsiFragmentRendererTest extends \PHPUnit_Framework_TestCase
         $strategy->render('/', $request, array('alt' => new ControllerReference('alt_controller')));
     }
 
+    /**
+     * @expectedException \LogicException
+     */
+    public function testRenderFallbackWithObjectAttributesThrowsException()
+    {
+        $strategy = new EsiFragmentRenderer(new Esi(), $this->getInlineStrategy(), new UriSigner('foo'));
+
+        $request = Request::create('/');
+
+        $reference = new ControllerReference('main_controller', array('foo' => new \stdClass()), array());
+
+        $strategy->render($reference, $request);
+    }
+
     private function getInlineStrategy($called = false)
     {
         $inline = $this->getMockBuilder('Symfony\Component\HttpKernel\Fragment\InlineFragmentRenderer')->disableOriginalConstructor()->getMock();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15056 |
| License | MIT |
| Doc PR | - |

Surrogate renderers cannot work with objects (rule introduced in #8437). As renderers should be interchangable, we should not allow passing objects to the fallback renderer either.
