### PR TITLE
fixed Twig deprecation notices

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.3",
         "doctrine/common": "~2.4",
-        "twig/twig": "~1.20|~2.0",
+        "twig/twig": "~1.23|~2.0",
         "psr/log": "~1.0"
     },
     "replace": {

--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -21,7 +21,7 @@ use Symfony\Component\Form\Extension\Core\View\ChoiceView;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class FormExtension extends \Twig_Extension
+class FormExtension extends \Twig_Extension implements \Twig_Extension_InitRuntimeInterface
 {
     /**
      * This property is public so that it can be accessed directly from compiled

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "twig/twig": "~1.20|~2.0"
+        "twig/twig": "~1.23|~2.0"
     },
     "require-dev": {
         "symfony/finder": "~2.3",

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -34,7 +34,7 @@
         "symfony/process": "~2.0,>=2.0.5",
         "symfony/validator": "~2.2",
         "symfony/yaml": "~2.0,>=2.0.5",
-        "twig/twig": "~1.20|~2.0"
+        "twig/twig": "~1.23|~2.0"
     },
     "autoload": {
         "psr-0": { "Symfony\\Bundle\\SecurityBundle\\": "" }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

To avoid deprecation notices when upgrading to Twig 1.23.
