### PR TITLE
remove polyfills for unsupported php versions

### DIFF
--- a/src/Symfony/Component/Asset/composer.json
+++ b/src/Symfony/Component/Asset/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.9"
+        "php": ">=5.5.9"
     },
     "suggest": {
         "symfony/http-foundation": ""

--- a/src/Symfony/Component/HttpFoundation/composer.json
+++ b/src/Symfony/Component/HttpFoundation/composer.json
@@ -16,8 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9",
-        "symfony/polyfill-php54": "~1.0"
+        "php": ">=5.5.9"
     },
     "require-dev": {
         "symfony/expression-language": "~2.8|~3.0"

--- a/src/Symfony/Component/Intl/composer.json
+++ b/src/Symfony/Component/Intl/composer.json
@@ -25,8 +25,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "symfony/polyfill-intl-icu": "~1.0",
-        "symfony/polyfill-php54": "~1.0"
+        "symfony/polyfill-intl-icu": "~1.0"
     },
     "require-dev": {
         "symfony/filesystem": "~2.8|~3.0"

--- a/src/Symfony/Component/Security/Core/composer.json
+++ b/src/Symfony/Component/Security/Core/composer.json
@@ -17,9 +17,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "symfony/polyfill-php55": "~1.0",
         "symfony/polyfill-php56": "~1.0",
-        "symfony/polyfill-php70": "~1.0",
         "symfony/polyfill-util": "~1.0"
     },
     "require-dev": {

--- a/src/Symfony/Component/Security/Guard/composer.json
+++ b/src/Symfony/Component/Security/Guard/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.9",
+        "php": ">=5.5.9",
         "symfony/security-core": "~2.8|~3.0",
         "symfony/security-http": "~2.8|~3.0"
     },

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -20,11 +20,10 @@
         "symfony/event-dispatcher": "~2.8|~3.0",
         "symfony/http-foundation": "~2.8|~3.0",
         "symfony/http-kernel": "~2.8|~3.0",
-        "symfony/polyfill-php55": "~1.0",
         "symfony/polyfill-php56": "~1.0",
         "symfony/polyfill-php70": "~1.0",
         "symfony/polyfill-util": "~1.0",
-        "symfony/property-access": "~2.8|~3.0",
+        "symfony/property-access": "~2.8|~3.0"
     },
     "replace": {
         "symfony/security-core": "self.version",

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -16,8 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9",
-        "symfony/polyfill-php55": "~1.0"
+        "php": ">=5.5.9"
     },
     "require-dev": {
         "symfony/yaml": "~2.8|~3.0",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Remove obsolete polyfills in master as introduced in #16317
