### PR TITLE
[ci] Tmp force phpunit/phpunit-mock-objects <= 3.0.0

### DIFF
--- a/phpunit
+++ b/phpunit
@@ -49,6 +49,7 @@ if (!file_exists("$PHPUNIT_DIR/phpunit-$PHPUNIT_VERSION/phpunit") || md5_file(__
     $zip->close();
     chdir("phpunit-$PHPUNIT_VERSION");
     passthru("$COMPOSER remove --no-update symfony/yaml");
+    passthru("$COMPOSER require --no-update phpunit/phpunit-mock-objects \"<=3.0.0\"");
     passthru("$COMPOSER require --dev --no-update symfony/phpunit-bridge \">=2.8@dev\"");
     passthru("$COMPOSER install --prefer-source --no-progress --ansi");
     file_put_contents('phpunit', <<<EOPHP


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

To make tests green again until https://github.com/sebastianbergmann/phpunit-mock-objects/pull/272 or https://github.com/sebastianbergmann/phpunit-mock-objects/pull/268 is merged+tagged.
