### PR TITLE
Set back libxml settings after testings.

### DIFF
--- a/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
+++ b/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
@@ -63,11 +63,14 @@ class XmlUtilsTest extends \PHPUnit_Framework_TestCase
 
     public function testLoadFileWithInternalErrorsEnabled()
     {
-        libxml_use_internal_errors(true);
+        $internalErrors = libxml_use_internal_errors(true);
 
         $this->assertSame(array(), libxml_get_errors());
         $this->assertInstanceOf('DOMDocument', XmlUtils::loadFile(__DIR__.'/../Fixtures/Util/invalid_schema.xml'));
         $this->assertSame(array(), libxml_get_errors());
+
+        libxml_clear_errors();
+        libxml_use_internal_errors($internalErrors);
     }
 
     /**
@@ -144,7 +147,7 @@ class XmlUtilsTest extends \PHPUnit_Framework_TestCase
     public function testLoadEmptyXmlFile()
     {
         $file = __DIR__.'/../Fixtures/foo.xml';
-        $this->setExpectedException('InvalidArgumentException', 'File '.$file.' does not contain valid XML, it is empty.');
+        $this->setExpectedException('InvalidArgumentException', sprintf('File %s does not contain valid XML, it is empty.', $file));
         XmlUtils::loadFile($file);
     }
 

--- a/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
@@ -30,7 +30,7 @@ class XliffFileLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testLoadWithInternalErrorsEnabled()
     {
-        libxml_use_internal_errors(true);
+        $internalErrors = libxml_use_internal_errors(true);
 
         $this->assertSame(array(), libxml_get_errors());
 
@@ -41,6 +41,9 @@ class XliffFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('en', $catalogue->getLocale());
         $this->assertEquals(array(new FileResource($resource)), $catalogue->getResources());
         $this->assertSame(array(), libxml_get_errors());
+
+        libxml_clear_errors();
+        libxml_use_internal_errors($internalErrors);
     }
 
     public function testLoadWithResname()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [yes] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

Tests that change the `libxml_use_internal_errors` should set back the flag to the previous setting when done testing.
