### PR TITLE
[SecurityBundle] make ACL an optional dependency

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -116,6 +116,10 @@ class SecurityExtension extends Extension
 
     private function aclLoad($config, ContainerBuilder $container)
     {
+        if (!interface_exists('Symfony\Component\Security\Acl\Model\AclInterface')) {
+            throw new \LogicException('You must install symfony/security-acl in order to use the ACL functionality.');
+        }
+
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('security_acl.xml');
 

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -18,7 +18,6 @@
     "require": {
         "php": ">=5.5.9",
         "symfony/security": "~2.8|~3.0",
-        "symfony/security-acl": "~2.8|~3.0",
         "symfony/http-kernel": "~2.8|~3.0",
         "symfony/polyfill-php70": "~1.0"
     },
@@ -30,6 +29,7 @@
         "symfony/form": "~2.8|~3.0",
         "symfony/framework-bundle": "~2.8|~3.0",
         "symfony/http-foundation": "~2.8|~3.0",
+        "symfony/security-acl": "~2.8|~3.0",
         "symfony/twig-bundle": "~2.8|~3.0",
         "symfony/twig-bridge": "~2.8|~3.0",
         "symfony/process": "~2.8|~3.0",
@@ -38,6 +38,9 @@
         "symfony/expression-language": "~2.8|~3.0",
         "doctrine/doctrine-bundle": "~1.4",
         "twig/twig": "~1.23|~2.0"
+    },
+    "suggest": {
+        "symfony/security-acl": "For using the ACL functionality of this bundle"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bundle\\SecurityBundle\\": "" },


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | - |

Fixes https://github.com/symfony/symfony/issues/14718#issuecomment-159432198.
Together with doctrine/DoctrineCacheBundle#77 we do not have ACL in the symfony-standard 3.0 by default anymore.
