### PR TITLE
[DI] Deprecate ContainerAware in favor of ContainerAwareTrait

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 2.8.0
 -----
 
+ * deprecated the abstract ContainerAware class in favor of ContainerAwareTrait
  * deprecated IntrospectableContainerInterface, to be merged with ContainerInterface in 3.0
  * allowed specifying a directory to recursively load all configuration files it contains
  * deprecated the concept of scopes

--- a/src/Symfony/Component/DependencyInjection/ContainerAware.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerAware.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\DependencyInjection;
  * A simple implementation of ContainerAwareInterface.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since version 2.8, to be removed in 3.0. Use the ContainerAwareTrait instead.
  */
 abstract class ContainerAware implements ContainerAwareInterface
 {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | - |

To be merged before #16411 (that then should be rebased) if we agree that this is the right approach (which I believe personally).
The deprecation notice will be triggered by the existing mechanism in the DebugClassLoader (it can't be added inline because that would make symfony itself trigger it).
PHP 5.3 users migrating to 3.0 must already move to 2.8+5.5 beforehand so this is really on the CUP (Continuous Upgrade Path).
