### PR TITLE
[VarDumper] Deprecate VarDumperTestCase in favor of the trait

### DIFF
--- a/src/Symfony/Component/VarDumper/Test/VarDumperTestCase.php
+++ b/src/Symfony/Component/VarDumper/Test/VarDumperTestCase.php
@@ -16,6 +16,8 @@ use Symfony\Component\VarDumper\Dumper\CliDumper;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @deprecated since version 2.8, to be removed in 3.0. Use the VarDumperTestTrait instead.
  */
 abstract class VarDumperTestCase extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Because people must upgrade to PHP 5.5 before upgrading to Sf 3.0, this can be done on the 2.8 branch.
