### PR TITLE
[Security] Remove supportsAttribute/Class from VoterInterface and AccessDecisionManagerInterface

### DIFF
--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -13,7 +13,7 @@ CHANGELOG
  * deprecated `Symfony\Component\Security\Core\Util\ClassUtils`, use
    `Symfony\Component\Security\Acl\Util\ClassUtils` instead
  * deprecated the `Symfony\Component\Security\Core\Util\SecureRandom` class in favor of the `random_bytes()` function
- * deprecated `supportsAttribute()` and `supportsClass()` methods of
+ * removed `supportsAttribute()` and `supportsClass()` methods from
    `Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface` and
    `Symfony\Component\Security\Core\Authorization\Voter\VoterInterface`.
  * deprecated `getSupportedAttributes()` and `getSupportedClasses()` methods of

--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManagerInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManagerInterface.php
@@ -30,26 +30,4 @@ interface AccessDecisionManagerInterface
      * @return bool true if the access is granted, false otherwise
      */
     public function decide(TokenInterface $token, array $attributes, $object = null);
-
-    /**
-     * Checks if the access decision manager supports the given attribute.
-     *
-     * @param string $attribute An attribute
-     *
-     * @return bool true if this decision manager supports the attribute, false otherwise
-     *
-     * @deprecated since version 2.8, to be removed in 3.0.
-     */
-    public function supportsAttribute($attribute);
-
-    /**
-     * Checks if the access decision manager supports the given class.
-     *
-     * @param string $class A class name
-     *
-     * @return true if this decision manager can process the class
-     *
-     * @deprecated since version 2.8, to be removed in 3.0.
-     */
-    public function supportsClass($class);
 }

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.php
@@ -25,28 +25,6 @@ interface VoterInterface
     const ACCESS_DENIED = -1;
 
     /**
-     * Checks if the voter supports the given attribute.
-     *
-     * @param string $attribute An attribute
-     *
-     * @return bool true if this Voter supports the attribute, false otherwise
-     *
-     * @deprecated since version 2.8, to be removed in 3.0.
-     */
-    public function supportsAttribute($attribute);
-
-    /**
-     * Checks if the voter supports the given class.
-     *
-     * @param string $class A class name
-     *
-     * @return bool true if this Voter can process the class
-     *
-     * @deprecated since version 2.8, to be removed in 3.0.
-     */
-    public function supportsClass($class);
-
-    /**
      * Returns the vote for the given parameters.
      *
      * This method must return one of the following constants:


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The BC Promise says that [methods can't be removed from interfaces](http://symfony.com/doc/current/contributing/code/bc.html#changing-interfaces). I'd like to challenge this.

Would this PR introduce any practical BC-break?

If not, I see the benefit of removing deprecated methods in 2.8: allowing one to move its code to 3.0-style today. Right now, it's not possible, because I _have_ to implement the deprecated methods to honour the contract.

Thought?
