### PR TITLE
Remove dead code in the PropertyPath constructor

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyPath.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPath.php
@@ -37,13 +37,6 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
     private $elements = array();
 
     /**
-     * The singular forms of the elements in the property path.
-     *
-     * @var array
-     */
-    private $singulars = array();
-
-    /**
      * The number of elements in the property path.
      *
      * @var int
@@ -79,7 +72,6 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
         if ($propertyPath instanceof self) {
             /* @var PropertyPath $propertyPath */
             $this->elements = $propertyPath->elements;
-            $this->singulars = $propertyPath->singulars;
             $this->length = $propertyPath->length;
             $this->isIndex = $propertyPath->isIndex;
             $this->pathAsString = $propertyPath->pathAsString;
@@ -110,16 +102,7 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
                 $this->isIndex[] = true;
             }
 
-            $pos = false;
-            $singular = null;
-
-            if (false !== $pos) {
-                $singular = substr($element, $pos + 1);
-                $element = substr($element, 0, $pos);
-            }
-
             $this->elements[] = $element;
-            $this->singulars[] = $singular;
 
             $position += strlen($matches[1]);
             $remaining = $matches[4];
@@ -168,7 +151,6 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
         --$parent->length;
         $parent->pathAsString = substr($parent->pathAsString, 0, max(strrpos($parent->pathAsString, '.'), strrpos($parent->pathAsString, '[')));
         array_pop($parent->elements);
-        array_pop($parent->singulars);
         array_pop($parent->isIndex);
 
         return $parent;

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTest.php
@@ -46,21 +46,6 @@ class PropertyAccessorCollectionTest_Car
     }
 }
 
-class PropertyAccessorCollectionTest_CarCustomSingular
-{
-    public function addFoo($axis)
-    {
-    }
-
-    public function removeFoo($axis)
-    {
-    }
-
-    public function getAxes()
-    {
-    }
-}
-
 class PropertyAccessorCollectionTest_Engine
 {
 }
@@ -235,30 +220,6 @@ abstract class PropertyAccessorCollectionTest extends \PHPUnit_Framework_TestCas
             ->with('third');
 
         $this->propertyAccessor->setValue($car, 'structure.axes', $axesAfter);
-    }
-
-    public function testSetValueCallsCustomAdderAndRemover()
-    {
-        $this->markTestSkipped('This feature is temporarily disabled as of 2.1');
-
-        $car = $this->getMock(__CLASS__.'_CarCustomSingular');
-        $axesBefore = $this->getCollection(array(1 => 'second', 3 => 'fourth'));
-        $axesAfter = $this->getCollection(array(0 => 'first', 1 => 'second', 2 => 'third'));
-
-        $car->expects($this->at(0))
-            ->method('getAxes')
-            ->will($this->returnValue($axesBefore));
-        $car->expects($this->at(1))
-            ->method('removeFoo')
-            ->with('fourth');
-        $car->expects($this->at(2))
-            ->method('addFoo')
-            ->with('first');
-        $car->expects($this->at(3))
-            ->method('addFoo')
-            ->with('third');
-
-        $this->propertyAccessor->setValue($car, 'axes|foo', $axesAfter);
     }
 
     /**

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -112,15 +112,6 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(array('Bernhard'), $object->firstName);
     }
 
-    public function testGetValueIgnoresSingular()
-    {
-        $this->markTestSkipped('This feature is temporarily disabled as of 2.1');
-
-        $object = (object) array('children' => 'Many');
-
-        $this->assertEquals('Many', $this->propertyAccessor->getValue($object, 'children|child'));
-    }
-
     public function testGetValueReadsPropertyWithSpecialCharsExceptDot()
     {
         $array = (object) array('%!@$§' => 'Bernhard');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Custom singulars have been removed from the component before merging it in Symfony, but the code parsing them was only removed partially.
