### PR TITLE
[HttpKernel] clearstatcache() so the Cache sees when a .lck file has been released

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -106,7 +106,9 @@ class Store implements StoreInterface
 
     public function isLocked(Request $request)
     {
-        return is_file($this->getPath($this->getCacheKey($request).'.lck'));
+        $path = $this->getPath($this->getCacheKey($request).'.lck');
+        clearstatcache($path);
+        return is_file($path);
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -107,7 +107,7 @@ class Store implements StoreInterface
     public function isLocked(Request $request)
     {
         $path = $this->getPath($this->getCacheKey($request).'.lck');
-        clearstatcache($path);
+        clearstatcache(true, $path);
 
         return is_file($path);
     }

--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -108,6 +108,7 @@ class Store implements StoreInterface
     {
         $path = $this->getPath($this->getCacheKey($request).'.lck');
         clearstatcache($path);
+        
         return is_file($path);
     }
 

--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -108,7 +108,7 @@ class Store implements StoreInterface
     {
         $path = $this->getPath($this->getCacheKey($request).'.lck');
         clearstatcache($path);
-        
+
         return is_file($path);
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15813 |
| License | MIT |
| Doc PR | n/a |

I've been trying to debug #15813 and modified the Store in a way to keep unique request IDs in the .lck file. That way, I was hoping to find out which request is blocking and/or if the request is actually still running.

It turned out that `is_file()` would claim that a lock file still exists, but a subsequent attempt to read the information from that file returned "file not found" errors.

So, my assumption is that the `is_file()` result is based on the fstat cache and wrong once a process has seen the lock file.

@jakzal said in https://github.com/symfony/symfony/issues/15813#issuecomment-149013691 that `unlink()`ing the lock file should clear the statcache, but I doubt this is true across PHP processes.
