### PR TITLE
[Bridge\PhpUnit] Add extra clock-mocked namespaces in phpunit.xml.dist

### DIFF
--- a/src/Symfony/Component/HttpKernel/phpunit.xml.dist
+++ b/src/Symfony/Component/HttpKernel/phpunit.xml.dist
@@ -25,4 +25,14 @@
             </exclude>
         </whitelist>
     </filter>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener">
+            <arguments>
+                <array>
+                    <element><string>Symfony\Component\HttpFoundation</string></element>
+                </array>
+            </arguments>
+        </listener>
+    </listeners>
 </phpunit>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This fixes the currently failing tests on travis by:
- checking for class existence before checking for groups, recursively now, when loading `@group time-sensitive` annotations
- allow specifying extra clock-mocked namespaces in phpunit.xml files, required e.g. when HttpKernel is tested standalone and requires clock-mocks to be enabled for the HttpFoundation namespace.
