### PR TITLE
Fix the server variables in the router_*.php files

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/router_dev.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/router_dev.php
@@ -33,6 +33,10 @@ if (is_file($_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR.$_SERVER['SCRIPT_NAME'
 $_SERVER = array_merge($_SERVER, $_ENV);
 $_SERVER['SCRIPT_FILENAME'] = $_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR.'app_dev.php';
 
+// Since we are rewriting to app_dev.php, adjust SCRIPT_NAME and PHP_SELF accordingly
+$_SERVER['SCRIPT_NAME'] = DIRECTORY_SEPARATOR.'app_dev.php';
+$_SERVER['PHP_SELF'] = DIRECTORY_SEPARATOR.'app_dev.php';
+
 require 'app_dev.php';
 
 error_log(sprintf('%s:%d [%d]: %s', $_SERVER['REMOTE_ADDR'], $_SERVER['REMOTE_PORT'], http_response_code(), $_SERVER['REQUEST_URI']), 4);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/router_prod.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/router_prod.php
@@ -33,6 +33,10 @@ if (is_file($_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR.$_SERVER['SCRIPT_NAME'
 $_SERVER = array_merge($_SERVER, $_ENV);
 $_SERVER['SCRIPT_FILENAME'] = $_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR.'app.php';
 
+// Since we are rewriting to app.php, adjust SCRIPT_NAME and PHP_SELF accordingly
+$_SERVER['SCRIPT_NAME'] = DIRECTORY_SEPARATOR.'app.php';
+$_SERVER['PHP_SELF'] = DIRECTORY_SEPARATOR.'app.php';
+
 require 'app.php';
 
 error_log(sprintf('%s:%d [%d]: %s', $_SERVER['REMOTE_ADDR'], $_SERVER['REMOTE_PORT'], http_response_code(), $_SERVER['REQUEST_URI']), 4);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |

The built-in web server automatically rewrites everything to the `app_dev.php` script, but it does not adjust the server variables accordingly.

Here is the output of `print_r($_SERVER)` on Apache with mod_rewrite enabled (relevant lines only):

```
Array
(
    [REQUEST_URI] => /text-elements.html
    [SCRIPT_NAME] => /app_dev.php
    [PHP_SELF] => /app_dev.php
)
```

And here is the output of the exact same script on the built-in server:

```
Array
(
    [REQUEST_URI] => /text-elements.html
    [SCRIPT_NAME] => /text-elements.html
    [PHP_SELF] => /text-elements.html
)
```

And here is the return value of Symfony's `Request::getScriptName()` method:

``` php
// Apache: http://localhost/text-elements.html
echo $this->container->get('request_stack')->getCurrentRequest()->getScriptName(); // /app_dev.php

// Built-in web server: http://127.0.0.1:8000/text-elements.html
echo $this->container->get('request_stack')->getCurrentRequest()->getScriptName(); // /text-elements.html
```

This PR fixes the two server variables in the `router_dev.php` script.
