### PR TITLE
[SecurityBundle] Fix disabling of RoleHierarchyVoter when passing empty hierarchy

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -157,7 +157,7 @@ class SecurityExtension extends Extension
      */
     private function createRoleHierarchy($config, ContainerBuilder $container)
     {
-        if (!isset($config['role_hierarchy'])) {
+        if (!isset($config['role_hierarchy']) || 0 === count($config['role_hierarchy'])) {
             $container->removeDefinition('security.access.role_hierarchy_voter');
 
             return;

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -94,6 +94,33 @@ class SecurityExtensionTest extends \PHPUnit_Framework_TestCase
         $container->compile();
     }
 
+    public function testDisableRoleHierarchyVoter()
+    {
+        $container = $this->getRawContainer();
+
+        $container->loadFromExtension('security', array(
+            'providers' => array(
+                'default' => array('id' => 'foo'),
+            ),
+
+            'role_hierarchy' => null,
+
+            'firewalls' => array(
+                'some_firewall' => array(
+                    'pattern' => '/.*',
+                    'http_basic' => null,
+                ),
+            ),
+        ));
+
+        $container->compile();
+
+        $admDefinition = $container->getDefinition('security.access.decision_manager');
+        $registeredVoters = array_map('strval', $admDefinition->getArgument(0));
+
+        $this->assertNotContains('security.access.role_hierarchy_voter', $registeredVoters);
+    }
+
     protected function getRawContainer()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/Security/Tests/Core/Authorization/Voter/RoleHierarchyVoterTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Authorization/Voter/RoleHierarchyVoterTest.php
@@ -33,4 +33,19 @@ class RoleHierarchyVoterTest extends RoleVoterTest
             array(array('ROLE_FOO'), array('ROLE_FOOBAR'), VoterInterface::ACCESS_GRANTED),
         ));
     }
+
+    /**
+     * @dataProvider getVoteWithEmptyHierarchyTests
+     */
+    public function testVoteWithEmptyHierarchy($roles, $attributes, $expected)
+    {
+        $voter = new RoleHierarchyVoter(new RoleHierarchy(array()));
+
+        $this->assertSame($expected, $voter->vote($this->getToken($roles), null, $attributes));
+    }
+
+    public function getVoteWithEmptyHierarchyTests()
+    {
+        return parent::getVoteTests();
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16358 |
| License | MIT |
| Doc PR | - |
- When passing `role_hierarchy: ~` in the config, the role hierarchy voter was still enabled. I've now changed this so that an empty hierarchy also results in disabling this voter. With an empty hierarchy, the voter behaves exactly the same as the RoleVoter, so no BC break is introduced here.
- Added some tests for the RoleHierarchyVoter when passing an empty hierarchy. As it then behaves exactly like RoleVoter, the question is whether we shouldn't just always return ACCESS_ABSTAIN when the hierarchy is empty
