### PR TITLE
[HttpKernel] PostResponseEvent should extend the KernelEvent

### DIFF
--- a/src/Symfony/Component/HttpKernel/Event/PostResponseEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/PostResponseEvent.php
@@ -12,53 +12,26 @@
 namespace Symfony\Component\HttpKernel\Event;
 
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Allows to execute logic after a response was sent.
  *
+ * Since it's only triggered on master requests, the `getRequestType()` method
+ * will always return the value of `HttpKernelInterface::MASTER_REQUEST`.
+ *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
-class PostResponseEvent extends Event
+class PostResponseEvent extends KernelEvent
 {
-    /**
-     * The kernel in which this event was thrown.
-     *
-     * @var HttpKernelInterface
-     */
-    private $kernel;
-
-    private $request;
-
     private $response;
 
     public function __construct(HttpKernelInterface $kernel, Request $request, Response $response)
     {
-        $this->kernel = $kernel;
-        $this->request = $request;
+        parent::__construct($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+
         $this->response = $response;
-    }
-
-    /**
-     * Returns the kernel in which this event was thrown.
-     *
-     * @return HttpKernelInterface
-     */
-    public function getKernel()
-    {
-        return $this->kernel;
-    }
-
-    /**
-     * Returns the request for which this event was thrown.
-     *
-     * @return Request
-     */
-    public function getRequest()
-    {
-        return $this->request;
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16342 |
| License | MIT |
| Doc PR | - |

Technically the `PostResponseEvent` is a `KernelEvent`.
