### PR TITLE
[Bridge\PhpUnit] Fix clock-mock registration

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/SymfonyTestsListener.php
+++ b/src/Symfony/Bridge/PhpUnit/SymfonyTestsListener.php
@@ -56,6 +56,11 @@ class SymfonyTestsListener extends \PHPUnit_Framework_BaseTestListener
                     }
                 }
             }
+            foreach ($suite->tests() as $test) {
+                if ($test instanceof \PHPUnit_Framework_TestSuite && in_array('time-sensitive', \PHPUnit_Util_Test::getGroups($test->getName()), true)) {
+                    ClockMock::register($test->getName());
+                }
+            }
         } elseif (2 === $this->state) {
             $skipped = array();
             foreach ($suite->tests() as $test) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Once a method has been executed, PHP ignores any new function that could be injected in the namespace afterwards (HHVM does not ignore them btw).
Which means we have to inject clock-mocking functions into all clock-mocked namespaces before any actual implementation is used in that namespace.
This PR does it.
