### PR TITLE
[SecurityBundle] test legacy CSRF configuration options

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
@@ -92,6 +92,32 @@ class MainConfigurationTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @group legacy
+     */
+    public function testLegacyCsrfAliases()
+    {
+        $config = array(
+            'firewalls' => array(
+                'stub' => array(
+                    'logout' => array(
+                        'csrf_provider' => 'a_token_generator',
+                        'intention' => 'a_token_id',
+                    ),
+                ),
+            ),
+        );
+        $config = array_merge(static::$minimalConfig, $config);
+
+        $processor = new Processor();
+        $configuration = new MainConfiguration(array(), array());
+        $processedConfig = $processor->processConfiguration($configuration, array($config));
+        $this->assertTrue(isset($processedConfig['firewalls']['stub']['logout']['csrf_token_generator']));
+        $this->assertEquals('a_token_generator', $processedConfig['firewalls']['stub']['logout']['csrf_token_generator']);
+        $this->assertTrue(isset($processedConfig['firewalls']['stub']['logout']['csrf_token_id']));
+        $this->assertEquals('a_token_id', $processedConfig['firewalls']['stub']['logout']['csrf_token_id']);
+    }
+
+    /**
      * @expectedException \InvalidArgumentException
      */
     public function testCsrfOriginalAndAliasValueCausesException()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16704 |
| License | MIT |
| Doc PR |  |
