### PR TITLE
[Command] Added better support for custom default command

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -168,7 +168,11 @@ class Application
         if (true === $input->hasParameterOption(array('--help', '-h'), true)) {
             if (!$name) {
                 $name = 'help';
-                $input = new ArrayInput(array('command' => 'help'));
+                if ('list' !== $this->defaultCommand) {
+                    $input = new ArrayInput(array('command_name' => $this->defaultCommand));
+                } else {
+                    $input = new ArrayInput(array('command_name' => 'help'));
+                }
             } else {
                 $this->wantHelps = true;
             }
@@ -1017,6 +1021,8 @@ class Application
     public function setDefaultCommand($commandName)
     {
         $this->defaultCommand = $commandName;
+
+        return $this;
     }
 
     private function stringWidth($string)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |

Hello;

I write many CLI application, and "single command" in cli application is not so easy to write.
This is why I propose this patch. IMHO, this PR could replaces #9609.

See it in application:

``` php
#!/usr/bin/env php
<?php

require __DIR__.'/vendor/autoload.php';


use Symfony\Component\Console\Application;
use Symfony\Component\Console\Input\InputArgument;
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Input\InputOption;
use Symfony\Component\Console\Output\OutputInterface;

(new Application('echo', '1.0.0'))
    ->register('echo')
        ->addArgument('foo', InputArgument::OPTIONAL, 'The directory', 'foo')
        ->addOption('bar', null, InputOption::VALUE_REQUIRED, 'Foobar', 'bar')
        ->setCode(function(InputInterface $input, OutputInterface $output) {
            $output->writeln('start');
            $output->writeln($input->getArgument('foo'));
            $output->writeln($input->getOption('bar'));
        })
    ->getApplication()
    ->setUniqueCommand('echo')
    ->run();
```

Some usage:

```
>(3)[{..}eg/dev/github.com/symfony/symfony](console-one-app) php test.php 
start
foo
bar
```

```
>(3)[{..}eg/dev/github.com/symfony/symfony](console-one-app) php test.php  "first argument"
start
first argument
bar
```

```
>(3)[{..}eg/dev/github.com/symfony/symfony](console-one-app) php test.php  "first argument" --bar="first option"
start
first argument
first option
```

```
>(3)[{..}eg/dev/github.com/symfony/symfony](console-one-app) php test.php  "first argument" --bar="first option" --help
Usage:
  echo [options] [--] [<foo>]

Arguments:
  foo                   The directory [default: "foo"]

Options:
      --bar=BAR         Foobar [default: "bar"]
  -h, --help            Display this help message
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
      --ansi            Force ANSI output
      --no-ansi         Disable ANSI output
  -n, --no-interaction  Do not ask any interactive question
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
```
