### PR TITLE
[Form+SecurityBundle] Trigger deprecation for csrf_provider+intention options

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -242,6 +242,8 @@ class MainConfiguration implements ConfigurationInterface
                 ->beforeNormalization()
                     ->ifTrue(function ($v) { return isset($v['csrf_provider']); })
                     ->then(function ($v) {
+                        @trigger_error("Setting the 'csrf_provider' configuration key on a security firewall is deprecated since version 2.8 and will be removed in 3.0. Use the 'csrf_token_generator' configuration key instead.", E_USER_DEPRECATED);
+
                         $v['csrf_token_generator'] = $v['csrf_provider'];
                         unset($v['csrf_provider']);
 
@@ -251,6 +253,8 @@ class MainConfiguration implements ConfigurationInterface
                 ->beforeNormalization()
                     ->ifTrue(function ($v) { return isset($v['intention']); })
                     ->then(function ($v) {
+                        @trigger_error("Setting the 'intention' configuration key on a security firewall is deprecated since version 2.8 and will be removed in 3.0. Use the 'csrf_token_id' key instead.", E_USER_DEPRECATED);
+
                         $v['csrf_token_id'] = $v['intention'];
                         unset($v['intention']);
 

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FormLoginFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FormLoginFactory.php
@@ -48,8 +48,23 @@ class FormLoginFactory extends AbstractFactory
         parent::addConfiguration($node);
 
         $node
+            ->beforeNormalization()
+                ->ifTrue(function ($v) { return isset($v['csrf_provider']) && isset($v['csrf_token_generator']); })
+                ->thenInvalid("You should define a value for only one of 'csrf_provider' and 'csrf_token_generator' on a security firewall. Use 'csrf_token_generator' as this replaces 'csrf_provider'.")
+            ->end()
+            ->beforeNormalization()
+                ->ifTrue(function ($v) { return isset($v['csrf_provider']); })
+                ->then(function ($v) {
+                    @trigger_error("Setting the 'csrf_provider' configuration key on a security firewall is deprecated since version 2.8 and will be removed in 3.0. Use the 'csrf_token_generator' configuration key instead.", E_USER_DEPRECATED);
+
+                    $v['csrf_token_generator'] = $v['csrf_provider'];
+                    unset($v['csrf_provider']);
+
+                    return $v;
+                })
+                ->end()
             ->children()
-                ->scalarNode('csrf_provider')->cannotBeEmpty()->end()
+                ->scalarNode('csrf_token_generator')->cannotBeEmpty()->end()
             ->end()
         ;
     }
@@ -78,7 +93,7 @@ class FormLoginFactory extends AbstractFactory
 
         $container
             ->getDefinition($listenerId)
-            ->addArgument(isset($config['csrf_provider']) ? new Reference($config['csrf_provider']) : null)
+            ->addArgument(isset($config['csrf_token_generator']) ? new Reference($config['csrf_token_generator']) : null)
         ;
 
         return $listenerId;

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
@@ -74,8 +74,8 @@ class MainConfigurationTest extends \PHPUnit_Framework_TestCase
             'firewalls' => array(
                 'stub' => array(
                     'logout' => array(
-                        'csrf_provider' => 'a_token_generator',
-                        'intention' => 'a_token_id',
+                        'csrf_token_generator' => 'a_token_generator',
+                        'csrf_token_id' => 'a_token_id',
                     ),
                 ),
             ),

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/config.yml
@@ -36,12 +36,12 @@ security:
                 username_parameter: "user_login[username]"
                 password_parameter: "user_login[password]"
                 csrf_parameter: "user_login[_token]"
-                csrf_provider: security.csrf.token_manager
+                csrf_token_generator: security.csrf.token_manager
             anonymous: ~
             logout:
                 path: /logout_path
                 target: /
-                csrf_provider: security.csrf.token_manager
+                csrf_token_generator: security.csrf.token_manager
 
     access_control:
         - { path: .*, roles: IS_AUTHENTICATED_FULLY }

--- a/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
@@ -123,6 +123,10 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
     {
         // BC clause for the "intention" option
         $csrfTokenId = function (Options $options) {
+            if (null !== $options['intention']) {
+                @trigger_error('The form option "intention" is deprecated since version 2.8 and will be removed in 3.0. Use "csrf_token_id" instead.', E_USER_DEPRECATED);
+            }
+
             return $options['intention'];
         };
 
@@ -137,15 +141,28 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
                 : new CsrfProviderAdapter($options['csrf_provider']);
         };
 
+        $defaultTokenManager = $this->defaultTokenManager;
+        $csrfProviderNormalizer = function (Options $options, $csrfProvider) use ($defaultTokenManager) {
+            if (null !== $csrfProvider) {
+                @trigger_error('The form option "csrf_provider" is deprecated since version 2.8 and will be removed in 3.0. Use "csrf_token_manager" instead.', E_USER_DEPRECATED);
+
+                return $csrfProvider;
+            }
+
+            return $defaultTokenManager;
+        };
+
         $resolver->setDefaults(array(
             'csrf_protection' => $this->defaultEnabled,
             'csrf_field_name' => $this->defaultFieldName,
             'csrf_message' => 'The CSRF token is invalid. Please try to resubmit the form.',
             'csrf_token_manager' => $csrfTokenManager,
             'csrf_token_id' => $csrfTokenId,
-            'csrf_provider' => $this->defaultTokenManager,
-            'intention' => null,
+            'csrf_provider' => null, // deprecated
+            'intention' => null, // deprecated
         ));
+
+        $resolver->setNormalizer('csrf_provider', $csrfProviderNormalizer);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

ping @stof 
