### PR TITLE
Bugfix, issue #16488, Phpunit tests wont run if composer is installed

### DIFF
--- a/phpunit
+++ b/phpunit
@@ -13,7 +13,7 @@ $PHP = defined('PHP_BINARY') ? PHP_BINARY : 'php';
 $PHP = ProcessUtils::escapeArgument($PHP);
 $COMPOSER_INTERPRETER = $PHP;
 
-if (!file_exists($COMPOSER = __DIR__ . '/composer.phar')) {
+if (!file_exists($COMPOSER = __DIR__.'/composer.phar')) {
     $COMPOSER = rtrim('\\' === DIRECTORY_SEPARATOR ? `where.exe composer.phar` : (`which composer.phar` ?: `which composer`));
     if (file_exists($COMPOSER)) {
         //If composer is found in the path, an interpreter won't be needed to execute it
@@ -21,7 +21,7 @@ if (!file_exists($COMPOSER = __DIR__ . '/composer.phar')) {
     } else {
         stream_copy_to_stream(
             fopen('https://getcomposer.org/composer.phar', 'rb'),
-            fopen($COMPOSER = __DIR__ . '/composer.phar', 'wb')
+            fopen($COMPOSER = __DIR__.'/composer.phar', 'wb')
         );
     }
 }

--- a/phpunit
+++ b/phpunit
@@ -10,19 +10,23 @@ require __DIR__.'/src/Symfony/Component/Process/ProcessUtils.php';
 $PHPUNIT_VERSION = PHP_VERSION_ID >= 70000 ? '5.0' : '4.8';
 $PHPUNIT_DIR = __DIR__.'/.phpunit';
 $PHP = defined('PHP_BINARY') ? PHP_BINARY : 'php';
+$PHP = ProcessUtils::escapeArgument($PHP);
+$COMPOSER_INTERPRETER = $PHP;
 
-if (!file_exists($COMPOSER = __DIR__.'/composer.phar')) {
+if (!file_exists($COMPOSER = __DIR__ . '/composer.phar')) {
     $COMPOSER = rtrim('\\' === DIRECTORY_SEPARATOR ? `where.exe composer.phar` : (`which composer.phar` ?: `which composer`));
-    if (!file_exists($COMPOSER)) {
+    if (file_exists($COMPOSER)) {
+        //If composer is found in the path, an interpreter won't be needed to execute it
+        $COMPOSER_INTERPRETER = '';
+    } else {
         stream_copy_to_stream(
             fopen('https://getcomposer.org/composer.phar', 'rb'),
-            fopen($COMPOSER = __DIR__.'/composer.phar', 'wb')
+            fopen($COMPOSER = __DIR__ . '/composer.phar', 'wb')
         );
     }
 }
 
-$PHP = ProcessUtils::escapeArgument($PHP);
-$COMPOSER = $PHP.' '.ProcessUtils::escapeArgument($COMPOSER);
+$COMPOSER = $COMPOSER_INTERPRETER.' '.ProcessUtils::escapeArgument($COMPOSER);
 
 if (!file_exists("$PHPUNIT_DIR/phpunit-$PHPUNIT_VERSION/phpunit") || md5_file(__FILE__) !== @file_get_contents("$PHPUNIT_DIR/.md5")) {
     // Build a standalone phpunit without symfony/yaml


### PR DESCRIPTION
Bugfix, issue #16488 , Phpunit tests wont run if composer is installedin a wrapper

If composer is installed and found in the path (for example in `/usr/local/bin`), an interpreter should not be necessary for executing it.
This will help when the composer-executable found in the path is not an actual php-file, but an wrapper for composer.
This is the case when composer have been installed using the homebrew package manager.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | #16488 |
| License | MIT |
| Doc PR |  |
- [ ] One test fails. `1) Symfony\Component\Process\Tests\SimpleProcessTest::testSignal - Failed asserting that null matches expected 'Caught SIGUSR1'.`
