### PR TITLE
[Validator] added L18n validator

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
@@ -10,7 +10,7 @@
         <parameter key="validator.builder.factory.class">Symfony\Component\Validator\Validation</parameter>
         <parameter key="validator.mapping.cache.apc.class">Symfony\Component\Validator\Mapping\Cache\ApcCache
         </parameter>
-        <parameter key="validator.mapping.cache.prefix"/>
+        <parameter key="validator.mapping.cache.prefix" />
         <parameter
             key="validator.validator_factory.class">Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory
         </parameter>
@@ -21,23 +21,23 @@
 
     <services>
         <service id="validator" class="%validator.class%">
-            <factory service="validator.builder" method="getValidator"/>
+            <factory service="validator.builder" method="getValidator" />
         </service>
 
         <service id="validator.builder" class="%validator.builder.class%">
-            <factory class="%validator.builder.factory.class%" method="createValidatorBuilder"/>
+            <factory class="%validator.builder.factory.class%" method="createValidatorBuilder" />
             <call method="setConstraintValidatorFactory">
-                <argument type="service" id="validator.validator_factory"/>
+                <argument type="service" id="validator.validator_factory" />
             </call>
             <call method="setTranslator">
-                <argument type="service" id="translator"/>
+                <argument type="service" id="translator" />
             </call>
             <call method="setTranslationDomain">
                 <argument>%validator.translation_domain%</argument>
             </call>
         </service>
 
-        <service id="validator.mapping.class_metadata_factory" alias="validator" public="false"/>
+        <service id="validator.mapping.class_metadata_factory" alias="validator" public="false" />
 
         <service id="validator.mapping.cache.apc" class="%validator.mapping.cache.apc.class%" public="false">
             <argument>%validator.mapping.cache.prefix%</argument>
@@ -56,24 +56,24 @@
         </service>
 
         <service id="validator.validator_factory" class="%validator.validator_factory.class%" public="false">
-            <argument type="service" id="service_container"/>
-            <argument type="collection"/>
+            <argument type="service" id="service_container" />
+            <argument type="collection" />
         </service>
 
         <service id="validator.expression" class="%validator.expression.class%">
-            <argument type="service" id="property_accessor"/>
-            <tag name="validator.constraint_validator" alias="validator.expression"/>
+            <argument type="service" id="property_accessor" />
+            <tag name="validator.constraint_validator" alias="validator.expression" />
+        </service>
+
+        <service id="validator.l18n" class="Symfony\Component\Validator\Constraints\L18nValidator">
+            <argument type="service" id="request_stack"/>
+            <tag name="validator.constraint_validator" alias="validator.l18n"/>
         </service>
 
         <service id="validator.email" class="%validator.email.class%">
             <argument type="service" id="request_stack" />
-
-        <service id="validator.l18n" class="Symfony\Component\Validator\Constraints\L18nValidator">
-            <argument type="service" id="request_stack" />
-            <tag name="validator.constraint_validator" alias="validator.l18n" />
-        </service>
             <argument></argument>
-            <tag name="validator.constraint_validator" alias="Symfony\Component\Validator\Constraints\EmailValidator"/>
+            <tag name="validator.constraint_validator" alias="Symfony\Component\Validator\Constraints\EmailValidator" />
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
@@ -8,14 +8,10 @@
         <parameter key="validator.class">Symfony\Component\Validator\Validator\ValidatorInterface</parameter>
         <parameter key="validator.builder.class">Symfony\Component\Validator\ValidatorBuilderInterface</parameter>
         <parameter key="validator.builder.factory.class">Symfony\Component\Validator\Validation</parameter>
-        <parameter key="validator.mapping.cache.apc.class">Symfony\Component\Validator\Mapping\Cache\ApcCache
-        </parameter>
+        <parameter key="validator.mapping.cache.apc.class">Symfony\Component\Validator\Mapping\Cache\ApcCache</parameter>
         <parameter key="validator.mapping.cache.prefix" />
-        <parameter
-            key="validator.validator_factory.class">Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory
-        </parameter>
-        <parameter key="validator.expression.class">Symfony\Component\Validator\Constraints\ExpressionValidator
-        </parameter>
+        <parameter key="validator.validator_factory.class">Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory</parameter>
+        <parameter key="validator.expression.class">Symfony\Component\Validator\Constraints\ExpressionValidator</parameter>
         <parameter key="validator.email.class">Symfony\Component\Validator\Constraints\EmailValidator</parameter>
     </parameters>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
@@ -1,45 +1,50 @@
 <?xml version="1.0" ?>
 
 <container xmlns="http://symfony.com/schema/dic/services"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
         <parameter key="validator.class">Symfony\Component\Validator\Validator\ValidatorInterface</parameter>
         <parameter key="validator.builder.class">Symfony\Component\Validator\ValidatorBuilderInterface</parameter>
         <parameter key="validator.builder.factory.class">Symfony\Component\Validator\Validation</parameter>
-        <parameter key="validator.mapping.cache.apc.class">Symfony\Component\Validator\Mapping\Cache\ApcCache</parameter>
-        <parameter key="validator.mapping.cache.prefix" />
-        <parameter key="validator.validator_factory.class">Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory</parameter>
-        <parameter key="validator.expression.class">Symfony\Component\Validator\Constraints\ExpressionValidator</parameter>
+        <parameter key="validator.mapping.cache.apc.class">Symfony\Component\Validator\Mapping\Cache\ApcCache
+        </parameter>
+        <parameter key="validator.mapping.cache.prefix"/>
+        <parameter
+            key="validator.validator_factory.class">Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory
+        </parameter>
+        <parameter key="validator.expression.class">Symfony\Component\Validator\Constraints\ExpressionValidator
+        </parameter>
         <parameter key="validator.email.class">Symfony\Component\Validator\Constraints\EmailValidator</parameter>
     </parameters>
 
     <services>
         <service id="validator" class="%validator.class%">
-            <factory service="validator.builder" method="getValidator" />
+            <factory service="validator.builder" method="getValidator"/>
         </service>
 
         <service id="validator.builder" class="%validator.builder.class%">
-            <factory class="%validator.builder.factory.class%" method="createValidatorBuilder" />
+            <factory class="%validator.builder.factory.class%" method="createValidatorBuilder"/>
             <call method="setConstraintValidatorFactory">
-                <argument type="service" id="validator.validator_factory" />
+                <argument type="service" id="validator.validator_factory"/>
             </call>
             <call method="setTranslator">
-                <argument type="service" id="translator" />
+                <argument type="service" id="translator"/>
             </call>
             <call method="setTranslationDomain">
                 <argument>%validator.translation_domain%</argument>
             </call>
         </service>
 
-        <service id="validator.mapping.class_metadata_factory" alias="validator" public="false" />
+        <service id="validator.mapping.class_metadata_factory" alias="validator" public="false"/>
 
         <service id="validator.mapping.cache.apc" class="%validator.mapping.cache.apc.class%" public="false">
             <argument>%validator.mapping.cache.prefix%</argument>
         </service>
 
-        <service id="validator.mapping.cache.doctrine.apc" class="Symfony\Component\Validator\Mapping\Cache\DoctrineCache" public="false">
+        <service id="validator.mapping.cache.doctrine.apc"
+                 class="Symfony\Component\Validator\Mapping\Cache\DoctrineCache" public="false">
             <argument type="service">
                 <service class="Doctrine\Common\Cache\ApcCache">
                     <call method="setNamespace">
@@ -51,18 +56,24 @@
         </service>
 
         <service id="validator.validator_factory" class="%validator.validator_factory.class%" public="false">
-            <argument type="service" id="service_container" />
-            <argument type="collection" />
+            <argument type="service" id="service_container"/>
+            <argument type="collection"/>
         </service>
 
         <service id="validator.expression" class="%validator.expression.class%">
-            <argument type="service" id="property_accessor" />
-            <tag name="validator.constraint_validator" alias="validator.expression" />
+            <argument type="service" id="property_accessor"/>
+            <tag name="validator.constraint_validator" alias="validator.expression"/>
         </service>
 
         <service id="validator.email" class="%validator.email.class%">
+            <argument type="service" id="request_stack" />
+
+        <service id="validator.l18n" class="Symfony\Component\Validator\Constraints\L18nValidator">
+            <argument type="service" id="request_stack" />
+            <tag name="validator.constraint_validator" alias="validator.l18n" />
+        </service>
             <argument></argument>
-            <tag name="validator.constraint_validator" alias="Symfony\Component\Validator\Constraints\EmailValidator" />
+            <tag name="validator.constraint_validator" alias="Symfony\Component\Validator\Constraints\EmailValidator"/>
         </service>
     </services>
 </container>

--- a/src/Symfony/Component/Validator/ConstraintValidatorFactory.php
+++ b/src/Symfony/Component/Validator/ConstraintValidatorFactory.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator;
 
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Validator\Constraints\ExpressionValidator;
 use Symfony\Component\Validator\Constraints\L18nValidator;
 
@@ -29,6 +30,9 @@ class ConstraintValidatorFactory implements ConstraintValidatorFactoryInterface
 
     private $propertyAccessor;
 
+    /**
+     * @var RequestStack
+     */
     private $requestStack;
 
     public function __construct($propertyAccessor = null, $requestStack = null)

--- a/src/Symfony/Component/Validator/ConstraintValidatorFactory.php
+++ b/src/Symfony/Component/Validator/ConstraintValidatorFactory.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator;
 
 use Symfony\Component\Validator\Constraints\ExpressionValidator;
+use Symfony\Component\Validator\Constraints\L18nValidator;
 
 /**
  * Default implementation of the ConstraintValidatorFactoryInterface.
@@ -28,9 +29,12 @@ class ConstraintValidatorFactory implements ConstraintValidatorFactoryInterface
 
     private $propertyAccessor;
 
-    public function __construct($propertyAccessor = null)
+    private $requestStack;
+
+    public function __construct($propertyAccessor = null, $requestStack = null)
     {
         $this->propertyAccessor = $propertyAccessor;
+        $this->requestStack = $requestStack;
     }
 
     /**
@@ -41,9 +45,17 @@ class ConstraintValidatorFactory implements ConstraintValidatorFactoryInterface
         $className = $constraint->validatedBy();
 
         if (!isset($this->validators[$className])) {
-            $this->validators[$className] = 'validator.expression' === $className
-                ? new ExpressionValidator($this->propertyAccessor)
-                : new $className();
+            switch ($className) {
+                case 'validator.expression':
+                    $this->validators[$className] = new ExpressionValidator($this->propertyAccessor);
+                    break;
+                case 'validator.l18n':
+                    $this->validators[$className] = new L18nValidator($this->requestStack);
+                    break;
+                default:
+                    $this->validators[$className] = new $className();
+                    break;
+            }
         }
 
         return $this->validators[$className];

--- a/src/Symfony/Component/Validator/Constraints/L18n.php
+++ b/src/Symfony/Component/Validator/Constraints/L18n.php
@@ -28,7 +28,7 @@ class L18n extends Constraint
     public $constraint;
 
     /**
-     * @var string $locale
+     * @var string
      */
     private $locale;
 
@@ -68,5 +68,4 @@ class L18n extends Constraint
     {
         return 'validator.l18n';
     }
-
 }

--- a/src/Symfony/Component/Validator/Constraints/L18n.php
+++ b/src/Symfony/Component/Validator/Constraints/L18n.php
@@ -22,10 +22,7 @@ use Symfony\Component\Validator\Exception\MissingOptionsException;
  */
 class L18n extends Constraint
 {
-    /**
-     * @var Constraint
-     */
-    public $constraint;
+    public $constraints = array();
 
     /**
      * @var string
@@ -42,7 +39,23 @@ class L18n extends Constraint
         }
 
         $this->locale = $options['locale'];
-        $this->constraint = $options['value'];
+        $this->constraints = $options['constraints'];
+    }
+
+    /**
+     * @return string
+     */
+    public function getDefaultOption()
+    {
+        return 'constraints';
+    }
+
+    /**
+     * @return array
+     */
+    public function getRequiredOptions()
+    {
+        return array('constraints');
     }
 
     /**
@@ -54,18 +67,19 @@ class L18n extends Constraint
     }
 
     /**
-     * @return Constraint
-     */
-    public function getConstraint()
-    {
-        return $this->constraint;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function validatedBy()
     {
         return 'validator.l18n';
     }
+
+    /**
+     * @return string
+     */
+    protected function getCompositeOption()
+    {
+        return 'constraints';
+    }
+
 }

--- a/src/Symfony/Component/Validator/Constraints/L18n.php
+++ b/src/Symfony/Component/Validator/Constraints/L18n.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\MissingOptionsException;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY", "CLASS", "ANNOTATION"})
+ *
+ * @author Michael Hindley <mikael.chojnacki@gmail.com>
+ */
+class L18n extends Constraint
+{
+    /**
+     * @var Constraint
+     */
+    public $constraint;
+
+    /**
+     * @var string $locale
+     */
+    private $locale;
+
+    /**
+     * @param null $options
+     */
+    public function __construct($options = null)
+    {
+        if (!$options['locale']) {
+            throw new MissingOptionsException('Locale is missing');
+        }
+
+        $this->locale = $options['locale'];
+        $this->constraint = $options['value'];
+    }
+
+    /**
+     * @return string
+     */
+    public function getLocale()
+    {
+        return $this->locale;
+    }
+
+    /**
+     * @return Constraint
+     */
+    public function getConstraint()
+    {
+        return $this->constraint;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validatedBy()
+    {
+        return 'validator.l18n';
+    }
+
+}

--- a/src/Symfony/Component/Validator/Constraints/L18nValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/L18nValidator.php
@@ -35,7 +35,7 @@ class L18nValidator extends ConstraintValidator
     }
 
     /**
-     * @param mixed $value
+     * @param mixed      $value
      * @param Constraint $constraint
      */
     public function validate($value, Constraint $constraint)

--- a/src/Symfony/Component/Validator/Constraints/L18nValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/L18nValidator.php
@@ -15,9 +15,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
-use Symfony\Component\Validator\Exception\InvalidArgumentException;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
-use Symfony\Component\Validator\Validator;
 
 /**
  * @author Michael Hindley <mikael.chojnacki@gmail.com>
@@ -38,7 +36,7 @@ class L18nValidator extends ConstraintValidator
     }
 
     /**
-     * @param mixed $value
+     * @param mixed      $value
      * @param Constraint $constraint
      */
     public function validate($value, Constraint $constraint)
@@ -49,7 +47,7 @@ class L18nValidator extends ConstraintValidator
         }
 
         if (!$constraint instanceof L18n) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__ . '\L18n');
+            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\L18n');
         }
 
         if (null === $value) {
@@ -66,12 +64,12 @@ class L18nValidator extends ConstraintValidator
             $validator = $context->getValidator()->inContext($context);
 
             foreach ($value as $key => $element) {
-                $validator->atPath('[' . $key . ']')->validate($element, $constraint->constraints);
+                $validator->atPath('['.$key.']')->validate($element, $constraint->constraints);
             }
         } else {
             // 2.4 API
             foreach ($value as $key => $element) {
-                $context->validateValue($element, $constraint->constraints, '[' . $key . ']');
+                $context->validateValue($element, $constraint->constraints, '['.$key.']');
             }
         }
     }

--- a/src/Symfony/Component/Validator/Constraints/L18nValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/L18nValidator.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\InvalidArgumentException;
+
+/**
+ * @author Michael Hindley <mikael.chojnacki@gmail.com>
+ */
+class L18nValidator extends ConstraintValidator
+{
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @param RequestStack $requestStack
+     */
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    /**
+     * @param mixed $value
+     * @param Constraint $constraint
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        // Check that the locale is matching, else ignore this constraint
+        if ($this->requestStack->getCurrentRequest()->getLocale() !== $constraint->getLocale()) {
+            return;
+        }
+        // Every constraint has a validatedBy method which determines the validator
+        $validatorClass = $constraint->getConstraint()->validatedBy();
+
+        // Expression needs dependencies in it's constructor
+        if ($validatorClass === Expression::class) {
+            throw new InvalidArgumentException(
+                sprintf('%s is not supported by the %s', Expression::class, this::class)
+            );
+        }
+
+        // Instantiate the validator class and init it providing the same context
+        $validator = new $validatorClass();
+        $validator->initialize($this->context);
+        $validator->validate($value, $constraint->getConstraint());
+    }
+
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/L18nValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/L18nValidatorTest.php
@@ -65,7 +65,7 @@ class L18nValidatorTest extends AbstractConstraintValidatorTest
         $i = 0;
 
         foreach ($array as $key => $value) {
-            $this->expectValidateValueAt($i++, '[' . $key . ']', $value, array($constraint));
+            $this->expectValidateValueAt($i++, '['.$key.']', $value, array($constraint));
         }
 
         $this->validator->validate($array, new L18n(array('locale' => 'en', 'constraints' => array($constraint))));
@@ -86,7 +86,7 @@ class L18nValidatorTest extends AbstractConstraintValidatorTest
         $i = 0;
 
         foreach ($array as $key => $value) {
-            $this->expectValidateValueAt($i++, '[' . $key . ']', $value, array($constraint1, $constraint2));
+            $this->expectValidateValueAt($i++, '['.$key.']', $value, array($constraint1, $constraint2));
         }
 
         $this->validator->validate($array, new L18n(array('locale' => 'en', 'constraints' => $constraints)));

--- a/src/Symfony/Component/Validator/Tests/Constraints/L18nValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/L18nValidatorTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\L18n;
+use Symfony\Component\Validator\Constraints\L18nValidator;
+use Symfony\Component\Validator\ConstraintValidator;
+
+class L18nValidatorTest extends AbstractConstraintValidatorTest
+{
+    /**
+     * @param string $locale
+     *
+     * @return L18nValidator
+     */
+    protected function createValidator($locale = 'en')
+    {
+        $request = new Request();
+        $request->setLocale($locale);
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $validator = new L18nValidator($requestStack);
+
+        return $validator;
+    }
+
+    public function testNoViolationsAreCreated()
+    {
+        $fakeValidator = new DontAddViolationValidator();
+
+        $mockConstraint = $this->getMock('Symfony\Component\Validator\Constraint');
+        $mockConstraint->method('validatedBy')->willReturn(
+            get_class($fakeValidator)
+        );
+
+        $validator = $this->createValidator();
+        $validator->initialize($this->context);
+
+        $validator->validate(
+            null,
+            new L18n(
+                array('locale' => 'en', 'value' => $mockConstraint)
+            )
+        );
+
+        $this->assertCount(0, $this->context->getViolations());
+    }
+
+    public function testNoViolationIsCreatedForDifferentLocale()
+    {
+        $fakeValidator = new AddViolationValidator();
+
+        $mockConstraint = $this->getMock('Symfony\Component\Validator\Constraint');
+        $mockConstraint->method('validatedBy')->willReturn(
+            get_class($fakeValidator)
+        );
+
+        $validator = $this->createValidator();
+        $validator->initialize($this->context);
+
+        $validator->validate(
+            null,
+            new L18n(
+                array('locale' => 'sv', 'value' => $mockConstraint)
+            )
+        );
+
+        $this->assertCount(0, $this->context->getViolations());
+    }
+
+    public function testViolationIsCreated()
+    {
+        $fakeValidator = new AddViolationValidator();
+
+        $mockConstraint = $this->getMock('Symfony\Component\Validator\Constraint');
+        $mockConstraint->method('validatedBy')->willReturn(
+            get_class($fakeValidator)
+        );
+
+        $validator = $this->createValidator();
+        $validator->initialize($this->context);
+
+        $validator->validate(
+            null,
+            new L18n(
+                array('locale' => 'en', 'value' => $mockConstraint)
+            )
+        );
+
+        $this->assertCount(1, $this->context->getViolations());
+    }
+
+}
+
+class AddViolationValidator extends ConstraintValidator
+{
+    public function validate($value, Constraint $constraint)
+    {
+        $this->context->addViolation('');
+    }
+}
+
+class DontAddViolationValidator extends ConstraintValidator
+{
+    public function validate($value, Constraint $constraint){}
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | no |
| License | MIT |
| Doc PR | no |
## HackDay PR
## Feature

Wrapping assertions based on locale in the currentRequest.
## Use Case

Helpful when asserting the same property in a different manner based on locale, for example when making an api that is consumed in several countries.

The assertion is only fired if the locale matches the locale in the currentRequest from the RequestStack.

![image](https://cloud.githubusercontent.com/assets/1016639/11608094/6bdf2a0c-9b60-11e5-9be0-e3d890554051.png)
