### PR TITLE
[HttpFoundation] Remove deprecated class method parameter

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -128,13 +128,12 @@ class ParameterBag implements \IteratorAggregate, \Countable
      *
      * @param string $key     The parameter key
      * @param string $default The default value if the parameter key does not exist
-     * @param bool   $deep    If true, a path like foo[bar] will find deeper items
      *
      * @return string The filtered value
      */
-    public function getAlpha($key, $default = '', $deep = false)
+    public function getAlpha($key, $default = '')
     {
-        return preg_replace('/[^[:alpha:]]/', '', $this->get($key, $default, $deep));
+        return preg_replace('/[^[:alpha:]]/', '', $this->get($key, $default));
     }
 
     /**
@@ -142,13 +141,12 @@ class ParameterBag implements \IteratorAggregate, \Countable
      *
      * @param string $key     The parameter key
      * @param string $default The default value if the parameter key does not exist
-     * @param bool   $deep    If true, a path like foo[bar] will find deeper items
      *
      * @return string The filtered value
      */
-    public function getAlnum($key, $default = '', $deep = false)
+    public function getAlnum($key, $default = '')
     {
-        return preg_replace('/[^[:alnum:]]/', '', $this->get($key, $default, $deep));
+        return preg_replace('/[^[:alnum:]]/', '', $this->get($key, $default));
     }
 
     /**
@@ -156,14 +154,13 @@ class ParameterBag implements \IteratorAggregate, \Countable
      *
      * @param string $key     The parameter key
      * @param string $default The default value if the parameter key does not exist
-     * @param bool   $deep    If true, a path like foo[bar] will find deeper items
      *
      * @return string The filtered value
      */
-    public function getDigits($key, $default = '', $deep = false)
+    public function getDigits($key, $default = '')
     {
         // we need to remove - and + because they're allowed in the filter
-        return str_replace(array('-', '+'), '', $this->filter($key, $default, $deep, FILTER_SANITIZE_NUMBER_INT));
+        return str_replace(array('-', '+'), '', $this->filter($key, $default, FILTER_SANITIZE_NUMBER_INT));
     }
 
     /**
@@ -171,13 +168,12 @@ class ParameterBag implements \IteratorAggregate, \Countable
      *
      * @param string $key     The parameter key
      * @param int    $default The default value if the parameter key does not exist
-     * @param bool   $deep    If true, a path like foo[bar] will find deeper items
      *
      * @return int The filtered value
      */
-    public function getInt($key, $default = 0, $deep = false)
+    public function getInt($key, $default = 0)
     {
-        return (int) $this->get($key, $default, $deep);
+        return (int) $this->get($key, $default);
     }
 
     /**
@@ -185,13 +181,12 @@ class ParameterBag implements \IteratorAggregate, \Countable
      *
      * @param string $key     The parameter key
      * @param mixed  $default The default value if the parameter key does not exist
-     * @param bool   $deep    If true, a path like foo[bar] will find deeper items
      *
      * @return bool The filtered value
      */
-    public function getBoolean($key, $default = false, $deep = false)
+    public function getBoolean($key, $default = false)
     {
-        return $this->filter($key, $default, $deep, FILTER_VALIDATE_BOOLEAN);
+        return $this->filter($key, $default, FILTER_VALIDATE_BOOLEAN);
     }
 
     /**
@@ -199,7 +194,6 @@ class ParameterBag implements \IteratorAggregate, \Countable
      *
      * @param string $key     Key.
      * @param mixed  $default Default = null.
-     * @param bool   $deep    Default = false.
      * @param int    $filter  FILTER_* constant.
      * @param mixed  $options Filter options.
      *
@@ -207,9 +201,9 @@ class ParameterBag implements \IteratorAggregate, \Countable
      *
      * @return mixed
      */
-    public function filter($key, $default = null, $deep = false, $filter = FILTER_DEFAULT, $options = array())
+    public function filter($key, $default = null, $filter = FILTER_DEFAULT, $options = array())
     {
-        $value = $this->get($key, $default, $deep);
+        $value = $this->get($key, $default);
 
         // Always turn $options into an array - this allows filter_var option shortcuts.
         if (!is_array($options) && $options) {

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -137,26 +137,26 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEmpty($bag->filter('nokey'), '->filter() should return empty by default if no key is found');
 
-        $this->assertEquals('0123', $bag->filter('digits', '', false, FILTER_SANITIZE_NUMBER_INT), '->filter() gets a value of parameter as integer filtering out invalid characters');
+        $this->assertEquals('0123', $bag->filter('digits', '', FILTER_SANITIZE_NUMBER_INT), '->filter() gets a value of parameter as integer filtering out invalid characters');
 
-        $this->assertEquals('example@example.com', $bag->filter('email', '', false, FILTER_VALIDATE_EMAIL), '->filter() gets a value of parameter as email');
+        $this->assertEquals('example@example.com', $bag->filter('email', '', FILTER_VALIDATE_EMAIL), '->filter() gets a value of parameter as email');
 
-        $this->assertEquals('http://example.com/foo', $bag->filter('url', '', false, FILTER_VALIDATE_URL, array('flags' => FILTER_FLAG_PATH_REQUIRED)), '->filter() gets a value of parameter as URL with a path');
+        $this->assertEquals('http://example.com/foo', $bag->filter('url', '', FILTER_VALIDATE_URL, array('flags' => FILTER_FLAG_PATH_REQUIRED)), '->filter() gets a value of parameter as URL with a path');
 
         // This test is repeated for code-coverage
-        $this->assertEquals('http://example.com/foo', $bag->filter('url', '', false, FILTER_VALIDATE_URL, FILTER_FLAG_PATH_REQUIRED), '->filter() gets a value of parameter as URL with a path');
+        $this->assertEquals('http://example.com/foo', $bag->filter('url', '', FILTER_VALIDATE_URL, FILTER_FLAG_PATH_REQUIRED), '->filter() gets a value of parameter as URL with a path');
 
-        $this->assertFalse($bag->filter('dec', '', false, FILTER_VALIDATE_INT, array(
+        $this->assertFalse($bag->filter('dec', '', FILTER_VALIDATE_INT, array(
             'flags' => FILTER_FLAG_ALLOW_HEX,
             'options' => array('min_range' => 1, 'max_range' => 0xff),
         )), '->filter() gets a value of parameter as integer between boundaries');
 
-        $this->assertFalse($bag->filter('hex', '', false, FILTER_VALIDATE_INT, array(
+        $this->assertFalse($bag->filter('hex', '', FILTER_VALIDATE_INT, array(
             'flags' => FILTER_FLAG_ALLOW_HEX,
             'options' => array('min_range' => 1, 'max_range' => 0xff),
         )), '->filter() gets a value of parameter as integer between boundaries');
 
-        $this->assertEquals(array('bang'), $bag->filter('array', '', false), '->filter() gets a value of parameter as an array');
+        $this->assertEquals(array('bang'), $bag->filter('array', ''), '->filter() gets a value of parameter as an array');
     }
 
     public function testGetIterator()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

$deep argument in Symfony\Component\HttpFoundation\BagParameter::get was deprecated  in 2.8 and removed in master, but it is still used in the code of the class (and in the filter() method)
