### PR TITLE
leave cache-control no-cache as is

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
@@ -290,8 +290,8 @@ class ResponseHeaderBag extends HeaderBag
         }
 
         $header = $this->getCacheControlHeader();
-        // private, if s-maxage is not defined, public/private is not set, and this is not "no-cache"
-        if (!isset($this->cacheControl['s-maxage']) && !isset($this->cacheControl['public']) && !isset($this->cacheControl['private']) && !isset($this->cacheControl['no-cache'])) {
+        // private, if public/private is not set, and this is not "no-cache", and s-maxage is not defined,
+        if (!isset($this->cacheControl['public']) && !isset($this->cacheControl['private']) && !isset($this->cacheControl['no-cache']) && !isset($this->cacheControl['s-maxage'])) {
             return $header.', private';
         }
 

--- a/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
@@ -290,12 +290,8 @@ class ResponseHeaderBag extends HeaderBag
         }
 
         $header = $this->getCacheControlHeader();
-        if (isset($this->cacheControl['public']) || isset($this->cacheControl['private'])) {
-            return $header;
-        }
-
-        // public if s-maxage is defined, private otherwise
-        if (!isset($this->cacheControl['s-maxage'])) {
+        // private, if s-maxage is not defined, public/private is not set, and this is not "no-cache"
+        if (!isset($this->cacheControl['s-maxage']) && !isset($this->cacheControl['public']) && !isset($this->cacheControl['private']) && !isset($this->cacheControl['no-cache'])) {
             return $header.', private';
         }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
@@ -38,6 +38,10 @@ class ResponseHeaderBagTest extends \PHPUnit_Framework_TestCase
                 array('fOo' => array('BAR'), 'Cache-Control' => array('no-cache')),
             ),
             array(
+                array('fOo' => 'BAR', 'Cache-Control' => array('no-cache')),
+                array('fOo' => array('BAR'), 'Cache-Control' => array('no-cache')),
+            ),
+            array(
                 array('ETag' => 'xyzzy'),
                 array('ETag' => array('xyzzy'), 'Cache-Control' => array('private, must-revalidate')),
             ),
@@ -142,6 +146,15 @@ class ResponseHeaderBagTest extends \PHPUnit_Framework_TestCase
         $bag->replace(array('Cache-Control' => 'public'));
         $this->assertEquals('public', $bag->get('Cache-Control'));
         $this->assertTrue($bag->hasCacheControlDirective('public'));
+
+        $bag = new ResponseHeaderBag(array('Etag' => 'aaaa'));
+        $this->assertEquals('private, must-revalidate', $bag->get('Cache-Control'));
+        $this->assertTrue($bag->hasCacheControlDirective('private'));
+        $this->assertTrue($bag->hasCacheControlDirective('must-revalidate'));
+
+        $bag->replace(array());
+        $this->assertEquals('no-cache', $bag->get('Cache-Control'));
+        $this->assertTrue($bag->hasCacheControlDirective('no-cache'));
     }
 
     public function testReplaceWithRemove()

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
@@ -274,6 +274,14 @@ class ResponseHeaderBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('text/html'), $allHeaders['Content-type']);
     }
 
+    public function testEquality()
+    {
+        $headers = new ResponseHeaderBag();
+        $anotherHeaders = new ResponseHeaderBag($headers->allPreserveCase());
+
+        $this->assertEquals($headers->allPreserveCase(), $anotherHeaders->allPreserveCase());
+    }
+
     public function provideMakeDisposition()
     {
         return array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16171 |
| License | MIT |
| Doc PR |  |

Fix, that do not add "private" for "no-cache" in ResponseHeaderBag. By default there is "no-cache" returned, and that mean we must follow same logic (avoid add "private") when "no-cache" present.
