### PR TITLE
Fix - trying to cover or use not existing method

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -143,7 +143,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers Symfony\Component\DependencyInjection\ContainerBuilder::get
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::setShared
      */
     public function testNonSharedServicesReturnsDifferentInstances()
     {

--- a/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
@@ -198,7 +198,6 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Symfony\Component\DependencyInjection\Definition::setDeprecated
      * @covers Symfony\Component\DependencyInjection\Definition::isDeprecated
-     * @covers Symfony\Component\DependencyInjection\Definition::hasCustomDeprecationTemplate
      * @covers Symfony\Component\DependencyInjection\Definition::getDeprecationMessage
      */
     public function testSetIsDeprecated()


### PR DESCRIPTION
Hi,

While running coverage tests I noticed errors:
"Trying to @cover or @use not existing method "Symfony\Component\DependencyInjection*"."

This patch fixes these problems.

Best regards,
Michal

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
