### PR TITLE
[VarDumper] Ability to dump without arguments

### DIFF
--- a/src/Symfony/Component/VarDumper/VarDumper.php
+++ b/src/Symfony/Component/VarDumper/VarDumper.php
@@ -25,7 +25,7 @@ class VarDumper
 {
     private static $handler;
 
-    public static function dump($var)
+    public static function dump($var = 'NO ARGUMENTS PASSED')
     {
         if (null === self::$handler) {
             $cloner = new VarCloner();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | no |
| License | MIT |

Dump without passing a variable, we can use VarDumper just to make a breakpoint for example.
it avoids to pass variables as foo, bar :)
