### PR TITLE
[3.0][FrameworkBundle] Expose global Resources/public directory to the assets:install command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
@@ -111,29 +111,48 @@ EOT
         $rows = array();
         $copyUsed = false;
         $exitCode = 0;
-        /** @var BundleInterface $bundle */
-        foreach ($this->getContainer()->get('kernel')->getBundles() as $bundle) {
-            if (!is_dir($originDir = $bundle->getPath().'/Resources/public')) {
+
+        $kernel = $this->getContainer()->get('kernel');
+        $pubFolders = array_merge(
+            [
+                'app assets' => [
+                    'name' => 'app assets',
+                    'originDir' => $kernel->getRootDir().'/Resources/public',
+                    'targetDir' => $targetArg.'/assets',
+                ],
+            ],
+            array_map(
+                function (BundleInterface $bundle) use ($bundlesDir) {
+                    return [
+                        'name' => $bundle->getName(),
+                        'originDir' => $bundle->getPath().'/Resources/public',
+                        'targetDir' => $bundlesDir.preg_replace('/bundle$/', '', strtolower($bundle->getName())),
+                    ];
+                },
+                $kernel->getBundles()
+            )
+        );
+
+        foreach ($pubFolders as $pubFolder) {
+            if (!is_dir($pubFolder['originDir'])) {
                 continue;
             }
 
-            $targetDir = $bundlesDir.preg_replace('/bundle$/', '', strtolower($bundle->getName()));
-
             if (OutputInterface::VERBOSITY_VERBOSE <= $output->getVerbosity()) {
-                $message = sprintf("%s\n-> %s", $bundle->getName(), $targetDir);
+                $message = sprintf("%s\n-> %s", $pubFolder['name'], $pubFolder['targetDir']);
             } else {
-                $message = $bundle->getName();
+                $message = $pubFolder['name'];
             }
 
             try {
-                $this->filesystem->remove($targetDir);
+                $this->filesystem->remove($pubFolder['targetDir']);
 
                 if (self::METHOD_RELATIVE_SYMLINK === $expectedMethod) {
-                    $method = $this->relativeSymlinkWithFallback($originDir, $targetDir);
+                    $method = $this->relativeSymlinkWithFallback($pubFolder['originDir'], $pubFolder['targetDir']);
                 } elseif (self::METHOD_ABSOLUTE_SYMLINK === $expectedMethod) {
-                    $method = $this->absoluteSymlinkWithFallback($originDir, $targetDir);
+                    $method = $this->absoluteSymlinkWithFallback($pubFolder['originDir'], $pubFolder['targetDir']);
                 } else {
-                    $method = $this->hardCopy($originDir, $targetDir);
+                    $method = $this->hardCopy($pubFolder['originDir'], $pubFolder['targetDir']);
                 }
 
                 if (self::METHOD_COPY === $method) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | None |
| License | MIT |
| Doc PR | None |

**Description**
This PR refactors the AssetsInstallCommand so as to treat the global `app/Resources/public` directory exactly the same as the rest of `Resources/public` directories from the registered bundles, thus giving the developer the option to store the application assets in a centralized location outside the `web` directory.

Assets stored in the `app/Resources/public` directory can now be passed as arguments to the `assets` function or inside `javascripts/stylesheets` blocks (i.e. can be fully managed with Assetic), and they are installed in the `web/assets` directory (to avoid potential name conflicts with the bundles).

**Examples**

Hard copies:

```
$ bin/console assets:install

 Installing assets as hard copies.

 --- ----------------- ---------------- 
      Bundle            Method / Error  
 --- ----------------- ---------------- 
  ✔   app assets        copy            
  ✔   FrameworkBundle   copy            
 --- ----------------- ---------------- 

 ! [NOTE] Some assets were installed via copy. If you make changes to these assets you have to run this command again.

 [OK] All assets were successfully installed.

$ tree web/

web/
├── app_dev.php
├── apple-touch-icon.png
├── app.php
├── assets
│   ├── css
│   │   ├── bootstrap.css
│   │   └── bootstrap-theme.css
│   └── js
│       ├── bootstrap.js
│       └── jquery.js
├── bundles
│   └── framework
│       ├── css
│       │   ├── body.css
│       │   ├── exception.css
│       │   └── structure.css
│       └── images
│           ├── blue_picto_less.gif
│           ├── blue_picto_more.gif
│           ├── grey_magnifier.png
│           └── logo_symfony.png
├── config.php
├── favicon.ico
└── robots.txt
```

Absolute symlinks:

```
$ bin/console assets:install --symlink

 Trying to install assets as absolute symbolic links.

 --- ----------------- ------------------ 
      Bundle            Method / Error    
 --- ----------------- ------------------ 
  ✔   app assets        absolute symlink  
  ✔   FrameworkBundle   absolute symlink  
 --- ----------------- ------------------ 


 [OK] All assets were successfully installed.                                                          

$ tree web

web/
├── app_dev.php
├── apple-touch-icon.png
├── app.php
├── assets -> /var/workspace/project/app/Resources/public
├── bundles
│   └── framework -> /var/workspace/project/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Resources/public
├── config.php
├── favicon.ico
└── robots.txt
```

Relative symlinks:

```
$ bin/console assets:install --symlink --relative

 Trying to install assets as relative symbolic links.

 --- ----------------- ------------------ 
      Bundle            Method / Error    
 --- ----------------- ------------------ 
  ✔   app assets        relative symlink  
  ✔   FrameworkBundle   relative symlink  
 --- ----------------- ------------------ 


 [OK] All assets were successfully installed.

$ tree web

web/
├── app_dev.php
├── apple-touch-icon.png
├── app.php
├── assets -> ../app/Resources/public/
├── bundles
│   └── framework -> ../../vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Resources/public/
├── config.php
├── favicon.ico
└── robots.txt


```
