### PR TITLE
[Bridge/Doctrine+Ldap] Fix tests

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -995,13 +995,13 @@ class EntityTypeTest extends TypeTestCase
             'property3' => 2,
         ));
 
-        $choiceList1 = $form->get('property1')->getConfig()->getOption('choice_list');
-        $choiceList2 = $form->get('property2')->getConfig()->getOption('choice_list');
-        $choiceList3 = $form->get('property3')->getConfig()->getOption('choice_list');
+        $choiceLoader1 = $form->get('property1')->getConfig()->getOption('choice_loader');
+        $choiceLoader2 = $form->get('property2')->getConfig()->getOption('choice_loader');
+        $choiceLoader3 = $form->get('property3')->getConfig()->getOption('choice_loader');
 
-        $this->assertInstanceOf('Symfony\Component\Form\ChoiceList\ChoiceListInterface', $choiceList1);
-        $this->assertSame($choiceList1, $choiceList2);
-        $this->assertSame($choiceList1, $choiceList3);
+        $this->assertInstanceOf('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface', $choiceLoader1);
+        $this->assertSame($choiceLoader1, $choiceLoader2);
+        $this->assertSame($choiceLoader1, $choiceLoader3);
     }
 
     public function testCacheChoiceLists()
@@ -1024,8 +1024,8 @@ class EntityTypeTest extends TypeTestCase
             'choice_label' => 'name',
         ));
 
-        $this->assertInstanceOf('Symfony\Component\Form\ChoiceList\ChoiceListInterface', $field1->getConfig()->getOption('choice_list'));
-        $this->assertSame($field1->getConfig()->getOption('choice_list'), $field2->getConfig()->getOption('choice_list'));
+        $this->assertInstanceOf('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface', $field1->getConfig()->getOption('choice_loader'));
+        $this->assertSame($field1->getConfig()->getOption('choice_loader'), $field2->getConfig()->getOption('choice_loader'));
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/LdapBindAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/LdapBindAuthenticationProviderTest.php
@@ -16,6 +16,9 @@ use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\User\User;
 use Symfony\Component\Ldap\Exception\ConnectionException;
 
+/**
+ * @requires extension ldap
+ */
 class LdapBindAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/src/Symfony/Component/Security/Core/Tests/User/LdapUserProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/LdapUserProviderTest.php
@@ -14,6 +14,9 @@ namespace Symfony\Component\Security\Core\Tests\User;
 use Symfony\Component\Security\Core\User\LdapUserProvider;
 use Symfony\Component\Ldap\Exception\ConnectionException;
 
+/**
+ * @requires extension ldap
+ */
 class LdapUserProviderTest extends \PHPUnit_Framework_TestCase
 {
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Using "choice_list" is deprecated and thus can't work with 3.0 deps loaded. Test upgrades backported from #16725 
@csarrazi : the Ldap tests now require the ldap extension. Annotations added.
