### PR TITLE
[FrameworkBundle] [Translation] Fixed translations not written when no translations directory in update command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -196,10 +196,10 @@ EOF
                     $bundleTransPath = $path;
                 }
             }
-
-            if ($bundleTransPath) {
-                $writer->writeTranslations($operation->getResult(), $input->getOption('output-format'), array('path' => $bundleTransPath, 'default_locale' => $this->getContainer()->getParameter('kernel.default_locale')));
+            if (!$bundleTransPath) {
+                $bundleTransPath = end($transPaths).'translations';
             }
+            $writer->writeTranslations($operation->getResult(), $input->getOption('output-format'), array('path' => $bundleTransPath, 'default_locale' => $this->getContainer()->getParameter('kernel.default_locale')));
 
             if (true === $input->getOption('dump-messages')) {
                 $resultMessage .= ' and translation files were updated.';


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Currently when you run the TranslationUpdateCommand and want to write the translation in the domain file without a `translations` directory the output is `[OK] Success` but the file is not created.
