### PR TITLE
[Process] Remove PHP_BINARY existence check

### DIFF
--- a/src/Symfony/Component/Process/PhpExecutableFinder.php
+++ b/src/Symfony/Component/Process/PhpExecutableFinder.php
@@ -44,7 +44,7 @@ class PhpExecutableFinder
         }
 
         // PHP_BINARY return the current sapi executable
-        if (defined('PHP_BINARY') && PHP_BINARY && in_array(PHP_SAPI, array('cli', 'cli-server', 'phpdbg')) && is_file(PHP_BINARY)) {
+        if (PHP_BINARY && in_array(PHP_SAPI, array('cli', 'cli-server', 'phpdbg')) && is_file(PHP_BINARY)) {
             return PHP_BINARY.$args;
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets | - |
| License | MIT |

`PHP_BINARY` constant will always exists as of PHP >= 5.4.
