### PR TITLE
[3.0] [VarDumper] Tests fixed

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/HtmlDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/HtmlDumperTest.php
@@ -79,7 +79,7 @@ class HtmlDumperTest extends \PHPUnit_Framework_TestCase
   </samp>}
   "<span class=sf-dump-key>closure</span>" => <span class=sf-dump-note>Closure</span> {{$r}<samp>
     <span class=sf-dump-meta>class</span>: "<span class=sf-dump-str title="48 characters">Symfony\Component\VarDumper\Tests\HtmlDumperTest</span>"
-    <span class=sf-dump-meta>this</span>: <abbr title="Symfony\Component\VarDumper\Tests\HtmlDumperTest" class=sf-dump-note>HtmlDumperTest</abbr> {{$r} &#8230;}
+    <span class=sf-dump-meta>this</span>: <abbr title="Symfony\Component\VarDumper\Tests\HtmlDumperTest" class=sf-dump-note>HtmlDumperTest</abbr> {{$r} &%s;}
     <span class=sf-dump-meta>parameters</span>: {<samp>
       <span class=sf-dump-meta>\$a</span>: {}
       <span class=sf-dump-meta>&amp;\$b</span>: {<samp>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Fixes broken test after merge. 
Original 2.8 commit: https://github.com/symfony/symfony/commit/303f05baafc2267b72812c44670493433b7acb0f#diff-c45f29f2b7f10a6e3583f92526da067dR55

Fixes Travis failure of VarDumper: https://travis-ci.org/symfony/symfony/jobs/88382131#L2413
