### PR TITLE
[FrameworkBundle] Disable built-in server commands when Process component is missing

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerCommand.php
@@ -27,6 +27,10 @@ abstract class ServerCommand extends ContainerAwareCommand
             return false;
         }
 
+        if (!class_exists('Symfony\Component\Process\Process')) {
+            return false;
+        }
+
         return parent::isEnabled();
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
@@ -28,18 +28,6 @@ class ServerRunCommand extends ServerCommand
     /**
      * {@inheritdoc}
      */
-    public function isEnabled()
-    {
-        if (PHP_VERSION_ID < 50400 || defined('HHVM_VERSION')) {
-            return false;
-        }
-
-        return parent::isEnabled();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     protected function configure()
     {
         $this

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -55,7 +55,7 @@
         "symfony/validator": "For using validation",
         "symfony/yaml": "For using the debug:config and lint:yaml commands",
         "doctrine/cache": "For using alternative cache drivers",
-        "symfony/process": "For using the server:run command"
+        "symfony/process": "For using the server:run, server:start, server:stop, and server:status commands"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bundle\\FrameworkBundle\\": "" },

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -54,7 +54,8 @@
         "symfony/serializer": "For using the serializer service",
         "symfony/validator": "For using validation",
         "symfony/yaml": "For using the debug:config and lint:yaml commands",
-        "doctrine/cache": "For using alternative cache drivers"
+        "doctrine/cache": "For using alternative cache drivers",
+        "symfony/process": "For using the server:run command"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bundle\\FrameworkBundle\\": "" },


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This also backports the improvement for the `suggest` section from #16650 to the `2.7` branch and improves it by also mentioning the other built-in server commands.
