### PR TITLE
Moved question prompt to readline() function

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -173,7 +173,7 @@ class QuestionHelper extends Helper
             $message = $question->getPrompt();
         }
 
-        if ($this->inputStream == STDIN && function_exists('readline')) {
+        if ($this->inputStream === STDIN && function_exists('readline')) {
             $this->readlinePrompt = $message;
         } else {
             $output->write($message);

--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -30,6 +30,7 @@ class QuestionHelper extends Helper
     private $inputStream;
     private static $shell;
     private static $stty;
+    private $readlinePrompt;
 
     /**
      * Asks a question to the user.
@@ -172,7 +173,11 @@ class QuestionHelper extends Helper
             $message = $question->getPrompt();
         }
 
-        $output->write($message);
+        if ($this->inputStream == STDIN && function_exists('readline')) {
+            $this->readlinePrompt = $message;
+        } else {
+            $output->write($message);
+        }
     }
 
     /**
@@ -438,7 +443,7 @@ class QuestionHelper extends Helper
     private function readFromInput($stream)
     {
         if (STDIN === $stream && function_exists('readline')) {
-            $ret = readline();
+            $ret = readline($this->readlinePrompt);
         } else {
             $ret = fgets($stream, 4096);
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15583 |
| License | MIT |
| Doc PR |  |

This PR fixes the issue as described in #15583 by capturing the output of `writePrompt()` and passing this as the actual prompt in the `readline()` method. This way, all readline functionality (cursus movements, screen redraws and screen resizing) will work as expected.
