### PR TITLE
[WIP] [Ldap] Marked the Ldap component as internal

### DIFF
--- a/src/Symfony/Component/Ldap/Exception/ConnectionException.php
+++ b/src/Symfony/Component/Ldap/Exception/ConnectionException.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Ldap\Exception;
  * ConnectionException is throw if binding to ldap can not be established.
  *
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ *
+ * @internal
  */
 class ConnectionException extends \RuntimeException
 {

--- a/src/Symfony/Component/Ldap/Exception/LdapException.php
+++ b/src/Symfony/Component/Ldap/Exception/LdapException.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Ldap\Exception;
  * LdapException is throw if php ldap module is not loaded.
  *
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ *
+ * @internal
  */
 class LdapException extends \RuntimeException
 {

--- a/src/Symfony/Component/Ldap/LdapClient.php
+++ b/src/Symfony/Component/Ldap/LdapClient.php
@@ -18,6 +18,8 @@ use Symfony\Component\Ldap\Exception\LdapException;
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  * @author Francis Besset <francis.besset@gmail.com>
  * @author Charles Sarrazin <charles@sarraz.in>
+ *
+ * @internal
  */
 class LdapClient implements LdapClientInterface
 {

--- a/src/Symfony/Component/Ldap/LdapClientInterface.php
+++ b/src/Symfony/Component/Ldap/LdapClientInterface.php
@@ -18,12 +18,11 @@ use Symfony\Component\Ldap\Exception\ConnectionException;
  *
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  * @author Charles Sarrazin <charles@sarraz.in>
+ *
+ * @internal
  */
 interface LdapClientInterface
 {
-    const LDAP_ESCAPE_FILTER = 0x01;
-    const LDAP_ESCAPE_DN = 0x02;
-
     /**
      * Return a connection bound to the ldap.
      *

--- a/src/Symfony/Component/Ldap/README.md
+++ b/src/Symfony/Component/Ldap/README.md
@@ -1,10 +1,14 @@
 Ldap Component
-=============
+==============
 
 A Ldap client for PHP on top of PHP's ldap extension.
 
-This component also provides a stub for the missing
-`ldap_escape` function in PHP versions lower than 5.6.
+Disclaimer
+----------
+
+This component is currently marked as internal, as it
+still needs some work. Breaking changes will be introduced
+in the next minor version of Symfony.
 
 Documentation
 -------------

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/LdapBindAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/LdapBindAuthenticationProvider.php
@@ -74,7 +74,7 @@ class LdapBindAuthenticationProvider extends UserAuthenticationProvider
         $password = $token->getCredentials();
 
         try {
-            $username = $this->ldap->escape($username, '', LdapClientInterface::LDAP_ESCAPE_DN);
+            $username = $this->ldap->escape($username, '', LDAP_ESCAPE_DN);
             $dn = str_replace('{username}', $username, $this->dnString);
 
             $this->ldap->bind($dn, $password);

--- a/src/Symfony/Component/Security/Core/User/LdapUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/LdapUserProvider.php
@@ -57,7 +57,7 @@ class LdapUserProvider implements UserProviderInterface
     {
         try {
             $this->ldap->bind($this->searchDn, $this->searchPassword);
-            $username = $this->ldap->escape($username, '', LdapClientInterface::LDAP_ESCAPE_FILTER);
+            $username = $this->ldap->escape($username, '', LDAP_ESCAPE_FILTER);
             $query = str_replace('{username}', $username, $this->defaultSearch);
             $search = $this->ldap->find($this->baseDn, $query);
         } catch (ConnectionException $e) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | no |
| License | MIT |
| Doc PR | not yet |

As mentioned earlier, the LDAP component suffers from a few problems, addressed in PR #15994
However, as raised by @Tobion, the component does not yet have tests (they can be added at a later time, though), and is not considered stable yet.
