### PR TITLE
Sent out a status text for unknown HTTP headers.

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -454,7 +454,7 @@ class Response
         }
 
         if (null === $text) {
-            $this->statusText = isset(self::$statusTexts[$code]) ? self::$statusTexts[$code] : '';
+            $this->statusText = isset(self::$statusTexts[$code]) ? self::$statusTexts[$code] : 'Unknown status text';
 
             return $this;
         }

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -454,7 +454,7 @@ class Response
         }
 
         if (null === $text) {
-            $this->statusText = isset(self::$statusTexts[$code]) ? self::$statusTexts[$code] : 'Unknown status text';
+            $this->statusText = isset(self::$statusTexts[$code]) ? self::$statusTexts[$code] : 'unknown status';
 
             return $this;
         }

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -695,7 +695,7 @@ class ResponseTest extends ResponseTestCase
             array('200', null, 'OK'),
             array('200', false, ''),
             array('200', 'foo', 'foo'),
-            array('199', null, 'Unknown status text'),
+            array('199', null, 'unknown status'),
             array('199', false, ''),
             array('199', 'foo', 'foo'),
         );

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -695,7 +695,7 @@ class ResponseTest extends ResponseTestCase
             array('200', null, 'OK'),
             array('200', false, ''),
             array('200', 'foo', 'foo'),
-            array('199', null, ''),
+            array('199', null, 'Unknown status text'),
             array('199', false, ''),
             array('199', 'foo', 'foo'),
         );


### PR DESCRIPTION
- The HTTP RFC explains that header('HTTP/1.1 418 ') should be fine, see http://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html#sec6.1
- Apache itself though is broken, see https://gist.github.com/anonymous/a863d7b493c4b09733ec

The fix is to sent out some status text, when we don't know a better text.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
