### PR TITLE
Show Viewscript names in html comments

### DIFF
--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -91,7 +91,11 @@ class PhpEngine implements EngineInterface, \ArrayAccess
 
             $slots->set('_content', array_pop($this->stack));
         }
-
+        
+        if ($_SERVER['environment'] !== 'prod') {
+            $content = '<!-- Start Viewscript: '.$this->parser->parse($name).' -->'.$content.'<!-- End Viewscript: '.$this->parser->parse($name).' -->';
+        }
+        
         return $content;
     }
 


### PR DESCRIPTION
[Symfony] [Component] [Templating] PhpEngine.php Added a set of comments to help identify a viewscript

| Q | A |
| --- | --- |
| Bug fix? | [no] |
| New feature? | [yes] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [no] |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

I work with a large team of front end developers and I always put this line in, which helps them navigate the codebase to find the view they are looking to edit.

I did this very quickly and there may be a better way to get the value of $_SERVER['environment'] - but I think it is a worthwhile change.

Makes a huge difference on dev and it would be good if I didn't have to put it back in after each composer update :)
