### PR TITLE
[2.7][Asset] Ability to set empty version strategy in packages

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -99,7 +99,7 @@ class Configuration implements ConfigurationInterface
 
                         foreach ($v['templating']['packages'] as $name => $config) {
                             $v['assets']['packages'][$name] = array(
-                                'version' => (string) $config['version'],
+                                'version' => null === $config['version'] ? null : (string) $config['version'],
                                 'version_format' => $config['version_format'],
                                 'base_path' => '',
                                 'base_urls' => array_values(array_unique(array_merge($config['base_urls']['http'], $config['base_urls']['ssl']))),
@@ -488,7 +488,13 @@ class Configuration implements ConfigurationInterface
                             ->prototype('array')
                                 ->fixXmlConfig('base_url')
                                 ->children()
-                                    ->scalarNode('version')->defaultNull()->end()
+                                    ->scalarNode('version')
+                                        ->defaultNull()
+                                        ->beforeNormalization()
+                                        ->ifTrue(function ($v) { return '' === $v; })
+                                        ->then(function ($v) { return; })
+                                        ->end()
+                                    ->end()
                                     ->scalarNode('version_format')->defaultValue('%%s?%%s')->end()
                                     ->arrayNode('base_urls')
                                         ->performNoDeepMerging()
@@ -547,7 +553,12 @@ class Configuration implements ConfigurationInterface
                             ->prototype('array')
                                 ->fixXmlConfig('base_url')
                                 ->children()
-                                    ->scalarNode('version')->defaultNull()->end()
+                                    ->scalarNode('version')
+                                        ->beforeNormalization()
+                                        ->ifTrue(function ($v) { return '' === $v; })
+                                        ->then(function ($v) { return; })
+                                        ->end()
+                                    ->end()
                                     ->scalarNode('version_format')->defaultNull()->end()
                                     ->scalarNode('base_path')->defaultValue('')->end()
                                     ->arrayNode('base_urls')

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -589,7 +589,7 @@ class FrameworkExtension extends Extension
 
         $namedPackages = array();
         foreach ($config['packages'] as $name => $package) {
-            if (null === $package['version']) {
+            if (!array_key_exists('version', $package)) {
                 $version = $defaultVersion;
             } else {
                 $format = $package['version_format'] ?: $config['version_format'];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/assets.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/assets.php
@@ -20,6 +20,10 @@ $container->loadFromExtension('framework', array(
             'bar' => array(
                 'base_urls' => array('https://bar2.example.com'),
             ),
+            'bar_null_version' => array(
+                'version' => null,
+                'base_urls' => array('https://bar3.example.com'),
+            ),
         ),
     ),
 ));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/legacy_templating_assets.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/legacy_templating_assets.php
@@ -18,6 +18,10 @@ $container->loadFromExtension('framework', array(
             'bar' => array(
                 'base_urls' => array('https://bar2.example.com'),
             ),
+            'bar_null_version' => array(
+                'version' => null,
+                'base_urls' => array('https://bar3.example.com'),
+            ),
         ),
     ),
 ));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/assets.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/assets.xml
@@ -18,6 +18,9 @@
             <framework:package name="bar">
                 <framework:base-url>https://bar2.example.com</framework:base-url>
             </framework:package>
+            <framework:package name="bar_null_version" version="">
+                <framework:base-url>https://bar3.example.com</framework:base-url>
+            </framework:package>
         </framework:assets>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/legacy_templating_assets.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/legacy_templating_assets.xml
@@ -18,6 +18,9 @@
             <framework:package name="bar">
                 <framework:base-url>https://bar2.example.com</framework:base-url>
             </framework:package>
+            <framework:package name="bar_null_version" version="">
+                <framework:base-url>https://bar3.example.com</framework:base-url>
+            </framework:package>
         </framework:templating>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/assets.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/assets.yml
@@ -14,3 +14,6 @@ framework:
                 version_format: %%s-%%s
             bar:
                 base_urls: ["https://bar2.example.com"]
+            bar_null_version:
+                version: null
+                base_urls: "https://bar3.example.com"

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/legacy_templating_assets.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/legacy_templating_assets.yml
@@ -13,3 +13,6 @@ framework:
                 version_format: %%s-%%s
             bar:
                 base_urls: "https://bar2.example.com"
+            bar_null_version:
+                version: null
+                base_urls: "https://bar3.example.com"

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -511,7 +511,7 @@ abstract class FrameworkExtensionTest extends TestCase
 
         // packages
         $packages = $packages->getArgument(1);
-        $this->assertCount($legacy ? 3 : 4, $packages);
+        $this->assertCount($legacy ? 4 : 5, $packages);
 
         if (!$legacy) {
             $package = $container->getDefinition($packages['images_path']);
@@ -525,7 +525,10 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertPathPackage($container, $package, '', '1.0.0', '%%s-%%s');
 
         $package = $container->getDefinition($packages['bar']);
-        $this->assertUrlPackage($container, $package, array('https://bar2.example.com'), $legacy ? '' : 'SomeVersionScheme', $legacy ? '%%s?%%s' : '%%s?version=%%s');
+        $this->assertUrlPackage($container, $package, array('https://bar2.example.com'), $legacy ? null : 'SomeVersionScheme', $legacy ? '%%s?%%s' : '%%s?version=%%s');
+
+        $this->assertEquals($legacy ? 'assets.empty_version_strategy' : 'assets._version__default', (string) $container->getDefinition('assets._package_bar')->getArgument(1));
+        $this->assertEquals('assets.empty_version_strategy', (string) $container->getDefinition('assets._package_bar_null_version')->getArgument(1));
     }
 
     private function assertPathPackage(ContainerBuilder $container, DefinitionDecorator $package, $basePath, $version, $format)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no, but not sure, as for me test was wrong |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14832 |
| License | MIT |
| Doc PR |  |

Comment about '' thing. As you can see in xml test - we can't for attribute set null value. And for xml version '' empty string considered as null value, that affect all others formats and test is changed.
