### PR TITLE
[HttpKernel] Add `@group time-sensitive` on some transient tests

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/TimeDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/TimeDataCollectorTest.php
@@ -15,6 +15,9 @@ use Symfony\Component\HttpKernel\DataCollector\TimeDataCollector;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @group time-sensitive
+ */
 class TimeDataCollectorTest extends \PHPUnit_Framework_TestCase
 {
     public function testCollect()

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
@@ -23,6 +23,8 @@ use Symfony\Component\HttpKernel\Tests\Logger;
  * ExceptionListenerTest.
  *
  * @author Robert Schönthal <seroscho@googlemail.com>
+ *
+ * @group time-sensitive
  */
 class ExceptionListenerTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15617 |
| License | MIT |
| Doc PR | - |
