### PR TITLE
Add the PHP 7 polyfill for the random_bytes function

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -19,7 +19,8 @@
         "php": ">=5.3.9",
         "symfony/security": "~2.8|~3.0.0",
         "symfony/security-acl": "~2.7|~3.0.0",
-        "symfony/http-kernel": "~2.2|~3.0.0"
+        "symfony/http-kernel": "~2.2|~3.0.0",
+        "symfony/polyfill-php70": "~1.0"
     },
     "require-dev": {
         "symfony/browser-kit": "~2.4|~3.0.0",

--- a/src/Symfony/Component/Security/Core/composer.json
+++ b/src/Symfony/Component/Security/Core/composer.json
@@ -19,6 +19,7 @@
         "php": ">=5.3.9",
         "symfony/polyfill-php55": "~1.0",
         "symfony/polyfill-php56": "~1.0",
+        "symfony/polyfill-php70": "~1.0",
         "symfony/polyfill-util": "~1.0"
     },
     "require-dev": {

--- a/src/Symfony/Component/Security/Csrf/composer.json
+++ b/src/Symfony/Component/Security/Csrf/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": ">=5.3.9",
         "symfony/polyfill-php56": "~1.0",
+        "symfony/polyfill-php70": "~1.0",
         "symfony/security-core": "~2.4|~3.0.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Some classes (like the `SecureRandom` class) currently depends on the `random_bytes` function, which is only available in the PHP 7 polyfill
