### PR TITLE
Re-adding the ability to add a resource to the RouteCollectionBuilder

### DIFF
--- a/src/Symfony/Component/Routing/RouteCollectionBuilder.php
+++ b/src/Symfony/Component/Routing/RouteCollectionBuilder.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Routing;
 
 use Symfony\Component\Config\Exception\FileLoaderLoadException;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\Config\Resource\ResourceInterface;
 
 /**
  * Helps add and import routes into a RouteCollection.
@@ -35,6 +36,7 @@ class RouteCollectionBuilder
     private $options = array();
     private $schemes;
     private $methods;
+    private $resources = array();
 
     /**
      * @param LoaderInterface $loader
@@ -238,6 +240,20 @@ class RouteCollectionBuilder
     }
 
     /**
+     * Adds a resource for this collection.
+     *
+     * @param ResourceInterface $resource
+     *
+     * @return $this
+     */
+    private function addResource(ResourceInterface $resource)
+    {
+        $this->resources[] = $resource;
+
+        return $this;
+    }
+
+    /**
      * Creates the final ArrayCollection, returns it, and clears everything.
      *
      * @return RouteCollection
@@ -290,6 +306,10 @@ class RouteCollectionBuilder
                 $subCollection->addPrefix($this->prefix);
 
                 $routeCollection->addCollection($subCollection);
+            }
+
+            foreach ($this->resources as $resource) {
+                $routeCollection->addResource($resource);
             }
         }
 

--- a/src/Symfony/Component/Routing/Tests/RouteCollectionBuilderTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCollectionBuilderTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Routing\Tests;
 
+use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\RouteCollectionBuilder;
@@ -29,6 +30,7 @@ class RouteCollectionBuilderTest extends \PHPUnit_Framework_TestCase
         $originalRoute = new Route('/foo/path');
         $expectedCollection = new RouteCollection();
         $expectedCollection->add('one_test_route', $originalRoute);
+        $expectedCollection->addResource(new FileResource('file_resource.yml'));
 
         $resolvedLoader
             ->expects($this->once())
@@ -52,6 +54,8 @@ class RouteCollectionBuilderTest extends \PHPUnit_Framework_TestCase
         $addedCollection = $importedRoutes->build();
         $route = $addedCollection->get('one_test_route');
         $this->assertSame($originalRoute, $route);
+        // should return file_resource.yml, which is in the original collection
+        $this->assertCount(1, $addedCollection->getResources());
     }
 
     /**


### PR DESCRIPTION
We need this because when you import a RouteCollection and this has a resource
on it, we need to pass that resource forward to the RouteCollectionBuilder
