### PR TITLE
[FrameworkBundle] Add helpful exception for controller service

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerResolver.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerResolver.php
@@ -63,8 +63,18 @@ class ControllerResolver extends BaseControllerResolver
                 list($service, $method) = explode(':', $controller, 2);
 
                 return array($this->container->get($service), $method);
-            } elseif ($this->container->has($controller) && method_exists($service = $this->container->get($controller), '__invoke')) {
-                return $service;
+            } elseif ($this->container->has($controller)) {
+                $controllerInstance = $this->container->get($controller);
+                if (!method_exists($controllerInstance, '__invoke')) {
+                    $exceptionMessage = sprintf(
+                        'The class "%s" specified as controller service "%s" must define an __invoke method, but does not.',
+                        get_class($controllerInstance),
+                        $controller
+                    );
+                    throw new \LogicException($exceptionMessage);
+                }
+
+                return $controllerInstance;
             } else {
                 throw new \LogicException(sprintf('Unable to parse the controller name "%s".', $controller));
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This adds an additional exception when a controller is
defined by only the service name, but lacks the necessary
__invoke() method.
