### PR TITLE
[DependencyInjection] added a way to reference dynamic environment variables in service definitions

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveParameterPlaceHoldersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveParameterPlaceHoldersPass.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
+use Symfony\Component\DependencyInjection\EnvVariable;
 
 /**
  * Resolves all parameter placeholders "%somevalue%" to their real values.
@@ -36,7 +37,7 @@ class ResolveParameterPlaceHoldersPass implements CompilerPassInterface
             try {
                 $definition->setClass($parameterBag->resolveValue($definition->getClass()));
                 $definition->setFile($parameterBag->resolveValue($definition->getFile()));
-                $definition->setArguments($parameterBag->resolveValue($definition->getArguments()));
+                $definition->setArguments($parameterBag->resolveValue($definition->getArguments(), array(), true));
                 if ($definition->getFactoryClass(false)) {
                     $definition->setFactoryClass($parameterBag->resolveValue($definition->getFactoryClass(false)));
                 }
@@ -50,11 +51,11 @@ class ResolveParameterPlaceHoldersPass implements CompilerPassInterface
 
                 $calls = array();
                 foreach ($definition->getMethodCalls() as $name => $arguments) {
-                    $calls[$parameterBag->resolveValue($name)] = $parameterBag->resolveValue($arguments);
+                    $calls[$parameterBag->resolveValue($name)] = $parameterBag->resolveValue($arguments, array(), true);
                 }
                 $definition->setMethodCalls($calls);
 
-                $definition->setProperties($parameterBag->resolveValue($definition->getProperties()));
+                $definition->setProperties($parameterBag->resolveValue($definition->getProperties(), array(), true));
             } catch (ParameterNotFoundException $e) {
                 $e->setSourceId($id);
 

--- a/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Dumper;
 
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
+use Symfony\Component\DependencyInjection\EnvVariable;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -136,6 +137,8 @@ class GraphvizDumper extends Dumper
         foreach ($arguments as $argument) {
             if ($argument instanceof Parameter) {
                 $argument = $this->container->hasParameter($argument) ? $this->container->getParameter($argument) : null;
+            } elseif ($argument instanceof EnvVariable) {
+                $argument = '$'.$argument.'$';
             } elseif (is_string($argument) && preg_match('/^%([^%]+)%$/', $argument, $match)) {
                 $argument = $this->container->hasParameter($match[1]) ? $this->container->getParameter($match[1]) : null;
             }

--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Dumper;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\EnvVariable;
 use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Definition;
@@ -371,6 +372,8 @@ class XmlDumper extends Dumper
                 return 'false';
             case $value instanceof Parameter:
                 return '%'.$value.'%';
+            case $value instanceof EnvVariable:
+                return '$'.$value.'$';
             case is_object($value) || is_resource($value):
                 throw new RuntimeException('Unable to dump a service container if a parameter is an object or a resource.');
             default:

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -15,6 +15,7 @@ use Symfony\Component\Yaml\Dumper as YmlDumper;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\EnvVariable;
 use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
@@ -274,6 +275,8 @@ class YamlDumper extends Dumper
             return $code;
         } elseif ($value instanceof Reference) {
             return $this->getServiceCall((string) $value, $value);
+        } elseif ($value instanceof EnvVariable) {
+            return sprintf('$%s$', (string) $value);
         } elseif ($value instanceof Parameter) {
             return $this->getParameterCall((string) $value);
         } elseif ($value instanceof Expression) {

--- a/src/Symfony/Component/DependencyInjection/EnvVariable.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVariable.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection;
+
+/**
+ * Represents an environment variable value.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class EnvVariable
+{
+    private $id;
+
+    /**
+     * Constructor.
+     *
+     * @param string $id The environment variable name
+     */
+    public function __construct($id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * __toString.
+     *
+     * @return string The environment variable name
+     */
+    public function __toString()
+    {
+        return (string) $this->id;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -214,6 +214,10 @@ class ParameterBag implements ParameterBagInterface
             return $this->resolved ? $this->get($key) : $this->resolveValue($this->get($key), $resolving);
         }
 
+        if (preg_match('/^\$([^\$\s]+)\$$/', $value, $match)) {
+            return getenv($match[1]);
+        }
+
         $self = $this;
 
         return preg_replace_callback('/%%|%([^%\s]+)%/', function ($match) use ($self, $resolving, $value) {

--- a/src/Symfony/Component/DependencyInjection/Tests/EnvVariableTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/EnvVariableTest.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests;
+
+use Symfony\Component\DependencyInjection\EnvVariable;
+
+class EnvVariableTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstructor()
+    {
+        $ref = new EnvVariable('foo');
+        $this->assertEquals('foo', (string) $ref, '__construct() sets the id of the env variable, which is used for the __toString() method');
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container9.php
@@ -4,6 +4,7 @@ require_once __DIR__.'/../includes/classes.php';
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\EnvVariable;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\ExpressionLanguage\Expression;
@@ -14,7 +15,7 @@ $container
     ->addTag('foo', array('foo' => 'foo'))
     ->addTag('foo', array('bar' => 'bar', 'baz' => 'baz'))
     ->setFactory(array('Bar\\FooClass', 'getInstance'))
-    ->setArguments(array('foo', new Reference('foo.baz'), array('%foo%' => 'foo is %foo%', 'foobar' => '%foo%'), true, new Reference('service_container')))
+    ->setArguments(array('foo', new Reference('foo.baz'), array('%foo%' => 'foo is %foo%', 'foobar' => '%foo%', 'foo_env' => new EnvVariable('FOO')), true, new Reference('service_container')))
     ->setProperties(array('foo' => 'bar', 'moo' => new Reference('foo.baz'), 'qux' => array('%foo%' => 'foo is %foo%', 'foobar' => '%foo%')))
     ->addMethodCall('setBar', array(new Reference('bar')))
     ->addMethodCall('initialize')
@@ -27,7 +28,7 @@ $container
 ;
 $container
     ->register('bar', 'Bar\FooClass')
-    ->setArguments(array('foo', new Reference('foo.baz'), new Parameter('foo_bar')))
+    ->setArguments(array('foo', new Reference('foo.baz'), new Parameter('foo_bar'), new EnvVariable('FOO')))
     ->setConfigurator(array(new Reference('foo.baz'), 'configure'))
 ;
 $container

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
@@ -64,7 +64,7 @@ class ProjectServiceContainer extends Container
     {
         $a = $this->get('foo.baz');
 
-        $this->services['bar'] = $instance = new \Bar\FooClass('foo', $a, $this->getParameter('foo_bar'));
+        $this->services['bar'] = $instance = new \Bar\FooClass('foo', $a, $this->getParameter('foo_bar'), getenv('FOO'));
 
         $a->configure($instance);
 
@@ -186,7 +186,7 @@ class ProjectServiceContainer extends Container
     {
         $a = $this->get('foo.baz');
 
-        $this->services['foo'] = $instance = \Bar\FooClass::getInstance('foo', $a, array($this->getParameter('foo') => 'foo is '.$this->getParameter('foo').'', 'foobar' => $this->getParameter('foo')), true, $this);
+        $this->services['foo'] = $instance = \Bar\FooClass::getInstance('foo', $a, array($this->getParameter('foo') => 'foo is '.$this->getParameter('foo').'', 'foobar' => $this->getParameter('foo'), 'foo_env' => getenv('FOO')), true, $this);
 
         $instance->setBar($this->get('bar'));
         $instance->initialize();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -75,7 +75,7 @@ class ProjectServiceContainer extends Container
     {
         $a = $this->get('foo.baz');
 
-        $this->services['bar'] = $instance = new \Bar\FooClass('foo', $a, $this->getParameter('foo_bar'));
+        $this->services['bar'] = $instance = new \Bar\FooClass('foo', $a, $this->getParameter('foo_bar'), getenv('FOO'));
 
         $a->configure($instance);
 
@@ -187,7 +187,7 @@ class ProjectServiceContainer extends Container
     {
         $a = $this->get('foo.baz');
 
-        $this->services['foo'] = $instance = \Bar\FooClass::getInstance('foo', $a, array('bar' => 'foo is bar', 'foobar' => 'bar'), true, $this);
+        $this->services['foo'] = $instance = \Bar\FooClass::getInstance('foo', $a, array('bar' => 'foo is bar', 'foobar' => 'bar', 'foo_env' => getenv('FOO')), true, $this);
 
         $instance->setBar($this->get('bar'));
         $instance->initialize();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
@@ -14,6 +14,7 @@
       <argument type="collection">
         <argument key="%foo%">foo is %foo%</argument>
         <argument key="foobar">%foo%</argument>
+        <argument key="foo_env">$FOO$</argument>
       </argument>
       <argument>true</argument>
       <argument type="service" id="service_container"/>
@@ -38,6 +39,7 @@
       <argument>foo</argument>
       <argument type="service" id="foo.baz"/>
       <argument>%foo_bar%</argument>
+      <argument>$FOO$</argument>
       <configurator service="foo.baz" method="configure"/>
     </service>
     <service id="foo_bar" class="%foo_class%" shared="false"/>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
@@ -9,7 +9,7 @@ services:
         tags:
             - { name: foo, foo: foo }
             - { name: foo, bar: bar, baz: baz }
-        arguments: [foo, '@foo.baz', { '%foo%': 'foo is %foo%', foobar: '%foo%' }, true, '@service_container']
+        arguments: [foo, '@foo.baz', { '%foo%': 'foo is %foo%', foobar: '%foo%', foo_env: $FOO$ }, true, '@service_container']
         properties: { foo: bar, moo: '@foo.baz', qux: { '%foo%': 'foo is %foo%', foobar: '%foo%' } }
         calls:
             - [setBar, ['@bar']]
@@ -23,7 +23,7 @@ services:
         configurator: ['%baz_class%', configureStatic1]
     bar:
         class: Bar\FooClass
-        arguments: [foo, '@foo.baz', '%foo_bar%']
+        arguments: [foo, '@foo.baz', '%foo_bar%', $FOO$]
         configurator: ['@foo.baz', configure]
     foo_bar:
         class: %foo_class%


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yesish |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #10138, #7555 |
| License | MIT |
| Doc PR | not yet |

When hosting a Symfony app on some PaaS like Heroku, or even if you are just using Docker, you need a way to reference environment variables in the container. That's already possible in Symfony but the values are dumped into the cache. This PR adds a way to reference an env variable that is resolved dynamically even on a compiled container.

ping @dzuelke
