### PR TITLE
[2.8] Deprecate the correct APC cache service

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
@@ -36,6 +36,8 @@
         <service id="validator.mapping.class_metadata_factory" alias="validator" public="false" />
 
         <service id="validator.mapping.cache.apc" class="%validator.mapping.cache.apc.class%" public="false">
+            <deprecated>The "%service_id%" service is deprecated since Symfony 2.5 and will be removed in 3.0. Use the "validator.mapping.cache.doctrine.apc" service instead.</deprecated>
+
             <argument>%validator.mapping.cache.prefix%</argument>
         </service>
 
@@ -47,7 +49,6 @@
                     </call>
                 </service>
             </argument>
-            <deprecated>The "%service_id%" service is deprecated since Symfony 2.8 and will be removed in 3.0.</deprecated>
         </service>
 
         <service id="validator.validator_factory" class="%validator.validator_factory.class%" public="false">


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | http://stackoverflow.com/q/34107796/1149495 |
| License | MIT |
| Doc PR | - |

The new service was marked as deprecated instead of the old one, this PR fixes that.
