### PR TITLE
[Console][ProgressBar] redrawFrequency should never be 0

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -68,10 +68,8 @@ class ProgressBar
             // disable overwrite when output does not support ANSI codes.
             $this->overwrite = false;
 
-            if ($this->max > 10) {
-                // set a reasonable redraw frequency so output isn't flooded
-                $this->setRedrawFrequency($max / 10);
-            }
+            // set a reasonable redraw frequency so output isn't flooded
+            $this->setRedrawFrequency($max / 10);
         }
 
         $this->startTime = time();
@@ -317,11 +315,11 @@ class ProgressBar
     /**
      * Sets the redraw frequency.
      *
-     * @param int $freq The frequency in steps
+     * @param int|float $freq The frequency in steps
      */
     public function setRedrawFrequency($freq)
     {
-        $this->redrawFreq = (int) $freq;
+        $this->redrawFreq = max((int) $freq, 1);
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -296,7 +296,7 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
 
     public function testRedrawFrequency()
     {
-        $bar = $this->getMock('Symfony\Component\Console\Helper\ProgressBar', array('display'), array($output = $this->getOutputStream(), 6));
+        $bar = $this->getMock('Symfony\Component\Console\Helper\ProgressBar', array('display'), array($this->getOutputStream(), 6));
         $bar->expects($this->exactly(4))->method('display');
 
         $bar->setRedrawFrequency(2);
@@ -305,6 +305,26 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
         $bar->advance(2);
         $bar->advance(2);
         $bar->advance(1);
+    }
+
+    public function testRedrawFrequencyIsAtLeastOneIfZeroGiven()
+    {
+        $bar = $this->getMock('Symfony\Component\Console\Helper\ProgressBar', array('display'), array($this->getOutputStream()));
+
+        $bar->expects($this->exactly(2))->method('display');
+        $bar->setRedrawFrequency(0);
+        $bar->start();
+        $bar->advance();
+    }
+
+    public function testRedrawFrequencyIsAtLeastOneIfSmallerOneGiven()
+    {
+        $bar = $this->getMock('Symfony\Component\Console\Helper\ProgressBar', array('display'), array($this->getOutputStream()));
+
+        $bar->expects($this->exactly(2))->method('display');
+        $bar->setRedrawFrequency(0.9);
+        $bar->start();
+        $bar->advance();
     }
 
     public function testMultiByteSupport()


### PR DESCRIPTION
Set the redraw frequency at least to 1. Setting it to 0 would otherwise produce a "division by zero" error.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
### why?

I had a piece of code that used a ProgressBar and set the redraw frequency to a calculated value. In some cases this calculated value was 0 (or just smaller than 1, internally a cast to `int` is made). In the `setProgress` the redraw frequency is used for a calculation of the period. There the error happens (and shows that redraw frequency should never be 0).
### Ticket

There is no ticket concerning this issue. I could do one, if you want.
### Tests

This gets tested implicitly in `ProgressBarTest::testNonDecoratedOutputWithoutMax`.
