### PR TITLE
[FrameworkBundle] Disable the server:run command when Process component is missing

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
@@ -34,6 +34,10 @@ class ServerRunCommand extends ContainerAwareCommand
             return false;
         }
 
+        if (!class_exists('Symfony\Component\Process\Process')) {
+            return false;
+        }
+
         return parent::isEnabled();
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -48,7 +48,8 @@
         "symfony/finder": "For using the translation loader and cache warmer",
         "symfony/form": "For using forms",
         "symfony/validator": "For using validation",
-        "symfony/serializer": "For using the serializer service"
+        "symfony/serializer": "For using the serializer service",
+        "symfony/process": "For using the server:run command"
     },
     "autoload": {
         "psr-0": { "Symfony\\Bundle\\FrameworkBundle\\": "" },


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This also backports the improvement for the `suggest` section from #16650 to the `2.3` branch.
