### PR TITLE
[Controller] Improved the hardcoded status for the redirection in the base Controller.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -77,7 +77,7 @@ class Controller extends ContainerAware
      *
      * @return RedirectResponse
      */
-    public function redirect($url, $status = 302)
+    public function redirect($url, $status = Response::HTTP_FOUND)
     {
         return new RedirectResponse($url, $status);
     }
@@ -91,7 +91,7 @@ class Controller extends ContainerAware
      *
      * @return RedirectResponse
      */
-    protected function redirectToRoute($route, array $parameters = array(), $status = 302)
+    protected function redirectToRoute($route, array $parameters = array(), $status = Response::HTTP_FOUND)
     {
         return $this->redirect($this->generateUrl($route, $parameters), $status);
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16513 |
| License | MIT |
| Doc PR | none |

The default status code in the redirect and redirectToRoute methods are being hardcoded. Can we use the constant values from Symfony\Component\HttpFoundation\Response instead?
