### PR TITLE
[Form] Add missing tests for StringUtil::fqcnToBlockPrefix()

### DIFF
--- a/src/Symfony/Component/Form/Tests/Util/StringUtilTest.php
+++ b/src/Symfony/Component/Form/Tests/Util/StringUtilTest.php
@@ -74,4 +74,31 @@ class StringUtilTest extends \PHPUnit_Framework_TestCase
 //            array('200B'),
         );
     }
+
+    /**
+     * @dataProvider fqcnToBlockPrefixProvider
+     */
+    public function testFqcnToBlockPrefix($fqcn, $expectedBlockPrefix)
+    {
+        $blockPrefix = StringUtil::fqcnToBlockPrefix($fqcn);
+
+        $this->assertSame($expectedBlockPrefix, $blockPrefix);
+    }
+
+    public function fqcnToBlockPrefixProvider()
+    {
+        return array(
+            array('TYPE', 'type'),
+            array('\Type', 'type'),
+            array('\UserType', 'user'),
+            array('UserType', 'user'),
+            array('Vendor\Name\Space\Type', 'type'),
+            array('Vendor\Name\Space\UserForm', 'user_form'),
+            array('Vendor\Name\Space\UserType', 'user'),
+            array('Vendor\Name\Space\usertype', 'user'),
+            array('Symfony\Component\Form\Form', 'form'),
+            array('Vendor\Name\Space\BarTypeBazType', 'bar_type_baz'),
+            array('FooBarBazType', 'foo_bar_baz'),
+        );
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16762 |
| License | MIT |
| Doc PR | - |
