### PR TITLE
[Composer] Added PSR-4 Namespace for PHPUnit Bridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -97,6 +97,7 @@
             "Symfony\\Bridge\\ProxyManager\\": "src/Symfony/Bridge/ProxyManager/",
             "Symfony\\Bridge\\Swiftmailer\\": "src/Symfony/Bridge/Swiftmailer/",
             "Symfony\\Bridge\\Twig\\": "src/Symfony/Bridge/Twig/",
+            "Symfony\\Bridge\\PhpUnit\\": "src/Symfony/Bridge/PhpUnit/",
             "Symfony\\Bundle\\": "src/Symfony/Bundle/",
             "Symfony\\Component\\": "src/Symfony/Component/"
         },


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | None |
| License | MIT |
| Doc PR | None |

PHPUnit Bridge Namespace was missing in the PSR-4 section of composer.json causing some `Class 'Symfony\Bridge\PhpUnit\DeprecationErrorHandler' not found` fatal error when loading `src/Symfony/Bridge/PhpUnit/bootstrap.php` when running tests.
