### PR TITLE
[LDAP] ldap_set_option should be called with a valid link identifier

### DIFF
--- a/src/Symfony/Component/Ldap/LdapClient.php
+++ b/src/Symfony/Component/Ldap/LdapClient.php
@@ -109,10 +109,10 @@ class LdapClient implements LdapClientInterface
                 $host = 'ldaps://'.$host;
             }
 
+            $this->connection = ldap_connect($host, $this->port);
+
             ldap_set_option($this->connection, LDAP_OPT_PROTOCOL_VERSION, $this->version);
             ldap_set_option($this->connection, LDAP_OPT_REFERRALS, $this->optReferrals);
-
-            $this->connection = ldap_connect($host, $this->port);
 
             if ($this->useStartTls) {
                 ldap_start_tls($this->connection);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
