### PR TITLE
[HttpKernel] Don't reset on shutdown but in FrameworkBundle/Test/KernelTestCase

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Test;
 
+use Symfony\Component\DependencyInjection\ResettableContainerInterface;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\KernelInterface;
 
@@ -171,7 +172,11 @@ abstract class KernelTestCase extends \PHPUnit_Framework_TestCase
     protected static function ensureKernelShutdown()
     {
         if (null !== static::$kernel) {
+            $container = static::$kernel->getContainer();
             static::$kernel->shutdown();
+            if ($container instanceof ResettableContainerInterface) {
+                $container->reset();
+            }
         }
     }
 

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -23,7 +23,6 @@ use Symfony\Component\DependencyInjection\Loader\IniFileLoader;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Loader\DirectoryLoader;
 use Symfony\Component\DependencyInjection\Loader\ClosureLoader;
-use Symfony\Component\DependencyInjection\ResettableContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
@@ -169,10 +168,6 @@ abstract class Kernel implements KernelInterface, TerminableInterface
         foreach ($this->getBundles() as $bundle) {
             $bundle->shutdown();
             $bundle->setContainer(null);
-        }
-
-        if ($this->container instanceof ResettableContainerInterface) {
-            $this->container->reset();
         }
 
         $this->container = null;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15185 |
| License | MIT |
| Doc PR | - |

While trying to migrate Blackfire to 2.8-beta, I found this BC-break: by resetting the container on kernel shut-down, functional tests are broken when they need to use the container after a call to `$this->client->request()`. Broken because e.g . the session or the profiler state is lost between consecutive requests in the same test, and because a call to $container->get('kernel') throws a synthetic-related exception.

This PR fixes the BC-break by reverting to the <=2.7 behavior (not resetting the container on kernel shut-down), and moving resetting to the KernelTestCase.
