### PR TITLE
[Debug] fix readme: DebugClassLoader moved to debug itself

### DIFF
--- a/src/Symfony/Component/Debug/README.md
+++ b/src/Symfony/Component/Debug/README.md
@@ -15,6 +15,7 @@ Debug::enable();
 You can also use the tools individually:
 
 ```php
+use Symfony\Component\Debug\DebugClassLoader;
 use Symfony\Component\Debug\ErrorHandler;
 use Symfony\Component\Debug\ExceptionHandler;
 
@@ -25,10 +26,8 @@ if ('cli' !== php_sapi_name()) {
     ini_set('display_errors', 1);
 }
 ErrorHandler::register();
+DebugClassLoader::enable();
 ```
-
-Note that the `Debug::enable()` call also registers the debug class loader
-from the Symfony ClassLoader component when available.
 
 This component can optionally take advantage of the features of the HttpKernel
 and HttpFoundation components.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/pull/16663#discussion_r45866385 |
| License | MIT |
| Doc PR | - |
