### PR TITLE
[Security][SecurityBundle] Use csrf_token_id instead of deprecated intention

### DIFF
--- a/UPGRADE-2.8.md
+++ b/UPGRADE-2.8.md
@@ -455,6 +455,15 @@ Security
  * The `VoterInterface::supportsClass` and `supportsAttribute` methods were
    deprecated and will be removed from the interface in 3.0.
 
+ * The `intention` option is deprecated for all the authentication listeners,
+   and will be removed in 3.0. Use the `csrf_token_id` option instead.
+
+SecurityBundle
+--------------
+
+ * The `intention` firewall listener setting is deprecated, and will be removed in 3.0.
+   Use the `csrf_token_id` option instead.
+
 Config
 ------
 

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * deprecated the `key` setting of `anonymous`, `remember_me` and `http_digest`
    in favor of the `secret` setting.
+ * deprecated the `intention` firewall listener setting in favor of the `csrf_token_id`.
 
 2.6.0
 -----

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FormLoginFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FormLoginFactory.php
@@ -29,7 +29,7 @@ class FormLoginFactory extends AbstractFactory
         $this->addOption('username_parameter', '_username');
         $this->addOption('password_parameter', '_password');
         $this->addOption('csrf_parameter', '_csrf_token');
-        $this->addOption('intention', 'authenticate');
+        $this->addOption('csrf_token_id', 'authenticate');
         $this->addOption('post_only', true);
     }
 

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -299,7 +299,7 @@ class SecurityExtension extends Extension
             $listener = $container->setDefinition($listenerId, new DefinitionDecorator('security.logout_listener'));
             $listener->replaceArgument(3, array(
                 'csrf_parameter' => $firewall['logout']['csrf_parameter'],
-                'intention' => $firewall['logout']['csrf_token_id'],
+                'csrf_token_id' => $firewall['logout']['csrf_token_id'],
                 'logout_path' => $firewall['logout']['path'],
             ));
             $listeners[] = new Reference($listenerId);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/CsrfFormLoginBundle/Form/UserLoginType.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/CsrfFormLoginBundle/Form/UserLoginType.php
@@ -79,12 +79,12 @@ class UserLoginType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        /* Note: the form's intention must correspond to that for the form login
+        /* Note: the form's csrf_token_id must correspond to that for the form login
          * listener in order for the CSRF token to validate successfully.
          */
 
         $resolver->setDefaults(array(
-            'intention' => 'authenticate',
+            'csrf_token_id' => 'authenticate',
         ));
     }
 }

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -18,6 +18,8 @@ CHANGELOG
    `Symfony\Component\Security\Core\Authorization\Voter\VoterInterface`.
  * deprecated `getSupportedAttributes()` and `getSupportedClasses()` methods of
    `Symfony\Component\Security\Core\Authorization\Voter\AbstractVoter`, use `supports()` instead.
+ * deprecated the `intention` option for all the authentication listeners,
+   use the `csrf_token_id` option instead.
 
 2.7.0
 -----

--- a/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
@@ -58,6 +58,10 @@ class LogoutListener implements ListenerInterface
         }
 
         if (isset($options['intention'])) {
+            if (isset($options['csrf_token_id'])) {
+                throw new \InvalidArgumentException(sprintf('You should only define an option for one of "intention" or "csrf_token_id" for the "%s". Use the "csrf_token_id" as it replaces "intention".', __CLASS__));
+            }
+
             @trigger_error('The "intention" option for the '.__CLASS__.' is deprecated since version 2.8 and will be removed in 3.0. Use the "csrf_token_id" option instead.', E_USER_DEPRECATED);
 
             $options['csrf_token_id'] = $options['intention'];

--- a/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
@@ -57,11 +57,17 @@ class LogoutListener implements ListenerInterface
             throw new InvalidArgumentException('The CSRF token manager should be an instance of CsrfProviderInterface or CsrfTokenManagerInterface.');
         }
 
+        if (isset($options['intention'])) {
+            @trigger_error('The "intention" option for the '.__CLASS__.' is deprecated since version 2.8 and will be removed in 3.0. Use the "csrf_token_id" option instead.', E_USER_DEPRECATED);
+
+            $options['csrf_token_id'] = $options['intention'];
+        }
+
         $this->tokenStorage = $tokenStorage;
         $this->httpUtils = $httpUtils;
         $this->options = array_merge(array(
             'csrf_parameter' => '_csrf_token',
-            'intention' => 'logout',
+            'csrf_token_id' => 'logout',
             'logout_path' => '/logout',
         ), $options);
         $this->successHandler = $successHandler;
@@ -101,7 +107,7 @@ class LogoutListener implements ListenerInterface
         if (null !== $this->csrfTokenManager) {
             $csrfToken = ParameterBagUtils::getRequestParameterValue($request, $this->options['csrf_parameter']);
 
-            if (false === $this->csrfTokenManager->isTokenValid(new CsrfToken($this->options['intention'], $csrfToken))) {
+            if (false === $this->csrfTokenManager->isTokenValid(new CsrfToken($this->options['csrf_token_id'], $csrfToken))) {
                 throw new LogoutException('Invalid CSRF token.');
             }
         }

--- a/src/Symfony/Component/Security/Http/Firewall/SimpleFormAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SimpleFormAuthenticationListener.php
@@ -70,6 +70,12 @@ class SimpleFormAuthenticationListener extends AbstractAuthenticationListener
             throw new InvalidArgumentException('The CSRF token manager should be an instance of CsrfProviderInterface or CsrfTokenManagerInterface.');
         }
 
+        if (isset($options['intention'])) {
+            @trigger_error('The "intention" option for the '.__CLASS__.' is deprecated since version 2.8 and will be removed in 3.0. Use the "csrf_token_id" option instead.', E_USER_DEPRECATED);
+
+            $options['csrf_token_id'] = $options['intention'];
+        }
+
         $this->simpleAuthenticator = $simpleAuthenticator;
         $this->csrfTokenManager = $csrfTokenManager;
 
@@ -77,7 +83,7 @@ class SimpleFormAuthenticationListener extends AbstractAuthenticationListener
             'username_parameter' => '_username',
             'password_parameter' => '_password',
             'csrf_parameter' => '_csrf_token',
-            'intention' => 'authenticate',
+            'csrf_token_id' => 'authenticate',
             'post_only' => true,
         ), $options);
 
@@ -104,7 +110,7 @@ class SimpleFormAuthenticationListener extends AbstractAuthenticationListener
         if (null !== $this->csrfTokenManager) {
             $csrfToken = ParameterBagUtils::getRequestParameterValue($request, $this->options['csrf_parameter']);
 
-            if (false === $this->csrfTokenManager->isTokenValid(new CsrfToken($this->options['intention'], $csrfToken))) {
+            if (false === $this->csrfTokenManager->isTokenValid(new CsrfToken($this->options['csrf_token_id'], $csrfToken))) {
                 throw new InvalidCsrfTokenException('Invalid CSRF token.');
             }
         }

--- a/src/Symfony/Component/Security/Http/Firewall/SimpleFormAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SimpleFormAuthenticationListener.php
@@ -71,6 +71,10 @@ class SimpleFormAuthenticationListener extends AbstractAuthenticationListener
         }
 
         if (isset($options['intention'])) {
+            if (isset($options['csrf_token_id'])) {
+                throw new \InvalidArgumentException(sprintf('You should only define an option for one of "intention" or "csrf_token_id" for the "%s". Use the "csrf_token_id" as it replaces "intention".', __CLASS__));
+            }
+
             @trigger_error('The "intention" option for the '.__CLASS__.' is deprecated since version 2.8 and will be removed in 3.0. Use the "csrf_token_id" option instead.', E_USER_DEPRECATED);
 
             $options['csrf_token_id'] = $options['intention'];

--- a/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
@@ -48,11 +48,17 @@ class UsernamePasswordFormAuthenticationListener extends AbstractAuthenticationL
             throw new InvalidArgumentException('The CSRF token manager should be an instance of CsrfProviderInterface or CsrfTokenManagerInterface.');
         }
 
+        if (isset($options['intention'])) {
+            @trigger_error('The "intention" option for the '.__CLASS__.' is deprecated since version 2.8 and will be removed in 3.0. Use the "csrf_token_id" option instead.', E_USER_DEPRECATED);
+
+            $options['csrf_token_id'] = $options['intention'];
+        }
+
         parent::__construct($tokenStorage, $authenticationManager, $sessionStrategy, $httpUtils, $providerKey, $successHandler, $failureHandler, array_merge(array(
             'username_parameter' => '_username',
             'password_parameter' => '_password',
             'csrf_parameter' => '_csrf_token',
-            'intention' => 'authenticate',
+            'csrf_token_id' => 'authenticate',
             'post_only' => true,
         ), $options), $logger, $dispatcher);
 
@@ -79,7 +85,7 @@ class UsernamePasswordFormAuthenticationListener extends AbstractAuthenticationL
         if (null !== $this->csrfTokenManager) {
             $csrfToken = ParameterBagUtils::getRequestParameterValue($request, $this->options['csrf_parameter']);
 
-            if (false === $this->csrfTokenManager->isTokenValid(new CsrfToken($this->options['intention'], $csrfToken))) {
+            if (false === $this->csrfTokenManager->isTokenValid(new CsrfToken($this->options['csrf_token_id'], $csrfToken))) {
                 throw new InvalidCsrfTokenException('Invalid CSRF token.');
             }
         }

--- a/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
@@ -49,6 +49,10 @@ class UsernamePasswordFormAuthenticationListener extends AbstractAuthenticationL
         }
 
         if (isset($options['intention'])) {
+            if (isset($options['csrf_token_id'])) {
+                throw new \InvalidArgumentException(sprintf('You should only define an option for one of "intention" or "csrf_token_id" for the "%s". Use the "csrf_token_id" as it replaces "intention".', __CLASS__));
+            }
+
             @trigger_error('The "intention" option for the '.__CLASS__.' is deprecated since version 2.8 and will be removed in 3.0. Use the "csrf_token_id" option instead.', E_USER_DEPRECATED);
 
             $options['csrf_token_id'] = $options['intention'];

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/LogoutListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/LogoutListenerTest.php
@@ -213,7 +213,7 @@ class LogoutListenerTest extends \PHPUnit_Framework_TestCase
             $successHandler ?: $this->getSuccessHandler(),
             $options = array(
                 'csrf_parameter' => '_csrf_token',
-                'intention' => 'logout',
+                'csrf_token_id' => 'logout',
                 'logout_path' => '/logout',
                 'target_url' => '/',
             ),


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16720 |
| License | MIT |
| Doc PR | - |
