### PR TITLE
[HttpFoundation] added functionality to HeaderBag::contains()

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
@@ -74,7 +74,7 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $output = new SymfonyStyle($input, $output);
+        $output = new SymfonyStyle($input, $cliOutput = $output);
 
         if (!extension_loaded('pcntl')) {
             $output->error(array(
@@ -85,7 +85,7 @@ EOF
             if ($output->ask('Do you want to execute <info>server:run</info> immediately? [Yn] ', true)) {
                 $command = $this->getApplication()->find('server:run');
 
-                return $command->run($input, $output);
+                return $command->run($input, $cliOutput);
             }
 
             return 1;

--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -174,7 +174,19 @@ class HeaderBag implements \IteratorAggregate, \Countable
      */
     public function contains($key, $value)
     {
-        return in_array($value, $this->get($key, null, false));
+        $valuesInBag = $this->get($key, null, false);
+
+        if (in_array($value, $valuesInBag)) {
+            return true;
+        }
+
+        foreach ($valuesInBag as $v) {
+            if (strpos($v, $value) !== false) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/HeaderBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/HeaderBagTest.php
@@ -120,6 +120,14 @@ class HeaderBagTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($bag->contains('foo', 'bar'), '->contains first value');
         $this->assertTrue($bag->contains('foo', 'bor'), '->contains second value');
         $this->assertFalse($bag->contains('foo', 'nope'), '->contains unknown value');
+
+        // Basic string checking
+        $bag->set('arf', 'bow, wow');
+        $this->assertTrue($bag->contains('arf', 'bow, wow'), '->contains both values');
+        $this->assertTrue($bag->contains('arf', 'bow'), '->contains first value');
+        $this->assertTrue($bag->contains('arf', 'wow'), '->contains second value');
+        $this->assertTrue($bag->contains('arf', 'bow,'), '->contains string value');
+        $this->assertFalse($bag->contains('arf', 'wow,'), '->contains unknown string value');
     }
 
     public function testCacheControlDirectiveAccessors()


### PR DESCRIPTION
[HttpFoundation] added functionality to `HeaderBag::contains()` to do a string comparison if the initial array comparison fails

This change was made to clear up an ambiguity in the documentation for `HeaderBag::contains()`. Read the fixed ticket mentioned below for more info.

More than happy to make any changes needed! (I'm willing to make an update to the documentation to make it more explicit, if that is more agreeable.)

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16646 |
| License | MIT |
| Doc PR | n/a |
