### PR TITLE
[FrameworkBundle][Form] Better exception message for private form tagged services

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FormPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FormPass.php
@@ -34,6 +34,10 @@ class FormPass implements CompilerPassInterface
         $types = array();
 
         foreach ($container->findTaggedServiceIds('form.type') as $serviceId => $tag) {
+            $serviceDefinition = $container->getDefinition($serviceId);
+            if (!$serviceDefinition->isPublic()) {
+                throw new \InvalidArgumentException(sprintf('The service "%s" must be public as form types are lazy-loaded.', $serviceId));
+            }
             // The following if-else block is deprecated and will be removed
             // in Symfony 3.0
             // Deprecation errors are triggered in the form registry
@@ -44,7 +48,6 @@ class FormPass implements CompilerPassInterface
             }
 
             // Support type access by FQCN
-            $serviceDefinition = $container->getDefinition($serviceId);
             $types[$serviceDefinition->getClass()] = $serviceId;
         }
 
@@ -53,6 +56,11 @@ class FormPass implements CompilerPassInterface
         $typeExtensions = array();
 
         foreach ($container->findTaggedServiceIds('form.type_extension') as $serviceId => $tag) {
+            $serviceDefinition = $container->getDefinition($serviceId);
+            if (!$serviceDefinition->isPublic()) {
+                throw new \InvalidArgumentException(sprintf('The service "%s" must be public as form type extensions are lazy-loaded.', $serviceId));
+            }
+
             if (isset($tag[0]['extended_type'])) {
                 $extendedType = $tag[0]['extended_type'];
             } elseif (isset($tag[0]['alias'])) {
@@ -70,6 +78,12 @@ class FormPass implements CompilerPassInterface
 
         // Find all services annotated with "form.type_guesser"
         $guessers = array_keys($container->findTaggedServiceIds('form.type_guesser'));
+        foreach ($guessers as $serviceId) {
+            $serviceDefinition = $container->getDefinition($serviceId);
+            if (!$serviceDefinition->isPublic()) {
+                throw new \InvalidArgumentException(sprintf('The service "%s" must be public as form type guessers are lazy-loaded.', $serviceId));
+            }
+        }
 
         $definition->replaceArgument(3, $guessers);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/FormPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/FormPassTest.php
@@ -206,6 +206,39 @@ class FormPassTest extends \PHPUnit_Framework_TestCase
             'my.guesser2',
         ), $extDefinition->getArgument(3));
     }
+
+    /**
+     * @dataProvider privateTaggedServicesProvider
+     */
+    public function testPrivateTaggedServices($id, $tagName, $expectedExceptionMessage)
+    {
+        $container = new ContainerBuilder();
+        $container->addCompilerPass(new FormPass());
+
+        $extDefinition = new Definition('Symfony\Component\Form\Extension\DependencyInjection\DependencyInjectionExtension');
+        $extDefinition->setArguments(array(
+            new Reference('service_container'),
+            array(),
+            array(),
+            array(),
+        ));
+
+        $container->setDefinition('form.extension', $extDefinition);
+        $container->register($id, 'stdClass')->setPublic(false)->addTag($tagName);
+
+        $this->setExpectedException('\InvalidArgumentException', $expectedExceptionMessage);
+
+        $container->compile();
+    }
+
+    public function privateTaggedServicesProvider()
+    {
+        return array(
+            array('my.type', 'form.type', 'The service "my.type" must be public as form types are lazy-loaded'),
+            array('my.type_extension', 'form.type_extension', 'The service "my.type_extension" must be public as form type extensions are lazy-loaded'),
+            array('my.guesser', 'form.type_guesser', 'The service "my.guesser" must be public as form type guessers are lazy-loaded'),
+        );
+    }
 }
 
 class FormPassTest_Type1 extends AbstractType


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Similar to what is done in [RegisterListenerPass](https://github.com/symfony/symfony/blob/2.8/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php#L61-L63), those changes allow to have a better exception message when defining a private `form.type`, `form.type_extension` or `form.form_guesser` tagged service, and at container compilation instead of runtime:

> The service "my.form.type" must be public as form types are lazy-loaded.

instead of:

> You have requested a non-existent service "my.form.type"

If I'm right, similar cases were considered as new features in the past, so this targets 2.8.
