### PR TITLE
[HttpFoundation] Check Mongo effective connection before starting tests

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
@@ -34,6 +34,7 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
         $mongoClass = version_compare(phpversion('mongo'), '1.3.0', '<') ? 'Mongo' : 'MongoClient';
 
         $this->mongo = $this->getMockBuilder($mongoClass)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $this->options = array(
@@ -242,6 +243,7 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
     private function createMongoCollectionMock()
     {
         $mongoClient = $this->getMockBuilder('MongoClient')
+            ->disableOriginalConstructor()
             ->getMock();
         $mongoDb = $this->getMockBuilder('MongoDB')
             ->setConstructorArgs(array($mongoClient, 'database-name'))


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The test suite for `MongoDbSessionHandlerTest` is executed even if a connection can’t be established.
