### PR TITLE
OptionsResolver test coverage

### DIFF
--- a/src/Symfony/Component/OptionsResolver/Tests/LegacyOptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/LegacyOptionsResolverTest.php
@@ -20,11 +20,6 @@ use Symfony\Component\OptionsResolver\Options;
 class LegacyOptionsResolverTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var ReflectionMethod
-     */
-    private $reflectionMethod;
-
-    /**
      * @var OptionsResolver
      */
     private $resolver;
@@ -32,10 +27,6 @@ class LegacyOptionsResolverTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->resolver = new OptionsResolver();
-
-        $reflectionClass = new \ReflectionClass($this->resolver);
-        $this->reflectionMethod = $reflectionClass->getMethod('formatValue');
-        $this->reflectionMethod->setAccessible(true);
     }
 
     public function testResolve()
@@ -738,21 +729,5 @@ class LegacyOptionsResolverTest extends \PHPUnit_Framework_TestCase
         $this->resolver->overload('foo', 'bar');
 
         $this->assertSame(array('foo' => 'bar'), $this->resolver->resolve());
-    }
-
-    public function testFormatValueObject()
-    {
-        $this->assertEquals("Symfony\Component\OptionsResolver\OptionsResolver", $this->reflectionMethod->invoke($this->resolver, $this->resolver));
-    }
-
-    public function testFormatValueArray()
-    {
-        $this->assertEquals("array", $this->reflectionMethod->invoke($this->resolver, []));
-    }
-
-    public function testFormatValueResource()
-    {
-        $handle = fopen(__FILE__, "r");
-        $this->assertEquals("resource", $this->reflectionMethod->invoke($this->resolver, $handle));
     }
 }

--- a/src/Symfony/Component/OptionsResolver/Tests/LegacyOptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/LegacyOptionsResolverTest.php
@@ -20,6 +20,11 @@ use Symfony\Component\OptionsResolver\Options;
 class LegacyOptionsResolverTest extends \PHPUnit_Framework_TestCase
 {
     /**
+     * @var ReflectionMethod
+     */
+    private $reflectionMethod;
+
+    /**
      * @var OptionsResolver
      */
     private $resolver;
@@ -27,6 +32,10 @@ class LegacyOptionsResolverTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->resolver = new OptionsResolver();
+
+        $reflectionClass = new \ReflectionClass($this->resolver);
+        $this->reflectionMethod = $reflectionClass->getMethod('formatValue');
+        $this->reflectionMethod->setAccessible(true);
     }
 
     public function testResolve()
@@ -729,5 +738,21 @@ class LegacyOptionsResolverTest extends \PHPUnit_Framework_TestCase
         $this->resolver->overload('foo', 'bar');
 
         $this->assertSame(array('foo' => 'bar'), $this->resolver->resolve());
+    }
+
+    public function testFormatValueObject()
+    {
+        $this->assertEquals("Symfony\Component\OptionsResolver\OptionsResolver", $this->reflectionMethod->invoke($this->resolver, $this->resolver));
+    }
+
+    public function testFormatValueArray()
+    {
+        $this->assertEquals("array", $this->reflectionMethod->invoke($this->resolver, []));
+    }
+
+    public function testFormatValueResource()
+    {
+        $handle = fopen(__FILE__, "r");
+        $this->assertEquals("resource", $this->reflectionMethod->invoke($this->resolver, $handle));
     }
 }

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolver2Dot6Test.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolver2Dot6Test.php
@@ -498,30 +498,6 @@ class OptionsResolver2Dot6Test extends \PHPUnit_Framework_TestCase
         $this->resolver->resolve();
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     * @expectedExceptionMessage The option "foo" with value 42 is expected to be of type "string", but is of type "integer".
-     */
-    public function testResolveFailsIfInvalidType()
-    {
-        $this->resolver->setDefined('foo');
-        $this->resolver->setAllowedTypes('foo', 'string');
-
-        $this->resolver->resolve(array('foo' => 42));
-    }
-
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     * @expectedExceptionMessage The option "foo" with value null is expected to be of type "string", but is of type "NULL".
-     */
-    public function testResolveFailsIfInvalidTypeIsNull()
-    {
-        $this->resolver->setDefault('foo', null);
-        $this->resolver->setAllowedTypes('foo', 'string');
-
-        $this->resolver->resolve();
-    }
-
     public function testResolveSucceedsIfValidType()
     {
         $this->resolver->setDefault('foo', 'bar');
@@ -548,17 +524,6 @@ class OptionsResolver2Dot6Test extends \PHPUnit_Framework_TestCase
         $this->resolver->setAllowedTypes('foo', array('string', 'bool'));
 
         $this->assertNotEmpty($this->resolver->resolve());
-    }
-
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     */
-    public function testResolveFailsIfNotInstanceOfClass()
-    {
-        $this->resolver->setDefault('foo', 'bar');
-        $this->resolver->setAllowedTypes('foo', '\stdClass');
-
-        $this->resolver->resolve();
     }
 
     public function testResolveSucceedsIfInstanceOfClass()
@@ -1559,51 +1524,55 @@ class OptionsResolver2Dot6Test extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider getFormatValueData
      * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     * @expectedExceptionMessage The option "option" with value Symfony\Component\OptionsResolver\OptionsResolver is expected to be of type "string", but is of type "Symfony\Component\OptionsResolver\OptionsResolver".
      */
-    public function testFormatValueObject()
+    public function testFormatValue($actualType, $allowedType, $exceptionMessage)
     {
         $this->resolver->setDefined('option');
-        $this->resolver->setAllowedTypes('option', 'string');
+        $this->resolver->setAllowedTypes('option', $allowedType);
 
-        $this->resolver->resolve(array('option' => $this->resolver));
+        $this->resolver->resolve(array('option' => $actualType));
     }
 
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     * @expectedExceptionMessage The option "option" with value array is expected to be of type "string", but is of type "array".
-     */
-    public function testFormatValueArray()
+    public function getFormatValueData()
     {
-        $this->resolver->setDefined('option');
-        $this->resolver->setAllowedTypes('option', 'string');
-
-        $this->resolver->resolve(array('option' => array()));
-    }
-
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     * @expectedExceptionMessage The option "option" with value resource is expected to be of type "string", but is of type "resource".
-     */
-    public function testFormatValueResource()
-    {
-        $this->resolver->setDefined('option');
-        $this->resolver->setAllowedTypes('option', 'string');
-        $handle = fopen(__FILE__, "r");
-
-        $this->resolver->resolve(array('option' => $handle));
-    }
-
-    /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     * @expectedExceptionMessage The option "option" with value true is expected to be of type "string", but is of type "boolean".
-     */
-    public function testFormatValueTrue()
-    {
-        $this->resolver->setDefined('option');
-        $this->resolver->setAllowedTypes('option', 'string');
-
-        $this->resolver->resolve(array('option' => true));
+        return array(
+            array(
+                'actualType' => true,
+                'allowedType' => 'string',
+                'exceptionMessage' => 'The option "option" with value true is expected to be of type "string", but is of type "boolean".'
+            ),
+            array(
+                'actualType' => fopen(__FILE__, "r"),
+                'allowedType' => 'string',
+                'exceptionMessage' => 'The option "option" with value resource is expected to be of type "string", but is of type "resource".'
+            ),
+            array(
+                'actualType' => array(),
+                'allowedType' => 'string',
+                'exceptionMessage' => 'The option "option" with value array is expected to be of type "string", but is of type "array".'
+            ),
+            array(
+                'actualType' => $this->resolver,
+                'allowedType' => 'string',
+                'exceptionMessage' => 'The option "option" with value Symfony\Component\OptionsResolver\OptionsResolver is expected to be of type "string", but is of type "Symfony\Component\OptionsResolver\OptionsResolver".'
+            ),
+            array(
+                'actualType' => 42,
+                'allowedType' => 'string',
+                'exceptionMessage' => 'The option "option" with value 42 is expected to be of type "string", but is of type "integer".'
+            ),
+            array(
+                'actualType' => null,
+                'allowedType' => 'string',
+                'exceptionMessage' => 'The option "option" with value null is expected to be of type "string", but is of type "NULL".'
+            ),
+            array(
+                'actualType' => 'bar',
+                'allowedType' => '\stdClass',
+                'exceptionMessage' => ''
+            ),
+        );
     }
 }

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolver2Dot6Test.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolver2Dot6Test.php
@@ -1557,4 +1557,41 @@ class OptionsResolver2Dot6Test extends \PHPUnit_Framework_TestCase
 
         count($this->resolver);
     }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedExceptionMessage The option "option" with value Symfony\Component\OptionsResolver\OptionsResolver is expected to be of type "string", but is of type "Symfony\Component\OptionsResolver\OptionsResolver".
+     */
+    public function testFormatValueObject()
+    {
+        $this->resolver->setDefined('option');
+        $this->resolver->setAllowedTypes('option', 'string');
+
+        $this->resolver->resolve(array('option' => $this->resolver));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedExceptionMessage The option "option" with value array is expected to be of type "string", but is of type "array".
+     */
+    public function testFormatValueArray()
+    {
+        $this->resolver->setDefined('option');
+        $this->resolver->setAllowedTypes('option', 'string');
+
+        $this->resolver->resolve(array('option' => []));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedExceptionMessage The option "option" with value resource is expected to be of type "string", but is of type "resource".
+     */
+    public function testFormatValueResource()
+    {
+        $this->resolver->setDefined('option');
+        $this->resolver->setAllowedTypes('option', 'string');
+        $handle = fopen(__FILE__, "r");
+
+        $this->resolver->resolve(array('option' => $handle));
+    }
 }

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolver2Dot6Test.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolver2Dot6Test.php
@@ -1579,7 +1579,7 @@ class OptionsResolver2Dot6Test extends \PHPUnit_Framework_TestCase
         $this->resolver->setDefined('option');
         $this->resolver->setAllowedTypes('option', 'string');
 
-        $this->resolver->resolve(array('option' => []));
+        $this->resolver->resolve(array('option' => array()));
     }
 
     /**
@@ -1593,5 +1593,17 @@ class OptionsResolver2Dot6Test extends \PHPUnit_Framework_TestCase
         $handle = fopen(__FILE__, "r");
 
         $this->resolver->resolve(array('option' => $handle));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedExceptionMessage The option "option" with value true is expected to be of type "string", but is of type "boolean".
+     */
+    public function testFormatValueTrue()
+    {
+        $this->resolver->setDefined('option');
+        $this->resolver->setAllowedTypes('option', 'string');
+
+        $this->resolver->resolve(array('option' => true));
     }
 }

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolver2Dot6Test.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolver2Dot6Test.php
@@ -500,14 +500,12 @@ class OptionsResolver2Dot6Test extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider provideInvalidTypes
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
      */
     public function testResolveFailsIfInvalidType($actualType, $allowedType, $exceptionMessage)
     {
-        $this->setExpectedException('InvalidArgumentException', $exceptionMessage);
         $this->resolver->setDefined('option');
         $this->resolver->setAllowedTypes('option', $allowedType);
-
+        $this->setExpectedException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException', $exceptionMessage);
         $this->resolver->resolve(array('option' => $actualType));
     }
 
@@ -515,7 +513,8 @@ class OptionsResolver2Dot6Test extends \PHPUnit_Framework_TestCase
     {
         return array(
             array(true, 'string', 'The option "option" with value true is expected to be of type "string", but is of type "boolean".'),
-            array(fopen(__FILE__, "r"), 'string', 'The option "option" with value resource is expected to be of type "string", but is of type "resource".'),
+            array(false, 'string', 'The option "option" with value false is expected to be of type "string", but is of type "boolean".'),
+            array(fopen(__FILE__, 'r'), 'string', 'The option "option" with value resource is expected to be of type "string", but is of type "resource".'),
             array(array(), 'string', 'The option "option" with value array is expected to be of type "string", but is of type "array".'),
             array(new OptionsResolver(), 'string', 'The option "option" with value Symfony\Component\OptionsResolver\OptionsResolver is expected to be of type "string", but is of type "Symfony\Component\OptionsResolver\OptionsResolver".'),
             array(42, 'string', 'The option "option" with value 42 is expected to be of type "string", but is of type "integer".'),

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolver2Dot6Test.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolver2Dot6Test.php
@@ -498,6 +498,32 @@ class OptionsResolver2Dot6Test extends \PHPUnit_Framework_TestCase
         $this->resolver->resolve();
     }
 
+    /**
+     * @dataProvider provideInvalidTypes
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testResolveFailsIfInvalidType($actualType, $allowedType, $exceptionMessage)
+    {
+        $this->setExpectedException('InvalidArgumentException', $exceptionMessage);
+        $this->resolver->setDefined('option');
+        $this->resolver->setAllowedTypes('option', $allowedType);
+
+        $this->resolver->resolve(array('option' => $actualType));
+    }
+
+    public function provideInvalidTypes()
+    {
+        return array(
+            array(true, 'string', 'The option "option" with value true is expected to be of type "string", but is of type "boolean".'),
+            array(fopen(__FILE__, "r"), 'string', 'The option "option" with value resource is expected to be of type "string", but is of type "resource".'),
+            array(array(), 'string', 'The option "option" with value array is expected to be of type "string", but is of type "array".'),
+            array(new OptionsResolver(), 'string', 'The option "option" with value Symfony\Component\OptionsResolver\OptionsResolver is expected to be of type "string", but is of type "Symfony\Component\OptionsResolver\OptionsResolver".'),
+            array(42, 'string', 'The option "option" with value 42 is expected to be of type "string", but is of type "integer".'),
+            array(null, 'string', 'The option "option" with value null is expected to be of type "string", but is of type "NULL".'),
+            array('bar', '\stdClass', 'The option "option" with value "bar" is expected to be of type "\stdClass", but is of type "string".'),
+        );
+    }
+
     public function testResolveSucceedsIfValidType()
     {
         $this->resolver->setDefault('foo', 'bar');
@@ -1521,58 +1547,5 @@ class OptionsResolver2Dot6Test extends \PHPUnit_Framework_TestCase
         $this->resolver->setDefault('lazy1', function () {});
 
         count($this->resolver);
-    }
-
-    /**
-     * @dataProvider getFormatValueData
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     */
-    public function testFormatValue($actualType, $allowedType, $exceptionMessage)
-    {
-        $this->resolver->setDefined('option');
-        $this->resolver->setAllowedTypes('option', $allowedType);
-
-        $this->resolver->resolve(array('option' => $actualType));
-    }
-
-    public function getFormatValueData()
-    {
-        return array(
-            array(
-                'actualType' => true,
-                'allowedType' => 'string',
-                'exceptionMessage' => 'The option "option" with value true is expected to be of type "string", but is of type "boolean".'
-            ),
-            array(
-                'actualType' => fopen(__FILE__, "r"),
-                'allowedType' => 'string',
-                'exceptionMessage' => 'The option "option" with value resource is expected to be of type "string", but is of type "resource".'
-            ),
-            array(
-                'actualType' => array(),
-                'allowedType' => 'string',
-                'exceptionMessage' => 'The option "option" with value array is expected to be of type "string", but is of type "array".'
-            ),
-            array(
-                'actualType' => new OptionsResolver(),
-                'allowedType' => 'string',
-                'exceptionMessage' => 'The option "option" with value Symfony\Component\OptionsResolver\OptionsResolver is expected to be of type "string", but is of type "Symfony\Component\OptionsResolver\OptionsResolver".'
-            ),
-            array(
-                'actualType' => 42,
-                'allowedType' => 'string',
-                'exceptionMessage' => 'The option "option" with value 42 is expected to be of type "string", but is of type "integer".'
-            ),
-            array(
-                'actualType' => null,
-                'allowedType' => 'string',
-                'exceptionMessage' => 'The option "option" with value null is expected to be of type "string", but is of type "NULL".'
-            ),
-            array(
-                'actualType' => 'bar',
-                'allowedType' => '\stdClass',
-                'exceptionMessage' => ''
-            ),
-        );
     }
 }

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolver2Dot6Test.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolver2Dot6Test.php
@@ -1554,7 +1554,7 @@ class OptionsResolver2Dot6Test extends \PHPUnit_Framework_TestCase
                 'exceptionMessage' => 'The option "option" with value array is expected to be of type "string", but is of type "array".'
             ),
             array(
-                'actualType' => $this->resolver,
+                'actualType' => new OptionsResolver(),
                 'allowedType' => 'string',
                 'exceptionMessage' => 'The option "option" with value Symfony\Component\OptionsResolver\OptionsResolver is expected to be of type "string", but is of type "Symfony\Component\OptionsResolver\OptionsResolver".'
             ),


### PR DESCRIPTION
Hi,

This PR adds 100% test code coverage to OptionsResolver component.

Best regards,
Michal

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
