### PR TITLE
[FrameworkBundle][Validator] Fix apc cache service deprecation

### DIFF
--- a/UPGRADE-2.8.md
+++ b/UPGRADE-2.8.md
@@ -453,6 +453,28 @@ FrameworkBundle
            cookie_httponly: false
    ```
 
+ * The `validator.mapping.cache.apc` service is deprecated, and will be removed in 3.0.
+   Use `validator.mapping.cache.doctrine.apc` instead.
+   
+ * The ability to pass `apc` as the `framework.validation.cache` configuration key value is deprecated, 
+   and will be removed in 3.0. Use `validator.mapping.cache.doctrine.apc` instead:
+   
+   Before:
+   
+   ```yaml
+   framework:
+       validation:
+           cache: apc
+   ```
+
+   After:
+   
+   ```yaml
+   framework:
+       validation:
+           cache: validator.mapping.cache.doctrine.apc
+   ```
+
 Security
 --------
 

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -481,6 +481,27 @@ UPGRADE FROM 2.x to 3.0
    interface.
    The `security.csrf.token_manager` should be used instead.
 
+ * The `validator.mapping.cache.apc` service has been removed in favor of the `validator.mapping.cache.doctrine.apc` one.
+   
+ * The ability to pass `apc` as the `framework.validation.cache` configuration key value has been removed.
+   Use `validator.mapping.cache.doctrine.apc` instead:
+
+   Before:
+
+   ```yaml
+   framework:
+       validation:
+           cache: apc
+   ```
+
+   After:
+
+   ```yaml
+   framework:
+       validation:
+           cache: validator.mapping.cache.doctrine.apc
+   ```
+
 ### HttpKernel
 
  * The `Symfony\Component\HttpKernel\Log\LoggerInterface` has been removed in

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -645,7 +645,15 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('cache')
                             ->beforeNormalization()
                                 // Can be removed in 3.0, once ApcCache support is dropped
-                                ->ifString()->then(function ($v) { return 'apc' === $v ? 'validator.mapping.cache.apc' : $v; })
+                                ->ifString()->then(function ($v) {
+                                    if ('apc' === $v) {
+                                        @trigger_error('The ability to pass "apc" as the framework.validation.cache configuration key value is deprecated since version 2.8 and will be removed in 3.0. Use the "validator.mapping.cache.doctrine.apc" service id instead.', E_USER_DEPRECATED);
+
+                                        return 'validator.mapping.cache.apc';
+                                    }
+
+                                    return $v;
+                                })
                             ->end()
                         ->end()
                         ->booleanNode('enable_annotations')->defaultFalse()->end()

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
@@ -37,6 +37,7 @@
 
         <service id="validator.mapping.cache.apc" class="%validator.mapping.cache.apc.class%" public="false">
             <argument>%validator.mapping.cache.prefix%</argument>
+            <deprecated>The "%service_id%" service is deprecated since Symfony 2.5 and will be removed in 3.0.</deprecated>
         </service>
 
         <service id="validator.mapping.cache.doctrine.apc" class="Symfony\Component\Validator\Mapping\Cache\DoctrineCache" public="false">
@@ -47,7 +48,6 @@
                     </call>
                 </service>
             </argument>
-            <deprecated>The "%service_id%" service is deprecated since Symfony 2.8 and will be removed in 3.0.</deprecated>
         </service>
 
         <service id="validator.validator_factory" class="%validator.validator_factory.class%" public="false">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
@@ -55,7 +55,7 @@ $container->loadFromExtension('framework', array(
     ),
     'validation' => array(
         'enabled' => true,
-        'cache' => 'apc',
+        'cache' => 'validator.mapping.cache.doctrine.apc',
     ),
     'annotations' => array(
         'cache' => 'file',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
@@ -37,7 +37,7 @@
         <framework:translator enabled="true" fallback="fr" logging="true">
             <framework:path>%kernel.root_dir%/Fixtures/translations</framework:path>
         </framework:translator>
-        <framework:validation enabled="true" cache="apc" />
+        <framework:validation enabled="true" cache="validator.mapping.cache.doctrine.apc" />
         <framework:annotations cache="file" debug="true" file-cache-dir="%kernel.cache_dir%/annotations" />
         <framework:serializer enabled="true" enable-annotations="true" cache="serializer.mapping.cache.apc" name-converter="serializer.name_converter.camel_case_to_snake_case" />
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
@@ -43,7 +43,7 @@ framework:
         paths: ['%kernel.root_dir%/Fixtures/translations']
     validation:
         enabled: true
-        cache:   apc
+        cache:   validator.mapping.cache.doctrine.apc
     annotations:
         cache:   file
         debug:   true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -293,7 +293,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertSame('addMethodMapping', $calls[4][0]);
         $this->assertSame(array('loadValidatorMetadata'), $calls[4][1]);
         $this->assertSame('setMetadataCache', $calls[5][0]);
-        $this->assertEquals(array(new Reference('validator.mapping.cache.apc')), $calls[5][1]);
+        $this->assertEquals(array(new Reference('validator.mapping.cache.doctrine.apc')), $calls[5][1]);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Related to #16795

I guess the deprecation was on the wrong service.
Also, no deprecation notice was triggered about using `"apc"` as the value of the `framework.validation.cache` configuration option. This PR adds the missing deprecation.

> :memo: _NOTE_: The standard edition will need to be updated [here](https://github.com/symfony/symfony-standard/blob/2.8/app/config/config_prod.yml#L6). 
