### PR TITLE
[Translation] Add support for Armenian pluralization.

### DIFF
--- a/src/Symfony/Component/Translation/PluralizationRules.php
+++ b/src/Symfony/Component/Translation/PluralizationRules.php
@@ -131,6 +131,7 @@ class PluralizationRules
             case 'fr':
             case 'gun':
             case 'hi':
+            case 'hy':
             case 'ln':
             case 'mg':
             case 'nso':

--- a/src/Symfony/Component/Translation/Tests/PluralizationRulesTest.php
+++ b/src/Symfony/Component/Translation/Tests/PluralizationRulesTest.php
@@ -61,7 +61,7 @@ class PluralizationRulesTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array('1', array('ay','bo', 'cgg','dz','id', 'ja', 'jbo', 'ka','kk','km','ko','ky')),
-            array('2', array('nl', 'fr', 'en', 'de', 'de_GE')),
+            array('2', array('nl', 'fr', 'en', 'de', 'de_GE', 'hy', 'hy_AM')),
             array('3', array('be','bs','cs','hr')),
             array('4', array('cy','mt', 'sl')),
             array('5', array()),


### PR DESCRIPTION
According to http://www.unicode.org/cldr/charts/27/supplemental/language_plural_rules.html#hy
Armenian has 2 forms of pluralization for cardinal numbers.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |
