### PR TITLE
Improved the code of the commands that use the new SymfonyStyle class

### DIFF
--- a/src/Symfony/Bridge/Twig/Command/DebugCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/DebugCommand.php
@@ -83,11 +83,11 @@ EOF
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $output = new SymfonyStyle($input, $output);
+        $io = new SymfonyStyle($input, $output);
         $twig = $this->getTwigEnvironment();
 
         if (null === $twig) {
-            $output->error('The Twig environment needs to be set.');
+            $io->error('The Twig environment needs to be set.');
 
             return 1;
         }
@@ -102,7 +102,7 @@ EOF
                 }
             }
             $data['tests'] = array_keys($data['tests']);
-            $output->writeln(json_encode($data));
+            $io->writeln(json_encode($data));
 
             return 0;
         }
@@ -121,10 +121,10 @@ EOF
                 continue;
             }
 
-            $output->section(ucfirst($type));
+            $io->section(ucfirst($type));
 
             ksort($items);
-            $output->listing($items);
+            $io->listing($items);
         }
 
         return 0;

--- a/src/Symfony/Bridge/Twig/Command/LintCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/LintCommand.php
@@ -85,17 +85,14 @@ EOF
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $stdout = $output;
-        $output = new SymfonyStyle($input, $output);
+        $io = new SymfonyStyle($input, $output);
 
         if (false !== strpos($input->getFirstArgument(), ':l')) {
-            $output->caution('The use of "twig:lint" command is deprecated since version 2.7 and will be removed in 3.0. Use the "lint:twig" instead.');
+            $io->caution('The use of "twig:lint" command is deprecated since version 2.7 and will be removed in 3.0. Use the "lint:twig" instead.');
         }
 
-        $twig = $this->getTwigEnvironment();
-
-        if (null === $twig) {
-            $output->error('The Twig environment needs to be set.');
+        if (null === $twig = $this->getTwigEnvironment()) {
+            $io->error('The Twig environment needs to be set.');
 
             return 1;
         }
@@ -112,12 +109,12 @@ EOF
                 $template .= fread(STDIN, 1024);
             }
 
-            return $this->display($input, $stdout, $output, array($this->validate($twig, $template, uniqid('sf_'))));
+            return $this->display($input, $output, $io, array($this->validate($twig, $template, uniqid('sf_'))));
         }
 
         $filesInfo = $this->getFilesInfo($twig, $filenames);
 
-        return $this->display($input, $stdout, $output, $filesInfo);
+        return $this->display($input, $output, $io, $filesInfo);
     }
 
     private function getFilesInfo(\Twig_Environment $twig, array $filenames)
@@ -161,35 +158,35 @@ EOF
         return array('template' => $template, 'file' => $file, 'valid' => true);
     }
 
-    private function display(InputInterface $input, OutputInterface $stdout, $output, $files)
+    private function display(InputInterface $input, OutputInterface $output, StyleInterface $io, $files)
     {
         switch ($input->getOption('format')) {
             case 'txt':
-                return $this->displayTxt($stdout, $output, $files);
+                return $this->displayTxt($output, $io, $files);
             case 'json':
-                return $this->displayJson($stdout, $files);
+                return $this->displayJson($output, $files);
             default:
                 throw new \InvalidArgumentException(sprintf('The format "%s" is not supported.', $input->getOption('format')));
         }
     }
 
-    private function displayTxt(OutputInterface $stdout, $output, $filesInfo)
+    private function displayTxt(OutputInterface $output, StyleInterface $io, $filesInfo)
     {
         $errors = 0;
 
         foreach ($filesInfo as $info) {
-            if ($info['valid'] && $stdout->isVerbose()) {
-                $output->comment('<info>OK</info>'.($info['file'] ? sprintf(' in %s', $info['file']) : ''));
+            if ($info['valid'] && $output->isVerbose()) {
+                $io->comment('<info>OK</info>'.($info['file'] ? sprintf(' in %s', $info['file']) : ''));
             } elseif (!$info['valid']) {
                 ++$errors;
-                $this->renderException($output, $info['template'], $info['exception'], $info['file']);
+                $this->renderException($io, $info['template'], $info['exception'], $info['file']);
             }
         }
 
         if ($errors === 0) {
-            $output->success(sprintf('All %d Twig files contain valid syntax.', count($filesInfo)));
+            $io->success(sprintf('All %d Twig files contain valid syntax.', count($filesInfo)));
         } else {
-            $output->warning(sprintf('%d Twig files have valid syntax and %d contain errors.', count($filesInfo) - $errors, $errors));
+            $io->warning(sprintf('%d Twig files have valid syntax and %d contain errors.', count($filesInfo) - $errors, $errors));
         }
 
         return min($errors, 1);

--- a/src/Symfony/Bridge/Twig/Command/LintCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/LintCommand.php
@@ -158,7 +158,7 @@ EOF
         return array('template' => $template, 'file' => $file, 'valid' => true);
     }
 
-    private function display(InputInterface $input, OutputInterface $output, StyleInterface $io, $files)
+    private function display(InputInterface $input, OutputInterface $output, SymfonyStyle $io, $files)
     {
         switch ($input->getOption('format')) {
             case 'txt':
@@ -170,7 +170,7 @@ EOF
         }
     }
 
-    private function displayTxt(OutputInterface $output, StyleInterface $io, $filesInfo)
+    private function displayTxt(OutputInterface $output, SymfonyStyle $io, $filesInfo)
     {
         $errors = 0;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -110,7 +110,7 @@ EOF
             $io->comment('Finished');
         }
 
-        $output->success(sprintf('Cache for the "%s" environment (debug=%s) was successfully cleared.', $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
+        $io->success(sprintf('Cache for the "%s" environment (debug=%s) was successfully cleared.', $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -55,7 +55,7 @@ EOF
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $outputIsVerbose = $output->isVerbose();
-        $output = new SymfonyStyle($input, $output);
+        $io = new SymfonyStyle($input, $output);
 
         $realCacheDir = $this->getContainer()->getParameter('kernel.cache_dir');
         $oldCacheDir = $realCacheDir.'_old';
@@ -70,7 +70,7 @@ EOF
         }
 
         $kernel = $this->getContainer()->get('kernel');
-        $output->comment(sprintf('Clearing the cache for the <info>%s</info> environment with debug <info>%s</info>', $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
+        $io->comment(sprintf('Clearing the cache for the <info>%s</info> environment with debug <info>%s</info>', $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
         $this->getContainer()->get('cache_clearer')->clear($realCacheDir);
 
         if ($input->getOption('no-warmup')) {
@@ -83,13 +83,13 @@ EOF
 
             if ($filesystem->exists($warmupDir)) {
                 if ($outputIsVerbose) {
-                    $output->comment('Clearing outdated warmup directory...');
+                    $io->comment('Clearing outdated warmup directory...');
                 }
                 $filesystem->remove($warmupDir);
             }
 
             if ($outputIsVerbose) {
-                $output->comment('Warming up cache...');
+                $io->comment('Warming up cache...');
             }
             $this->warmup($warmupDir, $realCacheDir, !$input->getOption('no-optional-warmers'));
 
@@ -101,13 +101,13 @@ EOF
         }
 
         if ($outputIsVerbose) {
-            $output->comment('Removing old cache directory...');
+            $io->comment('Removing old cache directory...');
         }
 
         $filesystem->remove($oldCacheDir);
 
         if ($outputIsVerbose) {
-            $output->comment('Finished');
+            $io->comment('Finished');
         }
 
         $output->success(sprintf('Cache for the "%s" environment (debug=%s) was successfully cleared.', $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheWarmupCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheWarmupCommand.php
@@ -54,10 +54,10 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $output = new SymfonyStyle($input, $output);
+        $io = new SymfonyStyle($input, $output);
 
         $kernel = $this->getContainer()->get('kernel');
-        $output->comment(sprintf('Warming up the cache for the <info>%s</info> environment with debug <info>%s</info>', $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
+        $io->comment(sprintf('Warming up the cache for the <info>%s</info> environment with debug <info>%s</info>', $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
 
         $warmer = $this->getContainer()->get('cache_warmer');
 
@@ -67,6 +67,6 @@ EOF
 
         $warmer->warmUp($this->getContainer()->getParameter('kernel.cache_dir'));
 
-        $output->success(sprintf('Cache for the "%s" environment (debug=%s) was successfully warmed.', $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
+        $io->success(sprintf('Cache for the "%s" environment (debug=%s) was successfully warmed.', $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
@@ -58,16 +58,16 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $output = new SymfonyStyle($input, $output);
+        $io = new SymfonyStyle($input, $output);
         if (false !== strpos($input->getFirstArgument(), ':d')) {
-            $output->caution('The use of "config:debug" command is deprecated since version 2.7 and will be removed in 3.0. Use the "debug:config" instead.');
+            $io->caution('The use of "config:debug" command is deprecated since version 2.7 and will be removed in 3.0. Use the "debug:config" instead.');
         }
 
         $name = $input->getArgument('name');
 
         if (empty($name)) {
-            $output->comment('Provide the name of a bundle as the first argument of this command to dump its configuration.');
-            $output->newLine();
+            $io->comment('Provide the name of a bundle as the first argument of this command to dump its configuration.');
+            $io->newLine();
             $this->listBundles($output);
 
             return;
@@ -87,12 +87,12 @@ EOF
         $config = $processor->processConfiguration($configuration, $configs);
 
         if ($name === $extension->getAlias()) {
-            $output->title(sprintf('Current configuration for extension with alias "%s"', $name));
+            $io->title(sprintf('Current configuration for extension with alias "%s"', $name));
         } else {
-            $output->title(sprintf('Current configuration for "%s"', $name));
+            $io->title(sprintf('Current configuration for "%s"', $name));
         }
 
-        $output->writeln(Yaml::dump(array($extension->getAlias() => $config), 3));
+        $io->writeln(Yaml::dump(array($extension->getAlias() => $config), 3));
     }
 
     private function compileContainer()

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
@@ -67,12 +67,12 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $output = new SymfonyStyle($input, $output);
+        $io = new SymfonyStyle($input, $output);
         $name = $input->getArgument('name');
 
         if (empty($name)) {
-            $output->comment('Provide the name of a bundle as the first argument of this command to dump its default configuration.');
-            $output->newLine();
+            $io->comment('Provide the name of a bundle as the first argument of this command to dump its default configuration.');
+            $io->newLine();
             $this->listBundles($output);
 
             return;
@@ -92,18 +92,18 @@ EOF
 
         switch ($input->getOption('format')) {
             case 'yaml':
-                $output->writeln(sprintf('# %s', $message));
+                $io->writeln(sprintf('# %s', $message));
                 $dumper = new YamlReferenceDumper();
                 break;
             case 'xml':
-                $output->writeln(sprintf('<!-- %s -->', $message));
+                $io->writeln(sprintf('<!-- %s -->', $message));
                 $dumper = new XmlReferenceDumper();
                 break;
             default:
-                $output->writeln($message);
+                $io->writeln($message);
                 throw new \InvalidArgumentException('Only the yaml and xml formats are supported.');
         }
 
-        $output->writeln($dumper->dump($configuration, $extension->getNamespace()));
+        $io->writeln($dumper->dump($configuration, $extension->getNamespace()));
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -94,9 +94,9 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $output = new SymfonyStyle($input, $output);
+        $io = new SymfonyStyle($input, $output);
         if (false !== strpos($input->getFirstArgument(), ':d')) {
-            $output->caution('The use of "container:debug" command is deprecated since version 2.7 and will be removed in 3.0. Use the "debug:container" instead.');
+            $io->caution('The use of "container:debug" command is deprecated since version 2.7 and will be removed in 3.0. Use the "debug:container" instead.');
         }
 
         $this->validateInput($input);
@@ -129,7 +129,7 @@ EOF
         $helper->describe($output, $object, $options);
 
         if (!$input->getArgument('name') && $input->isInteractive()) {
-            $output->comment('To search for a specific service, re-run this command with a search term. (e.g. <comment>debug:container log</comment>)');
+            $io->comment('To search for a specific service, re-run this command with a search term. (e.g. <comment>debug:container log</comment>)');
         }
     }
 
@@ -188,7 +188,7 @@ EOF
         return $this->containerBuilder = $container;
     }
 
-    private function findProperServiceName(InputInterface $input, SymfonyStyle $output, ContainerBuilder $builder, $name)
+    private function findProperServiceName(InputInterface $input, SymfonyStyle $io, ContainerBuilder $builder, $name)
     {
         if ($builder->has($name) || !$input->isInteractive()) {
             return $name;
@@ -199,7 +199,7 @@ EOF
             throw new \InvalidArgumentException(sprintf('No services found that match "%s".', $name));
         }
 
-        return $output->choice('Select one of the following services to display its information', $matchingServices);
+        return $io->choice('Select one of the following services to display its information', $matchingServices);
     }
 
     private function findServiceIdsContaining(ContainerBuilder $builder, $name)

--- a/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
@@ -59,13 +59,13 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $output = new SymfonyStyle($input, $output);
+        $io = new SymfonyStyle($input, $output);
         $dispatcher = $this->getEventDispatcher();
 
         $options = array();
         if ($event = $input->getArgument('event')) {
             if (!$dispatcher->hasListeners($event)) {
-                $output->warning(sprintf('The event "%s" does not have any registered listeners.', $event));
+                $io->warning(sprintf('The event "%s" does not have any registered listeners.', $event));
 
                 return;
             }
@@ -76,8 +76,8 @@ EOF
         $helper = new DescriptorHelper();
         $options['format'] = $input->getOption('format');
         $options['raw_text'] = $input->getOption('raw');
-        $options['output'] = $output;
-        $helper->describe($output, $dispatcher, $options);
+        $options['output'] = $io;
+        $helper->describe($io, $dispatcher, $options);
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterApacheDumperCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterApacheDumperCommand.php
@@ -75,11 +75,10 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $output = new SymfonyStyle($input, $output);
+        $io = new SymfonyStyle($input, $output);
 
-        $output->title('Router Apache Dumper');
-
-        $output->caution('The router:dump-apache command is deprecated since version 2.5 and will be removed in 3.0.');
+        $io->title('Router Apache Dumper');
+        $io->caution('The router:dump-apache command is deprecated since version 2.5 and will be removed in 3.0.');
 
         $router = $this->getContainer()->get('router');
 
@@ -93,6 +92,6 @@ EOF
 
         $dumper = new ApacheMatcherDumper($router->getRouteCollection());
 
-        $output->writeln($dumper->dump($dumpOptions), OutputInterface::OUTPUT_RAW);
+        $io->writeln($dumper->dump($dumpOptions), OutputInterface::OUTPUT_RAW);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -78,10 +78,10 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $output = new SymfonyStyle($input, $output);
+        $io = new SymfonyStyle($input, $output);
 
         if (false !== strpos($input->getFirstArgument(), ':d')) {
-            $output->caution('The use of "router:debug" command is deprecated since version 2.7 and will be removed in 3.0. Use the "debug:router" instead.');
+            $io->caution('The use of "router:debug" command is deprecated since version 2.7 and will be removed in 3.0. Use the "debug:router" instead.');
         }
 
         $name = $input->getArgument('name');
@@ -95,11 +95,11 @@ EOF
 
             $this->convertController($route);
 
-            $helper->describe($output, $route, array(
+            $helper->describe($io, $route, array(
                 'format' => $input->getOption('format'),
                 'raw_text' => $input->getOption('raw'),
                 'name' => $name,
-                'output' => $output,
+                'output' => $io,
             ));
         } else {
             $routes = $this->getContainer()->get('router')->getRouteCollection();
@@ -108,11 +108,11 @@ EOF
                 $this->convertController($route);
             }
 
-            $helper->describe($output, $routes, array(
+            $helper->describe($io, $routes, array(
                 'format' => $input->getOption('format'),
                 'raw_text' => $input->getOption('raw'),
                 'show_controllers' => $input->getOption('show-controllers'),
-                'output' => $output,
+                'output' => $io,
             ));
         }
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
@@ -76,7 +76,7 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $output = new SymfonyStyle($input, $output);
+        $io = new SymfonyStyle($input, $output);
 
         $router = $this->getContainer()->get('router');
         $context = $router->getContext();
@@ -94,26 +94,26 @@ EOF
 
         $traces = $matcher->getTraces($input->getArgument('path_info'));
 
-        $output->newLine();
+        $io->newLine();
 
         $matches = false;
         foreach ($traces as $trace) {
             if (TraceableUrlMatcher::ROUTE_ALMOST_MATCHES == $trace['level']) {
-                $output->text(sprintf('Route <info>"%s"</> almost matches but %s', $trace['name'], lcfirst($trace['log'])));
+                $io->text(sprintf('Route <info>"%s"</> almost matches but %s', $trace['name'], lcfirst($trace['log'])));
             } elseif (TraceableUrlMatcher::ROUTE_MATCHES == $trace['level']) {
-                $output->success(sprintf('Route "%s" matches', $trace['name']));
+                $io->success(sprintf('Route "%s" matches', $trace['name']));
 
                 $routerDebugCommand = $this->getApplication()->find('debug:router');
                 $routerDebugCommand->run(new ArrayInput(array('name' => $trace['name'])), $output);
 
                 $matches = true;
             } elseif ($input->getOption('verbose')) {
-                $output->text(sprintf('Route "%s" does not match: %s', $trace['name'], $trace['log']));
+                $io->text(sprintf('Route "%s" does not match: %s', $trace['name'], $trace['log']));
             }
         }
 
         if (!$matches) {
-            $output->error(sprintf('None of the routes match the path "%s"', $input->getArgument('path_info')));
+            $io->error(sprintf('None of the routes match the path "%s"', $input->getArgument('path_info')));
 
             return 1;
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
@@ -85,8 +85,7 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $stdout = $output;
-        $output = new SymfonyStyle($input, $output);
+        $io = new SymfonyStyle($input, $output);
         $documentRoot = $input->getOption('docroot');
 
         if (null === $documentRoot) {
@@ -94,7 +93,7 @@ EOF
         }
 
         if (!is_dir($documentRoot)) {
-            $output->error(sprintf('The given document root directory "%s" does not exist', $documentRoot));
+            $io->error(sprintf('The given document root directory "%s" does not exist', $documentRoot));
 
             return 1;
         }
@@ -107,17 +106,17 @@ EOF
         }
 
         if ($this->isOtherServerProcessRunning($address)) {
-            $output->error(sprintf('A process is already listening on http://%s.', $address));
+            $io->error(sprintf('A process is already listening on http://%s.', $address));
 
             return 1;
         }
 
         if ('prod' === $env) {
-            $output->error('Running PHP built-in server in production environment is NOT recommended!');
+            $io->error('Running PHP built-in server in production environment is NOT recommended!');
         }
 
-        $output->success(sprintf('Server running on http://%s', $address));
-        $output->comment('Quit the server with CONTROL-C.');
+        $io->success(sprintf('Server running on http://%s', $address));
+        $io->comment('Quit the server with CONTROL-C.');
 
         if (null === $builder = $this->createPhpProcessBuilder($output, $address, $input->getOption('router'), $env)) {
             return 1;
@@ -127,13 +126,13 @@ EOF
         $builder->setTimeout(null);
         $process = $builder->getProcess();
 
-        if (OutputInterface::VERBOSITY_VERBOSE > $stdout->getVerbosity()) {
+        if (OutputInterface::VERBOSITY_VERBOSE > $output->getVerbosity()) {
             $process->disableOutput();
         }
 
         $this
             ->getHelper('process')
-            ->run($stdout, $process, null, null, OutputInterface::VERBOSITY_VERBOSE);
+            ->run($output, $process, null, null, OutputInterface::VERBOSITY_VERBOSE);
 
         if (!$process->isSuccessful()) {
             $errorMessages = array('Built-in server terminated unexpectedly.');
@@ -142,13 +141,13 @@ EOF
                 $errorMessages[] = 'Run the command again with -v option for more details.';
             }
 
-            $output->error($errorMessages);
+            $io->error($errorMessages);
         }
 
         return $process->getExitCode();
     }
 
-    private function createPhpProcessBuilder(SymfonyStyle $output, $address, $router, $env)
+    private function createPhpProcessBuilder(SymfonyStyle $io, $address, $router, $env)
     {
         $router = $router ?: $this
             ->getContainer()
@@ -157,7 +156,7 @@ EOF
         ;
 
         if (!file_exists($router)) {
-            $output->error(sprintf('The given router script "%s" does not exist.', $router));
+            $io->error(sprintf('The given router script "%s" does not exist.', $router));
 
             return;
         }
@@ -166,7 +165,7 @@ EOF
         $finder = new PhpExecutableFinder();
 
         if (false === $binary = $finder->find()) {
-            $output->error('Unable to find PHP binary to run server.');
+            $io->error('Unable to find PHP binary to run server.');
 
             return;
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerStartCommand.php
@@ -74,15 +74,15 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $output = new SymfonyStyle($input, $cliOutput = $output);
+        $io = new SymfonyStyle($input, $cliOutput = $output);
 
         if (!extension_loaded('pcntl')) {
-            $output->error(array(
+            $io->error(array(
                 'This command needs the pcntl extension to run.',
                 'You can either install it or use the "server:run" command instead to run the built-in web server.',
             ));
 
-            if ($output->ask('Do you want to execute <info>server:run</info> immediately? [Yn] ', true)) {
+            if ($io->ask('Do you want to execute <info>server:run</info> immediately? [Yn] ', true)) {
                 $command = $this->getApplication()->find('server:run');
 
                 return $command->run($input, $cliOutput);
@@ -98,7 +98,7 @@ EOF
         }
 
         if (!is_dir($documentRoot)) {
-            $output->error(sprintf('The given document root directory "%s" does not exist.', $documentRoot));
+            $io->error(sprintf('The given document root directory "%s" does not exist.', $documentRoot));
 
             return 1;
         }
@@ -116,7 +116,7 @@ EOF
         }
 
         if (!$input->getOption('force') && $this->isOtherServerProcessRunning($address)) {
-            $output->error(array(
+            $io->error(array(
                 sprintf('A process is already listening on http://%s.', $address),
                 'Use the --force option if the server process terminated unexpectedly to start a new web server process.',
             ));
@@ -125,25 +125,25 @@ EOF
         }
 
         if ('prod' === $env) {
-            $output->error('Running PHP built-in server in production environment is NOT recommended!');
+            $io->error('Running PHP built-in server in production environment is NOT recommended!');
         }
 
         $pid = pcntl_fork();
 
         if ($pid < 0) {
-            $output->error('Unable to start the server process.');
+            $io->error('Unable to start the server process.');
 
             return 1;
         }
 
         if ($pid > 0) {
-            $output->success(sprintf('Web server listening on http://%s', $address));
+            $io->success(sprintf('Web server listening on http://%s', $address));
 
             return;
         }
 
         if (posix_setsid() < 0) {
-            $output->error('Unable to set the child process as session leader');
+            $io->error('Unable to set the child process as session leader');
 
             return 1;
         }
@@ -158,7 +158,7 @@ EOF
         touch($lockFile);
 
         if (!$process->isRunning()) {
-            $output->error('Unable to start the server process');
+            $io->error('Unable to start the server process');
             unlink($lockFile);
 
             return 1;
@@ -180,11 +180,11 @@ EOF
      *
      * @param string|null  $router File path of the custom router script, if set by the user; otherwise null
      * @param string       $env    The application environment
-     * @param SymfonyStyle $output An SymfonyStyle instance
+     * @param SymfonyStyle $io     An SymfonyStyle instance
      *
      * @return string|bool The absolute file path of the router script, or false on failure
      */
-    private function determineRouterScript($router, $env, SymfonyStyle $output)
+    private function determineRouterScript($router, $env, SymfonyStyle $io)
     {
         if (null === $router) {
             $router = $this
@@ -195,7 +195,7 @@ EOF
         }
 
         if (false === $path = realpath($router)) {
-            $output->error(sprintf('The given router script "%s" does not exist.', $router));
+            $io->error(sprintf('The given router script "%s" does not exist.', $router));
 
             return false;
         }
@@ -206,18 +206,18 @@ EOF
     /**
      * Creates a process to start PHP's built-in web server.
      *
-     * @param SymfonyStyle $output       A SymfonyStyle instance
+     * @param SymfonyStyle $io           A SymfonyStyle instance
      * @param string       $address      IP address and port to listen to
      * @param string       $documentRoot The application's document root
      * @param string       $router       The router filename
      *
      * @return Process The process
      */
-    private function createServerProcess(SymfonyStyle $output, $address, $documentRoot, $router)
+    private function createServerProcess(SymfonyStyle $io, $address, $documentRoot, $router)
     {
         $finder = new PhpExecutableFinder();
         if (false === $binary = $finder->find()) {
-            $output->error('Unable to find PHP binary to start server.');
+            $io->error('Unable to find PHP binary to start server.');
 
             return;
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerStatusCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerStatusCommand.php
@@ -43,7 +43,7 @@ class ServerStatusCommand extends ServerCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $output = new SymfonyStyle($input, $output);
+        $io = new SymfonyStyle($input, $output);
         $address = $input->getArgument('address');
 
         // remove an orphaned lock file
@@ -52,9 +52,9 @@ class ServerStatusCommand extends ServerCommand
         }
 
         if (file_exists($this->getLockFile($address))) {
-            $output->success(sprintf('Web server still listening on http://%s', $address));
+            $io->success(sprintf('Web server still listening on http://%s', $address));
         } else {
-            $output->warning(sprintf('No web server is listening on http://%s', $address));
+            $io->warning(sprintf('No web server is listening on http://%s', $address));
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerStopCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerStopCommand.php
@@ -55,7 +55,7 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $output = new SymfonyStyle($input, $output);
+        $io = new SymfonyStyle($input, $output);
 
         $address = $input->getArgument('address');
         if (false === strpos($address, ':')) {
@@ -65,12 +65,12 @@ EOF
         $lockFile = $this->getLockFile($address);
 
         if (!file_exists($lockFile)) {
-            $output->error(sprintf('No web server is listening on http://%s', $address));
+            $io->error(sprintf('No web server is listening on http://%s', $address));
 
             return 1;
         }
 
         unlink($lockFile);
-        $output->success(sprintf('Stopped the web server listening on http://%s', $address));
+        $io->success(sprintf('Stopped the web server listening on http://%s', $address));
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -92,9 +92,9 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $output = new SymfonyStyle($input, $output);
+        $io = new SymfonyStyle($input, $output);
         if (false !== strpos($input->getFirstArgument(), ':d')) {
-            $output->caution('The use of "translation:debug" command is deprecated since version 2.7 and will be removed in 3.0. Use the "debug:translation" instead.');
+            $io->caution('The use of "translation:debug" command is deprecated since version 2.7 and will be removed in 3.0. Use the "debug:translation" instead.');
         }
 
         $locale = $input->getArgument('locale');
@@ -151,7 +151,7 @@ EOF
                 $outputMessage .= sprintf(' and domain "%s"', $domain);
             }
 
-            $output->warning($outputMessage);
+            $io->warning($outputMessage);
 
             return;
         }
@@ -201,7 +201,7 @@ EOF
             }
         }
 
-        $output->table($headers, $rows);
+        $io->table($headers, $rows);
     }
 
     private function formatState($state)

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -69,11 +69,11 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $output = new SymfonyStyle($input, $output);
+        $io = new SymfonyStyle($input, $output);
 
         // check presence of force or dump-message
         if ($input->getOption('force') !== true && $input->getOption('dump-messages') !== true) {
-            $output->error('You must choose one of --force or --dump-messages');
+            $io->error('You must choose one of --force or --dump-messages');
 
             return 1;
         }
@@ -82,7 +82,7 @@ EOF
         $writer = $this->getContainer()->get('translation.writer');
         $supportedFormats = $writer->getFormats();
         if (!in_array($input->getOption('output-format'), $supportedFormats)) {
-            $output->error(array('Wrong output format', 'Supported formats are: '.implode(', ', $supportedFormats).'.'));
+            $io->error(array('Wrong output format', 'Supported formats are: '.implode(', ', $supportedFormats).'.'));
 
             return 1;
         }
@@ -112,12 +112,12 @@ EOF
             }
         }
 
-        $output->title('Translation Messages Extractor and Dumper');
-        $output->comment(sprintf('Generating "<info>%s</info>" translation files for "<info>%s</info>"', $input->getArgument('locale'), $currentName));
+        $io->title('Translation Messages Extractor and Dumper');
+        $io->comment(sprintf('Generating "<info>%s</info>" translation files for "<info>%s</info>"', $input->getArgument('locale'), $currentName));
 
         // load any messages from templates
         $extractedCatalogue = new MessageCatalogue($input->getArgument('locale'));
-        $output->comment('Parsing templates...');
+        $io->comment('Parsing templates...');
         $extractor = $this->getContainer()->get('translation.extractor');
         $extractor->setPrefix($input->getOption('prefix'));
         foreach ($transPaths as $path) {
@@ -129,7 +129,7 @@ EOF
 
         // load any existing messages from the translation files
         $currentCatalogue = new MessageCatalogue($input->getArgument('locale'));
-        $output->comment('Loading translation files...');
+        $io->comment('Loading translation files...');
         $loader = $this->getContainer()->get('translation.loader');
         foreach ($transPaths as $path) {
             $path .= 'translations';
@@ -145,7 +145,7 @@ EOF
 
         // Exit if no messages found.
         if (!count($operation->getDomains())) {
-            $output->warning('No translation messages were found.');
+            $io->warning('No translation messages were found.');
 
             return;
         }
@@ -153,15 +153,15 @@ EOF
         // show compiled list of messages
         if (true === $input->getOption('dump-messages')) {
             $extractedMessagesCount = 0;
-            $output->newLine();
+            $io->newLine();
             foreach ($operation->getDomains() as $domain) {
                 $newKeys = array_keys($operation->getNewMessages($domain));
                 $allKeys = array_keys($operation->getMessages($domain));
                 $domainMessagesCount = count($newKeys) + count($allKeys);
 
-                $output->section(sprintf('Messages extracted for domain "<info>%s</info>" (%d messages)', $domain, $domainMessagesCount));
+                $io->section(sprintf('Messages extracted for domain "<info>%s</info>" (%d messages)', $domain, $domainMessagesCount));
 
-                $output->listing(array_merge(
+                $io->listing(array_merge(
                     array_diff($allKeys, $newKeys),
                     array_map(function ($id) {
                         return sprintf('<fg=green>%s</>', $id);
@@ -175,7 +175,7 @@ EOF
             }
 
             if ($input->getOption('output-format') == 'xlf') {
-                $output->comment('Xliff output version is <info>1.2</info>');
+                $io->comment('Xliff output version is <info>1.2</info>');
             }
 
             $resultMessage = sprintf('%d messages were successfully extracted', $extractedMessagesCount);
@@ -187,7 +187,7 @@ EOF
 
         // save the files
         if ($input->getOption('force') === true) {
-            $output->comment('Writing files...');
+            $io->comment('Writing files...');
 
             $bundleTransPath = false;
             foreach ($transPaths as $path) {
@@ -208,6 +208,6 @@ EOF
             }
         }
 
-        $output->success($resultMessage);
+        $io->success($resultMessage);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/YamlLintCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/YamlLintCommand.php
@@ -63,10 +63,9 @@ EOF
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $stdout = $output;
-        $output = new SymfonyStyle($input, $output);
+        $io = new SymfonyStyle($input, $output);
         if (false !== strpos($input->getFirstArgument(), ':l')) {
-            $output->caution('The use of "yaml:lint" command is deprecated since version 2.7 and will be removed in 3.0. Use the "lint:yaml" instead.');
+            $io->caution('The use of "yaml:lint" command is deprecated since version 2.7 and will be removed in 3.0. Use the "lint:yaml" instead.');
         }
 
         $filename = $input->getArgument('filename');
@@ -81,7 +80,7 @@ EOF
                 $content .= fread(STDIN, 1024);
             }
 
-            return $this->display($input, $stdout, $output, array($this->validate($content)));
+            return $this->display($input, $output, $output, array($this->validate($content)));
         }
 
         if (0 !== strpos($filename, '@') && !is_readable($filename)) {
@@ -103,7 +102,7 @@ EOF
             $filesInfo[] = $this->validate(file_get_contents($file), $file);
         }
 
-        return $this->display($input, $stdout, $output, $filesInfo);
+        return $this->display($input, $output, $io, $filesInfo);
     }
 
     private function validate($content, $file = null)
@@ -118,36 +117,36 @@ EOF
         return array('file' => $file, 'valid' => true);
     }
 
-    private function display(InputInterface $input, OutputInterface $stdout, $output, $files)
+    private function display(InputInterface $input, OutputInterface $output, SymfonyStyle $io, $files)
     {
         switch ($input->getOption('format')) {
             case 'txt':
-                return $this->displayTxt($stdout, $output, $files);
+                return $this->displayTxt($output, $io, $files);
             case 'json':
-                return $this->displayJson($output, $files);
+                return $this->displayJson($io, $files);
             default:
                 throw new \InvalidArgumentException(sprintf('The format "%s" is not supported.', $input->getOption('format')));
         }
     }
 
-    private function displayTxt(OutputInterface $stdout, $output, $filesInfo)
+    private function displayTxt(OutputInterface $output, SymfonyStyle $io, $filesInfo)
     {
         $errors = 0;
 
         foreach ($filesInfo as $info) {
-            if ($info['valid'] && $stdout->isVerbose()) {
-                $output->comment('<info>OK</info>'.($info['file'] ? sprintf(' in %s', $info['file']) : ''));
+            if ($info['valid'] && $output->isVerbose()) {
+                $io->comment('<info>OK</info>'.($info['file'] ? sprintf(' in %s', $info['file']) : ''));
             } elseif (!$info['valid']) {
                 ++$errors;
-                $output->text(sprintf('<error> ERROR </error> in %s', $info['file']));
-                $output->text(sprintf('<error> >> %s</error>', $info['message']));
+                $io->text(sprintf('<error> ERROR </error> in %s', $info['file']));
+                $io->text(sprintf('<error> >> %s</error>', $info['message']));
             }
         }
 
         if ($errors === 0) {
-            $output->success(sprintf('All %d YAML files contain valid syntax.', count($filesInfo)));
+            $io->success(sprintf('All %d YAML files contain valid syntax.', count($filesInfo)));
         } else {
-            $output->warning(sprintf('%d YAML files have valid syntax and %d contain errors.', count($filesInfo) - $errors, $errors));
+            $io->warning(sprintf('%d YAML files have valid syntax and %d contain errors.', count($filesInfo) - $errors, $errors));
         }
 
         return min($errors, 1);

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -394,7 +394,7 @@ class TextDescriptor extends Descriptor
     /**
      * @param array $array
      */
-    private function renderEventListenerTable(EventDispatcherInterface $eventDispatcher, $event, array $eventListeners, SymfonyStyle $renderer)
+    private function renderEventListenerTable(EventDispatcherInterface $eventDispatcher, $event, array $eventListeners, SymfonyStyle $io)
     {
         $tableHeaders = array('Order', 'Callable', 'Priority');
         $tableRows = array();
@@ -404,7 +404,7 @@ class TextDescriptor extends Descriptor
             $tableRows[] = array(sprintf('#%d', $order + 1), $this->formatCallable($listener), $eventDispatcher->getListenerPriority($event, $listener));
         }
 
-        $renderer->table($tableHeaders, $tableRows);
+        $io->table($tableHeaders, $tableRows);
     }
 
     /**

--- a/src/Symfony/Bundle/SecurityBundle/Command/UserPasswordEncoderCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/UserPasswordEncoderCommand.php
@@ -84,9 +84,9 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $output = new SymfonyStyle($input, $output);
+        $io = new SymfonyStyle($input, $output);
 
-        $input->isInteractive() ? $output->title('Symfony Password Encoder Utility') : $output->newLine();
+        $input->isInteractive() ? $io->title('Symfony Password Encoder Utility') : $io->newLine();
 
         $password = $input->getArgument('password');
         $userClass = $input->getArgument('user-class');
@@ -101,12 +101,12 @@ EOF
 
         if (!$password) {
             if (!$input->isInteractive()) {
-                $output->error('The password must not be empty.');
+                $io->error('The password must not be empty.');
 
                 return 1;
             }
             $passwordQuestion = $this->createPasswordQuestion($input, $output);
-            $password = $output->askQuestion($passwordQuestion);
+            $password = $io->askQuestion($passwordQuestion);
         }
 
         $salt = null;
@@ -114,9 +114,9 @@ EOF
         if ($input->isInteractive() && !$emptySalt) {
             $emptySalt = true;
 
-            $output->note('The command will take care of generating a salt for you. Be aware that some encoders advise to let them generate their own salt. If you\'re using one of those encoders, please answer \'no\' to the question below. '.PHP_EOL.'Provide the \'empty-salt\' option in order to let the encoder handle the generation itself.');
+            $io->note('The command will take care of generating a salt for you. Be aware that some encoders advise to let them generate their own salt. If you\'re using one of those encoders, please answer \'no\' to the question below. '.PHP_EOL.'Provide the \'empty-salt\' option in order to let the encoder handle the generation itself.');
 
-            if ($output->confirm('Confirm salt generation ?')) {
+            if ($io->confirm('Confirm salt generation ?')) {
                 $salt = $this->generateSalt();
                 $emptySalt = false;
             }
@@ -133,15 +133,15 @@ EOF
         if (!$emptySalt) {
             $rows[] = array('Generated salt', $salt);
         }
-        $output->table(array('Key', 'Value'), $rows);
+        $io->table(array('Key', 'Value'), $rows);
 
         if (!$emptySalt) {
-            $output->note(sprintf('Make sure that your salt storage field fits the salt length: %s chars', strlen($salt)));
+            $io->note(sprintf('Make sure that your salt storage field fits the salt length: %s chars', strlen($salt)));
         } elseif ($bcryptWithoutEmptySalt) {
-            $output->note('Bcrypt encoder used: the encoder generated its own built-in salt.');
+            $io->note('Bcrypt encoder used: the encoder generated its own built-in salt.');
         }
 
-        $output->success('Password encoding succeeded');
+        $io->success('Password encoding succeeded');
     }
 
     /**

--- a/src/Symfony/Bundle/TwigBundle/Command/DebugCommand.php
+++ b/src/Symfony/Bundle/TwigBundle/Command/DebugCommand.php
@@ -58,11 +58,11 @@ class DebugCommand extends BaseDebugCommand implements ContainerAwareInterface
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $output = new SymfonyStyle($input, $output);
+        $io = new SymfonyStyle($input, $output);
         if (false !== strpos($input->getFirstArgument(), ':d')) {
-            $output->caution('The use of "twig:debug" command is deprecated since version 2.7 and will be removed in 3.0. Use the "debug:twig" instead.');
+            $io->caution('The use of "twig:debug" command is deprecated since version 2.7 and will be removed in 3.0. Use the "debug:twig" instead.');
         }
 
-        parent::execute($input, $output);
+        parent::execute($input, $io);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16000 |
| License | MIT |
| Doc PR | - |

When we updated the commands to use the new SymfonyStyle, I did the mistake of overriding the `$output` variable. Now we use the `$io` variable to wrap the SymfonyStyle and to perform input and output operations.
