### PR TITLE
[Form] Deprecated TimezoneType::getTimezones()

### DIFF
--- a/UPGRADE-2.8.md
+++ b/UPGRADE-2.8.md
@@ -251,6 +251,9 @@ Form
        <tag name="form.type_extension" extended-type="Symfony\Component\Form\Extension\Core\Type\TextType" />
    </service>
    ```
+   
+ * The `TimezoneType::getTimezones()` method was deprecated and will be removed
+   in Symfony 3.0. You should not use this method.
 
 Translator
 ----------

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -311,6 +311,9 @@ UPGRADE FROM 2.x to 3.0
 
  * The `Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList` class has been removed in
    favor of `Symfony\Component\Form\ChoiceList\ArrayChoiceList`.
+   
+ * The `TimezoneType::getTimezones()` method was removed. You should not use 
+   this method.
 
 ### FrameworkBundle
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
@@ -67,9 +67,13 @@ class TimezoneType extends AbstractType
      * overhead.
      *
      * @return array The timezone choices
+     *
+     * @deprecated Deprecated since version 2.8
      */
     public static function getTimezones()
     {
+        @trigger_error('The TimezoneType::getTimezones() method is deprecated since version 2.8 and will be removed in 3.0.', E_USER_DEPRECATED);
+
         if (null === static::$timezones) {
             static::$timezones = array();
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This method is useless as of https://github.com/symfony/symfony/pull/16681. It needs to be deprecated before we can remove it since it is public.
