### PR TITLE
Fixes the stack traces of the deprecation logs

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
@@ -169,6 +169,7 @@
             {% if index == 2 %}
                 <ul class="sf-call-stack" id="{{ id }}" class="hidden">
             {% endif %}
+
             {% if call.class is defined %}
                 {% set from = call.class|abbr_class ~ '::' ~ call.function|abbr_method() %}
             {% elseif call.function is defined %}
@@ -179,7 +180,14 @@
                 {% set from = '-' %}
             {% endif %}
 
-            <li><span class="text-small">Called from</span> {{ call.file is defined and call.line is defined ? call.file|format_file(call.line, from) : from|raw }}</li>
+            {% set file_name = (call.file is defined and call.line is defined) ? call.file|replace({'\\': '/'})|split('/')|last %}
+
+            <li>
+                {{ from|raw }}
+                {% if file_name %}
+                    <span class="text-small">(called from {{ call.file|format_file(call.line, file_name)|raw }})</span>
+                {% endif %}
+            </li>
 
             {% if index == stack|length - 1 %}
                 </ul>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16640 |
| License | MIT |
| Doc PR |  |

The stack trace information was displayed in a very confusing way. Now it's easier to understand what is called from which file and line.
### Before

![stack_trace_before](https://cloud.githubusercontent.com/assets/73419/11392640/5c02607a-935b-11e5-8f99-812fbd97aad3.png)
### After

![stack_trace_after](https://cloud.githubusercontent.com/assets/73419/11392650/5f0b821a-935b-11e5-8472-7fae9bd21149.png)
