### PR TITLE
[HttpFoundation] Delete not existing session handler proxy member

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/SessionHandlerProxy.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/SessionHandlerProxy.php
@@ -42,13 +42,7 @@ class SessionHandlerProxy extends AbstractProxy implements \SessionHandlerInterf
      */
     public function open($savePath, $sessionName)
     {
-        $return = (bool) $this->handler->open($savePath, $sessionName);
-
-        if (true === $return) {
-            $this->active = true;
-        }
-
-        return $return;
+        return (bool) $this->handler->open($savePath, $sessionName);
     }
 
     /**
@@ -56,8 +50,6 @@ class SessionHandlerProxy extends AbstractProxy implements \SessionHandlerInterf
      */
     public function close()
     {
-        $this->active = false;
-
         return (bool) $this->handler->close();
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

open() and close() SessionHandlerProxy method suse $this->active
that was removed from the parent AbstractProxy class after 2.8.
