### PR TITLE
Update Store.php

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -357,7 +357,7 @@ class Store implements StoreInterface
             return false;
         }
 
-        if (false === @rename($tmpFile, $path)) {
+        if (false === @copy($tmpFile, $path) || false === @unlink(@$tmpFile)) {
             return false;
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? |  |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

I encountered an issue when I tried to setup a caching system with FosHttpCacheBundle.

With FosHttpCacheBundle I can configure my proxy client like:

```
fos_http_cache:
    proxy_client:
        symfony:
            servers: 123.123.123.1:6060, 123.123.123.2
            base_url: example.com
```

But our code is stored on Amazon Elastic beanstalk on multi servers with dynamic IP. 
So we cannot set 'servers' parameter with dynamic IP and that's why we want to centralize cache files on Amazon S3.

I change my app\AppCache like: 

```
class AppCache extends EventDispatchingHttpCache
{

    /**
     * @param HttpKernelInterface $kernel
     * @param null                $cacheDir
     */
    public function __construct(HttpKernelInterface $kernel, $cacheDir = 's3://example.com/http_cache')
    {
        $client = \Aws\S3\S3Client::factory();
        $client->registerStreamWrapper();

        parent::__construct($kernel, $cacheDir);
    }
}
```

My $cacheDir is an external link on S3 : 's3://example.com/http_cache'

But I encountered an issue with the [save()](https://github.com/symfony/symfony/blob/2.8/src/Symfony/Component/HttpKernel/HttpCache/Store.php#L342) method in HttpCache\Store.php ([line 360: rename($tmpFile, $path)](https://github.com/symfony/symfony/blob/2.8/src/Symfony/Component/HttpKernel/HttpCache/Store.php#L360))

```
$path = 's3://example.com/http_cache/0123456789'
$tmpFile = tempnam(dirname($path), basename($path)); // give me this: '/tmp/0123456789'
```

That is why I changed this line with a 'copy' of the local temp file on S3 and 'unlink' the local temp file.

If you have a better idea ? I found this: https://github.com/FriendsOfSymfony/FOSHttpCache/issues/121 but I search a simpler solution.

Thanks
