### PR TITLE
[Validator] BicValidator - fixed raising violations to a maximum of one

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/BicValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/BicValidator.php
@@ -38,6 +38,8 @@ class BicValidator extends ConstraintValidator
                 ->setParameter('{{ value }}', $this->formatValue($value))
                 ->setCode(Bic::INVALID_LENGTH_ERROR)
                 ->addViolation();
+
+            return;
         }
 
         // must contain alphanumeric values only
@@ -46,6 +48,8 @@ class BicValidator extends ConstraintValidator
                 ->setParameter('{{ value }}', $this->formatValue($value))
                 ->setCode(Bic::INVALID_CHARACTERS_ERROR)
                 ->addViolation();
+
+            return;
         }
 
         // first 4 letters must be alphabetic (bank code)
@@ -54,6 +58,8 @@ class BicValidator extends ConstraintValidator
                 ->setParameter('{{ value }}', $this->formatValue($value))
                 ->setCode(Bic::INVALID_BANK_CODE_ERROR)
                 ->addViolation();
+
+            return;
         }
 
         // next 2 letters must be alphabetic (country code)
@@ -62,6 +68,8 @@ class BicValidator extends ConstraintValidator
                 ->setParameter('{{ value }}', $this->formatValue($value))
                 ->setCode(Bic::INVALID_COUNTRY_CODE_ERROR)
                 ->addViolation();
+
+            return;
         }
 
         // should contain uppercase characters only
@@ -70,6 +78,8 @@ class BicValidator extends ConstraintValidator
                 ->setParameter('{{ value }}', $this->formatValue($value))
                 ->setCode(Bic::INVALID_CASE_ERROR)
                 ->addViolation();
+
+            return;
         }
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

I just found a bug while using the constraint. For example my value "a" will raise three violations at one time. I just expected to get a maximum number of one.
This PR will fix that behavior.

I do not know how I can easily add Unit-Tests for that, can someone please help me?
