### PR TITLE
[Form] remove deprecated getTimezones() method

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
@@ -24,19 +24,12 @@ class TimezoneType extends AbstractType
     private static $timezones;
 
     /**
-     * Stores the available timezone choices.
-     *
-     * @var array
-     */
-    private static $flippedTimezones;
-
-    /**
      * {@inheritdoc}
      */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
-            'choices' => self::getFlippedTimezones(),
+            'choices' => self::getTimezones(),
             'choice_translation_domain' => false,
         ));
     }
@@ -66,48 +59,8 @@ class TimezoneType extends AbstractType
      * overhead.
      *
      * @return array The timezone choices
-     *
-     * @deprecated Deprecated since version 2.8
      */
-    public static function getTimezones()
-    {
-        @trigger_error('The TimezoneType::getTimezones() method is deprecated since version 2.8 and will be removed in 3.0.', E_USER_DEPRECATED);
-
-        if (null === static::$timezones) {
-            static::$timezones = array();
-
-            foreach (\DateTimeZone::listIdentifiers() as $timezone) {
-                $parts = explode('/', $timezone);
-
-                if (count($parts) > 2) {
-                    $region = $parts[0];
-                    $name = $parts[1].' - '.$parts[2];
-                } elseif (count($parts) > 1) {
-                    $region = $parts[0];
-                    $name = $parts[1];
-                } else {
-                    $region = 'Other';
-                    $name = $parts[0];
-                }
-
-                static::$timezones[$region][$timezone] = str_replace('_', ' ', $name);
-            }
-        }
-
-        return static::$timezones;
-    }
-
-    /**
-     * Returns the timezone choices.
-     *
-     * The choices are generated from the ICU function
-     * \DateTimeZone::listIdentifiers(). They are cached during a single request,
-     * so multiple timezone fields on the same page don't lead to unnecessary
-     * overhead.
-     *
-     * @return array The timezone choices
-     */
-    private static function getFlippedTimezones()
+    private static function getTimezones()
     {
         if (null === self::$timezones) {
             self::$timezones = array();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
