### PR TITLE
removed all @covers annotations

### DIFF
--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/ContainerBuilderTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/ContainerBuilderTest.php
@@ -24,9 +24,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::createService
-     */
     public function testCreateProxyServiceWithRuntimeInstantiator()
     {
         $builder = new ContainerBuilder();

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Instantiator/RuntimeInstantiatorTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Instantiator/RuntimeInstantiatorTest.php
@@ -18,8 +18,6 @@ use Symfony\Component\DependencyInjection\Definition;
  * Tests for {@see \Symfony\Bridge\ProxyManager\LazyProxy\Instantiator\RuntimeInstantiator}.
  *
  * @author Marco Pivetta <ocramius@gmail.com>
- *
- * @covers \Symfony\Bridge\ProxyManager\LazyProxy\Instantiator\RuntimeInstantiator
  */
 class RuntimeInstantiatorTest extends \PHPUnit_Framework_TestCase
 {

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
@@ -18,8 +18,6 @@ use Symfony\Component\DependencyInjection\Definition;
  * Tests for {@see \Symfony\Bridge\ProxyManager\LazyProxy\PhpDumper\ProxyDumper}.
  *
  * @author Marco Pivetta <ocramius@gmail.com>
- *
- * @covers \Symfony\Bridge\ProxyManager\LazyProxy\PhpDumper\ProxyDumper
  */
 class ProxyDumperTest extends \PHPUnit_Framework_TestCase
 {

--- a/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
@@ -73,27 +73,18 @@ EOF;
 
 class ClientTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers Symfony\Component\BrowserKit\Client::getHistory
-     */
     public function testGetHistory()
     {
         $client = new TestClient(array(), $history = new History());
         $this->assertSame($history, $client->getHistory(), '->getHistory() returns the History');
     }
 
-    /**
-     * @covers Symfony\Component\BrowserKit\Client::getCookieJar
-     */
     public function testGetCookieJar()
     {
         $client = new TestClient(array(), null, $cookieJar = new CookieJar());
         $this->assertSame($cookieJar, $client->getCookieJar(), '->getCookieJar() returns the CookieJar');
     }
 
-    /**
-     * @covers Symfony\Component\BrowserKit\Client::getRequest
-     */
     public function testGetRequest()
     {
         $client = new TestClient();
@@ -140,9 +131,6 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($json, $client->getRequest()->getContent());
     }
 
-    /**
-     * @covers Symfony\Component\BrowserKit\Client::getCrawler
-     */
     public function testGetCrawler()
     {
         $client = new TestClient();

--- a/src/Symfony/Component/Config/Tests/Loader/DelegatingLoaderTest.php
+++ b/src/Symfony/Component/Config/Tests/Loader/DelegatingLoaderTest.php
@@ -16,19 +16,12 @@ use Symfony\Component\Config\Loader\DelegatingLoader;
 
 class DelegatingLoaderTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers Symfony\Component\Config\Loader\DelegatingLoader::__construct
-     */
     public function testConstructor()
     {
         $loader = new DelegatingLoader($resolver = new LoaderResolver());
         $this->assertTrue(true, '__construct() takes a loader resolver as its first argument');
     }
 
-    /**
-     * @covers Symfony\Component\Config\Loader\DelegatingLoader::getResolver
-     * @covers Symfony\Component\Config\Loader\DelegatingLoader::setResolver
-     */
     public function testGetSetResolver()
     {
         $resolver = new LoaderResolver();
@@ -38,9 +31,6 @@ class DelegatingLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($resolver, $loader->getResolver(), '->setResolver() sets the resolver loader');
     }
 
-    /**
-     * @covers Symfony\Component\Config\Loader\DelegatingLoader::supports
-     */
     public function testSupports()
     {
         $loader1 = $this->getMock('Symfony\Component\Config\Loader\LoaderInterface');
@@ -54,9 +44,6 @@ class DelegatingLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($loader->supports('foo.foo'), '->supports() returns false if the resource is not loadable');
     }
 
-    /**
-     * @covers Symfony\Component\Config\Loader\DelegatingLoader::load
-     */
     public function testLoad()
     {
         $loader = $this->getMock('Symfony\Component\Config\Loader\LoaderInterface');

--- a/src/Symfony/Component/Config/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/Config/Tests/Loader/FileLoaderTest.php
@@ -16,9 +16,6 @@ use Symfony\Component\Config\Loader\LoaderResolver;
 
 class FileLoaderTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers Symfony\Component\Config\Loader\FileLoader
-     */
     public function testImportWithFileLocatorDelegation()
     {
         $locatorMock = $this->getMock('Symfony\Component\Config\FileLocatorInterface');

--- a/src/Symfony/Component/Config/Tests/Loader/LoaderResolverTest.php
+++ b/src/Symfony/Component/Config/Tests/Loader/LoaderResolverTest.php
@@ -15,9 +15,6 @@ use Symfony\Component\Config\Loader\LoaderResolver;
 
 class LoaderResolverTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers Symfony\Component\Config\Loader\LoaderResolver::__construct
-     */
     public function testConstructor()
     {
         $resolver = new LoaderResolver(array(
@@ -27,9 +24,6 @@ class LoaderResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array($loader), $resolver->getLoaders(), '__construct() takes an array of loaders as its first argument');
     }
 
-    /**
-     * @covers Symfony\Component\Config\Loader\LoaderResolver::resolve
-     */
     public function testResolve()
     {
         $loader = $this->getMock('Symfony\Component\Config\Loader\LoaderInterface');
@@ -42,10 +36,6 @@ class LoaderResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($loader, $resolver->resolve(function () {}), '->resolve() returns the loader for the given resource');
     }
 
-    /**
-     * @covers Symfony\Component\Config\Loader\LoaderResolver::getLoaders
-     * @covers Symfony\Component\Config\Loader\LoaderResolver::addLoader
-     */
     public function testLoaders()
     {
         $resolver = new LoaderResolver();

--- a/src/Symfony/Component/Console/Tests/Helper/HelperSetTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/HelperSetTest.php
@@ -16,9 +16,6 @@ use Symfony\Component\Console\Command\Command;
 
 class HelperSetTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers \Symfony\Component\Console\Helper\HelperSet::__construct
-     */
     public function testConstructor()
     {
         $mock_helper = $this->getGenericMockHelper('fake_helper');
@@ -28,9 +25,6 @@ class HelperSetTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($helperset->has('fake_helper_alias'), '__construct sets helper alias for given helper');
     }
 
-    /**
-     * @covers \Symfony\Component\Console\Helper\HelperSet::set
-     */
     public function testSet()
     {
         $helperset = new HelperSet();
@@ -49,9 +43,6 @@ class HelperSetTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($helperset->has('fake_helper_alias'), '->set() adds helper alias when set');
     }
 
-    /**
-     * @covers \Symfony\Component\Console\Helper\HelperSet::has
-     */
     public function testHas()
     {
         $helperset = new HelperSet(array('fake_helper_alias' => $this->getGenericMockHelper('fake_helper')));
@@ -59,9 +50,6 @@ class HelperSetTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($helperset->has('fake_helper_alias'), '->has() finds set helper by alias');
     }
 
-    /**
-     * @covers \Symfony\Component\Console\Helper\HelperSet::get
-     */
     public function testGet()
     {
         $helper_01 = $this->getGenericMockHelper('fake_helper_01');
@@ -82,9 +70,6 @@ class HelperSetTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    /**
-     * @covers \Symfony\Component\Console\Helper\HelperSet::setCommand
-     */
     public function testSetCommand()
     {
         $cmd_01 = new Command('foo');
@@ -100,9 +85,6 @@ class HelperSetTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($cmd_02, $helperset->getCommand(), '->setCommand() overwrites stored command with consecutive calls');
     }
 
-    /**
-     * @covers \Symfony\Component\Console\Helper\HelperSet::getCommand
-     */
     public function testGetCommand()
     {
         $cmd = new Command('foo');

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -29,12 +29,6 @@ use Symfony\Component\Config\Resource\FileResource;
 
 class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::setDefinitions
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::getDefinitions
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::setDefinition
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::getDefinition
-     */
     public function testDefinitions()
     {
         $builder = new ContainerBuilder();
@@ -62,9 +56,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::register
-     */
     public function testRegister()
     {
         $builder = new ContainerBuilder();
@@ -73,9 +64,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\Definition', $builder->getDefinition('foo'), '->register() returns the newly created Definition instance');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::has
-     */
     public function testHas()
     {
         $builder = new ContainerBuilder();
@@ -86,9 +74,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($builder->has('bar'), '->has() returns true if a service exists');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::get
-     */
     public function testGet()
     {
         $builder = new ContainerBuilder();
@@ -121,7 +106,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers                   \Symfony\Component\DependencyInjection\ContainerBuilder::get
      * @expectedException        \Symfony\Component\DependencyInjection\Exception\RuntimeException
      * @expectedExceptionMessage You have requested a synthetic service ("foo"). The DIC does not know how to construct this service.
      */
@@ -140,9 +124,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $builder->get('foo');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::get
-     */
     public function testGetReturnsNullOnInactiveScope()
     {
         $builder = new ContainerBuilder();
@@ -151,9 +132,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($builder->get('foo', ContainerInterface::NULL_ON_INVALID_REFERENCE));
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::get
-     */
     public function testGetReturnsNullOnInactiveScopeWhenServiceIsCreatedByAMethod()
     {
         $builder = new ProjectContainer();
@@ -161,9 +139,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($builder->get('foobaz', ContainerInterface::NULL_ON_INVALID_REFERENCE));
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::getServiceIds
-     */
     public function testGetServiceIds()
     {
         $builder = new ContainerBuilder();
@@ -173,11 +148,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('foo', 'bar', 'service_container'), $builder->getServiceIds(), '->getServiceIds() returns all defined service ids');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::setAlias
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::hasAlias
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::getAlias
-     */
     public function testAliases()
     {
         $builder = new ContainerBuilder();
@@ -204,9 +174,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::getAliases
-     */
     public function testGetAliases()
     {
         $builder = new ContainerBuilder();
@@ -229,9 +196,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(0, $builder->getAliases(), '->getAliases() does not return aliased services that have been overridden');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::setAliases
-     */
     public function testSetAliases()
     {
         $builder = new ContainerBuilder();
@@ -242,9 +206,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(isset($aliases['foobar']));
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::addAliases
-     */
     public function testAddAliases()
     {
         $builder = new ContainerBuilder();
@@ -256,10 +217,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(isset($aliases['foobar']));
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::addCompilerPass
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::getCompilerPassConfig
-     */
     public function testAddGetCompilerPass()
     {
         $builder = new ContainerBuilder();
@@ -270,9 +227,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(count($builder->getCompiler()->getPassConfig()->getPasses()) - 1, $builderCompilerPasses);
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::createService
-     */
     public function testCreateService()
     {
         $builder = new ContainerBuilder();
@@ -283,9 +237,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\FooClass', $builder->get('foo2'), '->createService() replaces parameters in the file provided by the service definition');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::createService
-     */
     public function testCreateProxyWithRealServiceInstantiator()
     {
         $builder = new ContainerBuilder();
@@ -299,9 +250,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('FooClass', get_class($foo1));
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::createService
-     */
     public function testCreateServiceClass()
     {
         $builder = new ContainerBuilder();
@@ -310,9 +258,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\stdClass', $builder->get('foo1'), '->createService() replaces parameters in the class provided by the service definition');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::createService
-     */
     public function testCreateServiceArguments()
     {
         $builder = new ContainerBuilder();
@@ -322,9 +267,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('foo' => 'bar', 'bar' => 'foo', $builder->get('bar'), '%unescape_it%'), $builder->get('foo1')->arguments, '->createService() replaces parameters and service references in the arguments provided by the service definition');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::createService
-     */
     public function testCreateServiceFactoryMethod()
     {
         $builder = new ContainerBuilder();
@@ -341,9 +283,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('foo' => 'bar', 'bar' => 'foo', $builder->get('bar')), $builder->get('foo1')->arguments, '->createService() passes the arguments to the factory method');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::createService
-     */
     public function testCreateServiceFactoryService()
     {
         $builder = new ContainerBuilder();
@@ -357,9 +296,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($builder->get('foo')->called, '->createService() calls the factory method to create the service instance');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::createService
-     */
     public function testCreateServiceMethodCalls()
     {
         $builder = new ContainerBuilder();
@@ -369,9 +305,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('bar', $builder->get('bar')), $builder->get('foo1')->bar, '->createService() replaces the values in the method calls arguments');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::createService
-     */
     public function testCreateServiceConfigurator()
     {
         $builder = new ContainerBuilder();
@@ -396,7 +329,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::createService
      * @expectedException \RuntimeException
      */
     public function testCreateSyntheticService()
@@ -406,9 +338,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $builder->get('foo');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::resolveServices
-     */
     public function testResolveServices()
     {
         $builder = new ContainerBuilder();
@@ -417,9 +346,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('foo' => array('foo', $builder->get('foo'))), $builder->resolveServices(array('foo' => array('foo', new Reference('foo')))), '->resolveServices() resolves service references to service instances in nested arrays');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::merge
-     */
     public function testMerge()
     {
         $container = new ContainerBuilder(new ParameterBag(array('bar' => 'foo')));
@@ -467,7 +393,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::merge
      * @expectedException \LogicException
      */
     public function testMergeLogicException()
@@ -478,9 +403,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $container->merge(new ContainerBuilder());
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::findTaggedServiceIds
-     */
     public function testfindTaggedServiceIds()
     {
         $builder = new ContainerBuilder();
@@ -499,9 +421,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(), $builder->findTaggedServiceIds('foobar'), '->findTaggedServiceIds() returns an empty array if there is annotated services');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::findDefinition
-     */
     public function testFindDefinition()
     {
         $container = new ContainerBuilder();
@@ -511,9 +430,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($definition, $container->findDefinition('foobar'), '->findDefinition() returns a Definition');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::addObjectResource
-     */
     public function testAddObjectResource()
     {
         $container = new ContainerBuilder();
@@ -537,9 +453,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(realpath(__DIR__.'/Fixtures/includes/classes.php'), realpath($resource->getResource()));
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::addClassResource
-     */
     public function testAddClassResource()
     {
         $container = new ContainerBuilder();
@@ -563,9 +476,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(realpath(__DIR__.'/Fixtures/includes/classes.php'), realpath($resource->getResource()));
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::compile
-     */
     public function testCompilesClassDefinitionsOfLazyServices()
     {
         $container = new ContainerBuilder();
@@ -588,10 +498,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEmpty($matchingResources);
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::getResources
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::addResource
-     */
     public function testResources()
     {
         $container = new ContainerBuilder();
@@ -608,10 +514,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(), $container->getResources());
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::registerExtension
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::getExtension
-     */
     public function testExtension()
     {
         $container = new ContainerBuilder();
@@ -757,10 +659,6 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $container->setDefinition('a', new Definition());
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::getExtensionConfig
-     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::prependExtensionConfig
-     */
     public function testExtensionConfig()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -19,9 +19,6 @@ use Symfony\Component\DependencyInjection\Exception\InactiveScopeException;
 
 class ContainerTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers Symfony\Component\DependencyInjection\Container::__construct
-     */
     public function testConstructor()
     {
         $sc = new Container();
@@ -55,9 +52,6 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Container::compile
-     */
     public function testCompile()
     {
         $sc = new Container(new ParameterBag(array('foo' => 'bar')));
@@ -66,9 +60,6 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('foo' => 'bar'), $sc->getParameterBag()->all(), '->compile() copies the current parameters to the new parameter bag');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Container::isFrozen
-     */
     public function testIsFrozen()
     {
         $sc = new Container(new ParameterBag(array('foo' => 'bar')));
@@ -77,19 +68,12 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($sc->isFrozen(), '->isFrozen() returns true if the parameters are frozen');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Container::getParameterBag
-     */
     public function testGetParameterBag()
     {
         $sc = new Container();
         $this->assertEquals(array(), $sc->getParameterBag()->all(), '->getParameterBag() returns an empty array if no parameter has been defined');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Container::setParameter
-     * @covers Symfony\Component\DependencyInjection\Container::getParameter
-     */
     public function testGetSetParameter()
     {
         $sc = new Container(new ParameterBag(array('foo' => 'bar')));
@@ -112,9 +96,6 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Container::getServiceIds
-     */
     public function testGetServiceIds()
     {
         $sc = new Container();
@@ -126,9 +107,6 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('scoped', 'scoped_foo', 'inactive', 'bar', 'foo_bar', 'foo.baz', 'circular', 'throw_exception', 'throws_exception_on_service_configuration', 'service_container'), $sc->getServiceIds(), '->getServiceIds() returns defined service ids by getXXXService() methods');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Container::set
-     */
     public function testSet()
     {
         $sc = new Container();
@@ -136,9 +114,6 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($foo, $sc->get('foo'), '->set() sets a service');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Container::set
-     */
     public function testSetWithNullResetTheService()
     {
         $sc = new Container();
@@ -177,9 +152,6 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($foo, $services['foo']['foo']);
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Container::get
-     */
     public function testGet()
     {
         $sc = new ProjectServiceContainer();
@@ -238,18 +210,12 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Container::get
-     */
     public function testGetReturnsNullOnInactiveScope()
     {
         $sc = new ProjectServiceContainer();
         $this->assertNull($sc->get('inactive', ContainerInterface::NULL_ON_INVALID_REFERENCE));
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Container::has
-     */
     public function testHas()
     {
         $sc = new ProjectServiceContainer();
@@ -262,9 +228,6 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($sc->has('foo\\baz'), '->has() returns true if a get*Method() is defined');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Container::initialized
-     */
     public function testInitialized()
     {
         $sc = new ProjectServiceContainer();

--- a/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
@@ -15,9 +15,6 @@ use Symfony\Component\DependencyInjection\Definition;
 
 class DefinitionTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers Symfony\Component\DependencyInjection\Definition::__construct
-     */
     public function testConstructor()
     {
         $def = new Definition('stdClass');
@@ -51,10 +48,6 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo.bar', $def->getFactoryService(), '->getFactoryService() returns current service to construct this service.');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Definition::setClass
-     * @covers Symfony\Component\DependencyInjection\Definition::getClass
-     */
     public function testSetGetClass()
     {
         $def = new Definition('stdClass');
@@ -62,11 +55,6 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $def->getClass(), '->getClass() returns the class name');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Definition::setArguments
-     * @covers Symfony\Component\DependencyInjection\Definition::getArguments
-     * @covers Symfony\Component\DependencyInjection\Definition::addArgument
-     */
     public function testArguments()
     {
         $def = new Definition('stdClass');
@@ -76,12 +64,6 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('foo', 'bar'), $def->getArguments(), '->addArgument() adds an argument');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Definition::setMethodCalls
-     * @covers Symfony\Component\DependencyInjection\Definition::addMethodCall
-     * @covers Symfony\Component\DependencyInjection\Definition::hasMethodCall
-     * @covers Symfony\Component\DependencyInjection\Definition::removeMethodCall
-     */
     public function testMethodCalls()
     {
         $def = new Definition('stdClass');
@@ -105,10 +87,6 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
         $def->addMethodCall('');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Definition::setFile
-     * @covers Symfony\Component\DependencyInjection\Definition::getFile
-     */
     public function testSetGetFile()
     {
         $def = new Definition('stdClass');
@@ -116,10 +94,6 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $def->getFile(), '->getFile() returns the file to include');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Definition::setScope
-     * @covers Symfony\Component\DependencyInjection\Definition::getScope
-     */
     public function testSetGetScope()
     {
         $def = new Definition('stdClass');
@@ -128,10 +102,6 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $def->getScope());
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Definition::setPublic
-     * @covers Symfony\Component\DependencyInjection\Definition::isPublic
-     */
     public function testSetIsPublic()
     {
         $def = new Definition('stdClass');
@@ -140,10 +110,6 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($def->isPublic(), '->isPublic() returns false if the instance must not be public.');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Definition::setSynthetic
-     * @covers Symfony\Component\DependencyInjection\Definition::isSynthetic
-     */
     public function testSetIsSynthetic()
     {
         $def = new Definition('stdClass');
@@ -152,10 +118,6 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($def->isSynthetic(), '->isSynthetic() returns true if the service is synthetic.');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Definition::setSynchronized
-     * @covers Symfony\Component\DependencyInjection\Definition::isSynchronized
-     */
     public function testSetIsSynchronized()
     {
         $def = new Definition('stdClass');
@@ -164,10 +126,6 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($def->isSynchronized(), '->isSynchronized() returns true if the service is synchronized.');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Definition::setLazy
-     * @covers Symfony\Component\DependencyInjection\Definition::isLazy
-     */
     public function testSetIsLazy()
     {
         $def = new Definition('stdClass');
@@ -176,10 +134,6 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($def->isLazy(), '->isLazy() returns true if the service is lazy.');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Definition::setAbstract
-     * @covers Symfony\Component\DependencyInjection\Definition::isAbstract
-     */
     public function testSetIsAbstract()
     {
         $def = new Definition('stdClass');
@@ -188,10 +142,6 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($def->isAbstract(), '->isAbstract() returns true if the instance must not be public.');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Definition::setConfigurator
-     * @covers Symfony\Component\DependencyInjection\Definition::getConfigurator
-     */
     public function testSetGetConfigurator()
     {
         $def = new Definition('stdClass');
@@ -199,9 +149,6 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $def->getConfigurator(), '->getConfigurator() returns the configurator');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Definition::clearTags
-     */
     public function testClearTags()
     {
         $def = new Definition('stdClass');
@@ -211,9 +158,6 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(), $def->getTags(), '->clearTags() removes all current tags');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Definition::clearTags
-     */
     public function testClearTag()
     {
         $def = new Definition('stdClass');
@@ -230,12 +174,6 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($def->hasTag('3foo3'));
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Definition::addTag
-     * @covers Symfony\Component\DependencyInjection\Definition::getTag
-     * @covers Symfony\Component\DependencyInjection\Definition::getTags
-     * @covers Symfony\Component\DependencyInjection\Definition::hasTag
-     */
     public function testTags()
     {
         $def = new Definition('stdClass');
@@ -253,9 +191,6 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
         ), '->getTags() returns all tags');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Definition::replaceArgument
-     */
     public function testSetArgument()
     {
         $def = new Definition('stdClass');

--- a/src/Symfony/Component/DependencyInjection/Tests/LazyProxy/Instantiator/RealServiceInstantiatorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/LazyProxy/Instantiator/RealServiceInstantiatorTest.php
@@ -18,8 +18,6 @@ use Symfony\Component\DependencyInjection\LazyProxy\Instantiator\RealServiceInst
  * Tests for {@see \Symfony\Component\DependencyInjection\Instantiator\RealServiceInstantiator}.
  *
  * @author Marco Pivetta <ocramius@gmail.com>
- *
- * @covers \Symfony\Component\DependencyInjection\LazyProxy\Instantiator\RealServiceInstantiator
  */
 class RealServiceInstantiatorTest extends \PHPUnit_Framework_TestCase
 {

--- a/src/Symfony/Component/DependencyInjection/Tests/LazyProxy/PhpDumper/NullDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/LazyProxy/PhpDumper/NullDumperTest.php
@@ -18,8 +18,6 @@ use Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\NullDumper;
  * Tests for {@see \Symfony\Component\DependencyInjection\PhpDumper\NullDumper}.
  *
  * @author Marco Pivetta <ocramius@gmail.com>
- *
- * @covers \Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\NullDumper
  */
 class NullDumperTest extends \PHPUnit_Framework_TestCase
 {

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/ClosureLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/ClosureLoaderTest.php
@@ -16,9 +16,6 @@ use Symfony\Component\DependencyInjection\Loader\ClosureLoader;
 
 class ClosureLoaderTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers Symfony\Component\DependencyInjection\Loader\ClosureLoader::supports
-     */
     public function testSupports()
     {
         $loader = new ClosureLoader(new ContainerBuilder());
@@ -27,9 +24,6 @@ class ClosureLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($loader->supports('foo.foo'), '->supports() returns true if the resource is loadable');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Loader\ClosureLoader::load
-     */
     public function testLoad()
     {
         $loader = new ClosureLoader($container = new ContainerBuilder());

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/IniFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/IniFileLoaderTest.php
@@ -33,10 +33,6 @@ class IniFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->loader = new IniFileLoader($this->container, new FileLocator(self::$fixturesPath.'/ini'));
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Loader\IniFileLoader::__construct
-     * @covers Symfony\Component\DependencyInjection\Loader\IniFileLoader::load
-     */
     public function testIniFileCanBeLoaded()
     {
         $this->loader->load('parameters.ini');
@@ -44,9 +40,6 @@ class IniFileLoaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Symfony\Component\DependencyInjection\Loader\IniFileLoader::__construct
-     * @covers Symfony\Component\DependencyInjection\Loader\IniFileLoader::load
-     *
      * @expectedException        \InvalidArgumentException
      * @expectedExceptionMessage The file "foo.ini" does not exist (in:
      */
@@ -56,9 +49,6 @@ class IniFileLoaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Symfony\Component\DependencyInjection\Loader\IniFileLoader::__construct
-     * @covers Symfony\Component\DependencyInjection\Loader\IniFileLoader::load
-     *
      * @expectedException        \InvalidArgumentException
      * @expectedExceptionMessage The "nonvalid.ini" file is not valid.
      */
@@ -67,9 +57,6 @@ class IniFileLoaderTest extends \PHPUnit_Framework_TestCase
         @$this->loader->load('nonvalid.ini');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Loader\IniFileLoader::supports
-     */
     public function testSupports()
     {
         $loader = new IniFileLoader(new ContainerBuilder(), new FileLocator());

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -17,9 +17,6 @@ use Symfony\Component\Config\FileLocator;
 
 class PhpFileLoaderTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers Symfony\Component\DependencyInjection\Loader\PhpFileLoader::supports
-     */
     public function testSupports()
     {
         $loader = new PhpFileLoader(new ContainerBuilder(), new FileLocator());
@@ -28,9 +25,6 @@ class PhpFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($loader->supports('foo.foo'), '->supports() returns true if the resource is loadable');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Loader\PhpFileLoader::load
-     */
     public function testLoad()
     {
         $loader = new PhpFileLoader($container = new ContainerBuilder(), new FileLocator());

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -329,9 +329,6 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Loader\XmlFileLoader::supports
-     */
     public function testSupports()
     {
         $loader = new XmlFileLoader(new ContainerBuilder(), new FileLocator());

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -179,9 +179,6 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\Loader\YamlFileLoader::supports
-     */
     public function testSupports()
     {
         $loader = new YamlFileLoader(new ContainerBuilder(), new FileLocator());

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/FrozenParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/FrozenParameterBagTest.php
@@ -15,9 +15,6 @@ use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
 
 class FrozenParameterBagTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag::__construct
-     */
     public function testConstructor()
     {
         $parameters = array(
@@ -29,7 +26,6 @@ class FrozenParameterBagTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag::clear
      * @expectedException \LogicException
      */
     public function testClear()
@@ -39,7 +35,6 @@ class FrozenParameterBagTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag::set
      * @expectedException \LogicException
      */
     public function testSet()
@@ -49,7 +44,6 @@ class FrozenParameterBagTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag::add
      * @expectedException \LogicException
      */
     public function testAdd()

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
@@ -18,9 +18,6 @@ use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 
 class ParameterBagTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers Symfony\Component\DependencyInjection\ParameterBag\ParameterBag::__construct
-     */
     public function testConstructor()
     {
         $bag = new ParameterBag($parameters = array(
@@ -30,9 +27,6 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($parameters, $bag->all(), '__construct() takes an array of parameters as its first argument');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ParameterBag\ParameterBag::clear
-     */
     public function testClear()
     {
         $bag = new ParameterBag($parameters = array(
@@ -43,9 +37,6 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(), $bag->all(), '->clear() removes all parameters');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ParameterBag\ParameterBag::remove
-     */
     public function testRemove()
     {
         $bag = new ParameterBag(array(
@@ -58,10 +49,6 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(), $bag->all(), '->remove() converts key to lowercase before removing');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ParameterBag\ParameterBag::get
-     * @covers Symfony\Component\DependencyInjection\ParameterBag\ParameterBag::set
-     */
     public function testGetSet()
     {
         $bag = new ParameterBag(array('foo' => 'bar'));
@@ -117,9 +104,6 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ParameterBag\ParameterBag::has
-     */
     public function testHas()
     {
         $bag = new ParameterBag(array('foo' => 'bar'));
@@ -128,9 +112,6 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($bag->has('bar'), '->has() returns false if a parameter is not defined');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ParameterBag\ParameterBag::resolveValue
-     */
     public function testResolveValue()
     {
         $bag = new ParameterBag(array());
@@ -198,9 +179,6 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo.bar:1337', $bag->resolveValue('%host%:%port%'));
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ParameterBag\ParameterBag::resolve
-     */
     public function testResolveIndicatesWhyAParameterIsNeeded()
     {
         $bag = new ParameterBag(array('foo' => '%bar%'));
@@ -220,9 +198,6 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ParameterBag\ParameterBag::resolve
-     */
     public function testResolveUnescapesValue()
     {
         $bag = new ParameterBag(array(
@@ -236,9 +211,6 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('bar' => array('ding' => 'I\'m a bar %foo %bar')), $bag->get('foo'), '->resolveValue() supports % escaping by doubling it');
     }
 
-    /**
-     * @covers Symfony\Component\DependencyInjection\ParameterBag\ParameterBag::escapeValue
-     */
     public function testEscapeValue()
     {
         $bag = new ParameterBag();
@@ -253,7 +225,6 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Symfony\Component\DependencyInjection\ParameterBag\ParameterBag::resolve
      * @dataProvider stringsWithSpacesProvider
      */
     public function testResolveStringWithSpacesReturnsString($expected, $test, $description)

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterTest.php
@@ -15,9 +15,6 @@ use Symfony\Component\DependencyInjection\Parameter;
 
 class ParameterTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers Symfony\Component\DependencyInjection\Parameter::__construct
-     */
     public function testConstructor()
     {
         $ref = new Parameter('foo');

--- a/src/Symfony/Component/DependencyInjection/Tests/ReferenceTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ReferenceTest.php
@@ -15,9 +15,6 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class ReferenceTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers Symfony\Component\DependencyInjection\Reference::__construct
-     */
     public function testConstructor()
     {
         $ref = new Reference('foo');

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -24,9 +24,6 @@ class CrawlerTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $crawler, '__construct() takes a node as a first argument');
     }
 
-    /**
-     * @covers Symfony\Component\DomCrawler\Crawler::add
-     */
     public function testAdd()
     {
         $crawler = new Crawler();
@@ -62,9 +59,6 @@ class CrawlerTest extends \PHPUnit_Framework_TestCase
         $crawler->add(1);
     }
 
-    /**
-     * @covers Symfony\Component\DomCrawler\Crawler::addHtmlContent
-     */
     public function testAddHtmlContent()
     {
         $crawler = new Crawler();
@@ -79,7 +73,6 @@ class CrawlerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Symfony\Component\DomCrawler\Crawler::addHtmlContent
      * @requires extension mbstring
      */
     public function testAddHtmlContentCharset()
@@ -90,9 +83,6 @@ class CrawlerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Tiếng Việt', $crawler->filterXPath('//div')->text());
     }
 
-    /**
-     * @covers Symfony\Component\DomCrawler\Crawler::addHtmlContent
-     */
     public function testAddHtmlContentInvalidBaseTag()
     {
         $crawler = new Crawler(null, 'http://symfony.com');
@@ -102,9 +92,6 @@ class CrawlerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://symfony.com/contact', current($crawler->filterXPath('//a')->links())->getUri(), '->addHtmlContent() correctly handles a non-existent base tag href attribute');
     }
 
-    /**
-     * @covers Symfony\Component\DomCrawler\Crawler::addHtmlContent
-     */
     public function testAddHtmlContentUnsupportedCharset()
     {
         $crawler = new Crawler();
@@ -114,7 +101,6 @@ class CrawlerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Symfony\Component\DomCrawler\Crawler::addHtmlContent
      * @requires extension mbstring
      */
     public function testAddHtmlContentCharsetGbk()
@@ -126,9 +112,6 @@ class CrawlerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('中文', $crawler->filterXPath('//p')->text());
     }
 
-    /**
-     * @covers Symfony\Component\DomCrawler\Crawler::addHtmlContent
-     */
     public function testAddHtmlContentWithErrors()
     {
         $internalErrors = libxml_use_internal_errors(true);
@@ -154,9 +137,6 @@ EOF
         libxml_use_internal_errors($internalErrors);
     }
 
-    /**
-     * @covers Symfony\Component\DomCrawler\Crawler::addXmlContent
-     */
     public function testAddXmlContent()
     {
         $crawler = new Crawler();
@@ -165,9 +145,6 @@ EOF
         $this->assertEquals('foo', $crawler->filterXPath('//div')->attr('class'), '->addXmlContent() adds nodes from an XML string');
     }
 
-    /**
-     * @covers Symfony\Component\DomCrawler\Crawler::addXmlContent
-     */
     public function testAddXmlContentCharset()
     {
         $crawler = new Crawler();
@@ -176,9 +153,6 @@ EOF
         $this->assertEquals('Tiếng Việt', $crawler->filterXPath('//div')->text());
     }
 
-    /**
-     * @covers Symfony\Component\DomCrawler\Crawler::addXmlContent
-     */
     public function testAddXmlContentWithErrors()
     {
         $internalErrors = libxml_use_internal_errors(true);
@@ -202,9 +176,6 @@ EOF
         libxml_use_internal_errors($internalErrors);
     }
 
-    /**
-     * @covers Symfony\Component\DomCrawler\Crawler::addContent
-     */
     public function testAddContent()
     {
         $crawler = new Crawler();
@@ -240,9 +211,6 @@ EOF
         $this->assertEquals('日本語', $crawler->filterXPath('//body')->text(), '->addContent() can recognize "Shift_JIS" in html5 meta charset tag');
     }
 
-    /**
-     * @covers Symfony\Component\DomCrawler\Crawler::addDocument
-     */
     public function testAddDocument()
     {
         $crawler = new Crawler();
@@ -251,9 +219,6 @@ EOF
         $this->assertEquals('foo', $crawler->filterXPath('//div')->attr('class'), '->addDocument() adds nodes from a \DOMDocument');
     }
 
-    /**
-     * @covers Symfony\Component\DomCrawler\Crawler::addNodeList
-     */
     public function testAddNodeList()
     {
         $crawler = new Crawler();
@@ -262,9 +227,6 @@ EOF
         $this->assertEquals('foo', $crawler->filterXPath('//div')->attr('class'), '->addNodeList() adds nodes from a \DOMNodeList');
     }
 
-    /**
-     * @covers Symfony\Component\DomCrawler\Crawler::addNodes
-     */
     public function testAddNodes()
     {
         foreach ($this->createNodeList() as $node) {
@@ -277,9 +239,6 @@ EOF
         $this->assertEquals('foo', $crawler->filterXPath('//div')->attr('class'), '->addNodes() adds nodes from an array of nodes');
     }
 
-    /**
-     * @covers Symfony\Component\DomCrawler\Crawler::addNode
-     */
     public function testAddNode()
     {
         $crawler = new Crawler();
@@ -396,9 +355,6 @@ EOF
         $this->assertCount(7, $crawler->filterXPath('( ( //a | //div )//img | //ul )'));
     }
 
-    /**
-     * @covers Symfony\Component\DomCrawler\Crawler::filterXPath
-     */
     public function testFilterXPath()
     {
         $crawler = $this->createTestCrawler();
@@ -512,9 +468,6 @@ EOF
         $this->assertCount(9, $crawler->filterXPath('self::*/a'));
     }
 
-    /**
-     * @covers Symfony\Component\DomCrawler\Crawler::filter
-     */
     public function testFilter()
     {
         $crawler = $this->createTestCrawler();

--- a/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
@@ -41,7 +41,6 @@ class CookieTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider invalidNames
      * @expectedException \InvalidArgumentException
-     * @covers Symfony\Component\HttpFoundation\Cookie::__construct
      */
     public function testInstantiationThrowsExceptionIfCookieNameContainsInvalidCharacters($name)
     {
@@ -56,9 +55,6 @@ class CookieTest extends \PHPUnit_Framework_TestCase
         $cookie = new Cookie('MyCookie', 'foo', 'bar');
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\Cookie::getValue
-     */
     public function testGetValue()
     {
         $value = 'MyValue';

--- a/src/Symfony/Component/HttpFoundation/Tests/HeaderBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/HeaderBagTest.php
@@ -15,9 +15,6 @@ use Symfony\Component\HttpFoundation\HeaderBag;
 
 class HeaderBagTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers Symfony\Component\HttpFoundation\HeaderBag::__construct
-     */
     public function testConstructor()
     {
         $bag = new HeaderBag(array('foo' => 'bar'));
@@ -67,9 +64,6 @@ class HeaderBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('#a', $bag->getCacheControlDirective('public'));
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\HeaderBag::all
-     */
     public function testAll()
     {
         $bag = new HeaderBag(array('foo' => 'bar'));
@@ -79,9 +73,6 @@ class HeaderBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('foo' => array('BAR')), $bag->all(), '->all() gets all the input key are lower case');
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\HeaderBag::replace
-     */
     public function testReplace()
     {
         $bag = new HeaderBag(array('foo' => 'bar'));
@@ -91,9 +82,6 @@ class HeaderBagTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($bag->has('foo'), '->replace() overrides previously set the input');
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\HeaderBag::get
-     */
     public function testGet()
     {
         $bag = new HeaderBag(array('foo' => 'bar', 'fuzz' => 'bizz'));
@@ -119,9 +107,6 @@ class HeaderBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('value'), $bag->get('foo', 'nope', false), 'assoc indices of multi-valued headers are ignored');
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\HeaderBag::contains
-     */
     public function testContains()
     {
         $bag = new HeaderBag(array('foo' => 'bar', 'fuzz' => 'bizz'));
@@ -186,9 +171,6 @@ class HeaderBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(10, $bag->getCacheControlDirective('max-age'));
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\HeaderBag::getIterator
-     */
     public function testGetIterator()
     {
         $headers = array('foo' => 'bar', 'hello' => 'world', 'third' => 'charm');
@@ -203,9 +185,6 @@ class HeaderBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(count($headers), $i);
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\HeaderBag::count
-     */
     public function testCount()
     {
         $headers = array('foo' => 'bar', 'HELLO' => 'WORLD');

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -15,17 +15,11 @@ use Symfony\Component\HttpFoundation\ParameterBag;
 
 class ParameterBagTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers Symfony\Component\HttpFoundation\ParameterBag::__construct
-     */
     public function testConstructor()
     {
         $this->testAll();
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\ParameterBag::all
-     */
     public function testAll()
     {
         $bag = new ParameterBag(array('foo' => 'bar'));
@@ -54,9 +48,6 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('foo' => 'bar'), $bag->all());
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\ParameterBag::replace
-     */
     public function testReplace()
     {
         $bag = new ParameterBag(array('foo' => 'bar'));
@@ -66,9 +57,6 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($bag->has('foo'), '->replace() overrides previously set the input');
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\ParameterBag::get
-     */
     public function testGet()
     {
         $bag = new ParameterBag(array('foo' => 'bar', 'null' => null));
@@ -116,9 +104,6 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('default', $bag->get('bar[moo][foo]', 'default', true));
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\ParameterBag::set
-     */
     public function testSet()
     {
         $bag = new ParameterBag(array());
@@ -130,9 +115,6 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('baz', $bag->get('foo'), '->set() overrides previously set parameter');
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\ParameterBag::has
-     */
     public function testHas()
     {
         $bag = new ParameterBag(array('foo' => 'bar'));
@@ -141,9 +123,6 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($bag->has('unknown'), '->has() return false if a parameter is not defined');
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\ParameterBag::getAlpha
-     */
     public function testGetAlpha()
     {
         $bag = new ParameterBag(array('word' => 'foo_BAR_012'));
@@ -152,9 +131,6 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $bag->getAlpha('unknown'), '->getAlpha() returns empty string if a parameter is not defined');
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\ParameterBag::getAlnum
-     */
     public function testGetAlnum()
     {
         $bag = new ParameterBag(array('word' => 'foo_BAR_012'));
@@ -163,9 +139,6 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $bag->getAlnum('unknown'), '->getAlnum() returns empty string if a parameter is not defined');
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\ParameterBag::getDigits
-     */
     public function testGetDigits()
     {
         $bag = new ParameterBag(array('word' => 'foo_BAR_012'));
@@ -174,9 +147,6 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $bag->getDigits('unknown'), '->getDigits() returns empty string if a parameter is not defined');
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\ParameterBag::getInt
-     */
     public function testGetInt()
     {
         $bag = new ParameterBag(array('digits' => '0123'));
@@ -185,9 +155,6 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, $bag->getInt('unknown'), '->getInt() returns zero if a parameter is not defined');
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\ParameterBag::filter
-     */
     public function testFilter()
     {
         $bag = new ParameterBag(array(
@@ -223,9 +190,6 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('bang'), $bag->filter('array', '', false), '->filter() gets a value of parameter as an array');
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\ParameterBag::getIterator
-     */
     public function testGetIterator()
     {
         $parameters = array('foo' => 'bar', 'hello' => 'world');
@@ -240,9 +204,6 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(count($parameters), $i);
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\ParameterBag::count
-     */
     public function testCount()
     {
         $parameters = array('foo' => 'bar', 'hello' => 'world');

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -17,17 +17,11 @@ use Symfony\Component\HttpFoundation\Request;
 
 class RequestTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers Symfony\Component\HttpFoundation\Request::__construct
-     */
     public function testConstructor()
     {
         $this->testInitialize();
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\Request::initialize
-     */
     public function testInitialize()
     {
         $request = new Request();
@@ -94,9 +88,6 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('pl', $locale);
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\Request::create
-     */
     public function testCreate()
     {
         $request = Request::create('http://test.com/foo?bar=baz');
@@ -240,9 +231,6 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($request->isSecure());
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\Request::create
-     */
     public function testCreateCheckPrecedence()
     {
         // server is used by default
@@ -311,8 +299,6 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Symfony\Component\HttpFoundation\Request::getFormat
-     * @covers Symfony\Component\HttpFoundation\Request::setFormat
      * @dataProvider getFormatToMimeTypeMapProvider
      */
     public function testGetFormatFromMimeType($format, $mimeTypes)
@@ -327,9 +313,6 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\Request::getFormat
-     */
     public function testGetFormatFromMimeTypeWithParameters()
     {
         $request = new Request();
@@ -337,7 +320,6 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Symfony\Component\HttpFoundation\Request::getMimeType
      * @dataProvider getFormatToMimeTypeMapProvider
      */
     public function testGetMimeTypeFromFormat($format, $mimeTypes)
@@ -362,9 +344,6 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\Request::getUri
-     */
     public function testGetUri()
     {
         $server = array();
@@ -480,9 +459,6 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://host:8080/ba%20se/index_dev.php/foo%20bar/in+fo?query=string', $request->getUri());
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\Request::getUriForPath
-     */
     public function testGetUriForPath()
     {
         $request = Request::create('http://test.com/foo?bar=baz');
@@ -590,9 +566,6 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://servername/some/path', $request->getUriForPath('/some/path'));
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\Request::getUserInfo
-     */
     public function testGetUserInfo()
     {
         $request = new Request();
@@ -610,9 +583,6 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('0:0', $request->getUserInfo());
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\Request::getSchemeAndHttpHost
-     */
     public function testGetSchemeAndHttpHost()
     {
         $request = new Request();
@@ -636,8 +606,6 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Symfony\Component\HttpFoundation\Request::getQueryString
-     * @covers Symfony\Component\HttpFoundation\Request::normalizeQueryString
      * @dataProvider getQueryStringNormalizationData
      */
     public function testGetQueryString($query, $expectedQuery, $msg)
@@ -773,10 +741,6 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $request->getHost();
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\Request::setMethod
-     * @covers Symfony\Component\HttpFoundation\Request::getMethod
-     */
     public function testGetSetMethod()
     {
         $request = new Request();

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
@@ -20,7 +20,6 @@ use Symfony\Component\HttpFoundation\Cookie;
 class ResponseHeaderBagTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @covers Symfony\Component\HttpFoundation\ResponseHeaderBag::allPreserveCase
      * @dataProvider provideAllPreserveCase
      */
     public function testAllPreserveCase($headers, $expected)

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Attribute/AttributeBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Attribute/AttributeBagTest.php
@@ -169,9 +169,6 @@ class AttributeBagTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag::getIterator
-     */
     public function testGetIterator()
     {
         $i = 0;
@@ -183,9 +180,6 @@ class AttributeBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(count($this->array), $i);
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag::count
-     */
     public function testCount()
     {
         $this->assertEquals(count($this->array), count($this->bag));

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/FlashBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/FlashBagTest.php
@@ -132,9 +132,6 @@ class FlashBagTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\Session\Flash\FlashBag::getIterator
-     */
     public function testGetIterator()
     {
         $flashes = array('hello' => 'world', 'beep' => 'boop', 'notice' => 'nope');

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/SessionTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/SessionTest.php
@@ -190,9 +190,6 @@ class SessionTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\\Component\\HttpFoundation\\Session\\Flash\\FlashBagInterface', $this->session->getFlashBag());
     }
 
-    /**
-     * @covers Symfony\Component\HttpFoundation\Session\Session::getIterator
-     */
     public function testGetIterator()
     {
         $attributes = array('hello' => 'world', 'symfony' => 'rocks');
@@ -209,9 +206,6 @@ class SessionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(count($attributes), $i);
     }
 
-    /**
-     * @covers \Symfony\Component\HttpFoundation\Session\Session::count
-     */
     public function testGetCount()
     {
         $this->session->set('hello', 'world');

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
@@ -29,8 +29,6 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
     /**
      * When a time zone is not specified, it uses the system default however it returns null in the getter method.
      *
-     * @covers Symfony\Component\Intl\DateFormatter\IntlDateFormatter::getTimeZoneId
-     *
      * @see StubIntlDateFormatterTest::testDefaultTimeZoneIntl()
      */
     public function testConstructorDefaultTimeZone()
@@ -874,7 +872,6 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Symfony\Component\Intl\DateFormatter\IntlDateFormatter::getTimeZoneId
      * @dataProvider setTimeZoneIdProvider
      */
     public function testSetTimeZoneId($timeZoneId, $expectedTimeZoneId)

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsTest.php
@@ -392,7 +392,6 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Symfony\Component\OptionsResolver\Options::replace
      * @expectedException \Symfony\Component\OptionsResolver\Exception\OptionDefinitionException
      */
     public function testCannotReplaceAfterOptionWasRead()
@@ -406,7 +405,6 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Symfony\Component\OptionsResolver\Options::overload
      * @expectedException \Symfony\Component\OptionsResolver\Exception\OptionDefinitionException
      */
     public function testCannotOverloadAfterOptionWasRead()
@@ -418,7 +416,6 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Symfony\Component\OptionsResolver\Options::clear
      * @expectedException \Symfony\Component\OptionsResolver\Exception\OptionDefinitionException
      */
     public function testCannotClearAfterOptionWasRead()

--- a/src/Symfony/Component/Security/Tests/Core/Authentication/Token/AbstractTokenTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Authentication/Token/AbstractTokenTest.php
@@ -85,10 +85,6 @@ class AbstractTokenTest extends \PHPUnit_Framework_TestCase
         $token->eraseCredentials();
     }
 
-    /**
-     * @covers Symfony\Component\Security\Core\Authentication\Token\AbstractToken::serialize
-     * @covers Symfony\Component\Security\Core\Authentication\Token\AbstractToken::unserialize
-     */
     public function testSerialize()
     {
         $token = $this->getToken(array('ROLE_FOO'));
@@ -114,9 +110,6 @@ class AbstractTokenTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @covers Symfony\Component\Security\Core\Authentication\Token\AbstractToken::__construct
-     */
     public function testConstructor()
     {
         $token = $this->getToken(array('ROLE_FOO'));
@@ -129,10 +122,6 @@ class AbstractTokenTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(new Role('ROLE_FOO'), new Role('ROLE_BAR')), $token->getRoles());
     }
 
-    /**
-     * @covers Symfony\Component\Security\Core\Authentication\Token\AbstractToken::isAuthenticated
-     * @covers Symfony\Component\Security\Core\Authentication\Token\AbstractToken::setAuthenticated
-     */
     public function testAuthenticatedFlag()
     {
         $token = $this->getToken();
@@ -145,13 +134,6 @@ class AbstractTokenTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($token->isAuthenticated());
     }
 
-    /**
-     * @covers Symfony\Component\Security\Core\Authentication\Token\AbstractToken::getAttributes
-     * @covers Symfony\Component\Security\Core\Authentication\Token\AbstractToken::setAttributes
-     * @covers Symfony\Component\Security\Core\Authentication\Token\AbstractToken::hasAttribute
-     * @covers Symfony\Component\Security\Core\Authentication\Token\AbstractToken::getAttribute
-     * @covers Symfony\Component\Security\Core\Authentication\Token\AbstractToken::setAttribute
-     */
     public function testAttributes()
     {
         $attributes = array('foo' => 'bar');

--- a/src/Symfony/Component/Security/Tests/Core/User/UserTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/User/UserTest.php
@@ -16,7 +16,6 @@ use Symfony\Component\Security\Core\User\User;
 class UserTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @covers Symfony\Component\Security\Core\User\User::__construct
      * @expectedException \InvalidArgumentException
      */
     public function testConstructorException()
@@ -24,10 +23,6 @@ class UserTest extends \PHPUnit_Framework_TestCase
         new User('', 'superpass');
     }
 
-    /**
-     * @covers Symfony\Component\Security\Core\User\User::__construct
-     * @covers Symfony\Component\Security\Core\User\User::getRoles
-     */
     public function testGetRoles()
     {
         $user = new User('fabien', 'superpass');
@@ -37,38 +32,24 @@ class UserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('ROLE_ADMIN'), $user->getRoles());
     }
 
-    /**
-     * @covers Symfony\Component\Security\Core\User\User::__construct
-     * @covers Symfony\Component\Security\Core\User\User::getPassword
-     */
     public function testGetPassword()
     {
         $user = new User('fabien', 'superpass');
         $this->assertEquals('superpass', $user->getPassword());
     }
 
-    /**
-     * @covers Symfony\Component\Security\Core\User\User::__construct
-     * @covers Symfony\Component\Security\Core\User\User::getUsername
-     */
     public function testGetUsername()
     {
         $user = new User('fabien', 'superpass');
         $this->assertEquals('fabien', $user->getUsername());
     }
 
-    /**
-     * @covers Symfony\Component\Security\Core\User\User::getSalt
-     */
     public function testGetSalt()
     {
         $user = new User('fabien', 'superpass');
         $this->assertEquals('', $user->getSalt());
     }
 
-    /**
-     * @covers Symfony\Component\Security\Core\User\User::isAccountNonExpired
-     */
     public function testIsAccountNonExpired()
     {
         $user = new User('fabien', 'superpass');
@@ -78,9 +59,6 @@ class UserTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($user->isAccountNonExpired());
     }
 
-    /**
-     * @covers Symfony\Component\Security\Core\User\User::isCredentialsNonExpired
-     */
     public function testIsCredentialsNonExpired()
     {
         $user = new User('fabien', 'superpass');
@@ -90,9 +68,6 @@ class UserTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($user->isCredentialsNonExpired());
     }
 
-    /**
-     * @covers Symfony\Component\Security\Core\User\User::isAccountNonLocked
-     */
     public function testIsAccountNonLocked()
     {
         $user = new User('fabien', 'superpass');
@@ -102,9 +77,6 @@ class UserTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($user->isAccountNonLocked());
     }
 
-    /**
-     * @covers Symfony\Component\Security\Core\User\User::isEnabled
-     */
     public function testIsEnabled()
     {
         $user = new User('fabien', 'superpass');
@@ -114,9 +86,6 @@ class UserTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($user->isEnabled());
     }
 
-    /**
-     * @covers Symfony\Component\Security\Core\User\User::eraseCredentials
-     */
     public function testEraseCredentials()
     {
         $user = new User('fabien', 'superpass');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Some unit tests have a `@covers` PHPUnit annotations. Most of them were added a very long time ago, but since then, we did not use them anymore and the existing ones are not maintained (see #16413). So, I propose to remove them all.
