### PR TITLE
fix type assignement

### DIFF
--- a/src/Symfony/Component/Form/FormRegistry.php
+++ b/src/Symfony/Component/Form/FormRegistry.php
@@ -88,7 +88,7 @@ class FormRegistry implements FormRegistryInterface
                 }
             }
 
-            $this->types[$name] = $this->resolveAndAddType($type);
+            $this->types[$name] = $this->resolveType($type);
         }
 
         return $this->types[$name];
@@ -102,7 +102,7 @@ class FormRegistry implements FormRegistryInterface
      *
      * @return ResolvedFormTypeInterface The resolved type.
      */
-    private function resolveAndAddType(FormTypeInterface $type)
+    private function resolveType(FormTypeInterface $type)
     {
         $typeExtensions = array();
         $parentType = $type->getParent();

--- a/src/Symfony/Component/Form/FormRegistry.php
+++ b/src/Symfony/Component/Form/FormRegistry.php
@@ -88,7 +88,7 @@ class FormRegistry implements FormRegistryInterface
                 }
             }
 
-            $this->resolveAndAddType($type);
+            $this->types[$name] = $this->resolveAndAddType($type);
         }
 
         return $this->types[$name];
@@ -115,13 +115,11 @@ class FormRegistry implements FormRegistryInterface
             );
         }
 
-        $resolvedType = $this->resolvedTypeFactory->createResolvedType(
+        return $this->resolvedTypeFactory->createResolvedType(
             $type,
             $typeExtensions,
             $parentType ? $this->getType($parentType) : null
         );
-
-        $this->types[$fqcn] = $resolvedType;
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This PR make sure the original key is used when the type is resolved. Also the code now respect the PHPDoc.
