### PR TITLE
[3.0][Process] PhpExecutableFinder: Remove dead code

### DIFF
--- a/src/Symfony/Component/Process/PhpExecutableFinder.php
+++ b/src/Symfony/Component/Process/PhpExecutableFinder.php
@@ -19,13 +19,6 @@ namespace Symfony\Component\Process;
  */
 class PhpExecutableFinder
 {
-    private $executableFinder;
-
-    public function __construct()
-    {
-        $this->executableFinder = new ExecutableFinder();
-    }
-
     /**
      * Finds The PHP executable.
      *
@@ -45,26 +38,7 @@ class PhpExecutableFinder
             return PHP_BINARY.($includeArgs ? ' '.implode(' ', $this->findArguments()) : '');
         }
 
-        if ($php = getenv('PHP_PATH')) {
-            if (!is_executable($php)) {
-                return false;
-            }
-
-            return $php;
-        }
-
-        if ($php = getenv('PHP_PEAR_PHP_BIN')) {
-            if (is_executable($php)) {
-                return $php;
-            }
-        }
-
-        $dirs = array(PHP_BINDIR);
-        if ('\\' === DIRECTORY_SEPARATOR) {
-            $dirs[] = 'C:\xampp\php\\';
-        }
-
-        return $this->executableFinder->find('php', false, $dirs);
+        return false;
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Related tests were removed in https://github.com/symfony/symfony/commit/2e11b8b2cbc0e640ac07aa968f538f496924d50e#diff-2d31cfd27e007b2d083d8dd882278981L24.
I guess it makes sense as the min required PHP version is 5.5.9, so the `PHP_BINARY` constant should always exist.
