### PR TITLE
checkCredentials() force it to be an affirmative yes!

### DIFF
--- a/src/Symfony/Component/Security/Guard/GuardAuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Guard/GuardAuthenticatorInterface.php
@@ -73,7 +73,11 @@ interface GuardAuthenticatorInterface extends AuthenticationEntryPointInterface
     public function getUser($credentials, UserProviderInterface $userProvider);
 
     /**
-     * Throw an AuthenticationException if the credentials are invalid.
+     * Return true if the credentials are valid.
+     *
+     * If any value other than true is returned, authentication will
+     * fail. You may also throw an AuthenticationException if you wish
+     * to cause authentication to fail.
      *
      * The *credentials* are the return value from getCredentials()
      *

--- a/src/Symfony/Component/Security/Guard/GuardAuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Guard/GuardAuthenticatorInterface.php
@@ -73,7 +73,7 @@ interface GuardAuthenticatorInterface extends AuthenticationEntryPointInterface
     public function getUser($credentials, UserProviderInterface $userProvider);
 
     /**
-     * Return true if the credentials are valid.
+     * Returns true if the credentials are valid.
      *
      * If any value other than true is returned, authentication will
      * fail. You may also throw an AuthenticationException if you wish

--- a/src/Symfony/Component/Security/Guard/Provider/GuardAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Guard/Provider/GuardAuthenticationProvider.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Guard\Provider;
 
 use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Guard\GuardAuthenticatorInterface;
 use Symfony\Component\Security\Guard\Token\GuardTokenInterface;
@@ -122,7 +123,9 @@ class GuardAuthenticationProvider implements AuthenticationProviderInterface
         }
 
         $this->userChecker->checkPreAuth($user);
-        $guardAuthenticator->checkCredentials($token->getCredentials(), $user);
+        if (true !== $guardAuthenticator->checkCredentials($token->getCredentials(), $user)) {
+            throw new BadCredentialsException(sprintf('Authentication failed because %s::checkCredentials() did not return true', get_class($guardAuthenticator)));
+        };
         $this->userChecker->checkPostAuth($user);
 
         // turn the UserInterface into a TokenInterface

--- a/src/Symfony/Component/Security/Guard/Provider/GuardAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Guard/Provider/GuardAuthenticationProvider.php
@@ -124,8 +124,8 @@ class GuardAuthenticationProvider implements AuthenticationProviderInterface
 
         $this->userChecker->checkPreAuth($user);
         if (true !== $guardAuthenticator->checkCredentials($token->getCredentials(), $user)) {
-            throw new BadCredentialsException(sprintf('Authentication failed because %s::checkCredentials() did not return true', get_class($guardAuthenticator)));
-        };
+            throw new BadCredentialsException(sprintf('Authentication failed because %s::checkCredentials() did not return true.', get_class($guardAuthenticator)));
+        }
         $this->userChecker->checkPostAuth($user);
 
         // turn the UserInterface into a TokenInterface


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no (because 2.8 isn't released) |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This changes `GuardAuthenticatorInterface::checkCredentials()`: you now _must_ return true in order for authentication to pass.

Before: You could do nothing (i.e. return null) and authentication would pass. You threw an AuthenticationException to cause a failure.

New: You _must_ return `true` for authentication to pass. If you do nothing, we will throw a `BadCredentialsException` on your behalf. You can still throw your own exception.

This was a suggestion at symfony_live to make things more secure. I think it makes sense.
