### PR TITLE
[WebProfilerBundle] correct typo in show stack trace link

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
@@ -162,7 +162,7 @@
         {% endif %}
 
         {% if stack %}
-            <button class="btn-link text-small sf-toggle" data-toggle-selector="#{{ id }}" data-toggle-alt-content="Hide stack trace">Show strack trace</button>
+            <button class="btn-link text-small sf-toggle" data-toggle-selector="#{{ id }}" data-toggle-alt-content="Hide stack trace">Show stack trace</button>
         {% endif %}
 
         {% for index, call in stack if index > 1 %}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets | n/a |
| License | MIT |

Simple typo fix for link for showing stack trace in the Logs page of the 2.8/3.0 profiler.
