### PR TITLE
[FrameworkBundle] Fix PropertyInfo extractor namespace in framework bundle

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_info.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_info.xml
@@ -13,7 +13,7 @@
         </service>
 
         <!-- Extractor -->
-        <service id="property_info.reflection_extractor" class="Symfony\Component\PropertyInfo\ReflectionExtractor" public="false">
+        <service id="property_info.reflection_extractor" class="Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor" public="false">
             <tag name="property_info.list_extractor" priority="-1000" />
             <tag name="property_info.type_extractor" priority="-1000" />
             <tag name="property_info.access_extractor" priority="-1000" />


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The only failing test I had was because of the missing zendframework/zend-stdlib, adding it made tests pass.
