### PR TITLE
[3.0] Revert removal of correct APC cache service & remove deprecated one

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
@@ -28,8 +28,14 @@
 
         <service id="validator.mapping.class_metadata_factory" alias="validator" public="false" />
 
-        <service id="validator.mapping.cache.apc" class="Symfony\Component\Validator\Mapping\Cache\ApcCache" public="false">
-            <argument>%validator.mapping.cache.prefix%</argument>
+        <service id="validator.mapping.cache.doctrine.apc" class="Symfony\Component\Validator\Mapping\Cache\DoctrineCache" public="false">
+            <argument type="service">
+                <service class="Doctrine\Common\Cache\ApcCache">
+                    <call method="setNamespace">
+                        <argument>%validator.mapping.cache.prefix%</argument>
+                    </call>
+                </service>
+            </argument>
         </service>
 
         <service id="validator.validator_factory" class="Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory" public="false">


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | http://stackoverflow.com/q/34107796/1149495 |
| License | MIT |
| Doc PR | - |

See also https://github.com/symfony/symfony/pull/16865
