### PR TITLE
Tweaking deprecation message to include class name

### DIFF
--- a/src/Symfony/Component/Config/Resource/BCResourceInterfaceChecker.php
+++ b/src/Symfony/Component/Config/Resource/BCResourceInterfaceChecker.php
@@ -29,7 +29,7 @@ class BCResourceInterfaceChecker extends SelfCheckingResourceChecker
 
     public function isFresh(ResourceInterface $resource, $timestamp)
     {
-        @trigger_error('Resource checking through ResourceInterface::isFresh() is deprecated since 2.8 and will be removed in 3.0', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The class %s is performing resource checking through ResourceInterface::isFresh(), which is deprecated since 2.8 and will be removed in 3.0', get_class($resource)), E_USER_DEPRECATED);
 
         return parent::isFresh($resource, $timestamp); // For now, $metadata features the isFresh() method, so off we go (quack quack)
     }

--- a/src/Symfony/Component/Config/Resource/BCResourceInterfaceChecker.php
+++ b/src/Symfony/Component/Config/Resource/BCResourceInterfaceChecker.php
@@ -29,7 +29,7 @@ class BCResourceInterfaceChecker extends SelfCheckingResourceChecker
 
     public function isFresh(ResourceInterface $resource, $timestamp)
     {
-        @trigger_error(sprintf('The class %s is performing resource checking through ResourceInterface::isFresh(), which is deprecated since 2.8 and will be removed in 3.0', get_class($resource)), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The class "%s" is performing resource checking through ResourceInterface::isFresh(), which is deprecated since 2.8 and will be removed in 3.0', get_class($resource)), E_USER_DEPRECATED);
 
         return parent::isFresh($resource, $timestamp); // For now, $metadata features the isFresh() method, so off we go (quack quack)
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Before:

> Resource checking through ResourceInterface::isFresh() is deprecated since 2.8
> and will be removed in 3.0

After:

> The class Symfony\Bundle\AsseticBundle\Config\AsseticResource is performing
> resource checking through ResourceInterface::isFresh(), which is deprecated since 2.8
> and will be removed in 3.0
