### PR TITLE
[Security] These interface allways send deprecated because of wrong inheritance

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/SimpleFormAuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/SimpleFormAuthenticatorInterface.php
@@ -11,14 +11,13 @@
 
 namespace Symfony\Component\Security\Core\Authentication;
 
-use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Http\Authentication\SimpleFormAuthenticatorInterface as BaseSimpleFormAuthenticatorInterface;
 
 /**
  * @deprecated Deprecated since version 2.8, to be removed in 3.0. Use the same interface from Security\Http\Authentication instead.
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
-interface SimpleFormAuthenticatorInterface extends SimpleAuthenticatorInterface
+interface SimpleFormAuthenticatorInterface extends BaseSimpleFormAuthenticatorInterface
 {
-    public function createToken(Request $request, $username, $password, $providerKey);
 }

--- a/src/Symfony/Component/Security/Core/Authentication/SimplePreAuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/SimplePreAuthenticatorInterface.php
@@ -11,14 +11,13 @@
 
 namespace Symfony\Component\Security\Core\Authentication;
 
-use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Http\Authentication\SimplePreAuthenticatorInterface as BaseSimplePreAuthenticatorInterface;
 
 /**
  * @deprecated Since version 2.8, to be removed in 3.0. Use the same interface from Security\Http\Authentication instead.
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
-interface SimplePreAuthenticatorInterface extends SimpleAuthenticatorInterface
+interface SimplePreAuthenticatorInterface extends BaseSimplePreAuthenticatorInterface
 {
-    public function createToken(Request $request, $providerKey);
 }

--- a/src/Symfony/Component/Security/Http/Authentication/SimpleFormAuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Http/Authentication/SimpleFormAuthenticatorInterface.php
@@ -11,11 +11,13 @@
 
 namespace Symfony\Component\Security\Http\Authentication;
 
-use Symfony\Component\Security\Core\Authentication\SimpleFormAuthenticatorInterface as BaseSimpleFormAuthenticatorInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\SimpleAuthenticatorInterface;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
-interface SimpleFormAuthenticatorInterface extends BaseSimpleFormAuthenticatorInterface
+interface SimpleFormAuthenticatorInterface extends SimpleAuthenticatorInterface
 {
+    public function createToken(Request $request, $username, $password, $providerKey);
 }

--- a/src/Symfony/Component/Security/Http/Authentication/SimplePreAuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Http/Authentication/SimplePreAuthenticatorInterface.php
@@ -11,11 +11,13 @@
 
 namespace Symfony\Component\Security\Http\Authentication;
 
-use Symfony\Component\Security\Core\Authentication\SimplePreAuthenticatorInterface as BaseSimplePreAuthenticatorInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\SimpleAuthenticatorInterface;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
-interface SimplePreAuthenticatorInterface extends BaseSimplePreAuthenticatorInterface
+interface SimplePreAuthenticatorInterface extends SimpleAuthenticatorInterface
 {
+    public function createToken(Request $request, $providerKey);
 }

--- a/src/Symfony/Component/Security/Http/Firewall/SimplePreAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SimplePreAuthenticationListener.php
@@ -15,7 +15,7 @@ use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterfac
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Security\Core\Authentication\SimplePreAuthenticatorInterface;
+use Symfony\Component\Security\Http\Authentication\SimplePreAuthenticatorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16643 |
| License | MIT |
| Doc PR |  |
