### PR TITLE
[console] Add truncate method to FormatterHelper

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.1.0
+-----
+
+ * added truncate method to FormatterHelper
+
 2.8.0
 -----
 

--- a/src/Symfony/Component/Console/Helper/FormatterHelper.php
+++ b/src/Symfony/Component/Console/Helper/FormatterHelper.php
@@ -89,7 +89,7 @@ class FormatterHelper extends Helper
             return $message;
         }
 
-        return substr($message, 0, $length) . $suffix;
+        return substr($message, 0, $length).$suffix;
     }
 
     /**

--- a/src/Symfony/Component/Console/Helper/FormatterHelper.php
+++ b/src/Symfony/Component/Console/Helper/FormatterHelper.php
@@ -83,9 +83,9 @@ class FormatterHelper extends Helper
      */
     public function truncate($message, $length, $suffix = '...')
     {
-        $computedLength = $length - mb_strlen($suffix);
+        $computedLength = $length - $this->strlen($suffix);
 
-        if ($computedLength > mb_strlen($message)) {
+        if ($computedLength > $this->strlen($message)) {
             return $message;
         }
 

--- a/src/Symfony/Component/Console/Helper/FormatterHelper.php
+++ b/src/Symfony/Component/Console/Helper/FormatterHelper.php
@@ -83,13 +83,13 @@ class FormatterHelper extends Helper
      */
     public function truncate($message, $length, $suffix = '...')
     {
-        $computedLength = $length - strlen($suffix);
+        $computedLength = $length - mb_strlen($suffix);
 
-        if ($computedLength > strlen($message)) {
+        if ($computedLength > mb_strlen($message)) {
             return $message;
         }
 
-        return substr($message, 0, $length).$suffix;
+        return mb_substr($message, 0, $length).$suffix;
     }
 
     /**

--- a/src/Symfony/Component/Console/Helper/FormatterHelper.php
+++ b/src/Symfony/Component/Console/Helper/FormatterHelper.php
@@ -73,6 +73,26 @@ class FormatterHelper extends Helper
     }
 
     /**
+     * Truncates a message to the given length.
+     *
+     * @param string $message
+     * @param int    $length
+     * @param string $suffix
+     *
+     * @return string
+     */
+    public function truncate($message, $length, $suffix = '...')
+    {
+        $computedLength = $length - strlen($suffix);
+
+        if ($computedLength > strlen($message)) {
+            return $message;
+        }
+
+        return substr($message, 0, $length) . $suffix;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getName()

--- a/src/Symfony/Component/Console/Helper/FormatterHelper.php
+++ b/src/Symfony/Component/Console/Helper/FormatterHelper.php
@@ -89,7 +89,11 @@ class FormatterHelper extends Helper
             return $message;
         }
 
-        return mb_substr($message, 0, $length).$suffix;
+        if (false === $encoding = mb_detect_encoding($message, null, true)) {
+            return substr($message, 0, $length).$suffix;
+        }
+
+        return mb_substr($message, 0, $length, $encoding).$suffix;
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Helper/FormatterHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/FormatterHelperTest.php
@@ -89,4 +89,39 @@ class FormatterHelperTest extends \PHPUnit_Framework_TestCase
             '::formatBlock() escapes \'<\' chars'
         );
     }
+
+    public function testTruncatingWithShorterLengthThanMessageWithSuffix()
+    {
+        $formatter = new FormatterHelper();
+        $message = 'testing truncate';
+
+        $this->assertSame('test...', $formatter->truncate($message, 4));
+        $this->assertSame('testing truncat...', $formatter->truncate($message, 15));
+        $this->assertSame('testing truncate...', $formatter->truncate($message, 16));
+    }
+
+    public function testTruncatingMessageWithCustomSuffix()
+    {
+        $formatter = new FormatterHelper();
+        $message = 'testing truncate';
+
+        $this->assertSame('test!', $formatter->truncate($message, 4, '!'));
+    }
+
+    public function testTruncatingWithLongerLengthThanMessageWithSuffix()
+    {
+        $formatter = new FormatterHelper();
+        $message = 'test';
+
+        $this->assertSame($message, $formatter->truncate($message, 10));
+    }
+
+    public function testTruncatingWithNegativeLength()
+    {
+        $formatter = new FormatterHelper();
+        $message = 'testing truncate';
+
+        $this->assertSame('testing tru...', $formatter->truncate($message, -5));
+        $this->assertSame('...', $formatter->truncate($message, -100));
+    }
 }

--- a/src/Symfony/Component/Console/Tests/Helper/FormatterHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/FormatterHelperTest.php
@@ -98,6 +98,7 @@ class FormatterHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('test...', $formatter->truncate($message, 4));
         $this->assertSame('testing truncat...', $formatter->truncate($message, 15));
         $this->assertSame('testing truncate...', $formatter->truncate($message, 16));
+        $this->assertSame('zażółć gęślą...', $formatter->truncate('zażółć gęślą jaźń', 12));
     }
 
     public function testTruncatingMessageWithCustomSuffix()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11977 |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/6186 |

This PR adds a `truncate` method to `FormatterHelper`.
Message is truncated to the given length, then the suffix is appended to end of that string.
If the length is negative, number of letters to truncate is counted from the end of the message.
Suffix is always appended, unless truncate length is longer than message and suffix length.
