### PR TITLE
Fix BC for the default root form name

### DIFF
--- a/src/Symfony/Component/Form/FormFactory.php
+++ b/src/Symfony/Component/Form/FormFactory.php
@@ -74,15 +74,29 @@ class FormFactory implements FormFactoryInterface
                 $typeName = $type->getName();
             }
         } elseif ($type instanceof FormTypeInterface) {
-            // BC
-            $typeName = $type->getName();
+            if (method_exists($type, 'getBlockPrefix')) {
+                // As of Symfony 3.0, the block prefix of the type is used as
+                // default name
+                $name = $type->getBlockPrefix();
+            } else {
+                // BC
+                $typeName = $type->getName();
+            }
         } elseif (is_string($type)) {
-            // BC
-            $typeName = $type;
+            $resolvedType = $this->registry->getType($type);
+            if (method_exists($resolvedType, 'getBlockPrefix')) {
+                // As of Symfony 3.0, the block prefix of the type is used as
+                // default name
+                $name = $resolvedType->getBlockPrefix();
+            } else {
+                // BC
+                $typeName = $type;
+            }
         } else {
             throw new UnexpectedTypeException($type, 'string, Symfony\Component\Form\ResolvedFormTypeInterface or Symfony\Component\Form\FormTypeInterface');
         }
 
+        // BC when there is no block prefix
         if (null === $name) {
             if (false === strpos($typeName, '\\')) {
                 // No FQCN - leave unchanged for BC

--- a/src/Symfony/Component/Form/Tests/FormFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormFactoryTest.php
@@ -302,13 +302,52 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
         $this->factory->create(new \stdClass());
     }
 
+    public function testCreateUsesBlockPrefixIfTypeGivenAsString()
+    {
+        $options = array('a' => '1', 'b' => '2');
+        $resolvedOptions = array('a' => '2', 'b' => '3');
+
+        // the interface does not have the method, so use the real class
+        $resolvedType = $this->getMockBuilder('Symfony\Component\Form\ResolvedFormType')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $resolvedType->expects($this->any())
+            ->method('getBlockPrefix')
+            ->willReturn('TYPE_PREFIX');
+
+        $this->registry->expects($this->any())
+            ->method('getType')
+            ->with('TYPE')
+            ->will($this->returnValue($resolvedType));
+
+        $resolvedType->expects($this->once())
+            ->method('createBuilder')
+            ->with($this->factory, 'TYPE_PREFIX', $options)
+            ->will($this->returnValue($this->builder));
+
+        $this->builder->expects($this->any())
+            ->method('getOptions')
+            ->will($this->returnValue($resolvedOptions));
+
+        $resolvedType->expects($this->once())
+            ->method('buildForm')
+            ->with($this->builder, $resolvedOptions);
+
+        $this->builder->expects($this->once())
+            ->method('getForm')
+            ->will($this->returnValue('FORM'));
+
+        $this->assertSame('FORM', $this->factory->create('TYPE', null, $options));
+    }
+
     public function testCreateUsesTypeNameIfTypeGivenAsString()
     {
         $options = array('a' => '1', 'b' => '2');
         $resolvedOptions = array('a' => '2', 'b' => '3');
         $resolvedType = $this->getMockResolvedType();
 
-        $this->registry->expects($this->once())
+        $this->registry->expects($this->any())
             ->method('getType')
             ->with('TYPE')
             ->will($this->returnValue($resolvedType));
@@ -339,7 +378,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
         $resolvedOptions = array('a' => '2', 'b' => '3');
         $resolvedType = $this->getMockResolvedType();
 
-        $this->registry->expects($this->once())
+        $this->registry->expects($this->any())
             ->method('getType')
             ->with('Vendor\Name\Space\UserForm')
             ->will($this->returnValue($resolvedType));
@@ -370,7 +409,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
         $resolvedOptions = array('a' => '2', 'b' => '3');
         $resolvedType = $this->getMockResolvedType();
 
-        $this->registry->expects($this->once())
+        $this->registry->expects($this->any())
             ->method('getType')
             ->with('userform')
             ->will($this->returnValue($resolvedType));
@@ -401,7 +440,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
         $resolvedOptions = array('a' => '2', 'b' => '3');
         $resolvedType = $this->getMockResolvedType();
 
-        $this->registry->expects($this->once())
+        $this->registry->expects($this->any())
             ->method('getType')
             ->with('Vendor\Name\Space\UserType')
             ->will($this->returnValue($resolvedType));
@@ -432,7 +471,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
         $resolvedOptions = array('a' => '2', 'b' => '3');
         $resolvedType = $this->getMockResolvedType();
 
-        $this->registry->expects($this->once())
+        $this->registry->expects($this->any())
             ->method('getType')
             ->with('Vendor\Name\Space\Type')
             ->will($this->returnValue($resolvedType));
@@ -463,7 +502,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
         $resolvedOptions = array('a' => '2', 'b' => '3');
         $resolvedType = $this->getMockResolvedType();
 
-        $this->registry->expects($this->once())
+        $this->registry->expects($this->any())
             ->method('getType')
             ->with('Vendor\Name\Space\MyProfileHTMLType')
             ->will($this->returnValue($resolvedType));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15760 |
| License | MIT |
| Doc PR | n/a |

The block prefix is used, to match the previous behavior when using a custom block prefix.

The form type is now retrieved twice from the registry here, but this should not be an issue:
- unnamed forms are created only at the root, so only once per form at most (child forms are always named explicitly)
- the registry caches the resolved type, so the second access is just accessing the key in the array and returning it
