### PR TITLE
[Routing] mark internal classes

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/Dumper/DumperCollection.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/DumperCollection.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Routing\Matcher\Dumper;
  * Collection of routes.
  *
  * @author Arnaud Le Blanc <arnaud.lb@gmail.com>
+ *
+ * @internal
  */
 class DumperCollection implements \IteratorAggregate
 {

--- a/src/Symfony/Component/Routing/Matcher/Dumper/DumperPrefixCollection.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/DumperPrefixCollection.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Routing\Matcher\Dumper;
  * Prefix tree of routes preserving routes order.
  *
  * @author Arnaud Le Blanc <arnaud.lb@gmail.com>
+ *
+ * @internal
  */
 class DumperPrefixCollection extends DumperCollection
 {

--- a/src/Symfony/Component/Routing/Matcher/Dumper/DumperRoute.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/DumperRoute.php
@@ -17,6 +17,8 @@ use Symfony\Component\Routing\Route;
  * Container for a Route.
  *
  * @author Arnaud Le Blanc <arnaud.lb@gmail.com>
+ *
+ * @internal
  */
 class DumperRoute
 {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

These classes are an implementation detail of the PhpMatcherDumper that should not be relied upon.
