### PR TITLE
[SecurityBundle] disable the init:acl command if ACL is not used

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Command/InitAclCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/InitAclCommand.php
@@ -26,6 +26,18 @@ class InitAclCommand extends ContainerAwareCommand
     /**
      * {@inheritdoc}
      */
+    public function isEnabled()
+    {
+        if (!$this->getContainer()->has('security.acl.dbal.connection')) {
+            return false;
+        }
+
+        return parent::isEnabled();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function configure()
     {
         $this


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | somewhat |
| New feature? | somewhat |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | - |

Related to #16694 but this should go in 2.3 IMO because it was just forgotten. The other acl command already has this logic: https://github.com/symfony/symfony/blob/2.7/src/Symfony/Bundle/SecurityBundle/Command/SetAclCommand.php#L36

It ensures the command list is not flooded with unusable commands.
