### PR TITLE
[HttpFoundation] don't call constructors on Mongo mock objects

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
@@ -34,6 +34,7 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
         $mongoClass = version_compare(phpversion('mongo'), '1.3.0', '<') ? 'Mongo' : 'MongoClient';
 
         $this->mongo = $this->getMockBuilder($mongoClass)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $this->options = array(
@@ -202,13 +203,8 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
 
     private function createMongoCollectionMock()
     {
-        $mongoClient = $this->getMockBuilder('MongoClient')
-            ->getMock();
-        $mongoDb = $this->getMockBuilder('MongoDB')
-            ->setConstructorArgs(array($mongoClient, 'database-name'))
-            ->getMock();
         $collection = $this->getMockBuilder('MongoCollection')
-            ->setConstructorArgs(array($mongoDb, 'collection-name'))
+            ->disableOriginalConstructor()
             ->getMock();
 
         return $collection;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16287 |
| License | MIT |
| Doc PR |  |

Calling the parent constructor of the mocked `Mongo` class tries to
connect to a local MongoDB server which fails in case no local server
was configured.

Similarly, when the parent constructor of the mocked `MongoCollection`
class is called it performs checks on the passed arguments which fails
again when a connection was not established successfully before.
