### PR TITLE
[VarDumper] Fix return type and anonymous classes dumping

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/Caster.php
+++ b/src/Symfony/Component/VarDumper/Caster/Caster.php
@@ -54,6 +54,8 @@ class Caster
             foreach ($p as $i => $k) {
                 if (!isset($k[0]) || ("\0" !== $k[0] && !$reflector->hasProperty($k))) {
                     $p[$i] = self::PREFIX_DYNAMIC.$k;
+                } elseif (isset($k[16]) && "\0" === $k[16] && 0 === strpos($k, "\0class@anonymous\0")) {
+                    $p[$i] = "\0anonymous-".$reflector->name.strrchr($k, "\0");
                 }
             }
             $a = array_combine($p, $a);

--- a/src/Symfony/Component/VarDumper/Caster/ReflectionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ReflectionCaster.php
@@ -114,6 +114,9 @@ class ReflectionCaster
             'this' => 'getClosureThis',
         ));
 
+        if (isset($a[$prefix.'returnType'])) {
+            $a[$prefix.'returnType'] = (string) $a[$prefix.'returnType'];
+        }
         if (isset($a[$prefix.'this'])) {
             $a[$prefix.'this'] = new CutStub($a[$prefix.'this']);
         }

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -208,9 +208,12 @@ abstract class AbstractCloner implements ClonerInterface
         $obj = $stub->value;
         $class = $stub->class;
 
+        if (isset($class[15]) && "\0" === $class[15] && 0 === strpos($class, "class@anonymous\x00")) {
+            $class = get_parent_class($class);
+            $stub->class = 'anonymous-'.$class;
+        }
         if (isset($this->classInfo[$class])) {
             $classInfo = $this->classInfo[$class];
-            $stub->class = $classInfo[0];
         } else {
             $classInfo = array(
                 $class,

--- a/src/Symfony/Component/VarDumper/Tests/Caster/CasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/CasterTest.php
@@ -12,11 +12,12 @@
 namespace Symfony\Component\VarDumper\Tests\Caster;
 
 use Symfony\Component\VarDumper\Caster\Caster;
+use Symfony\Component\VarDumper\Test\VarDumperTestCase;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class CasterTest extends \PHPUnit_Framework_TestCase
+class CasterTest extends VarDumperTestCase
 {
     private $referenceArray = array(
         'null' => null,
@@ -28,7 +29,9 @@ class CasterTest extends \PHPUnit_Framework_TestCase
         "\0Foo\0private" => 'priv',
     );
 
-    /** @dataProvider provideFilter */
+    /**
+     * @dataProvider provideFilter
+     */
     public function testFilter($filter, $expectedDiff, $listedProperties = null)
     {
         if (null === $listedProperties) {
@@ -142,6 +145,23 @@ class CasterTest extends \PHPUnit_Framework_TestCase
                 ),
                 array('public', 'empty'),
             ),
+        );
+    }
+
+    /**
+     * @requires PHP 7.0
+     */
+    public function testAnonymousClass()
+    {
+        $c = eval('return new class extends stdClass { private $foo = "foo"; };');
+
+        $this->assertDumpMatchesFormat(
+            <<<'EOTXT'
+anonymous-stdClass {
+  -foo: "foo"
+}
+EOTXT
+            , $c
         );
     }
 }

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
@@ -60,4 +60,25 @@ EOTXT
             , $var
         );
     }
+
+    /**
+     * @requires PHP 7.0
+     */
+    public function testReturnType()
+    {
+        $f = eval('return function ():int {};');
+
+        $this->assertDumpMatchesFormat(
+            <<<'EOTXT'
+Closure {
+  returnType: "int"
+  class: "Symfony\Component\VarDumper\Tests\Caster\ReflectionCasterTest"
+  this: Symfony\Component\VarDumper\Tests\Caster\ReflectionCasterTest { …}
+  file: "%sReflectionCasterTest.php(69) : eval()'d code"
+  line: "1 to 1"
+}
+EOTXT
+            , $f
+        );
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

I missed that `getReturnType` returns a `ReflectionType` instance that should be casted to string.
