### PR TITLE
[Serializer] Fixed `array_unique` on array of objects in `getAllowedAttributes`.

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/ClassMetadataInterface.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassMetadataInterface.php
@@ -14,7 +14,9 @@ namespace Symfony\Component\Serializer\Mapping;
 /**
  * Stores metadata needed for serializing and deserializing objects of specific class.
  *
- * Primarily, the metadata stores the list of attributes to serialize or deserialize.
+ * Primarily, the metadata stores the set of attributes to serialize or deserialize.
+ *
+ * There may only exist one metadata for each attribute according to its name.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -204,7 +204,7 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
             }
         }
 
-        return array_unique($allowedAttributes);
+        return $allowedAttributes;
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -204,7 +204,7 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
             }
         }
 
-        return array_unique($allowedAttributes);
+        return $attributesAsString ? array_unique($allowedAttributes) : $allowedAttributes;
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/AbstractNormalizerDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/AbstractNormalizerDummy.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+
+/**
+ * Provides a dummy Normalizer which extends the AbstractNormalizer.
+ *
+ * @author Konstantin S. M. Möllers <ksm.moellers@gmail.com>
+ */
+class AbstractNormalizerDummy extends AbstractNormalizer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getAllowedAttributes($classOrObject, array $context, $attributesAsString = false)
+    {
+        return parent::getAllowedAttributes($classOrObject, $context, $attributesAsString);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($object, $format = null, array $context = array())
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return true;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Symfony\Component\Serializer\Tests\Normalizer;
+
+use Symfony\Component\Serializer\Mapping\AttributeMetadata;
+use Symfony\Component\Serializer\Mapping\ClassMetadata;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
+use Symfony\Component\Serializer\Tests\Fixtures\AbstractNormalizerDummy;
+
+/**
+ * Provides a dummy Normalizer which extends the AbstractNormalizer.
+ *
+ * @author Konstantin S. M. Möllers <ksm.moellers@gmail.com>
+ */
+class AbstractNormalizerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var AbstractNormalizerDummy
+     */
+    private $normalizer;
+
+    /**
+     * @var ClassMetadataFactoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $classMetadata;
+
+    protected function setUp()
+    {
+        $loader = $this->getMock('Symfony\Component\Serializer\Mapping\Loader\LoaderChain', [], [[]]);
+        $this->classMetadata = $this->getMock('Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory', [], [$loader]);
+        $this->normalizer = new AbstractNormalizerDummy($this->classMetadata);
+    }
+
+    public function testGetAllowedAttributesAsString()
+    {
+        $classMetadata = new ClassMetadata('c');
+
+        $a1 = new AttributeMetadata('a1');
+        $classMetadata->addAttributeMetadata($a1);
+
+        $a2 = new AttributeMetadata('a2');
+        $a2->addGroup('test');
+        $classMetadata->addAttributeMetadata($a2);
+
+        $a3 = new AttributeMetadata('a3');
+        $a3->addGroup('other');
+        $classMetadata->addAttributeMetadata($a3);
+
+        $a4 = new AttributeMetadata('a4');
+        $a4->addGroup('test');
+        $a4->addGroup('other');
+        $classMetadata->addAttributeMetadata($a4);
+
+        $this->classMetadata->method('getMetadataFor')->willReturn($classMetadata);
+
+        $result = $this->normalizer->getAllowedAttributes('c', ['groups' => ['test']], true);
+        $this->assertEquals(['a2', 'a4'], $result);
+
+        $result = $this->normalizer->getAllowedAttributes('c', ['groups' => ['other']], true);
+        $this->assertEquals(['a3', 'a4'], $result);
+    }
+
+    public function testGetAllowedAttributesAsObjects()
+    {
+        $classMetadata = new ClassMetadata('c');
+
+        $a1 = new AttributeMetadata('a1');
+        $classMetadata->addAttributeMetadata($a1);
+
+        $a2 = new AttributeMetadata('a2');
+        $a2->addGroup('test');
+        $classMetadata->addAttributeMetadata($a2);
+
+        $a3 = new AttributeMetadata('a3');
+        $a3->addGroup('other');
+        $classMetadata->addAttributeMetadata($a3);
+
+        $a4 = new AttributeMetadata('a4');
+        $a4->addGroup('test');
+        $a4->addGroup('other');
+        $classMetadata->addAttributeMetadata($a4);
+
+        $this->classMetadata->method('getMetadataFor')->willReturn($classMetadata);
+
+        $result = $this->normalizer->getAllowedAttributes('c', ['groups' => ['test']], false);
+        $this->assertEquals([$a2, $a4], $result);
+
+        $result = $this->normalizer->getAllowedAttributes('c', ['groups' => ['other']], false);
+        $this->assertEquals([$a3, $a4], $result);
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16445 |
| License | MIT |
| Doc PR | symfony/symfony-docs#16445 |
