### PR TITLE
Fixed tabs when there are several groups of tabs in the same page

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -359,6 +359,8 @@
                                 activeTab = activeTab.parentNode;
                             }
 
+                            /* get the full list of tabs through the parent of the active tab element */
+                            var tabNavigation = activeTab.parentNode.children;
                             for (var k = 0; k < tabNavigation.length; k++) {
                                 var tabId = tabNavigation[k].getAttribute('data-tab-id');
                                 document.getElementById(tabId).className = 'hidden';


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16506 |
| License | MIT |
| Doc PR | - |

Multiple tabs in the same page work again as expected:

![multiple_tabs](https://cloud.githubusercontent.com/assets/73419/11059933/310169c6-879d-11e5-91b2-b90af67b2a74.gif)
