### PR TITLE
[Serializer] ObjectNormalizer: don't serialize static methods and props

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -66,8 +66,9 @@ class ObjectNormalizer extends AbstractNormalizer
 
             // methods
             $reflClass = new \ReflectionClass($object);
-            foreach ($reflClass->getMethods(\ReflectionMethod::IS_PUBLIC) as $reflMethod) {
+            foreach ($reflClass->getMethods(\ReflectionMethod::IS_PUBLIC ) as $reflMethod) {
                 if (
+                    !$reflMethod->isStatic() &&
                     !$reflMethod->isConstructor() &&
                     !$reflMethod->isDestructor() &&
                     0 === $reflMethod->getNumberOfRequiredParameters()
@@ -86,7 +87,9 @@ class ObjectNormalizer extends AbstractNormalizer
 
             // properties
             foreach ($reflClass->getProperties(\ReflectionProperty::IS_PUBLIC) as $reflProperty) {
-                $attributes[$reflProperty->getName()] = true;
+                if (!$reflProperty->isStatic()) {
+                    $attributes[$reflProperty->getName()] = true;
+                }
             }
 
             $attributes = array_keys($attributes);

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -66,7 +66,7 @@ class ObjectNormalizer extends AbstractNormalizer
 
             // methods
             $reflClass = new \ReflectionClass($object);
-            foreach ($reflClass->getMethods(\ReflectionMethod::IS_PUBLIC ) as $reflMethod) {
+            foreach ($reflClass->getMethods(\ReflectionMethod::IS_PUBLIC) as $reflMethod) {
                 if (
                     !$reflMethod->isStatic() &&
                     !$reflMethod->isConstructor() &&

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -456,6 +456,11 @@ class ObjectNormalizerTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertFalse($this->normalizer->supportsNormalization(new \ArrayObject()));
     }
+
+    public function testNormalizeStatic()
+    {
+        $this->assertEquals(array('foo' => 'K'), $this->normalizer->normalize(new ObjectWithStaticPropertiesAndMethods()));
+    }
 }
 
 class ObjectDummy
@@ -603,5 +608,16 @@ class ObjectConstructorArgsWithDefaultValueDummy
     public function otherMethod()
     {
         throw new \RuntimeException('Dummy::otherMethod() should not be called');
+    }
+}
+
+class ObjectWithStaticPropertiesAndMethods
+{
+    public $foo = 'K';
+    public static $bar = 'A';
+
+    public static function getBaz()
+    {
+        return 'L';
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16485 |
| License | MIT |
| Doc PR | n/a |
