### PR TITLE
[DependencyInjection] Fix some edge cases with autowiring

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -138,13 +138,13 @@ class AutowirePass implements CompilerPassInterface
      */
     private function populateAvailableType($id, Definition $definition)
     {
-        if (!$definition->getClass()) {
-            return;
-        }
-
         foreach ($definition->getAutowiringTypes() as $type) {
             $this->definedTypes[$type] = true;
             $this->types[$type] = $id;
+        }
+
+        if (!$definition->getClass()) {
+            return;
         }
 
         if ($reflectionClass = $this->getReflectionClass($id, $definition)) {

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -138,11 +138,17 @@ class AutowirePass implements CompilerPassInterface
      */
     private function populateAvailableType($id, Definition $definition)
     {
+        // Never use abstract services
+        if ($definition->isAbstract()) {
+            return;
+        }
+
         foreach ($definition->getAutowiringTypes() as $type) {
             $this->definedTypes[$type] = true;
             $this->types[$type] = $id;
         }
 
+        // Cannot use reflection if the class isn't set
         if (!$definition->getClass()) {
             return;
         }

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
@@ -118,6 +118,7 @@ class ResolveDefinitionTemplatesPass implements CompilerPassInterface
         $def->setArguments($parentDef->getArguments());
         $def->setMethodCalls($parentDef->getMethodCalls());
         $def->setProperties($parentDef->getProperties());
+        $def->setAutowiringTypes($parentDef->getAutowiringTypes());
         if ($parentDef->getFactoryClass(false)) {
             $def->setFactoryClass($parentDef->getFactoryClass(false));
         }
@@ -200,6 +201,11 @@ class ResolveDefinitionTemplatesPass implements CompilerPassInterface
         // append method calls
         if (count($calls = $definition->getMethodCalls()) > 0) {
             $def->setMethodCalls(array_merge($def->getMethodCalls(), $calls));
+        }
+
+        // merge autowiring types
+        foreach ($definition->getAutowiringTypes() as $autowiringType) {
+            $def->addAutowiringType($autowiringType);
         }
 
         // these attributes are always taken from the child

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -216,6 +216,21 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
         $pass = new AutowirePass();
         $pass->process($container);
     }
+
+    public function testDontUseAbstractServices()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('abstract_foo', __NAMESPACE__.'\Foo')->setAbstract(true);
+        $container->register('foo', __NAMESPACE__.'\Foo');
+        $container->register('bar', __NAMESPACE__.'\Bar')->setAutowired(true);
+
+        $pass = new AutowirePass();
+        $pass->process($container);
+
+        $arguments = $container->getDefinition('bar')->getArguments();
+        $this->assertSame('foo', (string) $arguments[0]);
+    }
 }
 
 class Foo

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -189,7 +189,7 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $definition->getArgument(2));
     }
 
-    public function testDontTriggeruAutowiring()
+    public function testDontTriggerAutowiring()
     {
         $container = new ContainerBuilder();
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveDefinitionTemplatesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveDefinitionTemplatesPassTest.php
@@ -274,6 +274,26 @@ class ResolveDefinitionTemplatesPassTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($container->getDefinition('decorated_deprecated_parent')->isDeprecated());
     }
 
+    public function testProcessMergeAutowiringTypes()
+    {
+        $container = new ContainerBuilder();
+
+        $container
+            ->register('parent')
+            ->addAutowiringType('Foo')
+        ;
+
+        $container
+            ->setDefinition('child', new DefinitionDecorator('parent'))
+            ->addAutowiringType('Bar')
+        ;
+
+        $this->process($container);
+
+        $def = $container->getDefinition('child');
+        $this->assertEquals(array('Foo', 'Bar'), $def->getAutowiringTypes());
+    }
+
     protected function process(ContainerBuilder $container)
     {
         $pass = new ResolveDefinitionTemplatesPass();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Enhance the autowiring system:
- Works with parent definitions and decorator
- Always exclude parent definitions

It allows to autowire major services of the standard edition (tested with Swift Mailer, Monolog, Doctrine and Twig).
