### PR TITLE
Fix the FrameworkBundle dependencies

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": ">=5.3.9",
         "symfony/asset": "~2.7|~3.0.0",
+        "symfony/class-loader": "~2.1|~3.0.0",
         "symfony/dependency-injection": "~2.8",
         "symfony/config": "~2.8",
         "symfony/event-dispatcher": "~2.8|~3.0.0",
@@ -42,7 +43,6 @@
         "symfony/intl": "~2.3|~3.0.0",
         "symfony/security": "~2.6|~3.0.0",
         "symfony/form": "~2.8",
-        "symfony/class-loader": "~2.1|~3.0.0",
         "symfony/expression-language": "~2.6|~3.0.0",
         "symfony/process": "~2.0,>=2.0.5|~3.0.0",
         "symfony/validator": "~2.5|~3.0.0",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Due to the new ClassCacheCacheWarmer, the ClassLoader component is now a
required dependency of the bundle.

See the current test failures for component builds (TwigBundle and SecurityBundle tests are triggering fatal errors because of the missing class)
