### PR TITLE
[FrameworkBundle] Fix ClassCacheWarme when classes.php is already warmed

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ClassCacheCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ClassCacheCacheWarmer.php
@@ -34,6 +34,10 @@ class ClassCacheCacheWarmer implements CacheWarmerInterface
             return;
         }
 
+        if (file_exists($cacheDir.'/classes.php')) {
+            return;
+        }
+
         ClassCollectionLoader::load(include($classmap), $cacheDir, 'classes', false);
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Autoreloading was previously set to `false`, but actually we want to force it.
This could even lead to a fatal error when warming where it was already warmed as the previous `classes.php` is directly required.
