### PR TITLE
Upgrade information for the choice_value option

### DIFF
--- a/UPGRADE-2.8.md
+++ b/UPGRADE-2.8.md
@@ -186,6 +186,41 @@ Form
    }
    ```
 
+ * In Symfony 2.7 a small BC break was introduced with the new choices_as_values
+   option. In order to have the choice values populated to the html value attribute
+   you had to define the choice_value option. This is now not any more needed.
+ 
+   Before:
+
+   ```php
+   $form->add('status', 'choice', array(
+       'choices' => array(
+           'Enabled' => Status::ENABLED,
+           'Disabled' => Status::DISABLED,
+           'Ignored' => Status::IGNORED,
+       ),
+       'choices_as_values' => true,
+       // important if you rely on your option value attribute (e.g. for JavaScript)
+       // this will keep the same functionality as before
+       'choice_value' => function ($choice) {
+           return $choice;
+       },
+   ));
+   ```
+   
+   After (Symfony 2.8+):
+   
+   ```php
+   $form->add('status', ChoiceType::class, array(
+       'choices' => array(
+           'Enabled' => Status::ENABLED,
+           'Disabled' => Status::DISABLED,
+           'Ignored' => Status::IGNORED,
+       ),
+       'choices_as_values' => true
+   ));
+   ```
+
  * Returning type instances from `FormTypeInterface::getParent()` is deprecated
    and will not be supported anymore in Symfony 3.0. Return the fully-qualified
    class name of the parent type class instead.

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -365,6 +365,42 @@ UPGRADE FROM 2.x to 3.0
        }
    }
    ```
+   
+ * In Symfony 2.7 a small BC break was introduced with the new choices_as_values
+   option. In order to have the choice values populated to the html value attribute
+   you had to define the choice_value option. This is now not any more needed.
+ 
+   Before:
+
+   ```php
+   $form->add('status', 'choice', array(
+       'choices' => array(
+           'Enabled' => Status::ENABLED,
+           'Disabled' => Status::DISABLED,
+           'Ignored' => Status::IGNORED,
+       ),
+       // choices_as_values defaults to true in Symfony 3.0
+       // and setting it to anything else is deprecated as of 3.0
+       'choices_as_values' => true,
+       // important if you rely on your option value attribute (e.g. for JavaScript)
+       // this will keep the same functionality as before
+       'choice_value' => function ($choice) {
+           return $choice;
+       },
+   ));
+   ```
+   
+   After:
+   
+   ```php
+   $form->add('status', ChoiceType::class, array(
+       'choices' => array(
+           'Enabled' => Status::ENABLED,
+           'Disabled' => Status::DISABLED,
+           'Ignored' => Status::IGNORED,
+       )
+   ));
+   ```   
 
  * The `request` service was removed. You must inject the `request_stack`
    service instead.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Relates to #14825 and #14377. The behaviour was changed with #16681 so a not in the upgrade information makes sense to me.
