### PR TITLE
[Process] Always call proc_close

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -157,16 +157,7 @@ class Process
 
     public function __destruct()
     {
-        if ($this->isRunning()) {
-            $this->doSignal(15, false);
-            usleep(10000);
-        }
-        if ($this->isRunning()) {
-            usleep(100000);
-            $this->doSignal(9, false);
-        }
-
-        // Don't call ->stop() nor ->close() since we don't want to wait for the subprocess here
+        $this->stop(0);
     }
 
     public function __clone()

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -709,26 +709,23 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
      */
     public function testCheckTimeoutOnStartedProcess()
     {
-        $timeout = 0.5;
-        $precision = 100000;
         $process = $this->getProcess(self::$phpBin.' -r "sleep(3);"');
-        $process->setTimeout($timeout);
-        $start = microtime(true);
+        $process->setTimeout(0.5);
 
         $process->start();
+        $start = microtime(true);
 
         try {
             while ($process->isRunning()) {
                 $process->checkTimeout();
-                usleep($precision);
+                usleep(100000);
             }
             $this->fail('A RuntimeException should have been raised');
         } catch (RuntimeException $e) {
         }
         $duration = microtime(true) - $start;
 
-        $this->assertLessThan($timeout + $precision, $duration);
-        $this->assertFalse($process->isSuccessful());
+        $this->assertLessThan(1, $duration);
 
         throw $e;
     }

--- a/src/Symfony/Component/Process/Tests/SigchildDisabledProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/SigchildDisabledProcessTest.php
@@ -85,13 +85,9 @@ class SigchildDisabledProcessTest extends AbstractProcessTest
         parent::testProcessWithoutTermSignal();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Process\Exception\RuntimeException
-     * @expectedExceptionMessage This PHP has been compiled with --enable-sigchild. You must use setEnhanceSigchildCompatibility() to use this method.
-     */
     public function testCheckTimeoutOnStartedProcess()
     {
-        parent::testCheckTimeoutOnStartedProcess();
+        $this->markTestSkipped('Stopping with signal is not supported in sigchild environment');
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15617 |
| License | MIT |
| Doc PR | - |

This should fix one more transient test, and a wrong behavior.
