### PR TITLE
Bug #16343 [Router] Too many Routes ?

### DIFF
--- a/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
+++ b/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
@@ -53,7 +53,7 @@ use Psr\Log\LoggerInterface;
  */
 class {$options['class']} extends {$options['base_class']}
 {
-    private static \$declaredRoutes = {$this->generateDeclaredRoutes()};
+    private static \$declaredRoutes;
 
     /**
      * Constructor.
@@ -62,6 +62,9 @@ class {$options['class']} extends {$options['base_class']}
     {
         \$this->context = \$context;
         \$this->logger = \$logger;
+        if (null === self::\$declaredRoutes) {
+            self::\$declaredRoutes = {$this->generateDeclaredRoutes()};
+        }
     }
 
 {$this->generateGenerateMethod()}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/issues/16343 |
| License | MIT |
| Doc PR | N/A |

Seems there is an issue when you have more than 7265 routes declared,
The routes are generated into the cached appDevUrlGenerator.php but php only loads the last 7265 elements of the array.
