### PR TITLE
[Form] Added getBlockPrefix() to ResolvedFormTypeInterface

### DIFF
--- a/src/Symfony/Component/Form/Extension/DataCollector/Proxy/ResolvedTypeDataCollectorProxy.php
+++ b/src/Symfony/Component/Form/Extension/DataCollector/Proxy/ResolvedTypeDataCollectorProxy.php
@@ -46,17 +46,9 @@ class ResolvedTypeDataCollectorProxy implements ResolvedFormTypeInterface
     /**
      * {@inheritdoc}
      */
-    public function getName()
-    {
-        return $this->proxiedType->getName();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getBlockPrefix()
     {
-        return method_exists($this->proxiedType, 'getBlockPrefix') ? $this->proxiedType->getBlockPrefix() : $this->getName();
+        return $this->proxiedType->getBlockPrefix();
     }
 
     /**

--- a/src/Symfony/Component/Form/ResolvedFormType.php
+++ b/src/Symfony/Component/Form/ResolvedFormType.php
@@ -56,9 +56,7 @@ class ResolvedFormType implements ResolvedFormTypeInterface
     }
 
     /**
-     * Returns the prefix of the template block name for this type.
-     *
-     * @return string The prefix of the template block name
+     * {@inheritdoc}
      */
     public function getBlockPrefix()
     {

--- a/src/Symfony/Component/Form/ResolvedFormTypeInterface.php
+++ b/src/Symfony/Component/Form/ResolvedFormTypeInterface.php
@@ -21,6 +21,13 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 interface ResolvedFormTypeInterface
 {
     /**
+     * Returns the prefix of the template block name for this type.
+     *
+     * @return string The prefix of the template block name
+     */
+    public function getBlockPrefix();
+
+    /**
      * Returns the parent type.
      *
      * @return ResolvedFormTypeInterface|null The parent type or null.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This is the follow-up PR to #16724.

If you call `$form->getConfig()->getType()`, all the methods of FormType should be usable. In that sense, ResolvedFormType is the developer-facing version of FormType.

It is true that the same could be achieved with `getInnerType()`, but that method should be used in edge cases only as it clutters the code and makes it confusing to read:

``` php
$blockPrefix = $form->getConfig()->getType()->getInnerType()->getBlockPrefix();
```
