### PR TITLE
[travis] Reduce composer.json merge conflicts on per-components tests

### DIFF
--- a/.travis.php
+++ b/.travis.php
@@ -19,13 +19,15 @@ foreach ($dirs as $dir) {
     }
     echo "$dir\n";
 
-    $package = json_decode(file_get_contents($dir.'/composer.json'));
+    $json = file_get_contents($dir.'/composer.json');
+    $package = json_decode($json);
 
     $package->repositories = array(array(
         'type' => 'composer',
         'url' => 'file://'.__DIR__.'/',
     ));
-    file_put_contents($dir.'/composer.json', json_encode($package, $flags));
+    $json = rtrim(json_encode(array('repositories' => $package->repositories), $flags), "\n}").','.substr($json, 1);
+    file_put_contents($dir.'/composer.json', $json);
     passthru("cd $dir && tar -cf package.tar --exclude='package.tar' *");
 
     $package->version = $branch.'.x-dev';


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

json_decoding then re-encoding doesn't preserve the exact structure and leads to merge conflicts when testing deps=2.8. Simpler by-replace injection works better here. This fixes the issue happening on master right now.
