### PR TITLE
[WebProfilerBundle] Fix minitoolbar height

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -2,11 +2,19 @@
     background-color: #222;
     bottom: 0;
     display: none;
-    height: 36px;
-    padding: 5px 6px 0;
+    height: 30px;
+    padding: 6px 6px 0;
     position: fixed;
     right: 0;
     z-index: 99999;
+}
+.sf-minitoolbar a {
+    display: block;
+}
+.sf-minitoolbar svg,
+.sf-minitoolbar img {
+    max-height: 24px;
+    max-width: 24px;
 }
 
 .sf-toolbarreset * {
@@ -36,7 +44,8 @@
 }
 .sf-toolbarreset svg,
 .sf-toolbarreset img {
-    max-height: 20px;
+    max-height: 24px;
+    max-width: 24px;
 }
 
 .sf-toolbarreset .hide-button {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The height of the minimized toolbar icon was a bit off. This change makes sure the icon has the same height as the toolbar itself.
