### PR TITLE
[MonologBridge] Monolog Bridge 2.8 is incompatible with HttpKernel 3.0

### DIFF
--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -20,7 +20,7 @@
         "monolog/monolog": "~1.11"
     },
     "require-dev": {
-        "symfony/http-kernel": "~2.4|~3.0.0",
+        "symfony/http-kernel": "~2.4",
         "symfony/console": "~2.4|~3.0.0",
         "symfony/event-dispatcher": "~2.2|~3.0.0"
     },


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16837 |
| License | MIT |
| Doc PR | none |

Greetings from the SymfonyCon hackday. I wanted to start my day with an easy PR. :wink:

As pointed out by @anlutro in #16837, MonologBridge 2.8 uses a deprecated interface of HttpKernel that has been removed in 3.0. Because of this, MonologBridge 2.8 must not be marked as compatible with HttpKernel 3.0 in composer.json.
