### PR TITLE
[Security] Abstain vote for scalar values.

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/Voter/AbstractVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/AbstractVoter.php
@@ -58,7 +58,7 @@ abstract class AbstractVoter implements VoterInterface
      */
     public function vote(TokenInterface $token, $object, array $attributes)
     {
-        if (!$object || !$this->supportsClass(get_class($object))) {
+        if (!is_object($object) || !$this->supportsClass(get_class($object))) {
             return self::ACCESS_ABSTAIN;
         }
 

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/AbstractVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/AbstractVoterTest.php
@@ -40,6 +40,8 @@ class AbstractVoterTest extends \PHPUnit_Framework_TestCase
 
             array(array('EDIT'), VoterInterface::ACCESS_ABSTAIN, null, 'ACCESS_ABSTAIN if object is null'),
 
+            array(array('EDIT'), VoterInterface::ACCESS_ABSTAIN, 'foo', 'ACCESS_ABSTAIN for a non-object'),
+
             array(array(), VoterInterface::ACCESS_ABSTAIN, new \stdClass(), 'ACCESS_ABSTAIN if no attributes were provided'),
         );
     }


### PR DESCRIPTION
Avoids a PHP warning when a scalar value is passed to a voter extending the `AbstractVoter`. The method `isGranted` receives an object.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16554 |
| License | MIT |
| Doc PR | n/a |
