### PR TITLE
Unique entity custom message

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -470,4 +470,67 @@ class UniqueEntityValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate($entity, $constraint);
     }
+
+    public function testCustomMessageWithOneUniqueField()
+    {
+        $constraint = new UniqueEntity(array(
+            'message' => 'An entity with name "{{ name }}" already exists.',
+            'fields' => array('name'),
+            'em' => self::EM_NAME,
+        ));
+
+        $entity1 = new SingleIntIdEntity(1, 'Foo');
+        $entity2 = new SingleIntIdEntity(2, 'Foo');
+
+        $this->validator->validate($entity1, $constraint);
+
+        $this->assertNoViolation();
+
+        $this->em->persist($entity1);
+        $this->em->flush();
+
+        $this->validator->validate($entity1, $constraint);
+
+        $this->assertNoViolation();
+
+        $this->validator->validate($entity2, $constraint);
+
+        $this->buildViolation('An entity with name "{{ name }}" already exists.')
+            ->setParameters(array('{{ name }}' => 'Foo'))
+            ->atPath('property.path.name')
+            ->setInvalidValue('Foo')
+            ->assertRaised();
+    }
+
+    public function testCustomMessageWithTwoUniqueFields()
+    {
+        $constraint = new UniqueEntity(array(
+            'message' => 'An entity with name1 "{{ name }}" and name2 "{{ name2 }}" already exists.',
+            'fields' => array('name', 'name2'),
+            'em' => self::EM_NAME,
+            'errorPath' => 'name2',
+        ));
+
+        $entity1 = new DoubleNameEntity(1, 'Foo', 'Bar');
+        $entity2 = new DoubleNameEntity(2, 'Foo', 'Bar');
+
+        $this->validator->validate($entity1, $constraint);
+
+        $this->assertNoViolation();
+
+        $this->em->persist($entity1);
+        $this->em->flush();
+
+        $this->validator->validate($entity1, $constraint);
+
+        $this->assertNoViolation();
+
+        $this->validator->validate($entity2, $constraint);
+
+        $this->buildViolation('An entity with name1 "{{ name }}" and name2 "{{ name2 }}" already exists.')
+            ->setParameters(array('{{ name }}' => 'Foo', '{{ name2 }}' => 'Bar'))
+            ->atPath('property.path.name2')
+            ->setInvalidValue('Bar')
+            ->assertRaised();
+    }
 }

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -41,7 +41,8 @@
         "symfony/property-info": "",
         "doctrine/data-fixtures": "",
         "doctrine/dbal": "",
-        "doctrine/orm": ""
+        "doctrine/orm": "",
+        "symfony/property-access": ""
     },
     "autoload": {
         "psr-4": { "Symfony\\Bridge\\Doctrine\\": "" },


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Add the possibility to have custom message for unique entity constraint.
For example if we have a collection of entities in a form, the message can be more expressive.

Example:

``` php
/**
 * Town
 *
 * @ORM\Entity()
 * @UniqueEntity(fields={"city"}, message="The city '{{ city }}' is already used.")
 */
class Town
{
```

Reopen PR #15201 based now on branch 2.8
