### PR TITLE
[Form] Applied the comma separator

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
@@ -452,7 +452,7 @@ class NumberToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCase
      */
     public function testDecimalSeparatorMayNotBeCommaIfGroupingSeparatorIsComma()
     {
-        $transformer = new NumberToLocalizedStringTransformer(null, true);
+        $transformer = new NumberToLocalizedStringTransformer(null, ',');
 
         $transformer->reverseTransform('1,234,5');
     }
@@ -462,7 +462,7 @@ class NumberToLocalizedStringTransformerTest extends \PHPUnit_Framework_TestCase
      */
     public function testDecimalSeparatorMayNotBeCommaIfGroupingSeparatorIsCommaWithNoGroupSep()
     {
-        $transformer = new NumberToLocalizedStringTransformer(null, true);
+        $transformer = new NumberToLocalizedStringTransformer(null, ',');
 
         $transformer->reverseTransform('1234,5');
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

A comma should be used in these tests.
