### PR TITLE
[Process] Inherit env vars by default in PhpProcess

### DIFF
--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -334,8 +334,7 @@ abstract class Client
      */
     protected function doRequestInProcess($request)
     {
-        // We set the TMPDIR (for Macs) and TEMP (for Windows), because on these platforms the temp directory changes based on the user.
-        $process = new PhpProcess($this->getScript($request), null, array('TMPDIR' => sys_get_temp_dir(), 'TEMP' => sys_get_temp_dir()));
+        $process = new PhpProcess($this->getScript($request), null, null);
         $process->run();
 
         if (!$process->isSuccessful() || !preg_match('/^O\:\d+\:/', $process->getOutput())) {

--- a/src/Symfony/Component/BrowserKit/composer.json
+++ b/src/Symfony/Component/BrowserKit/composer.json
@@ -20,7 +20,7 @@
         "symfony/dom-crawler": "~2.0,>=2.0.5"
     },
     "require-dev": {
-        "symfony/process": "~2.0,>=2.0.5",
+        "symfony/process": "~2.3.34|~2.7,>=2.7.6",
         "symfony/css-selector": "~2.0,>=2.0.5"
     },
     "suggest": {

--- a/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
@@ -283,7 +283,7 @@ class ClassCollectionLoader
 
         $traits = array();
 
-        if (function_exists('get_declared_traits')) {
+        if (method_exists('ReflectionClass', 'getTraits')) {
             foreach ($classes as $c) {
                 foreach (self::resolveDependencies(self::computeTraitDeps($c), $c) as $trait) {
                     if ($trait !== $c) {

--- a/src/Symfony/Component/Process/PhpProcess.php
+++ b/src/Symfony/Component/Process/PhpProcess.php
@@ -27,13 +27,13 @@ class PhpProcess extends Process
     /**
      * Constructor.
      *
-     * @param string $script  The PHP script to run (as a string)
-     * @param string $cwd     The working directory
-     * @param array  $env     The environment variables
-     * @param int    $timeout The timeout in seconds
-     * @param array  $options An array of options for proc_open
+     * @param string      $script  The PHP script to run (as a string)
+     * @param string|null $cwd     The working directory or null to use the working dir of the current PHP process
+     * @param array|null  $env     The environment variables or null to use the same environment as the current PHP process
+     * @param int         $timeout The timeout in seconds
+     * @param array       $options An array of options for proc_open
      */
-    public function __construct($script, $cwd = null, array $env = array(), $timeout = 60, array $options = array())
+    public function __construct($script, $cwd = null, array $env = null, $timeout = 60, array $options = array())
     {
         $executableFinder = new PhpExecutableFinder();
         if (false === $php = $executableFinder->find()) {

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -121,7 +121,7 @@ class Process
      *
      * @param string         $commandline The command line to run
      * @param string|null    $cwd         The working directory or null to use the working dir of the current PHP process
-     * @param array|null     $env         The environment variables or null to inherit
+     * @param array|null     $env         The environment variables or null to use the same environment as the current PHP process
      * @param string|null    $stdin       The STDIN content
      * @param int|float|null $timeout     The timeout in seconds or null to disable
      * @param array          $options     An array of options for proc_open
@@ -851,7 +851,7 @@ class Process
 
         $this->env = array();
         foreach ($env as $key => $value) {
-            $this->env[(binary) $key] = (binary) $value;
+            $this->env[$key] = (string) $value;
         }
 
         return $this;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This is the cause of our failures on Windows, where the SYSTEMROOT env var is mandatory for mcrypt_create_iv to work.
I don't know why the browserkit client is run with no env inheritance and this looks like a bug.
Same for PhpProcess emptying the env by default, this looks like a bug, esp. since the parent `Process` class defaults to inheriting the env.
Tests are not broken by this change.
