### PR TITLE
[HttpKernel] Fix time-sensitive test case

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
@@ -15,6 +15,9 @@ use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @group time-sensitive
+ */
 class FragmentHandlerTest extends \PHPUnit_Framework_TestCase
 {
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Fixes these kind of failures:

```
1) Symfony\Component\HttpKernel\Tests\Fragment\FragmentHandlerTest::testRender
Expectation failed for method name is equal to <string:render> when invoked zero or more times

Parameter 1 for invocation Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface::render('/', Symfony\Component\HttpFoundation\Request Object (...), Array (...)) does not match expected value.

Failed asserting that two objects are equal.
--- Expected
+++ Actual
@@ @@
             'SERVER_PROTOCOL' => 'HTTP/1.1'
-            'REQUEST_TIME' => 1446551470
+            'REQUEST_TIME' => 1446551469
             'PATH_INFO' => ''
             'REQUEST_METHOD' => 'GET'
```
