### PR TITLE
[WebProfilerBundle] Added a top left border radius to the minified to…

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -1,5 +1,6 @@
 .sf-minitoolbar {
     background-color: #222;
+    border-top-left-radius: 4px;
     bottom: 0;
     display: none;
     height: 30px;
@@ -7,8 +8,8 @@
     position: fixed;
     right: 0;
     z-index: 99999;
-    border-top-left-radius: 4px;
 }
+
 .sf-minitoolbar a {
     display: block;
 }
@@ -358,11 +359,11 @@
 /* Override the setting when the toolbar is on the top */
 {% if position == 'top' %}
     .sf-minitoolbar {
+        border-bottom-left-radius: 4px;
+        border-top-left-radius: 0;
         bottom: auto;
         right: 0;
         top: 0;
-        border-top-left-radius: 0;
-        border-bottom-left-radius: 4px;
     }
 
     .sf-toolbarreset {

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -7,6 +7,9 @@
     position: fixed;
     right: 0;
     z-index: 99999;
+    -webkit-border-top-left-radius: 4px;
+    -moz-border-radius-topleft: 4px;
+    border-top-left-radius: 4px;
 }
 .sf-minitoolbar a {
     display: block;

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -7,8 +7,6 @@
     position: fixed;
     right: 0;
     z-index: 99999;
-    -webkit-border-top-left-radius: 4px;
-    -moz-border-radius-topleft: 4px;
     border-top-left-radius: 4px;
 }
 .sf-minitoolbar a {
@@ -363,6 +361,8 @@
         bottom: auto;
         right: 0;
         top: 0;
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 4px;
     }
 
     .sf-toolbarreset {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

The minified toolbar (to us at least) looked very out of place in all of our projects. Adding a border radius to the top left fixes that.

Chrome 46 
![schermafbeelding 2015-11-23 om 09 29 06](https://cloud.githubusercontent.com/assets/6209772/11332470/41240b96-91c6-11e5-9d03-4738ff213295.png)

Firefox 42
![schermafbeelding 2015-11-23 om 09 29 53](https://cloud.githubusercontent.com/assets/6209772/11332476/55fbf574-91c6-11e5-898b-1ba2590a813b.png)

Safari 9
![schermafbeelding 2015-11-23 om 09 30 33](https://cloud.githubusercontent.com/assets/6209772/11332485/6351525a-91c6-11e5-8cbc-14b7efd82ce0.png)

Cannot test on IE/Edge at the moment, will be able to later today.

(The screenshots do not have commit https://github.com/symfony/symfony/commit/04599125238d23e0c5388fbbcc6067055c970f62)
