### PR TITLE
[Console] Add command resolver (proof of concept)

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -516,8 +516,9 @@ class Application
 
         // filter out aliases for commands which are already on the list
         if (count($commands) > 1) {
-            $commands = array_filter($commands, function ($nameOrAlias) use ($commands) {
-                $commandName = $this->commands->get($nameOrAlias)->getName();
+            $resolver = $this->commands; 
+            $commands = array_filter($commands, function ($nameOrAlias) use ($resolver, $commands) {
+                $commandName = $resolver->get($nameOrAlias)->getName();
 
                 return $commandName === $nameOrAlias || !in_array($commandName, $commands);
             });

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -62,10 +62,9 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class Application
 {
-
-  /**
-   * @var CommandResolverInterface
-   */
+    /**
+     * @var CommandResolverInterface
+     */
     private $commands;
     private $wantHelps = false;
     private $runningCommand;

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -93,7 +93,7 @@ class Application
         $this->helperSet = $this->getDefaultHelperSet();
         $this->definition = $this->getDefaultInputDefinition();
 
-        $this->commandResolver = ($commandResolver !== null) ? $commandResolver : new CommandResolver();
+        $this->commandResolver = $commandResolver !== null ? $commandResolver : new CommandResolver();
 
         foreach ($this->getDefaultCommands() as $command) {
             $this->add($command);

--- a/src/Symfony/Component/Console/CommandsResolver/CommandResolver.php
+++ b/src/Symfony/Component/Console/CommandsResolver/CommandResolver.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\CommandsResolver;
+
+use Symfony\Component\Console\Command\Command;
+
+/**
+ * @author Ivan Shcherbak <dev@funivan.com>
+ */
+class CommandResolver implements CommandResolverInterface
+{
+    private $commands = array();
+
+  /**
+   * {@inheritdoc}
+   */
+  public function add(Command $command)
+  {
+      $this->commands[$command->getName()] = $command;
+
+      foreach ($command->getAliases() as $alias) {
+          $this->commands[$alias] = $command;
+      }
+
+      return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function has($name)
+  {
+      return !empty($this->commands[$name]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function get($name)
+  {
+      return !empty($this->commands[$name]) ? $this->commands[$name] : null;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getAll()
+  {
+      return $this->commands;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getAllNames()
+  {
+      return array_keys($this->commands);
+  }
+}

--- a/src/Symfony/Component/Console/CommandsResolver/CommandResolver.php
+++ b/src/Symfony/Component/Console/CommandsResolver/CommandResolver.php
@@ -26,13 +26,13 @@ class CommandResolver implements CommandResolverInterface
     public function add(Command $command)
     {
         $this->commands[$command->getName()] = $command;
-  
+
         foreach ($command->getAliases() as $alias) {
             $this->commands[$alias] = $command;
         }
-  
+
     }
-  
+
     /**
      * {@inheritdoc}
      */
@@ -40,7 +40,7 @@ class CommandResolver implements CommandResolverInterface
     {
         return !empty($this->commands[$name]);
     }
-  
+
     /**
      * {@inheritdoc}
      */
@@ -48,7 +48,7 @@ class CommandResolver implements CommandResolverInterface
     {
         return !empty($this->commands[$name]) ? $this->commands[$name] : null;
     }
-  
+
     /**
      * {@inheritdoc}
      */
@@ -56,7 +56,7 @@ class CommandResolver implements CommandResolverInterface
     {
         return $this->commands;
     }
-  
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Console/CommandsResolver/CommandResolver.php
+++ b/src/Symfony/Component/Console/CommandsResolver/CommandResolver.php
@@ -20,49 +20,48 @@ class CommandResolver implements CommandResolverInterface
 {
     private $commands = array();
 
-  /**
-   * {@inheritdoc}
-   */
-  public function add(Command $command)
-  {
-      $this->commands[$command->getName()] = $command;
-
-      foreach ($command->getAliases() as $alias) {
-          $this->commands[$alias] = $command;
-      }
-
-      return $this;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function has($name)
-  {
-      return !empty($this->commands[$name]);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function get($name)
-  {
-      return !empty($this->commands[$name]) ? $this->commands[$name] : null;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getAll()
-  {
-      return $this->commands;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getAllNames()
-  {
-      return array_keys($this->commands);
-  }
+    /**
+     * {@inheritdoc}
+     */
+    public function add(Command $command)
+    {
+        $this->commands[$command->getName()] = $command;
+  
+        foreach ($command->getAliases() as $alias) {
+            $this->commands[$alias] = $command;
+        }
+  
+    }
+  
+    /**
+     * {@inheritdoc}
+     */
+    public function has($name)
+    {
+        return !empty($this->commands[$name]);
+    }
+  
+    /**
+     * {@inheritdoc}
+     */
+    public function get($name)
+    {
+        return !empty($this->commands[$name]) ? $this->commands[$name] : null;
+    }
+  
+    /**
+     * {@inheritdoc}
+     */
+    public function getAll()
+    {
+        return $this->commands;
+    }
+  
+    /**
+     * {@inheritdoc}
+     */
+    public function getAllNames()
+    {
+        return array_keys($this->commands);
+    }
 }

--- a/src/Symfony/Component/Console/CommandsResolver/CommandResolver.php
+++ b/src/Symfony/Component/Console/CommandsResolver/CommandResolver.php
@@ -38,7 +38,7 @@ class CommandResolver implements CommandResolverInterface
      */
     public function has($name)
     {
-        return !empty($this->commands[$name]);
+        return isset($this->commands[$name]);
     }
 
     /**
@@ -46,7 +46,7 @@ class CommandResolver implements CommandResolverInterface
      */
     public function get($name)
     {
-        return !empty($this->commands[$name]) ? $this->commands[$name] : null;
+        return isset($this->commands[$name]) ? $this->commands[$name] : null;
     }
 
     /**

--- a/src/Symfony/Component/Console/CommandsResolver/CommandResolverInterface.php
+++ b/src/Symfony/Component/Console/CommandsResolver/CommandResolverInterface.php
@@ -22,7 +22,7 @@ interface CommandResolverInterface
      * @param Command $command
      */
     public function add(Command $command);
-  
+
     /**
      * Check if command exist.
      * 
@@ -31,7 +31,7 @@ interface CommandResolverInterface
      * @return bool
      */
     public function has($name);
-  
+
     /**
      * Get command by name or alias.
      * 
@@ -40,14 +40,14 @@ interface CommandResolverInterface
      * @return Command|null
      */
     public function get($name);
-  
+
     /**         
      * Return all available commands related to this application.
      * 
      * @return Command[]
      */
     public function getAll();
-  
+
     /**
      * Return all command names and aliases.
      * 

--- a/src/Symfony/Component/Console/CommandsResolver/CommandResolverInterface.php
+++ b/src/Symfony/Component/Console/CommandsResolver/CommandResolverInterface.php
@@ -18,7 +18,6 @@ use Symfony\Component\Console\Command\Command;
  */
 interface CommandResolverInterface
 {
-
   /**
    * @param Command $command
    *

--- a/src/Symfony/Component/Console/CommandsResolver/CommandResolverInterface.php
+++ b/src/Symfony/Component/Console/CommandsResolver/CommandResolverInterface.php
@@ -20,6 +20,7 @@ interface CommandResolverInterface
 {
     /**
      * Store initialized commands.
+     * Important! Commands with the same name will be overridden.
      *
      * @param Command $command
      */

--- a/src/Symfony/Component/Console/CommandsResolver/CommandResolverInterface.php
+++ b/src/Symfony/Component/Console/CommandsResolver/CommandResolverInterface.php
@@ -19,6 +19,8 @@ use Symfony\Component\Console\Command\Command;
 interface CommandResolverInterface
 {
     /**
+     * Store initialized commands.
+     *
      * @param Command $command
      */
     public function add(Command $command);

--- a/src/Symfony/Component/Console/CommandsResolver/CommandResolverInterface.php
+++ b/src/Symfony/Component/Console/CommandsResolver/CommandResolverInterface.php
@@ -18,42 +18,40 @@ use Symfony\Component\Console\Command\Command;
  */
 interface CommandResolverInterface
 {
-  /**
-   * @param Command $command
-   *
-   * @return $this
-   */
-  public function add(Command $command);
-
-  /**
-   * Check if command exist.
-   * 
-   * @param string $name
-   *
-   * @return bool
-   */
-  public function has($name);
-
-  /**
-   * Get command by name or alias.
-   * 
-   * @param string $name
-   *
-   * @return Command|null
-   */
-  public function get($name);
-
-  /**         
-   * Return all available commands related to this application.
-   * 
-   * @return Command[]
-   */
-  public function getAll();
-
-  /**
-   * Return all command names and aliases.
-   * 
-   * @return array
-   */
-  public function getAllNames();
+    /**
+     * @param Command $command
+     */
+    public function add(Command $command);
+  
+    /**
+     * Check if command exist.
+     * 
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function has($name);
+  
+    /**
+     * Get command by name or alias.
+     * 
+     * @param string $name
+     *
+     * @return Command|null
+     */
+    public function get($name);
+  
+    /**         
+     * Return all available commands related to this application.
+     * 
+     * @return Command[]
+     */
+    public function getAll();
+  
+    /**
+     * Return all command names and aliases.
+     * 
+     * @return array
+     */
+    public function getAllNames();
 }

--- a/src/Symfony/Component/Console/CommandsResolver/CommandResolverInterface.php
+++ b/src/Symfony/Component/Console/CommandsResolver/CommandResolverInterface.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\CommandsResolver;
+
+use Symfony\Component\Console\Command\Command;
+
+/**
+ * @author Ivan Shcherbak <dev@funivan.com>
+ */
+interface CommandResolverInterface
+{
+
+  /**
+   * @param Command $command
+   *
+   * @return $this
+   */
+  public function add(Command $command);
+
+  /**
+   * Check if command exist.
+   * 
+   * @param string $name
+   *
+   * @return bool
+   */
+  public function has($name);
+
+  /**
+   * Get command by name or alias.
+   * 
+   * @param string $name
+   *
+   * @return Command|null
+   */
+  public function get($name);
+
+  /**         
+   * Return all available commands related to this application.
+   * 
+   * @return Command[]
+   */
+  public function getAll();
+
+  /**
+   * Return all command names and aliases.
+   * 
+   * @return array
+   */
+  public function getAllNames();
+}

--- a/src/Symfony/Component/Console/Tests/CommandResolver/CommandResolverTest.php
+++ b/src/Symfony/Component/Console/Tests/CommandResolver/CommandResolverTest.php
@@ -16,8 +16,8 @@ use Symfony\Component\Console\Tests\Fixtures\CustomCommandResolver;
 use Symfony\Component\Console\Tests\Fixtures\LazyTestCommand;
 
 /**
-* @author Ivan Shcherbak <dev@funivan.com>
-*/
+ * @author Ivan Shcherbak <dev@funivan.com>
+ */
 class CommandResolverTest extends \PHPUnit_Framework_TestCase
 {
   public function testLazyCommandResolver()

--- a/src/Symfony/Component/Console/Tests/CommandResolver/CommandResolverTest.php
+++ b/src/Symfony/Component/Console/Tests/CommandResolver/CommandResolverTest.php
@@ -20,18 +20,18 @@ use Symfony\Component\Console\Tests\Fixtures\LazyTestCommand;
  */
 class CommandResolverTest extends \PHPUnit_Framework_TestCase
 {
-  public function testLazyCommandResolver()
-  {
-      $resolver = new CustomCommandResolver();
-      $names = $resolver->getAllNames();
-      $this->assertEquals(array('lazyTest'), $names);
-  }
+    public function testLazyCommandResolver()
+    {
+        $resolver = new CustomCommandResolver();
+        $names = $resolver->getAllNames();
+        $this->assertEquals(array('lazyTest'), $names);
+    }
 
-  public function testLazyLoadingCommands()
-  {
-      $application = new Application('foo', 'bar', new CustomCommandResolver());
-      $command = $application->get('lazyTest');
-      $this->assertNotEmpty($command);
-      $this->assertTrue($command instanceof LazyTestCommand);
-  }
+    public function testLazyLoadingCommands()
+    {
+        $application = new Application('foo', 'bar', new CustomCommandResolver());
+        $command = $application->get('lazyTest');
+        $this->assertNotEmpty($command);
+        $this->assertTrue($command instanceof LazyTestCommand);
+    }
 }

--- a/src/Symfony/Component/Console/Tests/CommandResolver/CommandResolverTest.php
+++ b/src/Symfony/Component/Console/Tests/CommandResolver/CommandResolverTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Test\CommandsResolver;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tests\Fixtures\CustomCommandResolver;
+use Symfony\Component\Console\Tests\Fixtures\LazyTestCommand;
+
+/**
+* @author Ivan Shcherbak <dev@funivan.com>
+*/
+class CommandResolverTest extends \PHPUnit_Framework_TestCase
+{
+  public function testLazyCommandResolver()
+  {
+      $resolver = new CustomCommandResolver();
+      $names = $resolver->getAllNames();
+      $this->assertEquals(array('lazyTest'), $names);
+  }
+
+  public function testLazyLoadingCommands()
+  {
+      $application = new Application('foo', 'bar', new CustomCommandResolver());
+      $command = $application->get('lazyTest');
+      $this->assertNotEmpty($command);
+      $this->assertTrue($command instanceof LazyTestCommand);
+  }
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/CustomCommandResolver.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/CustomCommandResolver.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\CommandsResolver\CommandResolverInterface;
  */
 class CustomCommandResolver implements CommandResolverInterface
 {
-    /**
+  /**
    * Cache commands.
    *
    * @var array

--- a/src/Symfony/Component/Console/Tests/Fixtures/CustomCommandResolver.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/CustomCommandResolver.php
@@ -1,0 +1,141 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Fixtures;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\CommandsResolver\CommandResolverInterface;
+
+/**
+ * @author Ivan Shcherbak <dev@funivan.com>
+ */
+class CustomCommandResolver implements CommandResolverInterface
+{
+    /**
+   * Cache commands.
+   *
+   * @var array
+   */
+  private $commands = array();
+
+  /**
+   * @var array
+   */
+  private static $commandsMap = array(
+    'lazyTest' => '\Symfony\Component\Console\Tests\Fixtures\LazyTestCommand',
+  );
+
+  /**
+   * @param string $commandClassName
+   *
+   * @return string|null
+   */
+  public static function getNameFromClass($commandClassName)
+  {
+      $commandClassName = '\\'.ltrim($commandClassName, '\\');
+      $name = array_search($commandClassName, self::$commandsMap);
+      if ($name === false) {
+          return;
+      }
+
+      return $name;
+  }
+
+  /**
+   * @param string $name
+   *
+   * @return string|null
+   */
+  public static function getClassFromName($name)
+  {
+      return isset(self::$commandsMap[$name]) ? self::$commandsMap[$name] : null;
+  }
+
+  /**
+   * @param Command $command
+   *
+   * @return $this
+   */
+  public function add(Command $command)
+  {
+      $this->commands[$command->getName()] = $command;
+
+      return $this;
+  }
+
+  /**
+   * Check if command exist.
+   *
+   * @param string $name
+   *
+   * @return bool
+   */
+  public function has($name)
+  {
+      if (isset($this->commands[$name])) {
+          return true;
+      }
+
+      return isset(self::$commandsMap[$name]);
+  }
+
+  /**
+   * Get command by name or alias.
+   *
+   * @param string $name
+   *
+   * @return Command|null
+   */
+  public function get($name)
+  {
+      if (isset($this->commands[$name])) {
+          return $this->commands[$name];
+      }
+
+      $class = self::getClassFromName($name);
+      if (empty($class)) {
+          return;
+      }
+
+      return new $class();
+  }
+
+  /**
+   * Return all available commands related to this application.
+   *
+   * @return Command[]
+   */
+  public function getAll()
+  {
+      $items = $this->commands;
+      foreach (self::$commandsMap as $command) {
+          $items[] = new $command();
+      }
+
+      return $items;
+  }
+
+  /**
+   * Return all command names and aliases.
+   *
+   * @return array
+   */
+  public function getAllNames()
+  {
+      $names = array_keys(self::$commandsMap);
+
+      if (!empty($this->commands)) {
+          $names = array_merge($names, array_keys($this->commands));
+      }
+
+      return $names;
+  }
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/CustomCommandResolver.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/CustomCommandResolver.php
@@ -19,123 +19,107 @@ use Symfony\Component\Console\CommandsResolver\CommandResolverInterface;
  */
 class CustomCommandResolver implements CommandResolverInterface
 {
-  /**
-   * Cache commands.
-   *
-   * @var array
-   */
-  private $commands = array();
+    /**
+     * Cache commands.
+     *
+     * @var array
+     */
+    private $commands = array();
 
-  /**
-   * @var array
-   */
-  private static $commandsMap = array(
-    'lazyTest' => '\Symfony\Component\Console\Tests\Fixtures\LazyTestCommand',
-  );
+    /**
+     * @var array
+     */
+    private static $commandsMap = array(
+      'lazyTest' => '\Symfony\Component\Console\Tests\Fixtures\LazyTestCommand',
+    );
 
-  /**
-   * @param string $commandClassName
-   *
-   * @return string|null
-   */
-  public static function getNameFromClass($commandClassName)
-  {
-      $commandClassName = '\\'.ltrim($commandClassName, '\\');
-      $name = array_search($commandClassName, self::$commandsMap);
-      if ($name === false) {
-          return;
-      }
+    /**
+     * @param string $commandClassName
+     *
+     * @return string|null
+     */
+    public static function getNameFromClass($commandClassName)
+    {
+        $commandClassName = '\\'.ltrim($commandClassName, '\\');
+        $name = array_search($commandClassName, self::$commandsMap);
+        if ($name === false) {
+            return;
+        }
 
-      return $name;
-  }
+        return $name;
+    }
 
-  /**
-   * @param string $name
-   *
-   * @return string|null
-   */
-  public static function getClassFromName($name)
-  {
-      return isset(self::$commandsMap[$name]) ? self::$commandsMap[$name] : null;
-  }
+    /**
+     * @param string $name
+     *
+     * @return string|null
+     */
+    public static function getClassFromName($name)
+    {
+        return isset(self::$commandsMap[$name]) ? self::$commandsMap[$name] : null;
+    }
 
-  /**
-   * @param Command $command
-   *
-   * @return $this
-   */
-  public function add(Command $command)
-  {
-      $this->commands[$command->getName()] = $command;
+    /**
+     * @inheritdoc
+     */
+    public function add(Command $command)
+    {
+        $this->commands[$command->getName()] = $command;
+    }
 
-      return $this;
-  }
+    /**
+     * @inheritdoc
+     */
+    public function has($name)
+    {
+        if (isset($this->commands[$name])) {
+            return true;
+        }
 
-  /**
-   * Check if command exist.
-   *
-   * @param string $name
-   *
-   * @return bool
-   */
-  public function has($name)
-  {
-      if (isset($this->commands[$name])) {
-          return true;
-      }
+        return isset(self::$commandsMap[$name]);
+    }
 
-      return isset(self::$commandsMap[$name]);
-  }
+    /**
+     * @inheritdoc
+     */
+    public function get($name)
+    {
+        if (isset($this->commands[$name])) {
+            return $this->commands[$name];
+        }
 
-  /**
-   * Get command by name or alias.
-   *
-   * @param string $name
-   *
-   * @return Command|null
-   */
-  public function get($name)
-  {
-      if (isset($this->commands[$name])) {
-          return $this->commands[$name];
-      }
+        $class = self::getClassFromName($name);
+        if (empty($class)) {
+            return;
+        }
 
-      $class = self::getClassFromName($name);
-      if (empty($class)) {
-          return;
-      }
+        return new $class();
+    }
 
-      return new $class();
-  }
+    /**
+     * @inheritdoc
+     */
+    public function getAll()
+    {
+        $items = $this->commands;
+        foreach (self::$commandsMap as $command) {
+            $items[] = new $command();
+        }
 
-  /**
-   * Return all available commands related to this application.
-   *
-   * @return Command[]
-   */
-  public function getAll()
-  {
-      $items = $this->commands;
-      foreach (self::$commandsMap as $command) {
-          $items[] = new $command();
-      }
+        return $items;
+    }
 
-      return $items;
-  }
+    /**
+     * @inheritdoc
+     */
+    public function getAllNames()
+    {
+        $names = array_keys(self::$commandsMap);
 
-  /**
-   * Return all command names and aliases.
-   *
-   * @return array
-   */
-  public function getAllNames()
-  {
-      $names = array_keys(self::$commandsMap);
+        if (!empty($this->commands)) {
+            $names = array_merge($names, array_keys($this->commands));
+        }
 
-      if (!empty($this->commands)) {
-          $names = array_merge($names, array_keys($this->commands));
-      }
-
-      return $names;
-  }
+        return $names;
+    }
 }

--- a/src/Symfony/Component/Console/Tests/Fixtures/CustomCommandResolver.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/CustomCommandResolver.php
@@ -60,7 +60,7 @@ class CustomCommandResolver implements CommandResolverInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function add(Command $command)
     {
@@ -68,7 +68,7 @@ class CustomCommandResolver implements CommandResolverInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function has($name)
     {
@@ -80,7 +80,7 @@ class CustomCommandResolver implements CommandResolverInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function get($name)
     {
@@ -97,7 +97,7 @@ class CustomCommandResolver implements CommandResolverInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getAll()
     {
@@ -110,7 +110,7 @@ class CustomCommandResolver implements CommandResolverInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getAllNames()
     {

--- a/src/Symfony/Component/Console/Tests/Fixtures/LazyTestCommand.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/LazyTestCommand.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Fixtures;
+
+use Symfony\Component\Console\Command\Command;
+
+/**
+ * @author Ivan Shcherbak <dev@funivan.com>
+ */
+class LazyTestCommand extends Command
+{
+    protected function configure()
+    {
+        parent::configure();
+        $name = CustomCommandResolver::getNameFromClass(get_class($this));
+        $this->setName($name);
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12063 |
| License | MIT |
| Doc PR | NA |

Hello. This is simple proof of concept for command resolver.
# Why?

On huge projects we should always initialize all commands, even if they are not used.
Some users want lazy-loading of commands. And there are a lot of ways how to do that. Store cache in files, db, initialize commands by unique id etc..
# How?

This PR introduce new interface `CommandResolverInterface`. Any user can implement logic and inject it to the application. With this interface developer can create commands _by request_ 
# BC ?

This interface is softly injected to this application. All tests pass. By default `CommandResolver` is simple holder for commands. 
# Current state

There are one problem: when we add `Command` to application, application add this command only if it is available. This logic is not covered in `CommandResolverInterface`. We put all responsibility to developer which Commands are available to application.

If it will be interesting to the team I can polish it (fix code style, possible change names of interface, write documentation etc.)
