### PR TITLE
[WebProfilerBundle] Filter links in search results

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -207,6 +207,7 @@ class ProfilerController
         }
 
         return new Response($this->twig->render('@WebProfiler/Profiler/toolbar.html.twig', array(
+            'request' => $request,
             'position' => $position,
             'profile' => $profile,
             'templates' => $this->getTemplateManager()->getTemplates($profile),
@@ -242,13 +243,13 @@ class ProfilerController
             $limit =
             $token = null;
         } else {
-            $ip = $session->get('_profiler_search_ip');
-            $method = $session->get('_profiler_search_method');
-            $url = $session->get('_profiler_search_url');
-            $start = $session->get('_profiler_search_start');
-            $end = $session->get('_profiler_search_end');
-            $limit = $session->get('_profiler_search_limit');
-            $token = $session->get('_profiler_search_token');
+            $ip = $request->query->get('ip', $session->get('_profiler_search_ip'));
+            $method = $request->query->get('method', $session->get('_profiler_search_method'));
+            $url = $request->query->get('url', $session->get('_profiler_search_url'));
+            $start = $request->query->get('start', $session->get('_profiler_search_start'));
+            $end = $request->query->get('end', $session->get('_profiler_search_end'));
+            $limit = $request->query->get('limit', $session->get('_profiler_search_limit'));
+            $token = $request->query->get('token', $session->get('_profiler_search_token'));
         }
 
         return new Response(
@@ -295,6 +296,7 @@ class ProfilerController
         $limit = $request->query->get('limit');
 
         return new Response($this->twig->render('@WebProfiler/Profiler/results.html.twig', array(
+            'request' => $request,
             'token' => $token,
             'profile' => $profile,
             'tokens' => $this->profiler->find($ip, $url, $limit, $method, $start, $end),
@@ -351,6 +353,7 @@ class ProfilerController
         $tokens = $this->profiler->find($ip, $url, $limit, $method, $start, $end);
 
         return new RedirectResponse($this->generator->generate('_profiler_search_results', array(
+            'request' => $request,
             'token' => $tokens ? $tokens[0]['token'] : 'empty',
             'ip' => $ip,
             'method' => $method,

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
@@ -64,7 +64,7 @@
                             {{ include('@WebProfiler/Icon/search.svg') }} <span class="hidden-small">Search</span>
                         </a>
 
-                        {{ render(path('_profiler_search_bar')) }}
+                        {{ render(path('_profiler_search_bar', request.query.all)) }}
                     </div>
                 </div>
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -365,6 +365,32 @@ tr.status-warning td {
 .highlight .number    { color: #F5871F; font-weight: bold; }
 .highlight .error     { color: #C82829; }
 
+{# Icons
+   ========================================================================= #}
+.sf-icon {
+    vertical-align: middle;
+    background-repeat: no-repeat;
+    background-size: contain;
+    width: 16px;
+    height: 16px;
+    display: inline-block;
+}
+.sf-icon svg {
+    width: 16px;
+    height: 16px;
+}
+.sf-icon.sf-medium,
+.sf-icon.sf-medium svg {
+    width: 24px;
+    height: 24px;
+}
+.sf-icon.sf-large,
+.sf-icon.sf-large svg {
+    width: 32px;
+    height: 32px;
+}
+
+
 {# Layout
    ========================================================================= #}
 .container {
@@ -847,6 +873,14 @@ table.logs .metadata strong {
 #search-results td {
     {{ mixins.sans_serif_font|raw }}
     vertical-align: middle;
+}
+
+#search-results .sf-search {
+    visibility: hidden;
+    margin-left: 2px;
+}
+#search-results tr:hover .sf-search {
+    visibility: visible;
 }
 
 {# Small screens

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/results.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/results.html.twig
@@ -31,9 +31,30 @@
                         <td class="text-center">
                             <span class="label {{ css_class }}">{{ result.status_code|default('n/a') }}</span>
                         </td>
-                        <td class="nowrap">{{ result.ip }}</td>
-                        <td>{{ result.method }}</td>
-                        <td class="break-long-words">{{ result.url }}</td>
+                        <td>
+                            <span class="nowrap">{{ result.ip }}</span>
+                            {% if request.session is not null %}
+                                <a href="{{ path('_profiler_search_results', request.query.all|merge({'ip': result.ip, 'token': result.token})) }}" title="Search">
+                                    <span title="Search" class="sf-icon sf-search">{{ include('@WebProfiler/Icon/search.svg') }}</span>
+                                </a>
+                            {% endif %}
+                        </td>
+                        <td>
+                            {{ result.method }}
+                            {% if request.session is not null %}
+                                <a href="{{ path('_profiler_search_results', request.query.all|merge({'method': result.method, 'token': result.token})) }}" title="Search">
+                                    <span title="Search" class="sf-icon sf-search">{{ include('@WebProfiler/Icon/search.svg') }}</span>
+                                </a>
+                            {% endif %}
+                        </td>
+                        <td class="break-long-words">
+                            {{ result.url }}
+                            {% if request.session is not null %}
+                                <a href="{{ path('_profiler_search_results', request.query.all|merge({'url': result.url, 'token': result.token})) }}" title="Search">
+                                    <span title="Search" class="sf-icon sf-search">{{ include('@WebProfiler/Icon/search.svg') }}</span>
+                                </a>
+                            {% endif %}
+                        </td>
                         <td class="text-small">
                             <span class="nowrap">{{ result.time|date('d-M-Y') }}</span>
                             <span class="nowrap newline">{{ result.time|date('H:i:s') }}</span>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14110 |
| License | MIT |
| Doc PR |  |

Quite often I find myself copy/pasting the results from the search results in the profiler search form. Adding links for this allows developers to narrow down to the proper profiler result fast.
