### PR TITLE
[DX] [PropertyInfo] Filter PropertyInfo Extractors with Interfaces

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/PropertyInfoPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/PropertyInfoPass.php
@@ -31,17 +31,8 @@ class PropertyInfoPass implements CompilerPassInterface
             return;
         }
 
-        $listExtractors = $this->findAndSortTaggedServices('property_info.list_extractor', $container);
-        $container->getDefinition('property_info')->replaceArgument(0, $listExtractors);
-
-        $typeExtractors = $this->findAndSortTaggedServices('property_info.type_extractor', $container);
-        $container->getDefinition('property_info')->replaceArgument(1, $typeExtractors);
-
-        $descriptionExtractors = $this->findAndSortTaggedServices('property_info.description_extractor', $container);
-        $container->getDefinition('property_info')->replaceArgument(2, $descriptionExtractors);
-
-        $accessExtractors = $this->findAndSortTaggedServices('property_info.access_extractor', $container);
-        $container->getDefinition('property_info')->replaceArgument(3, $accessExtractors);
+        $extractors = $this->findAndSortTaggedServices('property_info.extractor', $container);
+        $container->getDefinition('property_info')->replaceArgument(0, $extractors);
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1007,8 +1007,7 @@ class FrameworkExtension extends Extension
 
         if (class_exists('phpDocumentor\Reflection\ClassReflector')) {
             $definition = $container->register('property_info.php_doc_extractor', 'Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor');
-            $definition->addTag('property_info.description_extractor', array('priority' => -1000));
-            $definition->addTag('property_info.type_extractor', array('priority' => -1001));
+            $definition->addTag('property_info.extractor', array('priority' => -1001));
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_info.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_info.xml
@@ -7,16 +7,11 @@
     <services>
         <service id="property_info" class="Symfony\Component\PropertyInfo\PropertyInfoExtractor" >
             <argument type="collection" />
-            <argument type="collection" />
-            <argument type="collection" />
-            <argument type="collection" />
         </service>
 
         <!-- Extractor -->
         <service id="property_info.reflection_extractor" class="Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor" public="false">
-            <tag name="property_info.list_extractor" priority="-1000" />
-            <tag name="property_info.type_extractor" priority="-1000" />
-            <tag name="property_info.access_extractor" priority="-1000" />
+            <tag name="property_info.extractor" priority="-1000" />
         </service>
     </services>
 </container>

--- a/src/Symfony/Component/PropertyInfo/ExtractorInterface.php
+++ b/src/Symfony/Component/PropertyInfo/ExtractorInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Symfony\Component\PropertyInfo;
+
+/**
+ * Interface ExtractorInterface.
+ *
+ * @author Zander Baldwin <hello@zanderbaldwin.com>
+ */
+interface ExtractorInterface
+{
+}

--- a/src/Symfony/Component/PropertyInfo/PropertyAccessExtractorInterface.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyAccessExtractorInterface.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\PropertyInfo;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-interface PropertyAccessExtractorInterface
+interface PropertyAccessExtractorInterface extends ExtractorInterface
 {
     /**
      * Is the property readable?

--- a/src/Symfony/Component/PropertyInfo/PropertyDescriptionExtractorInterface.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyDescriptionExtractorInterface.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\PropertyInfo;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-interface PropertyDescriptionExtractorInterface
+interface PropertyDescriptionExtractorInterface extends ExtractorInterface
 {
     /**
      * Gets the short description of the property.

--- a/src/Symfony/Component/PropertyInfo/PropertyInfoExtractorInterface.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoExtractorInterface.php
@@ -20,4 +20,8 @@ namespace Symfony\Component\PropertyInfo;
  */
 interface PropertyInfoExtractorInterface extends PropertyTypeExtractorInterface, PropertyDescriptionExtractorInterface, PropertyAccessExtractorInterface, PropertyListExtractorInterface
 {
+    /**
+     * @param ExtractorInterface $extractor
+     */
+    public function addExtractor(ExtractorInterface $extractor);
 }

--- a/src/Symfony/Component/PropertyInfo/PropertyListExtractorInterface.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyListExtractorInterface.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\PropertyInfo;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-interface PropertyListExtractorInterface
+interface PropertyListExtractorInterface extends ExtractorInterface
 {
     /**
      * Gets the list of properties available for the given class.

--- a/src/Symfony/Component/PropertyInfo/PropertyTypeExtractorInterface.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyTypeExtractorInterface.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\PropertyInfo;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-interface PropertyTypeExtractorInterface
+interface PropertyTypeExtractorInterface extends ExtractorInterface
 {
     /**
      * Gets types of a property.

--- a/src/Symfony/Component/PropertyInfo/Tests/PropertyInfoExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/PropertyInfoExtractorTest.php
@@ -28,8 +28,7 @@ class PropertyInfoExtractorTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $extractors = array(new NullExtractor(), new DummyExtractor());
-        $this->propertyInfo = new PropertyInfoExtractor($extractors, $extractors, $extractors, $extractors);
+        $this->propertyInfo = new PropertyInfoExtractor(array(new NullExtractor(), new DummyExtractor()));
     }
 
     public function testInstanceOf()
@@ -38,6 +37,7 @@ class PropertyInfoExtractorTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface', $this->propertyInfo);
         $this->assertInstanceOf('Symfony\Component\PropertyInfo\PropertyDescriptionExtractorInterface', $this->propertyInfo);
         $this->assertInstanceOf('Symfony\Component\PropertyInfo\PropertyAccessExtractorInterface', $this->propertyInfo);
+        $this->assertInstanceOf('Symfony\Component\PropertyInfo\ExtractorInterface', $this->propertyInfo);
     }
 
     public function testGetShortDescription()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | No |
| New feature? | No |
| BC breaks? | Yes |
| Deprecations? | No |
| Tests pass? | Yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | symfony/symfony-docs#5974 |

To improve developer experience, require just one collection of extractors that filters by the interfaces that have been implemented on each extractor.
- Simplifies registering new extractors in the service container.
- Reduces duplication of semantics (intent defined by interfaces implemented, instead of interfaces implemented _and_ service container tag).
- Prevents _Call to undefined method_ fatal errors for extractors defined with the wrong service container tag.

_However_, this **does** break backwards-compatibility for:
- Manual instantiation of the [`PropertyInfoExtractor`](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php).
- Classes that extend [`PropertyInfoExtractor`](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php).
- Services tagged with any of the `property_info.*_extractor` tags.

I'm suggesting this change purely in the unlikely event that the PropertyInfo component can be classed as internal, since documentation is still pending.

/cc @dunglas 
