### PR TITLE
[2.8] Use correct height for toolbar clearer

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
@@ -21,7 +21,7 @@
     <style>
         {{ include('@WebProfiler/Profiler/toolbar.css.twig', { 'position': position, 'floatable': true }) }}
     </style>
-    <div id="sfToolbarClearer-{{ token }}" style="clear: both; height: 38px;"></div>
+    <div id="sfToolbarClearer-{{ token }}" style="clear: both; height: 36px;"></div>
 {% endif %}
 
 <div id="sfToolbarMainContent-{{ token }}" class="sf-toolbarreset clear-fix" data-no-turbolink>


### PR DESCRIPTION
The toolbar is 36px heigh, while the clearer is set at 38px. This means that there is 2px between the end of the page and the toolbar. This is especially not nice when the footer has a dark color (it renders a 2px white line between toolbar and footer).

| Q | A |
| --- | --- |
| Fixed tickets | - |
| License | MIT |
