### PR TITLE
[PropertyAccess] minor: constants as internal and removed unused var

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -24,19 +24,74 @@ use Symfony\Component\PropertyAccess\Exception\UnexpectedTypeException;
  */
 class PropertyAccessor implements PropertyAccessorInterface
 {
+    /**
+     * @internal
+     */
     const VALUE = 0;
+
+    /**
+     * @internal
+     */
     const IS_REF = 1;
+
+    /**
+     * @internal
+     */
     const IS_REF_CHAINED = 2;
+
+    /**
+     * @internal
+     */
     const ACCESS_HAS_PROPERTY = 0;
+
+    /**
+     * @internal
+     */
     const ACCESS_TYPE = 1;
+
+    /**
+     * @internal
+     */
     const ACCESS_NAME = 2;
+
+    /**
+     * @internal
+     */
     const ACCESS_REF = 3;
+
+    /**
+     * @internal
+     */
     const ACCESS_ADDER = 4;
+
+    /**
+     * @internal
+     */
     const ACCESS_REMOVER = 5;
+
+    /**
+     * @internal
+     */
     const ACCESS_TYPE_METHOD = 0;
+
+    /**
+     * @internal
+     */
     const ACCESS_TYPE_PROPERTY = 1;
+
+    /**
+     * @internal
+     */
     const ACCESS_TYPE_MAGIC = 2;
+
+    /**
+     * @internal
+     */
     const ACCESS_TYPE_ADDER_AND_REMOVER = 3;
+
+    /**
+     * @internal
+     */
     const ACCESS_TYPE_NOT_FOUND = 4;
 
     /**
@@ -579,7 +634,6 @@ class PropertyAccessor implements PropertyAccessorInterface
     private function getWriteAccessInfo($object, $property, $value)
     {
         $key = get_class($object).'::'.$property;
-        $guessedAdders = '';
 
         if (isset($this->writePropertyCache[$key])) {
             $access = $this->writePropertyCache[$key];
@@ -594,13 +648,7 @@ class PropertyAccessor implements PropertyAccessorInterface
             if (is_array($value) || $value instanceof \Traversable) {
                 $methods = $this->findAdderAndRemover($reflClass, $singulars);
 
-                if (null === $methods) {
-                    // It is sufficient to include only the adders in the error
-                    // message. If the user implements the adder but not the remover,
-                    // an exception will be thrown in findAdderAndRemover() that
-                    // the remover has to be implemented as well.
-                    $guessedAdders = '"add'.implode('()", "add', $singulars).'()", ';
-                } else {
+                if (null !== $methods) {
                     $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_ADDER_AND_REMOVER;
                     $access[self::ACCESS_ADDER] = $methods[0];
                     $access[self::ACCESS_REMOVER] = $methods[1];

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -634,6 +634,7 @@ class PropertyAccessor implements PropertyAccessorInterface
     private function getWriteAccessInfo($object, $property, $value)
     {
         $key = get_class($object).'::'.$property;
+        $guessedAdders = '';
 
         if (isset($this->writePropertyCache[$key])) {
             $access = $this->writePropertyCache[$key];
@@ -648,7 +649,13 @@ class PropertyAccessor implements PropertyAccessorInterface
             if (is_array($value) || $value instanceof \Traversable) {
                 $methods = $this->findAdderAndRemover($reflClass, $singulars);
 
-                if (null !== $methods) {
+                if (null === $methods) {
+                    // It is sufficient to include only the adders in the error
+                    // message. If the user implements the adder but not the remover,
+                    // an exception will be thrown in findAdderAndRemover() that
+                    // the remover has to be implemented as well.
+                    $guessedAdders = '"add'.implode('()", "add', $singulars).'()", ';
+                } else {
                     $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_ADDER_AND_REMOVER;
                     $access[self::ACCESS_ADDER] = $methods[0];
                     $access[self::ACCESS_REMOVER] = $methods[1];


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |
