### PR TITLE
[HttpKernel] Do not check log dir for write permission

### DIFF
--- a/src/Symfony/Component/HttpKernel/Exception/DisableLogDirectoryException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/DisableLogDirectoryException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Exception;
+
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+
+/**
+ * DisableLogDirectoryException.
+ *
+ * @author Asmir Mustafic <goetas@gmail.com>
+ */
+class DisableLogDirectoryException extends RuntimeException
+{
+}

--- a/src/Symfony/Component/HttpKernel/Exception/MethodNotImplementedException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/MethodNotImplementedException.php
@@ -14,10 +14,8 @@ namespace Symfony\Component\HttpKernel\Exception;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 
 /**
- * DisableLogDirectoryException.
- *
  * @author Asmir Mustafic <goetas@gmail.com>
  */
-class DisableLogDirectoryException extends RuntimeException
+class MethodNotImplementedException extends RuntimeException
 {
 }

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -34,7 +34,7 @@ use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\Config\Loader\DelegatingLoader;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\ClassLoader\ClassCollectionLoader;
-use Symfony\Component\HttpKernel\Exception\DisableLogDirectoryException;
+use Symfony\Component\HttpKernel\Exception\MethodNotImplementedException;
 
 /**
  * The Kernel is the heart of the Symfony system.
@@ -539,7 +539,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
 
         try {
             $logDir = realpath($this->getLogDir()) ?: $this->getLogDir();
-        } catch (DisableLogDirectoryException $e) {
+        } catch (MethodNotImplementedException $e) {
             $logDir = false;
         }
 
@@ -589,7 +589,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     {
         try{
             $logDir = $this->getLogDir();
-        } catch (DisableLogDirectoryException $e) {
+        } catch (MethodNotImplementedException $e) {
             $logDir = false;
         }
         foreach (array('cache' => $this->getCacheDir(), 'logs' => $logDir) as $name => $dir) {

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -543,7 +543,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
                 'kernel.debug' => $this->debug,
                 'kernel.name' => $this->name,
                 'kernel.cache_dir' => realpath($this->getCacheDir()) ?: $this->getCacheDir(),
-                'kernel.logs_dir' => realpath($this->getLogDir()) ?: $this->getLogDir(),
+                'kernel.logs_dir' => false !== $this->getLogDir() && realpath($this->getLogDir()) ? realpath($this->getLogDir()) : $this->getLogDir(),
                 'kernel.bundles' => $bundles,
                 'kernel.charset' => $this->getCharset(),
                 'kernel.container_class' => $this->getContainerClass(),
@@ -581,7 +581,9 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected function buildContainer()
     {
         foreach (array('cache' => $this->getCacheDir(), 'logs' => $this->getLogDir()) as $name => $dir) {
-            if (!is_dir($dir)) {
+            if (false === $dir && 'logs' === $name) {
+                continue;
+            } elseif (!is_dir($dir)) {
                 if (false === @mkdir($dir, 0777, true) && !is_dir($dir)) {
                     throw new \RuntimeException(sprintf("Unable to create the %s directory (%s)\n", $name, $dir));
                 }

--- a/src/Symfony/Component/HttpKernel/KernelInterface.php
+++ b/src/Symfony/Component/HttpKernel/KernelInterface.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\HttpKernel;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\HttpKernel\Exception\DisableLogDirectoryException;
 
 /**
  * The Kernel is the heart of the Symfony system.
@@ -163,6 +164,8 @@ interface KernelInterface extends HttpKernelInterface, \Serializable
      * Gets the log directory.
      *
      * @return string The log directory
+     *
+     * @throws DisableLogDirectoryException when the standard log directory is disabled
      */
     public function getLogDir();
 

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\HttpKernel\Tests;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\Config\EnvParametersResource;
-use Symfony\Component\HttpKernel\Exception\DisableLogDirectoryException;
+use Symfony\Component\HttpKernel\Exception\MethodNotImplementedException;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -164,7 +164,7 @@ class KernelTest extends \PHPUnit_Framework_TestCase
 
         $kernel->expects($this->any())
             ->method('getLogDir')
-            ->will($this->throwException(new DisableLogDirectoryException()));
+            ->will($this->throwException(new MethodNotImplementedException()));
 
         $reflection = new \ReflectionClass(get_class($kernel));
         $method = $reflection->getMethod('initializeContainer');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16572 |
| License | MIT |
| Doc PR |  |

The whole logging system relies on monolog, so the log directory is almost useless.
