### PR TITLE
[Form] Fix constraints could be null if not set

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -45,7 +45,7 @@ class FormValidator extends ConstraintValidator
 
             // Validate the data against the constraints defined
             // in the form
-            $constraints = $config->getOption('constraints');
+            $constraints = $config->getOption('constraints', array());
             foreach ($constraints as $constraint) {
                 foreach ($groups as $group) {
                     if (in_array($group, $constraint->groups)) {

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -125,10 +125,8 @@ class FormValidatorTest extends AbstractConstraintValidatorTest
 
     public function testNotExistingConstraintIndex()
     {
-        $object = $this->getMock('\stdClass');
-        $options = array();
-
-        $form = new FormBuilder('name', '\stdClass', $this->dispatcher, $this->factory, $options);
+        $object = new \stdClass;
+        $form = new FormBuilder('name', '\stdClass', $this->dispatcher, $this->factory);
         $form = $form->setData($object)->getForm();
 
         $this->validator->validate($form, new Form());

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -123,6 +123,19 @@ class FormValidatorTest extends AbstractConstraintValidatorTest
         $this->assertNoViolation();
     }
 
+    public function testNotExistingConstraintIndex()
+    {
+        $object = $this->getMock('\stdClass');
+        $options = array();
+
+        $form = new FormBuilder('name', '\stdClass', $this->dispatcher, $this->factory, $options);
+        $form = $form->setData($object)->getForm();
+
+        $this->validator->validate($form, new Form());
+
+        $this->assertNoViolation();
+    }
+
     public function testValidateConstraintsEvenIfNoCascadeValidation()
     {
         $object = $this->getMock('\stdClass');

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -125,7 +125,7 @@ class FormValidatorTest extends AbstractConstraintValidatorTest
 
     public function testNotExistingConstraintIndex()
     {
-        $object = new \stdClass;
+        $object = new \stdClass();
         $form = new FormBuilder('name', '\stdClass', $this->dispatcher, $this->factory);
         $form = $form->setData($object)->getForm();
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

If the form options has no key for constraints the default should be an empty array to be ignored by the loop in the FormValidator. The default without this fix is `null` and foreach will throw an error. 

The "Bug" also still exists in master-Branch.
