### PR TITLE
add composer exclude-from-classmap for new 2.8 components

### DIFF
--- a/src/Symfony/Component/Ldap/composer.json
+++ b/src/Symfony/Component/Ldap/composer.json
@@ -21,7 +21,10 @@
         "ext-ldap": "*"
     },
     "autoload": {
-        "psr-4": { "Symfony\\Component\\Ldap\\": "" }
+        "psr-4": { "Symfony\\Component\\Ldap\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
     },
     "minimum-stability": "dev",
     "extra": {

--- a/src/Symfony/Component/PropertyInfo/composer.json
+++ b/src/Symfony/Component/PropertyInfo/composer.json
@@ -39,7 +39,10 @@
         "symfony/serializer": "To use Serializer metadata"
     },
     "autoload": {
-        "psr-4": { "Symfony\\Component\\PropertyInfo\\": "" }
+        "psr-4": { "Symfony\\Component\\PropertyInfo\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
     },
     "minimum-stability": "dev",
     "extra": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |
#16397 for new components in 2.8 that was missing
