### PR TITLE
[Yaml] deprecated usage of @ and ` at the beginning of an unquoted string

### DIFF
--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 2.8.0
 -----
 
+ * Deprecated usage of @ and ` at the beginning of an unquoted string
  * Deprecated non-escaped \ in double-quoted strings when parsing Yaml
    ("Foo\Var" is not valid whereas "Foo\\Var" is)
 

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -236,6 +236,14 @@ class Inline
                 throw new ParseException(sprintf('Malformed inline YAML string (%s).', $scalar));
             }
 
+            // a non-quoted string cannot start with @ or ` (reserved)
+            if ($output && ('@' === $output[0] || '`' === $output[0])) {
+                @trigger_error(sprintf('Not quoting a scalar starting with "%s" is deprecated since Symfony 2.8 and will throw a ParseException in 3.0.', $output[0]), E_USER_DEPRECATED);
+
+                // to be thrown in 3.0
+                // throw new ParseException(sprintf('The reserved indicator "%s" cannot start a plain scalar; you need to quote the scalar.', $output[0]));
+            }
+
             if ($evaluate) {
                 $output = self::evaluateScalar($output, $references);
             }

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -190,6 +190,21 @@ class InlineTest extends \PHPUnit_Framework_TestCase
         Inline::parse('{ foo: * #foo }');
     }
 
+    /**
+     * @group legacy
+     * @dataProvider getReservedIndicators
+     * throws \Symfony\Component\Yaml\Exception\ParseException in 3.0
+     */
+    public function testParseUnquotedScalarStartingWithReservedIndicator($indicator)
+    {
+        Inline::parse(sprintf('{ foo: %sfoo }', $indicator));
+    }
+
+    public function getReservedIndicators()
+    {
+        return array(array('@'), array('`'));
+    }
+
     public function getTestsForParse()
     {
         return array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #16234 |
| License | MIT |
| Doc PR | n/a |
