### PR TITLE
[SecurityBundle] remove incompatible Twig version

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -34,7 +34,7 @@
         "symfony/process": "~2.0,>=2.0.5",
         "symfony/validator": "~2.2",
         "symfony/yaml": "~2.0,>=2.0.5",
-        "twig/twig": "~1.20|~2.0"
+        "twig/twig": "~1.20"
     },
     "autoload": {
         "psr-0": { "Symfony\\Bundle\\SecurityBundle\\": "" }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Currently, the SecurityBundle is not compatible with Twig 2.0 as it is
missing the implementation of the `Twig_Extension_InitRuntimeInterface`.
Thus, `initRuntime()` would not be called with Twig 2.0 anymore.

This should make the Travis builds green again and should be reverted when Twig 1.23 is released (can be done with #16331).
