### PR TITLE
Release v2.3.35

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -7,6 +7,25 @@ in 2.3 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.3.0...v2.3.1
 
+* 2.3.35 (2015-11-23)
+
+ * security #16631 CVE-2015-8124: Session Fixation in the "Remember Me" Login Feature (xabbuh)
+ * security #16630 CVE-2015-8125: Potential Remote Timing Attack Vulnerability in Security Remember-Me Service (xabbuh)
+ * bug #16588 Sent out a status text for unknown HTTP headers. (dawehner)
+ * bug #16295 [DependencyInjection] Unescape parameters for all types of injection (Nicofuma)
+ * bug #16574 [Process] Fix PhpProcess with phpdbg runtime (nicolas-grekas)
+ * bug #16352 Fix the server variables in the router_*.php files (leofeyer)
+ * bug #16537 [Validator] Allow an empty path with a non empty fragment or a query (jakzal)
+ * bug #16528 [Translation] Add support for Armenian pluralization. (marcosdsanchez)
+ * bug #16510 [Process] fix Proccess run with pts enabled (ewgRa)
+ * bug #16292 fix race condition at mkdir (#16258) (ewgRa)
+ * bug #16462 [PropertyAccess] Fix dynamic property accessing. (dunglas)
+ * bug #16294 [PropertyAccess] Major performance improvement (dunglas)
+ * bug #16331 fixed Twig deprecation notices (fabpot)
+ * bug #16306 [DoctrineBridge] Fix issue which prevent the profiler to explain a query  (Baachi)
+ * bug #16359 Use mb_detect_encoding with $strict = true (nicolas-grekas)
+ * bug #16144 [Security] don't allow to install the split Security packages (xabbuh)
+
 * 2.3.34 (2015-10-27)
 
  * bug #16288 [Process] Inherit env vars by default in PhpProcess (nicolas-grekas)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -51,19 +51,19 @@ Symfony is the result of the work of many people who made the code better
  - Florin Patan (florinpatan)
  - Eric Clemmons (ericclemmons)
  - Andrej Hudec (pulzarraider)
- - Deni
  - Maxime Steinhausser (ogizanagi)
+ - Deni
  - Henrik Westphal (snc)
  - Dariusz Górecki (canni)
  - Gábor Egyed (1ed)
  - Christian Raue
  - Arnout Boks (aboks)
- - Michel Weimerskirch (mweimerskirch)
  - Kevin Bond (kbond)
+ - Michel Weimerskirch (mweimerskirch)
+ - Douglas Greenshields (shieldo)
  - Lee McDermott
  - Brandon Turner
  - Luis Cordova (cordoval)
- - Douglas Greenshields (shieldo)
  - Daniel Holmes (dholmes)
  - Bart van den Burg (burgov)
  - Jordan Alliot (jalliot)
@@ -85,15 +85,17 @@ Symfony is the result of the work of many people who made the code better
  - Adrien Brault (adrienbrault)
  - excelwebzone
  - Jacob Dreesen (jdreesen)
+ - Michal Piotrowski (eventhorizon)
+ - Peter Kokot (maastermedia)
  - Fabien Pennequin (fabienpennequin)
  - Peter Rehm (rpet)
- - Peter Kokot (maastermedia)
+ - Pierre du Plessis (pierredup)
  - Alexander Schwenn (xelaris)
  - Gordon Franke (gimler)
  - Robert Schönthal (digitalkaoz)
  - Jérémy DERUSSÉ (jderusse)
  - Dariusz Ruminski
- - Michal Piotrowski (eventhorizon)
+ - Joshua Thijssen
  - Stefano Sala (stefano.sala)
  - David Buchmann (dbu)
  - Issei Murasawa (issei_m)
@@ -103,7 +105,6 @@ Symfony is the result of the work of many people who made the code better
  - Sebastian Hörl (blogsh)
  - Daniel Gomes (danielcsgomes)
  - Hidenori Goto (hidenorigoto)
- - Joshua Thijssen
  - Guilherme Blanco (guilhermeblanco)
  - Pablo Godel (pgodel)
  - Vladimir Reznichenko (kalessil)
@@ -116,6 +117,7 @@ Symfony is the result of the work of many people who made the code better
  - Clemens Tolboom
  - Helmer Aaviksoo
  - Baptiste Clavié (talus)
+ - Tugdual Saunier (tucksaun)
  - Hiromi Hishida (77web)
  - Matthieu Ouellette-Vachon (maoueh)
  - Michał Pipa (michal.pipa)
@@ -124,8 +126,7 @@ Symfony is the result of the work of many people who made the code better
  - Artur Kotyrba
  - Rouven Weßling (realityking)
  - Charles Sarrazin (csarrazi)
- - Pierre du Plessis (pierredup)
- - Tugdual Saunier (tucksaun)
+ - Warnar Boekkooi (boekkooi)
  - Andréia Bohner (andreia)
  - Dmitrii Chekaliuk (lazyhammer)
  - Clément JOBEILI (dator)
@@ -159,15 +160,17 @@ Symfony is the result of the work of many people who made the code better
  - Justin Hileman (bobthecow)
  - Michele Orselli (orso)
  - Sven Paulus (subsven)
- - Warnar Boekkooi (boekkooi)
  - Lars Strojny (lstrojny)
+ - Daniel Wehner
  - Rui Marinho (ruimarinho)
+ - Evgeniy (ewgraf)
  - Julien Brochet (mewt)
  - Sergey Linnik (linniksa)
  - Jáchym Toušek
  - Marcel Beerta (mazen)
  - Vincent AUBERT (vincent)
  - julien pauli (jpauli)
+ - Florian Lonqueu-Brochard (florianlb)
  - Francois Zaninotto
  - Alexander Kotynia (olden)
  - Daniel Tschinder
@@ -185,6 +188,7 @@ Symfony is the result of the work of many people who made the code better
  - Eugene Leonovich (rybakit)
  - Joseph Rouff (rouffj)
  - Félix Labrecque (woodspire)
+ - Tomáš Votruba (tomas_votruba)
  - GordonsLondon
  - Jan Sorgalla (jsor)
  - Ray
@@ -201,17 +205,19 @@ Symfony is the result of the work of many people who made the code better
  - Beau Simensen (simensen)
  - Robert Kiss (kepten)
  - Ruben Gonzalez (rubenrua)
+ - Marcos Sánchez
  - Kim Hemsø Rasmussen (kimhemsoe)
  - Diego Saint Esteben (dosten)
- - Florian Lonqueu-Brochard (florianlb)
  - Tom Van Looy (tvlooy)
  - Wouter Van Hecke
  - Peter Kruithof (pkruithof)
  - Michael Holm (hollo)
  - Marc Weistroff (futurecat)
+ - Blanchon Vincent (blanchonvincent)
  - Dawid Nowak
  - Kristen Gilden (kgilden)
  - Chris Smith (cs278)
+ - Richard van Laak (rvanlaak)
  - Florian Klein (docteurklein)
  - Manuel Kiessling (manuelkiessling)
  - Daniel Wehner
@@ -245,7 +251,7 @@ Symfony is the result of the work of many people who made the code better
  - Giorgio Premi
  - Erin Millard
  - Matthew Lewinski (lewinski)
- - Marcos Sánchez
+ - Antonio J. García Lagar (ajgarlag)
  - alquerci
  - Francesco Levorato
  - Vitaliy Zakharov (zakharovvi)
@@ -255,14 +261,11 @@ Symfony is the result of the work of many people who made the code better
  - Christian Gärtner (dagardner)
  - Tomasz Kowalczyk (thunderer)
  - François-Xavier de Guillebon (de-gui_f)
- - Daniel Wehner
  - Felix Labrecque
  - Yaroslav Kiliba
  - Stepan Anchugov (kix)
  - Terje Bråten
- - Evgeniy (ewgraf)
  - Robbert Klarenbeek (robbertkl)
- - Blanchon Vincent (blanchonvincent)
  - hossein zolfi (ocean)
  - Clément Gautier (clementgautier)
  - Eduardo Gulias (egulias)
@@ -285,6 +288,7 @@ Symfony is the result of the work of many people who made the code better
  - Shein Alexey
  - Joe Lencioni
  - Daniel Tschinder
+ - Diego Agulló (aeoris)
  - Kai
  - Lee Rowlands
  - Maximilian Reichel (phramz)
@@ -313,8 +317,9 @@ Symfony is the result of the work of many people who made the code better
  - Thomas Lallement (raziel057)
  - Jan Schumann
  - Niklas Fiekas
+ - Mark Challoner (markchalloner)
+ - Markus Bachmann (baachi)
  - lancergr
- - Antonio J. García Lagar (ajgarlag)
  - Olivier Dolbeau (odolbeau)
  - Roumen Damianoff (roumen)
  - vagrant
@@ -365,9 +370,10 @@ Symfony is the result of the work of many people who made the code better
  - Daniel Beyer
  - Andrew Udvare (audvare)
  - alexpods
- - Richard van Laak (rvanlaak)
+ - Tristan Darricau (nicofuma)
  - Erik Trapman (eriktrapman)
  - De Cock Xavier (xdecock)
+ - Possum
  - Scott Arciszewski
  - Norbert Orzechowicz (norzechowicz)
  - Matthijs van den Bos (matthijs)
@@ -381,6 +387,7 @@ Symfony is the result of the work of many people who made the code better
  - Dawid Pakuła (zulusx)
  - Florian Rey (nervo)
  - Rodrigo Borrego Bernabé (rodrigobb)
+ - Leo Feyer
  - MatTheCat
  - John Bafford (jbafford)
  - Denis Gorbachev (starfall)
@@ -410,7 +417,6 @@ Symfony is the result of the work of many people who made the code better
  - Christopher Davis (chrisguitarguy)
  - alcaeus
  - vitaliytv
- - Markus Bachmann (baachi)
  - Sebastian Blum
  - aubx
  - Ricky Su (ricky)
@@ -475,6 +481,7 @@ Symfony is the result of the work of many people who made the code better
  - Tiago Brito (blackmx)
  - Richard van den Brand (ricbra)
  - develop
+ - Hidde Wieringa
  - Mark Sonnabaum
  - Alexander Obuhovich (aik099)
  - jochenvdv
@@ -496,7 +503,6 @@ Symfony is the result of the work of many people who made the code better
  - avorobiev
  - Venu
  - Lars Vierbergen
- - Mark Challoner
  - Dennis Hotson
  - Andrew Tchircoff (andrewtch)
  - michaelwilliams
@@ -534,7 +540,6 @@ Symfony is the result of the work of many people who made the code better
  - Rafał Wrzeszcz (rafalwrzeszcz)
  - Reen Lokum
  - Martin Parsiegla (spea)
- - Possum
  - Denis Charrier (brucewouaigne)
  - Quentin Schuler
  - Pierre Vanliefland (pvanliefland)
@@ -558,12 +563,10 @@ Symfony is the result of the work of many people who made the code better
  - Patrick Allaert
  - Gustavo Falco (gfalco)
  - Matt Robinson (inanimatt)
- - Tristan Darricau (nicofuma)
  - Aleksey Podskrebyshev
  - Steffen Roßkamp
  - David Marín Carreño (davefx)
  - Jörn Lang (j.lang)
- - Leo Feyer
  - mwsaz
  - Benoît Bourgeois
  - corphi
@@ -589,7 +592,6 @@ Symfony is the result of the work of many people who made the code better
  - Balazs Csaba (balazscsaba2006)
  - Harry Walter (haswalt)
  - Johnson Page (jwpage)
- - Tomáš Votruba (tomas_votruba)
  - Michael Roterman (wtfzdotnet)
  - Arno Geurts
  - Adán Lobato (adanlobato)
@@ -638,6 +640,7 @@ Symfony is the result of the work of many people who made the code better
  - Jérôme Vasseur
  - Sander Coolen (scoolen)
  - Nicolas Le Goff (nlegoff)
+ - Anne-Sophie Bachelard (annesophie)
  - Manuele Menozzi
  - Anton Babenko (antonbabenko)
  - Irmantas Šiupšinskas (irmantas)
@@ -921,7 +924,6 @@ Symfony is the result of the work of many people who made the code better
  - Shane Preece (shane)
  - wusuopu
  - povilas
- - Diego Agulló
  - Alessandro Tagliapietra (alex88)
  - Biji (biji)
  - Gunnar Lium (gunnarlium)
@@ -1082,7 +1084,6 @@ Symfony is the result of the work of many people who made the code better
  - grifx
  - Robert Campbell
  - Matt Lehner
- - Hidde Wieringa
  - Hein Zaw Htet™
  - Ruben Kruiswijk
  - Michael J
@@ -1106,7 +1107,6 @@ Symfony is the result of the work of many people who made the code better
  - Alan Chen
  - Maerlyn
  - Even André Fiskvik
- - Diego Agulló
  - Dane Powell
  - Gerrit Drost
  - Lenar Lõhmus
@@ -1219,6 +1219,7 @@ Symfony is the result of the work of many people who made the code better
  - Sam Williams
  - Adrian Philipp
  - James Michael DuPont
+ - Eugene Wissner
  - Kasperki
  - Tammy D
  - Ondrej Slinták
@@ -1276,6 +1277,7 @@ Symfony is the result of the work of many people who made the code better
  - arduanov
  - sualko
  - Nicolas Roudaire
+ - Jérôme Vasseur
  - Alfonso (afgar)
  - Andreas Forsblom (aforsblo)
  - Alex Olmos (alexolmos)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -58,12 +58,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '2.3.35-DEV';
+    const VERSION = '2.3.35';
     const VERSION_ID = 20335;
     const MAJOR_VERSION = 2;
     const MINOR_VERSION = 3;
     const RELEASE_VERSION = 35;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     /**
      * Constructor.


### PR DESCRIPTION
Changes since last release: https://github.com/symfony/symfony/compare/v2.3.34...3b790dd

**Changelog**
- security #16631 CVE-2015-8124: Session Fixation in the "Remember Me" Login Feature (xabbuh)
- security #16630 CVE-2015-8125: Potential Remote Timing Attack Vulnerability in Security Remember-Me Service (xabbuh)
- bug #16588 Sent out a status text for unknown HTTP headers. (@dawehner)
- bug #16295 [DependencyInjection] Unescape parameters for all types of injection (@Nicofuma)
- bug #16574 [Process] Fix PhpProcess with phpdbg runtime (@nicolas-grekas)
- bug #16352 Fix the server variables in the router_*.php files (@leofeyer)
- bug #16537 [Validator] Allow an empty path with a non empty fragment or a query (@jakzal)
- bug #16528 [Translation] Add support for Armenian pluralization. (@marcosdsanchez)
- bug #16510 [Process] fix Proccess run with pts enabled (@ewgRa)
- bug #16292 fix race condition at mkdir (#16258) (@ewgRa)
- bug #16462 [PropertyAccess] Fix dynamic property accessing. (@dunglas)
- bug #16294 [PropertyAccess] Major performance improvement (@dunglas)
- bug #16331 fixed Twig deprecation notices (@fabpot)
- bug #16306 [DoctrineBridge] Fix issue which prevent the profiler to explain a query  (@Baachi)
- bug #16359 Use mb_detect_encoding with $strict = true (@nicolas-grekas)
- bug #16144 [Security] don't allow to install the split Security packages (@xabbuh)
