### PR TITLE
[Form] remove type check in FormRegistry::getType

### DIFF
--- a/src/Symfony/Component/Form/FormRegistry.php
+++ b/src/Symfony/Component/Form/FormRegistry.php
@@ -69,10 +69,6 @@ class FormRegistry implements FormRegistryInterface
      */
     public function getType($name)
     {
-        if (!is_string($name)) {
-            throw new UnexpectedTypeException($name, 'string');
-        }
-
         if (!isset($this->types[$name])) {
             $type = null;
 

--- a/src/Symfony/Component/Form/FormRegistryInterface.php
+++ b/src/Symfony/Component/Form/FormRegistryInterface.php
@@ -27,7 +27,6 @@ interface FormRegistryInterface
      *
      * @return ResolvedFormTypeInterface The type
      *
-     * @throws Exception\UnexpectedTypeException  if the passed name is not a string
      * @throws Exception\InvalidArgumentException if the type can not be retrieved from any extension
      */
     public function getType($name);

--- a/src/Symfony/Component/Form/Tests/FormRegistryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormRegistryTest.php
@@ -173,31 +173,11 @@ class FormRegistryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\Form\Exception\UnexpectedTypeException
-     */
-    public function testGetTypeThrowsExceptionIfParentNotFound()
-    {
-        $type = new FooSubType();
-
-        $this->extension1->addType($type);
-
-        $this->registry->getType($type);
-    }
-
-    /**
      * @expectedException \Symfony\Component\Form\Exception\InvalidArgumentException
      */
     public function testGetTypeThrowsExceptionIfTypeNotFound()
     {
         $this->registry->getType('bar');
-    }
-
-    /**
-     * @expectedException \Symfony\Component\Form\Exception\UnexpectedTypeException
-     */
-    public function testGetTypeThrowsExceptionIfNoString()
-    {
-        $this->registry->getType(array());
     }
 
     public function testHasTypeAfterLoadingFromExtension()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes (consistency) |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

remove validation of `FormRegistry::getType` as `FormRegistry::hasType` does not validate either. So `hasType` currently triggers a PHP warning with a wrong argument.
also developers do not work with the registry directly anyway but through the factory. and the factory already validates the value. So this validation is useless in reality.
