### PR TITLE
[Security] add USERNAME_NONE_PROVIDED constant

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Provider/AuthenticationProviderInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/AuthenticationProviderInterface.php
@@ -25,6 +25,13 @@ use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterfac
 interface AuthenticationProviderInterface extends AuthenticationManagerInterface
 {
     /**
+     * Username non provided
+     *
+     * @var string
+     */
+    const USERNAME_NONE_PROVIDED = 'NONE_PROVIDED';
+
+    /**
      * Checks whether this provider supports the given token.
      *
      * @param TokenInterface $token A TokenInterface instance

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/AuthenticationProviderInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/AuthenticationProviderInterface.php
@@ -25,7 +25,7 @@ use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterfac
 interface AuthenticationProviderInterface extends AuthenticationManagerInterface
 {
     /**
-     * Username non provided
+     * Use this constant for not provided username
      *
      * @var string
      */

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/LdapBindAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/LdapBindAuthenticationProvider.php
@@ -58,7 +58,7 @@ class LdapBindAuthenticationProvider extends UserAuthenticationProvider
      */
     protected function retrieveUser($username, UsernamePasswordToken $token)
     {
-        if ('NONE_PROVIDED' === $username) {
+        if (AuthenticationProviderInterface::USERNAME_NONE_PROVIDED === $username) {
             throw new UsernameNotFoundException('Username can not be null');
         }
 

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
@@ -63,7 +63,7 @@ abstract class UserAuthenticationProvider implements AuthenticationProviderInter
 
         $username = $token->getUsername();
         if ('' === $username || null === $username) {
-            $username = 'NONE_PROVIDED';
+            $username = AuthenticationProviderInterface::USERNAME_NONE_PROVIDED;
         }
 
         try {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | no |
| License | MIT |
| Doc PR | no |

I think that is better if we use a constant to define this string.
