### PR TITLE
[profiler] Fix conditional expression to provide a default value

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_item.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_item.html.twig
@@ -1,6 +1,6 @@
 <div class="sf-toolbar-block sf-toolbar-block-{{ name }} sf-toolbar-status-{{ status|default('normal') }} {{ additional_classes|default('') }}">
-    {% if link %}<a href="{{ path('_profiler', { token: token, panel: name }) }}">{% endif %}
+    {% if link is not defined or link %}<a href="{{ path('_profiler', { token: token, panel: name }) }}">{% endif %}
         <div class="sf-toolbar-icon">{{ icon|default('') }}</div>
-    {% if link %}</a>{% endif %}
+    {% if link is not defined or link %}</a>{% endif %}
         <div class="sf-toolbar-info">{{ text|default('') }}</div>
 </div>


### PR DESCRIPTION
**Fix conditional expression to provide a default value and prevent from the exception**

**From the cookbook**:
_{# the 'link' value set to 'false' means that this panel doesn't show a section in the web profiler (default is 'true'). #}_

Simple conditional expression is not enough to provide a default value for the link parameter if is missed.

``` twig
 {% if link %}
```

Custom collector

``` twig
{{ include('@WebProfiler/Profiler/toolbar_item.html.twig') }}
```

WebProfiler/Profiler/toolbar_item.html.twig

``` twig
 {% if link %}
```
