### PR TITLE
Fixing bad type-hint auto-wiring bug

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -104,7 +104,7 @@ class AutowirePass implements CompilerPassInterface
                 // Typehint against a non-existing class
 
                 if (!$parameter->isDefaultValueAvailable()) {
-                    throw new RuntimeException(sprintf('Cannot autowire argument %s for %s because the type-hinted class does not exist (%s).', $index + 1, $definition->getClass(), $reflectionException->getMessage()));
+                    throw new RuntimeException(sprintf('Cannot autowire argument %s for %s because the type-hinted class does not exist (%s).', $index + 1, $definition->getClass(), $reflectionException->getMessage()), 0, $reflectionException);
                 }
 
                 $value = $parameter->getDefaultValue();

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -104,7 +104,7 @@ class AutowirePass implements CompilerPassInterface
                 // Typehint against a non-existing class
 
                 if (!$parameter->isDefaultValueAvailable()) {
-                    throw new RuntimeException(sprintf('Cannot auto-wire argument %s for %s because the type-hinted class does not exist.', $index + 1, $definition->getClass()));
+                    throw new RuntimeException(sprintf('Cannot autowire argument %s for %s because the type-hinted class does not exist (%s).', $index + 1, $definition->getClass(), $reflectionException->getMessage()));
                 }
 
                 $value = $parameter->getDefaultValue();

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -104,7 +104,7 @@ class AutowirePass implements CompilerPassInterface
                 // Typehint against a non-existing class
 
                 if (!$parameter->isDefaultValueAvailable()) {
-                    continue;
+                    throw new RuntimeException(sprintf('Cannot auto-wire argument %s for %s because the type-hinted class does not exist.', $index+1, $definition->getClass()));
                 }
 
                 $value = $parameter->getDefaultValue();

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -104,7 +104,7 @@ class AutowirePass implements CompilerPassInterface
                 // Typehint against a non-existing class
 
                 if (!$parameter->isDefaultValueAvailable()) {
-                    throw new RuntimeException(sprintf('Cannot auto-wire argument %s for %s because the type-hinted class does not exist.', $index+1, $definition->getClass()));
+                    throw new RuntimeException(sprintf('Cannot auto-wire argument %s for %s because the type-hinted class does not exist.', $index + 1, $definition->getClass()));
                 }
 
                 $value = $parameter->getDefaultValue();

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -204,7 +204,7 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage Cannot auto-wire argument 2 for Symfony\Component\DependencyInjection\Tests\Compiler\BadTypeHintedArgument because the type-hinted class does not exist.
+     * @expectedExceptionMessage Cannot autowire argument 2 for Symfony\Component\DependencyInjection\Tests\Compiler\BadTypeHintedArgument because the type-hinted class does not exist (Class Symfony\Component\DependencyInjection\Tests\Compiler\NotARealClass does not exist).
      */
     public function testClassNotFoundThrowsException()
     {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -201,6 +201,21 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
 
         $this->assertCount(0, $container->getDefinition('bar')->getArguments());
     }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
+     * @expectedExceptionMessage Cannot auto-wire argument 2 for Symfony\Component\DependencyInjection\Tests\Compiler\BadTypeHintedArgument because the type-hinted class does not exist.
+     */
+    public function testClassNotFoundThrowsException()
+    {
+        $container = new ContainerBuilder();
+
+        $aDefinition = $container->register('a', __NAMESPACE__.'\BadTypeHintedArgument');
+        $aDefinition->setAutowired(true);
+
+        $pass = new AutowirePass();
+        $pass->process($container);
+    }
 }
 
 class Foo
@@ -295,6 +310,13 @@ class LesTilleuls
 class OptionalParameter
 {
     public function __construct(CollisionInterface $c = null, A $a, Foo $f = null)
+    {
+    }
+}
+
+class BadTypeHintedArgument
+{
+    public function __construct(Dunglas $k, NotARealClass $r)
     {
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Previously, if you type-hinted a bad class name, we did not set the argument value. In fact, with `continue`, we skipped setting the argument, which meant that if argument 2 was skipped, then argument 3 would be put into argument 2's location.

But really, if I type-hint a non-existent class, this should throw a clear exception. afaik, in the original PR, it was said that we cannot throw an exception for a non-existent class because a later compiler-pass may manipulate those class names and "fix" them to be real classes. But, that's an edge case, and I think if you're using advanced functionality like that, you should not use auto-wiring. Throwing an exception is much more user-friendly. I personally hit this issue and was trying to figure out what was going wrong :).

About the exception message: I would like to tell the user which class is type-hinted correctly, but getting the type-hinted class for a non-existent class is not possible with reflection.

Thanks!

cc @dunglas
