### PR TITLE
[Security] Add Guard authenticator <supports> method

### DIFF
--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -295,15 +295,15 @@ Security
  * Deprecated the HTTP digest authentication: `NonceExpiredException`,
    `DigestAuthenticationListener` and `DigestAuthenticationEntryPoint` will be
    removed in 4.0. Use another authentication system like `http_basic` instead.
+   
+ * The `GuardAuthenticatorInterface` has been deprecated and will be removed in 4.0.
+   Use `AuthenticatorInterface` instead.
 
 SecurityBundle
 --------------
 
  * Using voters that do not implement the `VoterInterface`is now deprecated in
    the `AccessDecisionManager` and this functionality will be removed in 4.0.
-
- * Using guard authenticator that implement the `GuardAuthenticatorInterface` is now
-   deprecated, this will be removed in 4.0. `AuthenticatorInterface` must be used now.
 
  * `FirewallContext::getListeners()` now returns `\Traversable|array`
 

--- a/UPGRADE-3.4.md
+++ b/UPGRADE-3.4.md
@@ -302,6 +302,9 @@ SecurityBundle
  * Using voters that do not implement the `VoterInterface`is now deprecated in
    the `AccessDecisionManager` and this functionality will be removed in 4.0.
 
+ * Using guard authenticator that implement the `GuardAuthenticatorInterface` is now
+   deprecated, this will be removed in 4.0. `AuthenticatorInterface` must be used now.
+
  * `FirewallContext::getListeners()` now returns `\Traversable|array`
 
  * `InitAclCommand::__construct()` now takes an instance of

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -659,6 +659,9 @@ Security
  * The `RoleInterface` has been removed. Extend the `Symfony\Component\Security\Core\Role\Role`
    class instead.
 
+ * The `GuardAuthenticatorInterface` has been removed. Implement
+   `Symfony\Component\Security\Guard\AuthenticatorInterface` class instead.
+
  * The `LogoutUrlGenerator::registerListener()` method expects a 6th `string $context = null` argument.
 
  * The `AccessDecisionManager::setVoters()` method has been removed. Pass the

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -659,9 +659,6 @@ Security
  * The `RoleInterface` has been removed. Extend the `Symfony\Component\Security\Core\Role\Role`
    class instead.
 
- * The `GuardAuthenticatorInterface` has been removed. Implement
-   `Symfony\Component\Security\Guard\AuthenticatorInterface` class instead.
-
  * The `LogoutUrlGenerator::registerListener()` method expects a 6th `string $context = null` argument.
 
  * The `AccessDecisionManager::setVoters()` method has been removed. Pass the
@@ -675,6 +672,9 @@ Security
  * Removed the HTTP digest authentication system. The `NonceExpiredException`,
    `DigestAuthenticationListener` and `DigestAuthenticationEntryPoint` classes
    have been removed. Use another authentication system like `http_basic` instead.
+
+ * The `GuardAuthenticatorInterface` interface has been removed.
+   Use `AuthenticatorInterface` instead.
 
 SecurityBundle
 --------------

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG
    requests.
  * deprecated HTTP digest authentication
  * Added a new password encoder for the Argon2i hashing algorithm
+ * deprecated `GuardAuthenticatorInterface` in favor of `AuthenticatorInterface`
 
 3.3.0
 -----

--- a/src/Symfony/Component/Security/Guard/AbstractGuardAuthenticator.php
+++ b/src/Symfony/Component/Security/Guard/AbstractGuardAuthenticator.php
@@ -23,17 +23,13 @@ use Symfony\Component\Security\Guard\Token\PostAuthenticationGuardToken;
 abstract class AbstractGuardAuthenticator implements AuthenticatorInterface
 {
     /**
-     * Default implementation of the AuthenticatorInterface::supports method
-     * As we still have the deprecated GuardAuthenticatorInterface, this method must be implemented here
-     * Once GuardAuthenticatorInterface will be removed, this method should be removed too.
+     * {@inheritdoc}
      *
-     * @param Request $request
-     *
-     * @return bool
+     * @deprecated since version 3.4, to be removed in 4.0
      */
     public function supports(Request $request)
     {
-        @trigger_error('The Symfony\Component\Security\Guard\AbstractGuardAuthenticator::supports default implementation is used. This is provided for backward compatibility on GuardAuthenticationInterface that is deprecated since version 3.1 and will be removed in 4.0. Provide your own implementation of the supports method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The "%s()" method is deprecated since version 3.4 and will be removed in 4.0. Implement the "%s::supports()" method in class "%s" instead.', __METHOD__, AuthenticatorInterface::class, get_class($this)), E_USER_DEPRECATED);
 
         return true;
     }

--- a/src/Symfony/Component/Security/Guard/AbstractGuardAuthenticator.php
+++ b/src/Symfony/Component/Security/Guard/AbstractGuardAuthenticator.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Guard;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Guard\Token\PostAuthenticationGuardToken;
 
@@ -19,8 +20,24 @@ use Symfony\Component\Security\Guard\Token\PostAuthenticationGuardToken;
  *
  * @author Ryan Weaver <ryan@knpuniversity.com>
  */
-abstract class AbstractGuardAuthenticator implements GuardAuthenticatorInterface
+abstract class AbstractGuardAuthenticator implements AuthenticatorInterface
 {
+    /**
+     * Default implementation of the AuthenticatorInterface::supports method
+     * As we still have the deprecated GuardAuthenticatorInterface, this method must be implemented here
+     * Once GuardAuthenticatorInterface will be removed, this method should be removed too.
+     *
+     * @param Request $request
+     *
+     * @return bool
+     */
+    public function supports(Request $request)
+    {
+        @trigger_error('The Symfony\Component\Security\Guard\AbstractGuardAuthenticator::supports default implementation is used. This is provided for backward compatibility on GuardAuthenticationInterface that is deprecated since version 3.1 and will be removed in 4.0. Provide your own implementation of the supports method instead.', E_USER_DEPRECATED);
+
+        return true;
+    }
+
     /**
      * Shortcut to create a PostAuthenticationGuardToken for you, if you don't really
      * care about which authenticated token you're using.

--- a/src/Symfony/Component/Security/Guard/AuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Guard/AuthenticatorInterface.php
@@ -18,6 +18,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Guard\Token\GuardTokenInterface;
+use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 
 /**
  * The interface for all "guard" authenticators.
@@ -27,11 +28,23 @@ use Symfony\Component\Security\Guard\Token\GuardTokenInterface;
  * one location.
  *
  * @author Ryan Weaver <ryan@knpuniversity.com>
- *
- * @deprecated Symfony\Component\Security\Guard\AuthenticatorInterface must be used instead
+ * @author Amaury Leroux de Lens <amaury@lerouxdelens.com>
  */
-interface GuardAuthenticatorInterface extends AuthenticatorInterface
+interface AuthenticatorInterface extends AuthenticationEntryPointInterface
 {
+    /**
+     * Does the authenticator support the given Request ?
+     *
+     * If this returns true, authentication will continue (e.g. getCredentials() will be called).
+     * If false, this authenticator is done. The next (if any) authenticators will be called and
+     * may authenticate the user, or leave the user as anonymous.
+     *
+     * @param Request $request
+     *
+     * @return bool
+     */
+    public function supports(Request $request);
+
     /**
      * Get the authentication credentials from the request and return them
      * as any type (e.g. an associate array). If you return null, authentication
@@ -41,14 +54,10 @@ interface GuardAuthenticatorInterface extends AuthenticatorInterface
      *
      * For example, for a form login, you might:
      *
-     *      if ($request->request->has('_username')) {
-     *          return array(
-     *              'username' => $request->request->get('_username'),
-     *              'password' => $request->request->get('_password'),
-     *          );
-     *      } else {
-     *          return;
-     *      }
+     *      return array(
+     *          'username' => $request->request->get('_username'),
+     *          'password' => $request->request->get('_password'),
+     *      );
      *
      * Or for an API token that's on a header, you might use:
      *
@@ -96,7 +105,7 @@ interface GuardAuthenticatorInterface extends AuthenticatorInterface
     public function checkCredentials($credentials, UserInterface $user);
 
     /**
-     * Create an authenticated token for the given user.
+     * Creates an authenticated token for the given user.
      *
      * If you don't care about which token class is used or don't really
      * understand what a "token" is, you can skip this method by extending
@@ -154,7 +163,6 @@ interface GuardAuthenticatorInterface extends AuthenticatorInterface
      *      done by having a _remember_me checkbox in your form, but
      *      can be configured by the "always_remember_me" and "remember_me_parameter"
      *      parameters under the "remember_me" firewall key
-     *  D) The onAuthenticationSuccess method returns a Response object
      *
      * @return bool
      */

--- a/src/Symfony/Component/Security/Guard/AuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Guard/AuthenticatorInterface.php
@@ -12,13 +12,6 @@
 namespace Symfony\Component\Security\Guard;
 
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Core\Exception\AuthenticationException;
-use Symfony\Component\Security\Core\User\UserInterface;
-use Symfony\Component\Security\Core\User\UserProviderInterface;
-use Symfony\Component\Security\Guard\Token\GuardTokenInterface;
-use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 
 /**
  * The interface for all "guard" authenticators.
@@ -30,14 +23,12 @@ use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface
  * @author Ryan Weaver <ryan@knpuniversity.com>
  * @author Amaury Leroux de Lens <amaury@lerouxdelens.com>
  */
-interface AuthenticatorInterface extends AuthenticationEntryPointInterface
+interface AuthenticatorInterface extends GuardAuthenticatorInterface
 {
     /**
-     * Does the authenticator support the given Request ?
+     * Does the authenticator support the given Request?
      *
-     * If this returns true, authentication will continue (e.g. getCredentials() will be called).
-     * If false, this authenticator is done. The next (if any) authenticators will be called and
-     * may authenticate the user, or leave the user as anonymous.
+     * If this returns false, the authenticator will be skipped.
      *
      * @param Request $request
      *
@@ -47,8 +38,7 @@ interface AuthenticatorInterface extends AuthenticationEntryPointInterface
 
     /**
      * Get the authentication credentials from the request and return them
-     * as any type (e.g. an associate array). If you return null, authentication
-     * will be skipped.
+     * as any type (e.g. an associate array).
      *
      * Whatever value you return here will be passed to getUser() and checkCredentials()
      *
@@ -65,106 +55,9 @@ interface AuthenticatorInterface extends AuthenticationEntryPointInterface
      *
      * @param Request $request
      *
-     * @return mixed|null
+     * @return mixed Any non-null value
+     *
+     * @throws \UnexpectedValueException If null is returned
      */
     public function getCredentials(Request $request);
-
-    /**
-     * Return a UserInterface object based on the credentials.
-     *
-     * The *credentials* are the return value from getCredentials()
-     *
-     * You may throw an AuthenticationException if you wish. If you return
-     * null, then a UsernameNotFoundException is thrown for you.
-     *
-     * @param mixed                 $credentials
-     * @param UserProviderInterface $userProvider
-     *
-     * @throws AuthenticationException
-     *
-     * @return UserInterface|null
-     */
-    public function getUser($credentials, UserProviderInterface $userProvider);
-
-    /**
-     * Returns true if the credentials are valid.
-     *
-     * If any value other than true is returned, authentication will
-     * fail. You may also throw an AuthenticationException if you wish
-     * to cause authentication to fail.
-     *
-     * The *credentials* are the return value from getCredentials()
-     *
-     * @param mixed         $credentials
-     * @param UserInterface $user
-     *
-     * @return bool
-     *
-     * @throws AuthenticationException
-     */
-    public function checkCredentials($credentials, UserInterface $user);
-
-    /**
-     * Creates an authenticated token for the given user.
-     *
-     * If you don't care about which token class is used or don't really
-     * understand what a "token" is, you can skip this method by extending
-     * the AbstractGuardAuthenticator class from your authenticator.
-     *
-     * @see AbstractGuardAuthenticator
-     *
-     * @param UserInterface $user
-     * @param string        $providerKey The provider (i.e. firewall) key
-     *
-     * @return GuardTokenInterface
-     */
-    public function createAuthenticatedToken(UserInterface $user, $providerKey);
-
-    /**
-     * Called when authentication executed, but failed (e.g. wrong username password).
-     *
-     * This should return the Response sent back to the user, like a
-     * RedirectResponse to the login page or a 403 response.
-     *
-     * If you return null, the request will continue, but the user will
-     * not be authenticated. This is probably not what you want to do.
-     *
-     * @param Request                 $request
-     * @param AuthenticationException $exception
-     *
-     * @return Response|null
-     */
-    public function onAuthenticationFailure(Request $request, AuthenticationException $exception);
-
-    /**
-     * Called when authentication executed and was successful!
-     *
-     * This should return the Response sent back to the user, like a
-     * RedirectResponse to the last page they visited.
-     *
-     * If you return null, the current request will continue, and the user
-     * will be authenticated. This makes sense, for example, with an API.
-     *
-     * @param Request        $request
-     * @param TokenInterface $token
-     * @param string         $providerKey The provider (i.e. firewall) key
-     *
-     * @return Response|null
-     */
-    public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey);
-
-    /**
-     * Does this method support remember me cookies?
-     *
-     * Remember me cookie will be set if *all* of the following are met:
-     *  A) This method returns true
-     *  B) The remember_me key under your firewall is configured
-     *  C) The "remember me" functionality is activated. This is usually
-     *      done by having a _remember_me checkbox in your form, but
-     *      can be configured by the "always_remember_me" and "remember_me_parameter"
-     *      parameters under the "remember_me" firewall key
-     *
-     * @return bool
-     */
-    public function supportsRememberMe();
 }

--- a/src/Symfony/Component/Security/Guard/Firewall/GuardAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Guard/Firewall/GuardAuthenticationListener.php
@@ -18,6 +18,7 @@ use Symfony\Component\Security\Guard\GuardAuthenticatorHandler;
 use Symfony\Component\Security\Guard\Token\PreAuthenticationGuardToken;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Guard\GuardAuthenticatorInterface;
+use Symfony\Component\Security\Guard\AuthenticatorInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -28,6 +29,7 @@ use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
  * Authentication listener for the "guard" system.
  *
  * @author Ryan Weaver <ryan@knpuniversity.com>
+ * @author Amaury Leroux de Lens <amaury@lerouxdelens.com>
  */
 class GuardAuthenticationListener implements ListenerInterface
 {
@@ -39,11 +41,11 @@ class GuardAuthenticationListener implements ListenerInterface
     private $rememberMeServices;
 
     /**
-     * @param GuardAuthenticatorHandler              $guardHandler          The Guard handler
-     * @param AuthenticationManagerInterface         $authenticationManager An AuthenticationManagerInterface instance
-     * @param string                                 $providerKey           The provider (i.e. firewall) key
-     * @param iterable|GuardAuthenticatorInterface[] $guardAuthenticators   The authenticators, with keys that match what's passed to GuardAuthenticationProvider
-     * @param LoggerInterface                        $logger                A LoggerInterface instance
+     * @param GuardAuthenticatorHandler         $guardHandler          The Guard handler
+     * @param AuthenticationManagerInterface    $authenticationManager An AuthenticationManagerInterface instance
+     * @param string                            $providerKey           The provider (i.e. firewall) key
+     * @param iterable|AuthenticatorInterface[] $guardAuthenticators   The authenticators, with keys that match what's passed to GuardAuthenticationProvider
+     * @param LoggerInterface                   $logger                A LoggerInterface instance
      */
     public function __construct(GuardAuthenticatorHandler $guardHandler, AuthenticationManagerInterface $authenticationManager, $providerKey, $guardAuthenticators, LoggerInterface $logger = null)
     {
@@ -92,7 +94,7 @@ class GuardAuthenticationListener implements ListenerInterface
         }
     }
 
-    private function executeGuardAuthenticator($uniqueGuardKey, GuardAuthenticatorInterface $guardAuthenticator, GetResponseEvent $event)
+    private function executeGuardAuthenticator($uniqueGuardKey, AuthenticatorInterface $guardAuthenticator, GetResponseEvent $event)
     {
         $request = $event->getRequest();
         try {
@@ -100,12 +102,38 @@ class GuardAuthenticationListener implements ListenerInterface
                 $this->logger->debug('Calling getCredentials() on guard configurator.', array('firewall_key' => $this->providerKey, 'authenticator' => get_class($guardAuthenticator)));
             }
 
+            // abort the execution of the authenticator if it doesn't support the request.
+            if ($guardAuthenticator instanceof GuardAuthenticatorInterface) {
+                // it's a GuardAuthenticatorInterface
+                // we support the previous behaviour to avoid BC break.
+                $credentialsCanBeNull = true;
+                @trigger_error('The Symfony\Component\Security\Guard\GuardAuthenticatorInterface interface is deprecated since version 3.1 and will be removed in 4.0. Use Symfony\Component\Security\Guard\Authenticator\GuardAuthenticatorInterface instead.', E_USER_DEPRECATED);
+            } else {
+                if (true !== $guardAuthenticator->supports($request)) {
+                    return;
+                }
+                // as there was a support for given request,
+                // authenticator is expected to give not-null credentials.
+                $credentialsCanBeNull = false;
+            }
+
             // allow the authenticator to fetch authentication info from the request
             $credentials = $guardAuthenticator->getCredentials($request);
 
-            // allow null to be returned to skip authentication
             if (null === $credentials) {
-                return;
+                // if GuardAuthenticatorInterface is used
+                // allow null to skip authentication.
+                if ($credentialsCanBeNull) {
+                    return;
+                }
+
+                // otherwise something went wrong and the authentication must fail
+                throw new \UnexpectedValueException(sprintf(
+                    'You must return some credentials from %s:getCredentials().
+                    To skip authentication, return false from %s::supports().',
+                    get_class($guardAuthenticator),
+                    get_class($guardAuthenticator)
+                ));
             }
 
             // create a token with the unique key, so that the provider knows which authenticator to use
@@ -172,12 +200,12 @@ class GuardAuthenticationListener implements ListenerInterface
      * Checks to see if remember me is supported in the authenticator and
      * on the firewall. If it is, the RememberMeServicesInterface is notified.
      *
-     * @param GuardAuthenticatorInterface $guardAuthenticator
-     * @param Request                     $request
-     * @param TokenInterface              $token
-     * @param Response                    $response
+     * @param AuthenticatorInterface $guardAuthenticator
+     * @param Request                $request
+     * @param TokenInterface         $token
+     * @param Response               $response
      */
-    private function triggerRememberMe(GuardAuthenticatorInterface $guardAuthenticator, Request $request, TokenInterface $token, Response $response = null)
+    private function triggerRememberMe(AuthenticatorInterface $guardAuthenticator, Request $request, TokenInterface $token, Response $response = null)
     {
         if (null === $this->rememberMeServices) {
             if (null !== $this->logger) {

--- a/src/Symfony/Component/Security/Guard/GuardAuthenticatorHandler.php
+++ b/src/Symfony/Component/Security/Guard/GuardAuthenticatorHandler.php
@@ -29,6 +29,8 @@ use Symfony\Component\Security\Http\SecurityEvents;
  * can be called directly (e.g. for manual authentication) or overridden.
  *
  * @author Ryan Weaver <ryan@knpuniversity.com>
+ *
+ * @final since version 3.4
  */
 class GuardAuthenticatorHandler
 {
@@ -68,7 +70,7 @@ class GuardAuthenticatorHandler
      *
      * @return null|Response
      */
-    public function handleAuthenticationSuccess(TokenInterface $token, Request $request, AuthenticatorInterface $guardAuthenticator, $providerKey)
+    public function handleAuthenticationSuccess(TokenInterface $token, Request $request, GuardAuthenticatorInterface $guardAuthenticator, $providerKey)
     {
         $response = $guardAuthenticator->onAuthenticationSuccess($request, $token, $providerKey);
 
@@ -95,7 +97,7 @@ class GuardAuthenticatorHandler
      *
      * @return Response|null
      */
-    public function authenticateUserAndHandleSuccess(UserInterface $user, Request $request, AuthenticatorInterface $authenticator, $providerKey)
+    public function authenticateUserAndHandleSuccess(UserInterface $user, Request $request, GuardAuthenticatorInterface $authenticator, $providerKey)
     {
         // create an authenticated token for the User
         $token = $authenticator->createAuthenticatedToken($user, $providerKey);
@@ -117,7 +119,7 @@ class GuardAuthenticatorHandler
      *
      * @return null|Response
      */
-    public function handleAuthenticationFailure(AuthenticationException $authenticationException, Request $request, AuthenticatorInterface $guardAuthenticator, $providerKey)
+    public function handleAuthenticationFailure(AuthenticationException $authenticationException, Request $request, GuardAuthenticatorInterface $guardAuthenticator, $providerKey)
     {
         $token = $this->tokenStorage->getToken();
         if ($token instanceof PostAuthenticationGuardToken && $providerKey === $token->getProviderKey()) {

--- a/src/Symfony/Component/Security/Guard/GuardAuthenticatorHandler.php
+++ b/src/Symfony/Component/Security/Guard/GuardAuthenticatorHandler.php
@@ -61,14 +61,14 @@ class GuardAuthenticatorHandler
     /**
      * Returns the "on success" response for the given GuardAuthenticator.
      *
-     * @param TokenInterface              $token
-     * @param Request                     $request
-     * @param GuardAuthenticatorInterface $guardAuthenticator
-     * @param string                      $providerKey        The provider (i.e. firewall) key
+     * @param TokenInterface         $token
+     * @param Request                $request
+     * @param AuthenticatorInterface $guardAuthenticator
+     * @param string                 $providerKey        The provider (i.e. firewall) key
      *
      * @return null|Response
      */
-    public function handleAuthenticationSuccess(TokenInterface $token, Request $request, GuardAuthenticatorInterface $guardAuthenticator, $providerKey)
+    public function handleAuthenticationSuccess(TokenInterface $token, Request $request, AuthenticatorInterface $guardAuthenticator, $providerKey)
     {
         $response = $guardAuthenticator->onAuthenticationSuccess($request, $token, $providerKey);
 
@@ -88,14 +88,14 @@ class GuardAuthenticatorHandler
      * Convenience method for authenticating the user and returning the
      * Response *if any* for success.
      *
-     * @param UserInterface               $user
-     * @param Request                     $request
-     * @param GuardAuthenticatorInterface $authenticator
-     * @param string                      $providerKey   The provider (i.e. firewall) key
+     * @param UserInterface          $user
+     * @param Request                $request
+     * @param AuthenticatorInterface $authenticator
+     * @param string                 $providerKey   The provider (i.e. firewall) key
      *
      * @return Response|null
      */
-    public function authenticateUserAndHandleSuccess(UserInterface $user, Request $request, GuardAuthenticatorInterface $authenticator, $providerKey)
+    public function authenticateUserAndHandleSuccess(UserInterface $user, Request $request, AuthenticatorInterface $authenticator, $providerKey)
     {
         // create an authenticated token for the User
         $token = $authenticator->createAuthenticatedToken($user, $providerKey);
@@ -110,14 +110,14 @@ class GuardAuthenticatorHandler
      * Handles an authentication failure and returns the Response for the
      * GuardAuthenticator.
      *
-     * @param AuthenticationException     $authenticationException
-     * @param Request                     $request
-     * @param GuardAuthenticatorInterface $guardAuthenticator
-     * @param string                      $providerKey             The key of the firewall
+     * @param AuthenticationException $authenticationException
+     * @param Request                 $request
+     * @param AuthenticatorInterface  $guardAuthenticator
+     * @param string                  $providerKey             The key of the firewall
      *
      * @return null|Response
      */
-    public function handleAuthenticationFailure(AuthenticationException $authenticationException, Request $request, GuardAuthenticatorInterface $guardAuthenticator, $providerKey)
+    public function handleAuthenticationFailure(AuthenticationException $authenticationException, Request $request, AuthenticatorInterface $guardAuthenticator, $providerKey)
     {
         $token = $this->tokenStorage->getToken();
         if ($token instanceof PostAuthenticationGuardToken && $providerKey === $token->getProviderKey()) {

--- a/src/Symfony/Component/Security/Guard/GuardAuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Guard/GuardAuthenticatorInterface.php
@@ -18,6 +18,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Guard\Token\GuardTokenInterface;
+use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 
 /**
  * The interface for all "guard" authenticators.
@@ -28,9 +29,9 @@ use Symfony\Component\Security\Guard\Token\GuardTokenInterface;
  *
  * @author Ryan Weaver <ryan@knpuniversity.com>
  *
- * @deprecated Symfony\Component\Security\Guard\AuthenticatorInterface must be used instead
+ * @deprecated since version 3.4, to be removed in 4.0. Use AuthenticatorInterface instead
  */
-interface GuardAuthenticatorInterface extends AuthenticatorInterface
+interface GuardAuthenticatorInterface extends AuthenticationEntryPointInterface
 {
     /**
      * Get the authentication credentials from the request and return them

--- a/src/Symfony/Component/Security/Guard/Provider/GuardAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Guard/Provider/GuardAuthenticationProvider.php
@@ -56,7 +56,7 @@ class GuardAuthenticationProvider implements AuthenticationProviderInterface
     /**
      * Finds the correct authenticator for the token and calls it.
      *
-     * @param TokenInterface|GuardTokenInterface $token
+     * @param GuardTokenInterface $token
      *
      * @return TokenInterface
      */
@@ -101,7 +101,7 @@ class GuardAuthenticationProvider implements AuthenticationProviderInterface
         // instances that will be checked if you have multiple firewalls.
     }
 
-    private function authenticateViaGuard(AuthenticatorInterface $guardAuthenticator, PreAuthenticationGuardToken $token)
+    private function authenticateViaGuard($guardAuthenticator, PreAuthenticationGuardToken $token)
     {
         // get the user from the GuardAuthenticator
         $user = $guardAuthenticator->getUser($token->getCredentials(), $this->userProvider);
@@ -142,6 +142,6 @@ class GuardAuthenticationProvider implements AuthenticationProviderInterface
 
     public function supports(TokenInterface $token)
     {
-        return $token instanceof TokenInterface;
+        return $token instanceof GuardTokenInterface;
     }
 }

--- a/src/Symfony/Component/Security/Guard/Provider/GuardAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Guard/Provider/GuardAuthenticationProvider.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Security\Guard\Provider;
 use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
-use Symfony\Component\Security\Guard\GuardAuthenticatorInterface;
+use Symfony\Component\Security\Guard\AuthenticatorInterface;
 use Symfony\Component\Security\Guard\Token\GuardTokenInterface;
 use Symfony\Component\Security\Guard\Token\PreAuthenticationGuardToken;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
@@ -32,7 +32,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationExpiredException;
 class GuardAuthenticationProvider implements AuthenticationProviderInterface
 {
     /**
-     * @var GuardAuthenticatorInterface[]
+     * @var AuthenticatorInterface[]
      */
     private $guardAuthenticators;
     private $userProvider;
@@ -40,10 +40,10 @@ class GuardAuthenticationProvider implements AuthenticationProviderInterface
     private $userChecker;
 
     /**
-     * @param iterable|GuardAuthenticatorInterface[] $guardAuthenticators The authenticators, with keys that match what's passed to GuardAuthenticationListener
-     * @param UserProviderInterface                  $userProvider        The user provider
-     * @param string                                 $providerKey         The provider (i.e. firewall) key
-     * @param UserCheckerInterface                   $userChecker
+     * @param iterable|AuthenticatorInterface[] $guardAuthenticators The authenticators, with keys that match what's passed to GuardAuthenticationListener
+     * @param UserProviderInterface             $userProvider        The user provider
+     * @param string                            $providerKey         The provider (i.e. firewall) key
+     * @param UserCheckerInterface              $userChecker
      */
     public function __construct($guardAuthenticators, UserProviderInterface $userProvider, $providerKey, UserCheckerInterface $userChecker)
     {
@@ -56,7 +56,7 @@ class GuardAuthenticationProvider implements AuthenticationProviderInterface
     /**
      * Finds the correct authenticator for the token and calls it.
      *
-     * @param GuardTokenInterface $token
+     * @param TokenInterface|GuardTokenInterface $token
      *
      * @return TokenInterface
      */
@@ -101,7 +101,7 @@ class GuardAuthenticationProvider implements AuthenticationProviderInterface
         // instances that will be checked if you have multiple firewalls.
     }
 
-    private function authenticateViaGuard(GuardAuthenticatorInterface $guardAuthenticator, PreAuthenticationGuardToken $token)
+    private function authenticateViaGuard(AuthenticatorInterface $guardAuthenticator, PreAuthenticationGuardToken $token)
     {
         // get the user from the GuardAuthenticator
         $user = $guardAuthenticator->getUser($token->getCredentials(), $this->userProvider);
@@ -142,6 +142,6 @@ class GuardAuthenticationProvider implements AuthenticationProviderInterface
 
     public function supports(TokenInterface $token)
     {
-        return $token instanceof GuardTokenInterface;
+        return $token instanceof TokenInterface;
     }
 }

--- a/src/Symfony/Component/Security/Guard/Tests/Firewall/GuardAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/Firewall/GuardAuthenticationListenerTest.php
@@ -14,7 +14,10 @@ namespace Symfony\Component\Security\Guard\Tests\Firewall;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Guard\AuthenticatorInterface;
 use Symfony\Component\Security\Guard\Firewall\GuardAuthenticationListener;
+use Symfony\Component\Security\Guard\GuardAuthenticatorInterface;
 use Symfony\Component\Security\Guard\Token\PreAuthenticationGuardToken;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
@@ -33,8 +36,8 @@ class GuardAuthenticationListenerTest extends TestCase
 
     public function testHandleSuccess()
     {
-        $authenticator = $this->getMockBuilder('Symfony\Component\Security\Guard\AuthenticatorInterface')->getMock();
-        $authenticateToken = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
+        $authenticator = $this->getMockBuilder(AuthenticatorInterface::class)->getMock();
+        $authenticateToken = $this->getMockBuilder(TokenInterface::class)->getMock();
         $providerKey = 'my_firewall';
 
         $credentials = array('username' => 'weaverryan', 'password' => 'all_your_base');
@@ -88,8 +91,8 @@ class GuardAuthenticationListenerTest extends TestCase
 
     public function testHandleSuccessStopsAfterResponseIsSet()
     {
-        $authenticator1 = $this->getMockBuilder('Symfony\Component\Security\Guard\AuthenticatorInterface')->getMock();
-        $authenticator2 = $this->getMockBuilder('Symfony\Component\Security\Guard\AuthenticatorInterface')->getMock();
+        $authenticator1 = $this->getMockBuilder(AuthenticatorInterface::class)->getMock();
+        $authenticator2 = $this->getMockBuilder(AuthenticatorInterface::class)->getMock();
 
         // mock the first authenticator to fail, and set a Response
         $authenticator1
@@ -104,7 +107,6 @@ class GuardAuthenticationListenerTest extends TestCase
             ->expects($this->once())
             ->method('handleAuthenticationFailure')
             ->willReturn(new Response());
-
         // the second authenticator should *never* be called
         $authenticator2
             ->expects($this->never())
@@ -123,8 +125,8 @@ class GuardAuthenticationListenerTest extends TestCase
 
     public function testHandleSuccessWithRememberMe()
     {
-        $authenticator = $this->getMockBuilder('Symfony\Component\Security\Guard\AuthenticatorInterface')->getMock();
-        $authenticateToken = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
+        $authenticator = $this->getMockBuilder(AuthenticatorInterface::class)->getMock();
+        $authenticateToken = $this->getMockBuilder(TokenInterface::class)->getMock();
         $providerKey = 'my_firewall_with_rememberme';
 
         $authenticator
@@ -171,7 +173,7 @@ class GuardAuthenticationListenerTest extends TestCase
 
     public function testHandleCatchesAuthenticationException()
     {
-        $authenticator = $this->getMockBuilder('Symfony\Component\Security\Guard\AuthenticatorInterface')->getMock();
+        $authenticator = $this->getMockBuilder(AuthenticatorInterface::class)->getMock();
         $providerKey = 'my_firewall2';
 
         $authException = new AuthenticationException('Get outta here crazy user with a bad password!');
@@ -210,7 +212,7 @@ class GuardAuthenticationListenerTest extends TestCase
      */
     public function testLegacyInterfaceNullCredentials()
     {
-        $authenticatorA = $this->getMockBuilder('Symfony\Component\Security\Guard\GuardAuthenticatorInterface')->getMock();
+        $authenticatorA = $this->getMockBuilder(GuardAuthenticatorInterface::class)->getMock();
         $providerKey = 'my_firewall3';
 
         $authenticatorA
@@ -243,8 +245,8 @@ class GuardAuthenticationListenerTest extends TestCase
      */
     public function testLegacyInterfaceKeepsWorking()
     {
-        $authenticator = $this->getMockBuilder('Symfony\Component\Security\Guard\GuardAuthenticatorInterface')->getMock();
-        $authenticateToken = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
+        $authenticator = $this->getMockBuilder(GuardAuthenticatorInterface::class)->getMock();
+        $authenticateToken = $this->getMockBuilder(TokenInterface::class)->getMock();
         $providerKey = 'my_firewall';
 
         $credentials = array('username' => 'weaverryan', 'password' => 'all_your_base');
@@ -332,7 +334,7 @@ class GuardAuthenticationListenerTest extends TestCase
 
     public function testSupportsReturnFalseSkipAuth()
     {
-        $authenticator = $this->getMockBuilder('Symfony\Component\Security\Guard\AuthenticatorInterface')->getMock();
+        $authenticator = $this->getMockBuilder(AuthenticatorInterface::class)->getMock();
         $providerKey = 'my_firewall4';
 
         $authenticator
@@ -359,9 +361,9 @@ class GuardAuthenticationListenerTest extends TestCase
     /**
      * @expectedException \UnexpectedValueException
      */
-    public function testSupportsReturnTrueRaiseMissingCredentialsException()
+    public function testReturnNullFromGetCredentials()
     {
-        $authenticator = $this->getMockBuilder('Symfony\Component\Security\Guard\AuthenticatorInterface')->getMock();
+        $authenticator = $this->getMockBuilder(AuthenticatorInterface::class)->getMock();
         $providerKey = 'my_firewall4';
 
         $authenticator

--- a/src/Symfony/Component/Security/Guard/Tests/GuardAuthenticatorHandlerTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/GuardAuthenticatorHandlerTest.php
@@ -128,7 +128,7 @@ class GuardAuthenticatorHandlerTest extends TestCase
         $this->dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
         $this->token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $this->request = new Request(array(), array(), array(), array(), array(), array());
-        $this->guardAuthenticator = $this->getMockBuilder('Symfony\Component\Security\Guard\GuardAuthenticatorInterface')->getMock();
+        $this->guardAuthenticator = $this->getMockBuilder('Symfony\Component\Security\Guard\AuthenticatorInterface')->getMock();
     }
 
     protected function tearDown()

--- a/src/Symfony/Component/Security/Guard/Tests/GuardAuthenticatorHandlerTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/GuardAuthenticatorHandlerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Security\Guard\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Guard\AuthenticatorInterface;
 use Symfony\Component\Security\Guard\GuardAuthenticatorHandler;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
@@ -128,7 +129,7 @@ class GuardAuthenticatorHandlerTest extends TestCase
         $this->dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
         $this->token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $this->request = new Request(array(), array(), array(), array(), array(), array());
-        $this->guardAuthenticator = $this->getMockBuilder('Symfony\Component\Security\Guard\AuthenticatorInterface')->getMock();
+        $this->guardAuthenticator = $this->getMockBuilder(AuthenticatorInterface::class)->getMock();
     }
 
     protected function tearDown()

--- a/src/Symfony/Component/Security/Guard/Tests/Provider/GuardAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/Provider/GuardAuthenticationProviderTest.php
@@ -12,6 +12,9 @@
 namespace Symfony\Component\Security\Guard\Tests\Provider;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Guard\AuthenticatorInterface;
 use Symfony\Component\Security\Guard\Provider\GuardAuthenticationProvider;
 use Symfony\Component\Security\Guard\Token\PostAuthenticationGuardToken;
 
@@ -25,6 +28,68 @@ class GuardAuthenticationProviderTest extends TestCase
     private $preAuthenticationToken;
 
     public function testAuthenticate()
+    {
+        $providerKey = 'my_cool_firewall';
+
+        $authenticatorA = $this->getMockBuilder(AuthenticatorInterface::class)->getMock();
+        $authenticatorB = $this->getMockBuilder(AuthenticatorInterface::class)->getMock();
+        $authenticatorC = $this->getMockBuilder(AuthenticatorInterface::class)->getMock();
+        $authenticators = array($authenticatorA, $authenticatorB, $authenticatorC);
+
+        // called 2 times - for authenticator A and B (stops on B because of match)
+        $this->preAuthenticationToken->expects($this->exactly(2))
+            ->method('getGuardProviderKey')
+            // it will return the "1" index, which will match authenticatorB
+            ->will($this->returnValue('my_cool_firewall_1'));
+
+        $enteredCredentials = array(
+            'username' => '_weaverryan_test_user',
+            'password' => 'guard_auth_ftw',
+        );
+        $this->preAuthenticationToken->expects($this->atLeastOnce())
+            ->method('getCredentials')
+            ->will($this->returnValue($enteredCredentials));
+
+        // authenticators A and C are never called
+        $authenticatorA->expects($this->never())
+            ->method('getUser');
+        $authenticatorC->expects($this->never())
+            ->method('getUser');
+
+        $mockedUser = $this->getMockBuilder(UserInterface::class)->getMock();
+        $authenticatorB->expects($this->once())
+            ->method('getUser')
+            ->with($enteredCredentials, $this->userProvider)
+            ->will($this->returnValue($mockedUser));
+        // checkCredentials is called
+        $authenticatorB->expects($this->once())
+            ->method('checkCredentials')
+            ->with($enteredCredentials, $mockedUser)
+            // authentication works!
+            ->will($this->returnValue(true));
+        $authedToken = $this->getMockBuilder(TokenInterface::class)->getMock();
+        $authenticatorB->expects($this->once())
+            ->method('createAuthenticatedToken')
+            ->with($mockedUser, $providerKey)
+            ->will($this->returnValue($authedToken));
+
+        // user checker should be called
+        $this->userChecker->expects($this->once())
+            ->method('checkPreAuth')
+            ->with($mockedUser);
+        $this->userChecker->expects($this->once())
+            ->method('checkPostAuth')
+            ->with($mockedUser);
+
+        $provider = new GuardAuthenticationProvider($authenticators, $this->userProvider, $providerKey, $this->userChecker);
+        $actualAuthedToken = $provider->authenticate($this->preAuthenticationToken);
+        $this->assertSame($authedToken, $actualAuthedToken);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyAuthenticate()
     {
         $providerKey = 'my_cool_firewall';
 

--- a/src/Symfony/Component/Security/Guard/Token/PreAuthenticationGuardToken.php
+++ b/src/Symfony/Component/Security/Guard/Token/PreAuthenticationGuardToken.php
@@ -29,7 +29,7 @@ class PreAuthenticationGuardToken extends AbstractToken implements GuardTokenInt
 
     /**
      * @param mixed  $credentials
-     * @param string $guardProviderKey Unique key that bind this token to a specific GuardAuthenticatorInterface
+     * @param string $guardProviderKey Unique key that bind this token to a specific AuthenticatorInterface
      */
     public function __construct($credentials, $guardProviderKey)
     {


### PR DESCRIPTION
This method will be called before starting an authentication against a guard authenticator.
The authentication will be tried only if the supports method returned `true`
This improves understanding of code, increase consistency and removes responsability for `getCredentials` method to decide if the current request should be supported or not.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR |  |
