### PR TITLE
[Security] Renamed key to secret Part 2

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -601,7 +601,8 @@ UPGRADE FROM 2.x to 3.0
 
  * The `Resources/` directory was moved to `Core/Resources/`
 
- * The `key` settings of `anonymous` and `remember_me` are renamed to `secret`.
+ * The `key` settings of `anonymous`, `remember_me` and `http_digest` are
+   renamed to `secret`.
 
    Before:
 
@@ -613,6 +614,8 @@ UPGRADE FROM 2.x to 3.0
                # ...
                anonymous: { key: "%secret%" }
                remember_me:
+                   key: "%secret%"
+               http_digest:
                    key: "%secret%"
    ```
 
@@ -626,6 +629,7 @@ UPGRADE FROM 2.x to 3.0
 
            <anonymous key="%secret%"/>
            <remember-me key="%secret%"/>
+           <http-digest key="%secret%"/>
        </firewall>
    </config>
    ```
@@ -638,6 +642,7 @@ UPGRADE FROM 2.x to 3.0
            // ...
            'anonymous' => array('key' => '%secret%'),
            'remember_me' => array('key' => '%secret%'),
+           'http_digest' => array('key' => '%secret%'),
        ),
    ));
    ```
@@ -653,6 +658,8 @@ UPGRADE FROM 2.x to 3.0
                anonymous: { secret: "%secret%" }
                remember_me:
                    secret: "%secret%"
+               http_digest:
+                   secret: "%secret%"
    ```
 
    ```xml
@@ -665,6 +672,7 @@ UPGRADE FROM 2.x to 3.0
 
            <anonymous secret="%secret%"/>
            <remember-me secret="%secret%"/>
+           <http-digest secret="%secret%"/>
        </firewall>
    </config>
    ```
@@ -677,6 +685,7 @@ UPGRADE FROM 2.x to 3.0
            // ...
            'anonymous' => array('secret' => '%secret%'),
            'remember_me' => array('secret' => '%secret%'),
+           'http_digest' => array('secret' => '%secret%'),
        ),
    ));
   ```

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -4,8 +4,8 @@ CHANGELOG
 2.8.0
 -----
 
- * deprecated the `key` setting of `anonymous` and `remember_me` in favor of the
-   `secret` setting.
+ * deprecated the `key` setting of `anonymous`, `remember_me` and `http_digest`
+   in favor of the `secret` setting.
 
 2.6.0
 -----

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpDigestFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpDigestFactory.php
@@ -58,10 +58,26 @@ class HttpDigestFactory implements SecurityFactoryInterface
     public function addConfiguration(NodeDefinition $node)
     {
         $node
+            ->beforeNormalization()
+                ->ifTrue(function ($v) { return isset($v['key']); })
+                ->then(function ($v) {
+                    if (isset($v['secret'])) {
+                        throw new \LogicException('Cannot set both key and secret options for http_digest, use only secret instead.');
+                    }
+
+                    @trigger_error('http_digest.key is deprecated since version 2.8 and will be removed in 3.0. Use http_digest.secret instead.', E_USER_DEPRECATED);
+
+                    $v['secret'] = $v['key'];
+
+                    unset($v['key']);
+
+                    return $v;
+                })
+            ->end()
             ->children()
                 ->scalarNode('provider')->end()
                 ->scalarNode('realm')->defaultValue('Secured Area')->end()
-                ->scalarNode('key')->isRequired()->cannotBeEmpty()->end()
+                ->scalarNode('secret')->isRequired()->cannotBeEmpty()->end()
             ->end()
         ;
     }
@@ -76,7 +92,7 @@ class HttpDigestFactory implements SecurityFactoryInterface
         $container
             ->setDefinition($entryPointId, new DefinitionDecorator('security.authentication.digest_entry_point'))
             ->addArgument($config['realm'])
-            ->addArgument($config['key'])
+            ->addArgument($config['secret'])
         ;
 
         return $entryPointId;

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
@@ -64,7 +64,7 @@ $container->loadFromExtension('security', array(
         'simple' => array('pattern' => '/login', 'security' => false),
         'secure' => array('stateless' => true,
             'http_basic' => true,
-            'http_digest' => array('key' => 'TheKey'),
+            'http_digest' => array('secret' => 'TheSecret'),
             'form_login' => true,
             'anonymous' => true,
             'switch_user' => true,

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
@@ -49,7 +49,7 @@
 
         <firewall name="secure" stateless="true">
             <http-basic />
-            <http-digest key="TheKey" />
+            <http-digest secret="TheSecret" />
             <form-login />
             <anonymous />
             <switch-user />

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
@@ -47,7 +47,7 @@ security:
             stateless: true
             http_basic: true
             http_digest:
-                key: TheKey
+                secret: TheSecret
             form_login: true
             anonymous: true
             switch_user: true

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -4,8 +4,8 @@ CHANGELOG
 2.8.0
 -----
 
- * deprecated `getKey()` of the `AnonymousToken`, `RememberMeToken` and `AbstractRememberMeServices` classes
-   in favor of `getSecret()`.
+ * deprecated `getKey()` of the `AnonymousToken`, `RememberMeToken`,
+   `AbstractRememberMeServices` and `DigestAuthenticationEntryPoint` classes in favor of `getSecret()`.
  * deprecated `Symfony\Component\Security\Core\Authentication\SimplePreAuthenticatorInterface`, use
    `Symfony\Component\Security\Http\Authentication\SimplePreAuthenticatorInterface` instead
  * deprecated `Symfony\Component\Security\Core\Authentication\SimpleFormAuthenticatorInterface`, use

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/AnonymousAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/AnonymousAuthenticationProviderTest.php
@@ -33,7 +33,7 @@ class AnonymousAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
      */
-    public function testAuthenticateWhenKeyIsNotValid()
+    public function testAuthenticateWhenSecretIsNotValid()
     {
         $provider = $this->getProvider('foo');
 
@@ -48,19 +48,19 @@ class AnonymousAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($token, $provider->authenticate($token));
     }
 
-    protected function getSupportedToken($key)
+    protected function getSupportedToken($secret)
     {
         $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\AnonymousToken', array('getSecret'), array(), '', false);
         $token->expects($this->any())
               ->method('getSecret')
-              ->will($this->returnValue($key))
+              ->will($this->returnValue($secret))
         ;
 
         return $token;
     }
 
-    protected function getProvider($key)
+    protected function getProvider($secret)
     {
-        return new AnonymousAuthenticationProvider($key);
+        return new AnonymousAuthenticationProvider($secret);
     }
 }

--- a/src/Symfony/Component/Security/Http/EntryPoint/DigestAuthenticationEntryPoint.php
+++ b/src/Symfony/Component/Security/Http/EntryPoint/DigestAuthenticationEntryPoint.php
@@ -24,15 +24,15 @@ use Psr\Log\LoggerInterface;
  */
 class DigestAuthenticationEntryPoint implements AuthenticationEntryPointInterface
 {
-    private $key;
+    private $secret;
     private $realmName;
     private $nonceValiditySeconds;
     private $logger;
 
-    public function __construct($realmName, $key, $nonceValiditySeconds = 300, LoggerInterface $logger = null)
+    public function __construct($realmName, $secret, $nonceValiditySeconds = 300, LoggerInterface $logger = null)
     {
         $this->realmName = $realmName;
-        $this->key = $key;
+        $this->secret = $secret;
         $this->nonceValiditySeconds = $nonceValiditySeconds;
         $this->logger = $logger;
     }
@@ -43,7 +43,7 @@ class DigestAuthenticationEntryPoint implements AuthenticationEntryPointInterfac
     public function start(Request $request, AuthenticationException $authException = null)
     {
         $expiryTime = microtime(true) + $this->nonceValiditySeconds * 1000;
-        $signatureValue = md5($expiryTime.':'.$this->key);
+        $signatureValue = md5($expiryTime.':'.$this->secret);
         $nonceValue = $expiryTime.':'.$signatureValue;
         $nonceValueBase64 = base64_encode($nonceValue);
 
@@ -65,11 +65,21 @@ class DigestAuthenticationEntryPoint implements AuthenticationEntryPointInterfac
     }
 
     /**
-     * @return string
+     * @deprecated Since version 2.8, to be removed in 3.0. Use getSecret() instead.
      */
     public function getKey()
     {
-        return $this->key;
+        @trigger_error(__method__.'() is deprecated since version 2.8 and will be removed in 3.0. Use getSecret() instead.', E_USER_DEPRECATED);
+
+        return $this->getSecret();
+    }
+
+    /**
+     * @return string
+     */
+    public function getSecret()
+    {
+        return $this->secret;
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/Firewall/AnonymousAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AnonymousAuthenticationListener.php
@@ -27,14 +27,14 @@ use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 class AnonymousAuthenticationListener implements ListenerInterface
 {
     private $tokenStorage;
-    private $key;
+    private $secret;
     private $authenticationManager;
     private $logger;
 
-    public function __construct(TokenStorageInterface $tokenStorage, $key, LoggerInterface $logger = null, AuthenticationManagerInterface $authenticationManager = null)
+    public function __construct(TokenStorageInterface $tokenStorage, $secret, LoggerInterface $logger = null, AuthenticationManagerInterface $authenticationManager = null)
     {
         $this->tokenStorage = $tokenStorage;
-        $this->key = $key;
+        $this->secret = $secret;
         $this->authenticationManager = $authenticationManager;
         $this->logger = $logger;
     }
@@ -51,7 +51,7 @@ class AnonymousAuthenticationListener implements ListenerInterface
         }
 
         try {
-            $token = new AnonymousToken($this->key, 'anon.', array());
+            $token = new AnonymousToken($this->secret, 'anon.', array());
             if (null !== $this->authenticationManager) {
                 $token = $this->authenticationManager->authenticate($token);
             }

--- a/src/Symfony/Component/Security/Http/Tests/EntryPoint/DigestAuthenticationEntryPointTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EntryPoint/DigestAuthenticationEntryPointTest.php
@@ -23,7 +23,7 @@ class DigestAuthenticationEntryPointTest extends \PHPUnit_Framework_TestCase
 
         $authenticationException = new AuthenticationException('TheAuthenticationExceptionMessage');
 
-        $entryPoint = new DigestAuthenticationEntryPoint('TheRealmName', 'TheKey');
+        $entryPoint = new DigestAuthenticationEntryPoint('TheRealmName', 'TheSecret');
         $response = $entryPoint->start($request, $authenticationException);
 
         $this->assertEquals(401, $response->getStatusCode());
@@ -34,7 +34,7 @@ class DigestAuthenticationEntryPointTest extends \PHPUnit_Framework_TestCase
     {
         $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
 
-        $entryPoint = new DigestAuthenticationEntryPoint('TheRealmName', 'TheKey');
+        $entryPoint = new DigestAuthenticationEntryPoint('TheRealmName', 'TheSecret');
         $response = $entryPoint->start($request);
 
         $this->assertEquals(401, $response->getStatusCode());
@@ -47,7 +47,7 @@ class DigestAuthenticationEntryPointTest extends \PHPUnit_Framework_TestCase
 
         $nonceExpiredException = new NonceExpiredException('TheNonceExpiredExceptionMessage');
 
-        $entryPoint = new DigestAuthenticationEntryPoint('TheRealmName', 'TheKey');
+        $entryPoint = new DigestAuthenticationEntryPoint('TheRealmName', 'TheSecret');
         $response = $entryPoint->start($request, $nonceExpiredException);
 
         $this->assertEquals(401, $response->getStatusCode());


### PR DESCRIPTION
Anonymous and RememberMe were already changed in https://github.com/symfony/symfony/pull/15141 This PR renames 2 more occurences of key in the Security: AnonymousAuthenticationListener and the Digest entry point.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
