### PR TITLE
[DoctrineBridge] Fix issue which prevent the profiler to explain a query 

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
+++ b/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
@@ -117,6 +117,9 @@ class DoctrineDataCollector extends DataCollector
     private function sanitizeQuery($connectionName, $query)
     {
         $query['explainable'] = true;
+        if (null === $query['params']) {
+            $query['params'] = array();
+        }
         if (!is_array($query['params'])) {
             $query['params'] = array($query['params']);
         }

--- a/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
@@ -79,9 +79,9 @@ class DoctrineDataCollectorTest extends \PHPUnit_Framework_TestCase
         $c = $this->createCollector($queries);
         $c->collect(new Request(), new Response());
 
-        $collected_queries = $c->getQueries();
-        $this->assertEquals($expected, $collected_queries['default'][0]['params'][0]);
-        $this->assertEquals($explainable, $collected_queries['default'][0]['explainable']);
+        $collectedQueries = $c->getQueries();
+        $this->assertEquals($expected, $collectedQueries['default'][0]['params'][0]);
+        $this->assertEquals($explainable, $collectedQueries['default'][0]['explainable']);
     }
 
     public function testCollectQueryWithNoParams()
@@ -93,11 +93,11 @@ class DoctrineDataCollectorTest extends \PHPUnit_Framework_TestCase
         $c = $this->createCollector($queries);
         $c->collect(new Request(), new Response());
 
-        $collected_queries = $c->getQueries();
-        $this->assertEquals(array(), $collected_queries['default'][0]['params']);
-        $this->assertTrue($collected_queries['default'][0]['explainable']);
-        $this->assertEquals(array(), $collected_queries['default'][1]['params']);
-        $this->assertTrue($collected_queries['default'][1]['explainable']);
+        $collectedQueries = $c->getQueries();
+        $this->assertEquals(array(), $collectedQueries['default'][0]['params']);
+        $this->assertTrue($collectedQueries['default'][0]['explainable']);
+        $this->assertEquals(array(), $collectedQueries['default'][1]['params']);
+        $this->assertTrue($collectedQueries['default'][1]['explainable']);
     }
 
     /**
@@ -112,9 +112,9 @@ class DoctrineDataCollectorTest extends \PHPUnit_Framework_TestCase
         $c->collect(new Request(), new Response());
         $c = unserialize(serialize($c));
 
-        $collected_queries = $c->getQueries();
-        $this->assertEquals($expected, $collected_queries['default'][0]['params'][0]);
-        $this->assertEquals($explainable, $collected_queries['default'][0]['explainable']);
+        $collectedQueries = $c->getQueries();
+        $this->assertEquals($expected, $collectedQueries['default'][0]['params'][0]);
+        $this->assertEquals($explainable, $collectedQueries['default'][0]['explainable']);
     }
 
     public function paramProvider()

--- a/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
@@ -84,6 +84,22 @@ class DoctrineDataCollectorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($explainable, $collected_queries['default'][0]['explainable']);
     }
 
+    public function testCollectQueryWithNoParams()
+    {
+        $queries = array(
+            array('sql' => 'SELECT * FROM table1', 'params' => array(), 'types' => array(), 'executionMS' => 1),
+            array('sql' => 'SELECT * FROM table1', 'params' => null, 'types' => null, 'executionMS' => 1),
+        );
+        $c = $this->createCollector($queries);
+        $c->collect(new Request(), new Response());
+
+        $collected_queries = $c->getQueries();
+        $this->assertEquals(array(), $collected_queries['default'][0]['params']);
+        $this->assertTrue($collected_queries['default'][0]['explainable']);
+        $this->assertEquals(array(), $collected_queries['default'][1]['params']);
+        $this->assertTrue($collected_queries['default'][1]['explainable']);
+    }
+
     /**
      * @dataProvider paramProvider
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

We currently develop a application which only use the doctrine/dbal and not the orm. And we run into a issue that the profiler can't explained any query.
This is because the `SQLLogger` will pass `null` instead of an empty array. And the `sanitizeQuery` method will currently transform this to `array(null)` which leads to an error.

I created an fork, so everyone can reproduce this.
https://github.com/Baachi/symfony-standard
