### PR TITLE
Always enable clock-mock for HttpFoundation

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -45,4 +45,14 @@
             </exclude>
         </whitelist>
     </filter>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener">
+            <arguments>
+                <array>
+                    <element><string>Symfony\Component\HttpFoundation</string></element>
+                </array>
+            </arguments>
+        </listener>
+    </listeners>
 </phpunit>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16660 |
| License | MIT |
| Doc PR | - |
