### PR TITLE
[Ldap] Use discovered DNs for the authentication bind

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Provider/LdapBindAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/LdapBindAuthenticationProvider.php
@@ -70,14 +70,12 @@ class LdapBindAuthenticationProvider extends UserAuthenticationProvider
      */
     protected function checkAuthentication(UserInterface $user, UsernamePasswordToken $token)
     {
-        $username = $token->getUsername();
         $password = $token->getCredentials();
 
         try {
-            $username = $this->ldap->escape($username, '', LDAP_ESCAPE_DN);
-            $dn = str_replace('{username}', $username, $this->dnString);
+            $username = $user->getUsername();
 
-            $this->ldap->bind($dn, $password);
+            $this->ldap->bind($username, $password);
         } catch (ConnectionException $e) {
             throw new BadCredentialsException('The presented password is invalid.');
         }

--- a/src/Symfony/Component/Security/Core/User/LdapUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/LdapUserProvider.php
@@ -74,7 +74,7 @@ class LdapUserProvider implements UserProviderInterface
 
         $user = $search[0];
 
-        return $this->loadUser($username, $user);
+        return $this->loadUser($user['dn'], $user);
     }
 
     public function loadUser($username, $user)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes - makes the authentication more flexible |
| BC breaks? | yes - when finished, would invalidate the need for the dn_string configuration setting, which has not yet been removed. |
| Deprecations? | no |
| Tests pass? | no - still need fixing |
| Fixed tickets | #16823 |
| License | MIT |
| Doc PR | TBD |
