### PR TITLE
[Security] AbstractVoter should abstain string objects

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/Voter/AbstractVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/AbstractVoter.php
@@ -58,7 +58,7 @@ abstract class AbstractVoter implements VoterInterface
      */
     public function vote(TokenInterface $token, $object, array $attributes)
     {
-        if (!$object || !$this->supportsClass(get_class($object))) {
+        if (!$object || !is_object($object) || !$this->supportsClass(get_class($object))) {
             return self::ACCESS_ABSTAIN;
         }
 

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/AbstractVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/AbstractVoterTest.php
@@ -39,6 +39,7 @@ class AbstractVoterTest extends \PHPUnit_Framework_TestCase
             array(array('EDIT'), VoterInterface::ACCESS_ABSTAIN, $this, 'ACCESS_ABSTAIN if class is not supported'),
 
             array(array('EDIT'), VoterInterface::ACCESS_ABSTAIN, null, 'ACCESS_ABSTAIN if object is null'),
+            array(array('EDIT'), VoterInterface::ACCESS_ABSTAIN, 'foo', 'ACCESS_ABSTAIN if object is string'),
 
             array(array(), VoterInterface::ACCESS_ABSTAIN, new \stdClass(), 'ACCESS_ABSTAIN if no attributes were provided'),
         );


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

The `AbstractVoter` is trying to get a class of an object, but if i pass a string to `isGranted` is breaks the complete voting process. Noticed by adding only one Voter which extends then`AbstractVoter`. So currently i am unable to use this abstract class in the whole project.
So we should not support string values in this voter.

```
$this->isGranted('VIEW', 'foo')
```
