### PR TITLE
Change order of ajax requests, last one at the top.

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -95,9 +95,8 @@
                     var tbody = tbodies[0];
 
                     var rows = document.createDocumentFragment();
-
                     if (requestStack.length) {
-                        for (var i = 0; i < requestStack.length; i++) {
+                        for (var i = (requestStack.length-1); i >= 0; i--) {
                             var request = requestStack[i];
 
                             var row = document.createElement('tr');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16831 |
| License | MIT |

Changed the order of ajax requests shown in the web profiler bar, the last one is at the top which is consistent with the profile search page.
