### PR TITLE
[2.8] Added a note about the new requirement iconv

### DIFF
--- a/UPGRADE-2.8.md
+++ b/UPGRADE-2.8.md
@@ -1,6 +1,20 @@
 ﻿UPGRADE FROM 2.7 to 2.8
 =======================
 
+All components
+--------------
+
+* Symfony now requires the iconv extension to be present, which is the case by
+  default in most environments. However, if you're not able to ensure this
+  extension to be installed in your target environment, you can add Symfony's
+  iconv polyfill to your project's composer.json file.
+
+  ```json
+  "require": {
+      "symfony/polyfill-iconv": "~1.0"
+  }
+  ```
+
 Form
 ----
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16778 |
| License | MIT |
| Doc PR | none |

When upgrading from 2.7 to 2.8, we need to ensure that `ext-iconv` is present. This PR adds a note about this to the UPGRADE-2.8 file.
