### PR TITLE
[Console] Fix bug with $output overloading

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
@@ -72,9 +72,9 @@ EOF
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $cliOutput)
     {
-        $output = new SymfonyStyle($input, $output);
+        $output = new SymfonyStyle($input, $cliOutput);
 
         if (!extension_loaded('pcntl')) {
             $output->error(array(
@@ -85,7 +85,7 @@ EOF
             if ($output->ask('Do you want to execute <info>server:run</info> immediately? [Yn] ', true)) {
                 $command = $this->getApplication()->find('server:run');
 
-                return $command->run($input, $output);
+                return $command->run($input, $cliOutput);
             }
 
             return 1;

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
@@ -72,9 +72,9 @@ EOF
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $cliOutput)
+    protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $output = new SymfonyStyle($input, $cliOutput);
+        $output = new SymfonyStyle($input, $cliOutput = $output);
 
         if (!extension_loaded('pcntl')) {
             $output->error(array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony-standard/issues/887, #16622 |
| License | MIT |
| Doc PR | - |

This is exactly why variable overloading isn't a great idea :)
