### PR TITLE
[Config] Throw an exception when using cannotBeEmpty() with numeric or boolean nodes

### DIFF
--- a/src/Symfony/Component/Config/Definition/Builder/BooleanNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/BooleanNodeDefinition.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Config\Definition\Builder;
 
 use Symfony\Component\Config\Definition\BooleanNode;
+use Symfony\Component\Config\Definition\Exception\InvalidDefinitionException;
 
 /**
  * This class provides a fluent interface for defining a node.
@@ -38,5 +39,15 @@ class BooleanNodeDefinition extends ScalarNodeDefinition
     protected function instantiateNode()
     {
         return new BooleanNode($this->name, $this->parent);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws InvalidDefinitionException
+     */
+    public function cannotBeEmpty()
+    {
+        throw new InvalidDefinitionException('->cannotBeEmpty() is not applicable to BooleanNodeDefinition.');
     }
 }

--- a/src/Symfony/Component/Config/Definition/Builder/NumericNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NumericNodeDefinition.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Config\Definition\Builder;
 
+use Symfony\Component\Config\Definition\Exception\InvalidDefinitionException;
+
 /**
  * Abstract class that contains common code of integer and float node definitions.
  *
@@ -57,5 +59,15 @@ abstract class NumericNodeDefinition extends ScalarNodeDefinition
         $this->min = $min;
 
         return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws InvalidDefinitionException
+     */
+    public function cannotBeEmpty()
+    {
+        throw new InvalidDefinitionException('->cannotBeEmpty() is not applicable to NumericNodeDefinition.');
     }
 }

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/BooleanNodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/BooleanNodeDefinitionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Tests\Definition\Builder;
+
+use Symfony\Component\Config\Definition\Builder\BooleanNodeDefinition;
+
+class BooleanNodeDefinitionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidDefinitionException
+     * @expectedExceptionMessage ->cannotBeEmpty() is not applicable to BooleanNodeDefinition.
+     */
+    public function testCannotBeEmptyThrowsAnException()
+    {
+        $def = new BooleanNodeDefinition('foo');
+        $def->cannotBeEmpty();
+    }
+}

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/NumericNodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/NumericNodeDefinitionTest.php
@@ -90,4 +90,14 @@ class NumericNodeDefinitionTest extends \PHPUnit_Framework_TestCase
         $node = $def->min(3.0)->max(7e2)->getNode();
         $this->assertEquals(4.5, $node->finalize(4.5));
     }
+
+    /**
+     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidDefinitionException
+     * @expectedExceptionMessage ->cannotBeEmpty() is not applicable to NumericNodeDefinition.
+     */
+    public function testCannotBeEmptyThrowsAnException()
+    {
+        $def = new NumericNodeDefinition('foo');
+        $def->cannotBeEmpty();
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16812 |
| License | MIT |
