### PR TITLE
[PhpUnitBridge] Add weak-verbose mode and match against message instead of test name

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -18,6 +18,9 @@ namespace Symfony\Bridge\PhpUnit;
  */
 class DeprecationErrorHandler
 {
+    const MODE_WEAK = 'weak';
+    const MODE_WEAK_VERBOSE = 'weak-verbose';
+
     private static $isRegistered = false;
 
     public static function register($mode = false)
@@ -64,7 +67,7 @@ class DeprecationErrorHandler
                     $group = 'remaining';
                 }
 
-                if (isset($mode[0]) && '/' === $mode[0] && preg_match($mode, $class.'::'.$method)) {
+                if (isset($mode[0]) && '/' === $mode[0] && preg_match($mode, $msg)) {
                     $e = new \Exception($msg);
                     $r = new \ReflectionProperty($e, 'trace');
                     $r->setAccessible(true);
@@ -78,7 +81,7 @@ class DeprecationErrorHandler
 
                     exit(1);
                 }
-                if ('legacy' !== $group && 'weak' !== $mode) {
+                if ('legacy' !== $group && self::MODE_WEAK !== $mode) {
                     $ref = &$deprecations[$group][$msg]['count'];
                     ++$ref;
                     $ref = &$deprecations[$group][$msg][$class.'::'.$method];
@@ -144,7 +147,7 @@ class DeprecationErrorHandler
                 if (!empty($notices)) {
                     echo "\n";
                 }
-                if ('weak' !== $mode && ($deprecations['unsilenced'] || $deprecations['remaining'] || $deprecations['other'])) {
+                if (self::MODE_WEAK !== $mode && self::MODE_WEAK_VERBOSE !== $mode && ($deprecations['unsilenced'] || $deprecations['remaining'] || $deprecations['other'])) {
                     exit(1);
                 }
             });

--- a/src/Symfony/Bridge/PhpUnit/README.md
+++ b/src/Symfony/Bridge/PhpUnit/README.md
@@ -14,9 +14,9 @@ It comes with the following features:
 By default any non-legacy-tagged or any non-@-silenced deprecation notices will
 make tests fail.
 This can be changed by setting the `SYMFONY_DEPRECATIONS_HELPER` environment
-variable to `weak`. This will make the bridge ignore deprecation notices and
-is useful to projects that must use deprecated interfaces for backward
-compatibility reasons.
+variable to `weak` or `weak-verbose`. This will make the bridge ignore
+deprecation notices and is useful to projects that must use deprecated interfaces
+for backward compatibility reasons.
 
 A summary of deprecation notices is displayed at the end of the test suite:
 
@@ -53,8 +53,9 @@ You have to decide either to:
    forward compatibility;
  * or move them to the **Legacy** section (by using one of the above way).
 
-In case you need to inspect the stack trace of a particular deprecation triggered by
-one of your unit tests, you can set the `SYMFONY_DEPRECATIONS_HELPER` env var to
-a regexp that matches this test case's `class::method` name. For example,
-`SYMFONY_DEPRECATIONS_HELPER=/^MyTest::testMethod$/ phpunit` will stop your test
-suite once a deprecation is triggered by the `MyTest::testMethod` test.
+In case you need to inspect the stack trace of a particular deprecation triggered
+by your unit tests, you can set the `SYMFONY_DEPRECATIONS_HELPER` env var to a
+regular expression that matches this deprecation's message, encapsed between `/`.
+For example, `SYMFONY_DEPRECATIONS_HELPER=/foobar/ phpunit` will stop your test
+suite once a deprecation notice is triggered whose message contains the "foobar"
+string.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14475 |
| License | MIT |
| Doc PR | - |

This is double a DX bug fix:
- the weak-verbose allows showing messages but exit with 0 (see #14475)
- matching against $class::$method was a mistake of mine: you can already `--filter` in phpunit to get by-test filtering but you can't select which message should be traced without this change. I stumbled upon this limitation while doing a Symfony 3 migration workshop...
