### PR TITLE
[Console] do not encode backslashes in console default description

### DIFF
--- a/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
@@ -187,10 +187,10 @@ class TextDescriptor extends Descriptor
     private function formatDefaultValue($default)
     {
         if (PHP_VERSION_ID < 50400) {
-            return str_replace('\/', '/', json_encode($default));
+            return str_replace(array('\/', '\\\\'), array('/', '\\'), json_encode($default));
         }
 
-        return json_encode($default, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        return str_replace('\\\\', '\\', json_encode($default, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16420 |
| License | MIT |
| Doc PR | - |
