### PR TITLE
Jsonresponse fix

### DIFF
--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -171,6 +171,10 @@ class JsonResponse extends Response
     {
         $this->encodingOptions = (int) $encodingOptions;
 
+        if ($this->content !== null) {
+            $this->data = $this->content;
+        }
+
         return $this->setData(json_decode($this->data));
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
@@ -213,6 +213,30 @@ class JsonResponseTest extends \PHPUnit_Framework_TestCase
 
         JsonResponse::create($serializable);
     }
+
+    public function testSetDataAfterSettingEncodingOptions()
+    {
+        $response = new JsonResponse();
+        $response->setData(array(array(1, 2, 3)));
+
+        $this->assertEquals('[[1,2,3]]', $response->getContent());
+
+        $response->setEncodingOptions(JSON_FORCE_OBJECT);
+        $response->setData(array(array(4, 5, 6)));
+        $this->assertEquals('{"0":{"0":4,"1":5,"2":6}}', $response->getContent());
+    }
+
+    public function testSetContentAfterSettingEncodingOptions()
+    {
+        $response = new JsonResponse();
+        $response->setData(array(array(1, 2, 3)));
+
+        $this->assertEquals('[[1,2,3]]', $response->getContent());
+
+        $response->setEncodingOptions(JSON_PRETTY_PRINT);
+        $response->setContent("['baz' => ['foo' => 'bar']]");
+        $this->assertEquals("['baz' => ['foo' => 'bar']]", $response->getContent());
+    }
 }
 
 if (interface_exists('JsonSerializable')) {

--- a/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
@@ -213,28 +213,24 @@ class JsonResponseTest extends \PHPUnit_Framework_TestCase
         JsonResponse::create($serializable);
     }
 
-    public function testSetDataAfterSettingEncodingOptions()
+    public function testDataAfterSettingEncodingOptions()
     {
         $response = new JsonResponse();
         $response->setData(array(array(1, 2, 3)));
 
         $this->assertEquals('[[1,2,3]]', $response->getContent());
-
         $response->setEncodingOptions(JSON_FORCE_OBJECT);
-        $response->setData(array(array(4, 5, 6)));
-        $this->assertEquals('{"0":{"0":4,"1":5,"2":6}}', $response->getContent());
+
+        $this->assertEquals('{"0":{"0":1,"1":2,"2":3}}', $response->getContent());
     }
 
-    public function testSetContentAfterSettingEncodingOptions()
+    public function testContentAfterSettingEncodingOptionsToBeEmpty()
     {
         $response = new JsonResponse();
-        $response->setData(array(array(1, 2, 3)));
+        $response->setContent('{"different":{"key":"value"}}');
+        $response->setEncodingOptions(JSON_FORCE_OBJECT);
 
-        $this->assertEquals('[[1,2,3]]', $response->getContent());
-
-        $response->setEncodingOptions(JSON_PRETTY_PRINT);
-        $response->setContent("['baz' => ['foo' => 'bar']]");
-        $this->assertEquals("['baz' => ['foo' => 'bar']]", $response->getContent());
+        $this->assertEquals($response->getContent(), '{"different":{"key":"value"}}');
     }
 }
 


### PR DESCRIPTION
Fixed JsonResponse setContent after settinh encoding options
[HttpFoundation][JsonResponse.php] udated setData() with getContent() when getContent is not empty

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | [The reference to the documentation PR if any] |
