### PR TITLE
[Serializer] polyfill for json_last_error_msg is in php 5.5

### DIFF
--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.9",
-        "symfony/polyfill-php54": "~1.0"
+        "symfony/polyfill-php55": "~1.0"
     },
     "require-dev": {
         "symfony/yaml": "~2.0,>=2.0.5|~3.0.0",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16317 |
| License | MIT |
| Doc PR | - |

We need the polyfill for `json_last_error_msg` which is part of php 5.5, not 5.4.
