### PR TITLE
[Routing][WIP] Deprecate UrlMatcher and implement PSR-7 support

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -895,6 +895,11 @@ class Request
         return $this->pathInfo;
     }
 
+    public function setPathInfo($pathInfo)
+    {
+        $this->pathInfo = $pathInfo;
+    }
+
     /**
      * Returns the root path from which this request is executed.
      *

--- a/src/Symfony/Component/Routing/CompiledRoute.php
+++ b/src/Symfony/Component/Routing/CompiledRoute.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Routing;
 
 /**
- * CompiledRoutes are returned by the RouteCompiler class.
+ * A CompiledRoute is the compiled version of a Route that has the regular expression computed for matching against the path/host.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */

--- a/src/Symfony/Component/Routing/Exception/MethodNotAllowedException.php
+++ b/src/Symfony/Component/Routing/Exception/MethodNotAllowedException.php
@@ -21,11 +21,11 @@ namespace Symfony\Component\Routing\Exception;
 class MethodNotAllowedException extends \RuntimeException implements ExceptionInterface
 {
     /**
-     * @var array
+     * @var string[]
      */
-    protected $allowedMethods = array();
+    private $allowedMethods = array();
 
-    public function __construct(array $allowedMethods, $message = null, $code = 0, \Exception $previous = null)
+    public function __construct(array $allowedMethods, $message = '', $code = 0, \Exception $previous = null)
     {
         $this->allowedMethods = array_map('strtoupper', $allowedMethods);
 
@@ -35,7 +35,7 @@ class MethodNotAllowedException extends \RuntimeException implements ExceptionIn
     /**
      * Gets the allowed HTTP methods.
      *
-     * @return array
+     * @return string[]
      */
     public function getAllowedMethods()
     {

--- a/src/Symfony/Component/Routing/Exception/SchemeNotAllowedException.php
+++ b/src/Symfony/Component/Routing/Exception/SchemeNotAllowedException.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Exception;
+
+/**
+ * The resource was not found because the URI scheme is not allowed.
+ *
+ * This exception should trigger an HTTP 404 response or a redirect to the correct scheme in your application code.
+ *
+ * @author Tobias Schultze <http://tobion.de>
+ */
+class SchemeNotAllowedException extends ResourceNotFoundException
+{
+    /**
+     * @var string[]
+     */
+    private $allowedSchemes = array();
+
+    public function __construct(array $allowedSchemes, $message = '', $code = 0, \Exception $previous = null)
+    {
+        $this->allowedSchemes = array_map('strtolower', $allowedSchemes);
+
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * Gets the allowed URI schemes.
+     *
+     * @return string[]
+     */
+    public function getAllowedSchemes()
+    {
+        return $this->allowedSchemes;
+    }
+}

--- a/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
+++ b/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
@@ -41,7 +41,7 @@ class PhpGeneratorDumper extends GeneratorDumper
         return <<<EOF
 <?php
 
-use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Psr\Log\LoggerInterface;
 
@@ -58,10 +58,9 @@ class {$options['class']} extends {$options['base_class']}
     /**
      * Constructor.
      */
-    public function __construct(RequestContext \$context, LoggerInterface \$logger = null)
+    public function __construct(\$baseUri = 'http://localhost/', LoggerInterface \$logger = null, \$httpPort = 80, \$httpsPort = 443)
     {
-        \$this->context = \$context;
-        \$this->logger = \$logger;
+        parent::__construct(new RouteCollection(), \$baseUri, \$logger, \$httpPort, \$httpsPort);
     }
 
 {$this->generateGenerateMethod()}

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -168,7 +168,9 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
     }
 
     /**
-     * Sets a parameter value.
+     * Sets a parameter value that will be used for placeholders by default.
+     *
+     * This placeholder parameter will be used if none has not been provided explicitly in the generate() method.
      *
      * @param string           $name  A parameter name
      * @param string|int|float $value The parameter value
@@ -181,10 +183,12 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
     /**
      * {@inheritdoc}
      *
-     * @deprecated since version 2.8, to be removed in 3.0. Use setBaseUri, setScriptName instead.
+     * @deprecated since version 2.8, to be removed in 3.0. Use setBaseUri and setScriptName instead.
      */
     public function setContext(RequestContext $context)
     {
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.8 and will be removed in 3.0. Use setBaseUri and setScriptName instead.', E_USER_DEPRECATED);
+
         $this->context = $context;
 
         $this->scheme = $this->context->getScheme();
@@ -203,6 +207,12 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
      */
     public function getContext()
     {
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.8 and will be removed in 3.0.', E_USER_DEPRECATED);
+
+        if (null === $this->context) {
+            $this->context = new RequestContext();
+        }
+
         return $this->context;
     }
 

--- a/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
@@ -26,6 +26,9 @@ use Symfony\Component\Routing\RequestContextAwareInterface;
  * less technical. Generating URIs, i.e. representation-independent resource identifiers,
  * is also possible.
  *
+ * In Symfony 3.0 the methods UrlGenerator::setBaseUri, UrlGenerator::setScriptName, UrlGenerator::setDefaultParameter
+ * will be added to the interface.
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Tobias Schultze <http://tobion.de>
  */

--- a/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
@@ -17,7 +17,7 @@ use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Routing\RequestContextAwareInterface;
 
 /**
- * UrlGeneratorInterface is the interface that all URL generator classes must implement.
+ * UrlGeneratorInterface describes a class that is able to generate a URL reference for a named route.
  *
  * The constants in this interface define the different types of resource references that
  * are declared in RFC 3986: http://tools.ietf.org/html/rfc3986

--- a/src/Symfony/Component/Routing/Matcher/PsrRequestMatcherInterface.php
+++ b/src/Symfony/Component/Routing/Matcher/PsrRequestMatcherInterface.php
@@ -11,28 +11,28 @@
 
 namespace Symfony\Component\Routing\Matcher;
 
-use Symfony\Component\HttpFoundation\Request;
+use Psr\Http\Message\RequestInterface;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 
 /**
- * Routing matcher interface to find route parameters based on a Symfony HttpFoundation Request.
+ * Routing matcher interface to find route parameters based on a PSR-7 RequestInterface.
  *
- * @author Fabien Potencier <fabien@symfony.com>
+ * @author Tobias Schultze <http://tobion.de>
  */
-interface RequestMatcherInterface
+interface PsrRequestMatcherInterface
 {
     /**
      * Returns the routing parameters of the route that matches the given request.
      *
      * If no route matches, one of the exceptions documented below must be thrown.
      *
-     * @param Request $request The request to match against
+     * @param RequestInterface $request The request to match against
      *
      * @return array An array of parameters
      *
      * @throws ResourceNotFoundException If no matching resource could be found
      * @throws MethodNotAllowedException If a matching resource was found but the request method is not allowed
      */
-    public function matchRequest(Request $request);
+    public function matchPsrRequest(RequestInterface $request);
 }

--- a/src/Symfony/Component/Routing/Matcher/RedirectableRequestMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/RedirectableRequestMatcher.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Matcher;
+
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @author Tobias Schultze <http://tobion.de>
+ */
+abstract class RedirectableRequestMatcher extends RequestMatcher
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function matchRequest(Request $request)
+    {
+        try {
+            $parameters = parent::matchRequest($request);
+        } catch (ResourceNotFoundException $e) {
+            $newScheme = 'http' === $request->getScheme() ? 'https' : 'http';
+            $newRequest = clone $request;
+            // TODO: This is not available. Another idea is to have a specialized ResourceNotFoundException
+            //$newRequest->setScheme($newScheme);
+
+            try {
+                parent::matchRequest($newRequest);
+
+                return $this->redirect($request->getPathInfo(), null, $newScheme);
+            } catch (ResourceNotFoundException $e2) {
+                throw $e;
+            }
+
+            if ('/' === substr($request->getPathInfo(), -1) || !in_array($request->getMethod(), array('HEAD', 'GET'))) {
+                throw $e;
+            }
+
+            $newRequest = clone $request;
+            $newRequest->setPathInfo($request->getPathInfo().'/');
+
+            try {
+                parent::matchRequest($newRequest);
+
+                return $this->redirect($newRequest->getPathInfo(), null);
+            } catch (ResourceNotFoundException $e2) {
+                // TODO: MethodNotAllowedException is not handled
+                throw $e;
+            }
+        }
+
+        return $parameters;
+    }
+
+    /**
+     * Returns parameters for handling a redirect.
+     *
+     * @param string      $path   The path info to redirect to.
+     * @param string      $route  The route name that matched
+     * @param string|null $scheme The URL scheme (null to keep the current one)
+     *
+     * @return array An array of parameters
+     */
+    abstract protected function redirect($path, $route, $scheme = null);
+}

--- a/src/Symfony/Component/Routing/Matcher/RedirectableUrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/RedirectableUrlMatcher.php
@@ -11,11 +11,16 @@
 
 namespace Symfony\Component\Routing\Matcher;
 
+@trigger_error('The '.__NAMESPACE__.'\RedirectableUrlMatcher class is deprecated since version 2.8 and will be removed in 3.0. Extend RedirectableRequestMatcher instead.', E_USER_DEPRECATED);
+
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\Route;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since version 2.8, to be removed in 3.0.
+ *             Extend {@link Symfony\Component\Routing\Matcher\RedirectableRequestMatcher} instead.
  */
 abstract class RedirectableUrlMatcher extends UrlMatcher implements RedirectableUrlMatcherInterface
 {

--- a/src/Symfony/Component/Routing/Matcher/RedirectableUrlMatcherInterface.php
+++ b/src/Symfony/Component/Routing/Matcher/RedirectableUrlMatcherInterface.php
@@ -11,10 +11,15 @@
 
 namespace Symfony\Component\Routing\Matcher;
 
+@trigger_error('The '.__NAMESPACE__.'\RedirectableUrlMatcherInterface is deprecated since version 2.8 and will be removed in 3.0. Extend RedirectableRequestMatcher instead.', E_USER_DEPRECATED);
+
 /**
  * RedirectableUrlMatcherInterface knows how to redirect the user.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since version 2.8, to be removed in 3.0.
+ *             Extend {@link Symfony\Component\Routing\Matcher\RedirectableRequestMatcher} instead.
  */
 interface RedirectableUrlMatcherInterface
 {

--- a/src/Symfony/Component/Routing/Matcher/RequestMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/RequestMatcher.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Routing\Matcher;
 
+use Psr\Http\Message\RequestInterface;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\Exception\SchemeNotAllowedException;
@@ -25,7 +26,7 @@ use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
  *
  * @author Tobias Schultze <http://tobion.de>
  */
-class RequestMatcher implements RequestMatcherInterface
+class RequestMatcher implements RequestMatcherInterface, PsrRequestMatcherInterface
 {
     /**
      * @var string[]
@@ -90,6 +91,14 @@ class RequestMatcher implements RequestMatcherInterface
         }
 
         throw new ResourceNotFoundException(sprintf('No route found for request "%s %s".', $request->getMethod(), $request->getPathInfo()));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function matchPsrRequest(RequestInterface $request)
+    {
+        // TODO
     }
 
     public function addExpressionLanguageProvider(ExpressionFunctionProviderInterface $provider)

--- a/src/Symfony/Component/Routing/Matcher/RequestMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/RequestMatcher.php
@@ -1,0 +1,189 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Matcher;
+
+use Symfony\Component\Routing\Exception\MethodNotAllowedException;
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+
+/**
+ * RequestMatcher tries to find a route that matches the request.
+ *
+ * @author Tobias Schultze <http://tobion.de>
+ */
+class RequestMatcher implements RequestMatcherInterface
+{
+    /**
+     * @var array
+     */
+    private $allow = array();
+
+    /**
+     * @var RouteCollection
+     */
+    private $routes;
+
+    private $expressionLanguage;
+
+    /**
+     * @var ExpressionFunctionProviderInterface[]
+     */
+    private $expressionLanguageProviders = array();
+
+    /**
+     * Constructor.
+     *
+     * @param RouteCollection $routes  A RouteCollection instance
+     */
+    public function __construct(RouteCollection $routes)
+    {
+        $this->routes = $routes;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function matchRequest(Request $request)
+    {
+        $this->allow = array();
+
+        if ($ret = $this->matchCollection($request, $this->routes)) {
+            return $ret;
+        }
+
+        throw $this->allow
+            ? new MethodNotAllowedException(array_unique($this->allow))
+            : new ResourceNotFoundException(sprintf('No routes found for request "%s %s".', $request->getMethod(), $request->getPathInfo()));
+    }
+
+    public function addExpressionLanguageProvider(ExpressionFunctionProviderInterface $provider)
+    {
+        $this->expressionLanguageProviders[] = $provider;
+    }
+
+    /**
+     * Tries to match a request with a set of routes.
+     *
+     * @param Request         $request The request
+     * @param RouteCollection $routes  The set of routes
+     *
+     * @return array|null An array of parameters for the matched route or null if none matched
+     *
+     * @throws ResourceNotFoundException If the resource could not be found
+     * @throws MethodNotAllowedException If the resource was found but the request method is not allowed
+     */
+    private function matchCollection(Request $request, RouteCollection $routes)
+    {
+        $path = rawurldecode($request->getPathInfo());
+        $host = $request->getHost();
+        $scheme = $request->getScheme();
+
+        foreach ($routes->all() as $name => $route) {
+            $compiledRoute = $route->compile();
+
+            // Check the static prefix of the path first. Only use the more expensive preg_match when the static prefix is the same.
+            if ('' !== $compiledRoute->getStaticPrefix() && 0 !== strpos($path, $compiledRoute->getStaticPrefix())) {
+                continue;
+            }
+
+            $pathMatches = array();
+            if (!preg_match($compiledRoute->getRegex(), $path, $pathMatches)) {
+                continue;
+            }
+
+            $hostMatches = array();
+            if ($compiledRoute->getHostRegex() && !preg_match($compiledRoute->getHostRegex(), $host, $hostMatches)) {
+                continue;
+            }
+
+            if ($requiredMethods = $route->getMethods()) {
+                // HEAD and GET are equivalent as per RFC
+                if ('HEAD' === $method = $request->getMethod()) {
+                    $method = 'GET';
+                }
+
+                if (!in_array($method, $requiredMethods)) {
+                    $this->allow = array_merge($this->allow, $requiredMethods);
+
+                    continue;
+                }
+            }
+
+            if ($route->getSchemes() && !in_array($scheme, $route->getSchemes())) {
+                continue;
+            }
+
+            if ($route->getCondition() && !$this->getExpressionLanguage()->evaluate($route->getCondition(), array('request' => $request))) {
+                continue;
+            }
+
+            return $this->getAttributes($route, $name, array_replace($pathMatches, $hostMatches));
+        }
+    }
+
+    /**
+     * Returns an array of values to use as request attributes.
+     *
+     * As this method requires the Route object, it is not available
+     * in matchers that do not have access to the matched Route instance
+     * (like the PHP and Apache matcher dumpers).
+     *
+     * @param Route  $route      The route we are matching against
+     * @param string $name       The name of the route
+     * @param array  $attributes An array of attributes from the matcher
+     *
+     * @return array An array of parameters
+     */
+    protected function getAttributes(Route $route, $name, array $attributes)
+    {
+        $attributes['_route'] = $name;
+
+        return $this->mergeDefaults($attributes, $route->getDefaults());
+    }
+
+    /**
+     * Get merged default parameters.
+     *
+     * @param array $params   The parameters
+     * @param array $defaults The defaults
+     *
+     * @return array Merged default parameters
+     */
+    private function mergeDefaults($params, $defaults)
+    {
+        foreach ($params as $key => $value) {
+            if (!is_int($key)) {
+                $defaults[$key] = $value;
+            }
+        }
+
+        return $defaults;
+    }
+
+    private function getExpressionLanguage()
+    {
+        if (null === $this->expressionLanguage) {
+            if (!class_exists('Symfony\Component\ExpressionLanguage\ExpressionLanguage')) {
+                throw new \RuntimeException('Unable to use expressions as the Symfony ExpressionLanguage component is not installed.');
+            }
+
+            $this->expressionLanguage = new ExpressionLanguage(null, $this->expressionLanguageProviders);
+        }
+
+        return $this->expressionLanguage;
+    }
+}

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Routing\Matcher;
 
+@trigger_error('The '.__NAMESPACE__.'\UrlMatcher class is deprecated since version 2.8 and will be removed in 3.0. Use the RequestMatcher instead.', E_USER_DEPRECATED);
+
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\RouteCollection;
@@ -24,6 +26,9 @@ use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
  * UrlMatcher matches URL based on a set of routes.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since version 2.8, to be removed in 3.0.
+ *             Use {@link Symfony\Component\Routing\Matcher\RequestMatcher} instead.
  */
 class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
 {

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcherInterface.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcherInterface.php
@@ -19,6 +19,9 @@ use Symfony\Component\Routing\Exception\MethodNotAllowedException;
  * UrlMatcherInterface is the interface that all URL matcher classes must implement.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since version 2.8, to be removed in 3.0.
+ *             Use {@link Symfony\Component\Routing\Matcher\RequestMatcherInterface} instead.
  */
 interface UrlMatcherInterface extends RequestContextAwareInterface
 {

--- a/src/Symfony/Component/Routing/RequestContext.php
+++ b/src/Symfony/Component/Routing/RequestContext.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Routing;
 
+@trigger_error('The '.__NAMESPACE__.'\RequestContext class is deprecated since version 2.8 and will be removed in 3.0. Use Symfony\Component\Routing\Matcher\RequestMatcherInterface::matchRequest instead.', E_USER_DEPRECATED);
+
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -20,6 +22,9 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Tobias Schultze <http://tobion.de>
+ *
+ * @deprecated since version 2.8, to be removed in 3.0.
+ *             Use request matching via {@link Symfony\Component\Routing\Matcher\RequestMatcherInterface} instead.
  */
 class RequestContext
 {

--- a/src/Symfony/Component/Routing/RequestContextAwareInterface.php
+++ b/src/Symfony/Component/Routing/RequestContextAwareInterface.php
@@ -11,6 +11,10 @@
 
 namespace Symfony\Component\Routing;
 
+/**
+ * @deprecated since version 2.8, to be removed in 3.0.
+ *             Use {@link Symfony\Component\Routing\Matcher\RequestMatcherInterface::matchRequest} instead.
+ */
 interface RequestContextAwareInterface
 {
     /**

--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Routing;
 
 /**
- * A Route describes a route and its parameters.
+ * A route describes how a web resource is addressable and its parameters via path/host placeholders and defaults.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Tobias Schultze <http://tobion.de>

--- a/src/Symfony/Component/Routing/RouteCompilerInterface.php
+++ b/src/Symfony/Component/Routing/RouteCompilerInterface.php
@@ -12,14 +12,14 @@
 namespace Symfony\Component\Routing;
 
 /**
- * RouteCompilerInterface is the interface that all RouteCompiler classes must implement.
+ * Interface to compile Route instances to CompiledRoute instances.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
 interface RouteCompilerInterface
 {
     /**
-     * Compiles the current route instance.
+     * Compiles the given route instance.
      *
      * @param Route $route A Route instance
      *

--- a/src/Symfony/Component/Routing/RouterInterface.php
+++ b/src/Symfony/Component/Routing/RouterInterface.php
@@ -15,7 +15,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
 
 /**
- * RouterInterface is the interface that all Router classes must implement.
+ * RouterInterface describes an all-in-one package that can both match requests as well as generate URI references.
  *
  * This interface is the concatenation of UrlMatcherInterface and UrlGeneratorInterface.
  *

--- a/src/Symfony/Component/Routing/RouterInterface.php
+++ b/src/Symfony/Component/Routing/RouterInterface.php
@@ -19,6 +19,8 @@ use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
  *
  * This interface is the concatenation of UrlMatcherInterface and UrlGeneratorInterface.
  *
+ * In Symfony 3.0 it will be a concatenation of RequestMatcherInterface, PsrRequestMatcherInterface and UrlGeneratorInterface.
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  */
 interface RouterInterface extends UrlMatcherInterface, UrlGeneratorInterface

--- a/src/Symfony/Component/Routing/composer.json
+++ b/src/Symfony/Component/Routing/composer.json
@@ -2,13 +2,17 @@
     "name": "symfony/routing",
     "type": "library",
     "description": "Symfony Routing Component",
-    "keywords": ["routing", "router", "URL", "URI"],
+    "keywords": ["route", "router", "URL", "URI", "PSR-7", "request", "matching"],
     "homepage": "https://symfony.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Fabien Potencier",
             "email": "fabien@symfony.com"
+        },
+        {
+            "name": "Tobias Schultze",
+            "homepage": "http://tobion.de"
         },
         {
             "name": "Symfony Community",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | somewhat |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | YES |
| Tests pass? | yes |
| Fixed tickets | #9781 #14723 #8705 |
| License | MIT |
| Doc PR | - |

WIP trying to fix several architectural problems of routing component.
1. Get rid of `UrlMatcher::match($pathinfo)` and instead rely on `RequestMatcher::matchRequest`.
2. Add PSR-7 support via something like `PsrRequestMatcher::matchPsrRequest`. This has the added benefit, that the Routing component stays independent of HttpFoundation. Inside the symfony we framework we can just use `matchRequest` (so we don't have the overhead to transform a HttpFoundation request to PSR-7). People using the Routing component standalone can just use any PSR-7 implementation.
3. Due to 1) and 2) we would ideally not need the `RequestContext` at all anymore. The matcher has all the information it needs in the request itself. And the generator mainly needs the base URI only (string for symfony or UriInterface for PSR-7) in order to know how to construct relative references. But it doesn't need the full request info like the method which is irrelevant when generating links.

Todo:
- [ ] finish `matchPsrRequest` implementation
- [ ] change `PhpMatcherDumper` and matching logic in `Router`
- [ ] find an alternative for TraceableUrlMatcher
- [ ] better `redirect` signature
- [ ] change Framework bundle to use `RedirectableRequestMatcher` and some other cleanups like `https_port` config handling
