### PR TITLE
[FrameworkBundle] deprecate the ContainerAwareCommand class

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 2.8.0
 -----
 
+ * Deprecated the `ContainerAwareCommand` class in favor of the `ContainerAwareTrait`
  * Deprecated the `alias` option of the `form.type_extension` tag in favor of the
    `extended_type`/`extended-type` option
  * Deprecated the `alias` option of the `form.type` tag

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerAwareCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerAwareCommand.php
@@ -19,6 +19,8 @@ use Symfony\Component\DependencyInjection\ContainerAwareInterface;
  * Command.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since version 2.8, to be removed in 3.0. Use the ContainerAwareTrait instead.
  */
 abstract class ContainerAwareCommand extends Command implements ContainerAwareInterface
 {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Now that we deprecated the `ContainerAware` class in #16424 I think we should do the same with the `ContainerAwareCommand` class.
