### PR TITLE
[Translation][Writer] avoid calling setBackup if the dumper is not FileDumper

### DIFF
--- a/src/Symfony/Component/Translation/Tests/Writer/TranslationWriterTest.php
+++ b/src/Symfony/Component/Translation/Tests/Writer/TranslationWriterTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Tests\Writer;
+
+use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Translation\Writer\TranslationWriter;
+
+class TranslationWriterTest extends \PHPUnit_Framework_TestCase
+{
+    public function testWriteTranslations()
+    {
+        $dumper = $this->getMock('Symfony\Component\Translation\Dumper\DumperInterface');
+        $dumper
+            ->expects($this->once())
+            ->method('dump');
+
+        $writer = new TranslationWriter();
+        $writer->addDumper('test', $dumper);
+        $writer->writeTranslations(new MessageCatalogue(array()), 'test');
+    }
+
+    public function testDisableBackup()
+    {
+        $dumper = $this->getMock('Symfony\Component\Translation\Dumper\DumperInterface');
+        $dumper
+            ->expects($this->never())
+            ->method('setBackup');
+        $phpDumper = $this->getMock('Symfony\Component\Translation\Dumper\PhpFileDumper');
+        $phpDumper
+            ->expects($this->once())
+            ->method('setBackup');
+
+        $writer = new TranslationWriter();
+        $writer->addDumper('test', $dumper);
+        $writer->addDumper('php', $phpDumper);
+        $writer->disableBackup();
+    }
+}

--- a/src/Symfony/Component/Translation/Writer/TranslationWriter.php
+++ b/src/Symfony/Component/Translation/Writer/TranslationWriter.php
@@ -45,7 +45,9 @@ class TranslationWriter
     public function disableBackup()
     {
         foreach ($this->dumpers as $dumper) {
-            $dumper->setBackup(false);
+            if (method_exists($dumper, 'setBackup')) {
+                $dumper->setBackup(false);
+            }
         }
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | n/a |
