### PR TITLE
[Ldap] Escape carriage returns in LDAP DNs.

### DIFF
--- a/src/Symfony/Component/Ldap/LdapClient.php
+++ b/src/Symfony/Component/Ldap/LdapClient.php
@@ -99,7 +99,20 @@ class LdapClient implements LdapClientInterface
      */
     public function escape($subject, $ignore = '', $flags = 0)
     {
-        return ldap_escape($subject, $ignore, $flags);
+        $value = ldap_escape($subject, $ignore, $flags);
+
+        // Per RFC 4514, leading/trailing spaces should be encoded in DNs, as well as carriage returns.
+        if ((int)$flags & LDAP_ESCAPE_DN) {
+            if (!empty($value) && $value[0] === ' ') {
+                $value = '\\20' . substr($value, 1);
+            }
+            if (!empty($value) && $value[strlen($value) - 1] === ' ') {
+                $value = substr($value, 0, -1) . '\\20';
+            }
+            $value = str_replace("\r", '\0d', $value);
+        }
+
+        return $value;
     }
 
     private function connect()

--- a/src/Symfony/Component/Ldap/LdapClient.php
+++ b/src/Symfony/Component/Ldap/LdapClient.php
@@ -102,12 +102,12 @@ class LdapClient implements LdapClientInterface
         $value = ldap_escape($subject, $ignore, $flags);
 
         // Per RFC 4514, leading/trailing spaces should be encoded in DNs, as well as carriage returns.
-        if ((int)$flags & LDAP_ESCAPE_DN) {
+        if ((int) $flags & LDAP_ESCAPE_DN) {
             if (!empty($value) && $value[0] === ' ') {
-                $value = '\\20' . substr($value, 1);
+                $value = '\\20'.substr($value, 1);
             }
             if (!empty($value) && $value[strlen($value) - 1] === ' ') {
-                $value = substr($value, 0, -1) . '\\20';
+                $value = substr($value, 0, -1).'\\20';
             }
             $value = str_replace("\r", '\0d', $value);
         }

--- a/src/Symfony/Component/Ldap/Tests/LdapClientTest.php
+++ b/src/Symfony/Component/Ldap/Tests/LdapClientTest.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Ldap\Tests;
+
+use Symfony\Component\Ldap\LdapClient;
+use Symfony\Polyfill\Php56\Php56 as p;
+
+class LdapClientTest extends \PHPUnit_Framework_TestCase
+{
+    public function testLdapEscape()
+    {
+        $ldap = new LdapClient();
+
+        $this->assertEquals('\20foo\3dbar\0d(baz)*\20', $ldap->escape(" foo=bar\r(baz)* ", null, p::LDAP_ESCAPE_DN));
+    }
+}

--- a/src/Symfony/Component/Ldap/Tests/LdapClientTest.php
+++ b/src/Symfony/Component/Ldap/Tests/LdapClientTest.php
@@ -14,6 +14,9 @@ namespace Symfony\Component\Ldap\Tests;
 use Symfony\Component\Ldap\LdapClient;
 use Symfony\Polyfill\Php56\Php56 as p;
 
+/**
+ * @requires extension ldap
+ */
 class LdapClientTest extends \PHPUnit_Framework_TestCase
 {
     public function testLdapEscape()


### PR DESCRIPTION
Depends upon this commit in polyfill: https://github.com/symfony/polyfill/pull/14

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Carriage returns are supposed to be escaped in a LDAP DN. Leading and trailing spaces should be encoded as well. The spaces were taken care of in the polyfill implementation of `ldap_escape`, but the actual PHP function doesn't do the same. So I moved that logic within the component function and removed it from the polyfill function.
