### PR TITLE
[DependencyInjection] fixed definition loosing property shared when decorated by a parent definition

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
@@ -211,6 +211,7 @@ class ResolveDefinitionTemplatesPass implements CompilerPassInterface
         // these attributes are always taken from the child
         $def->setAbstract($definition->isAbstract());
         $def->setScope($definition->getScope(false), false);
+        $def->setShared($definition->isShared());
         $def->setTags($definition->getTags());
 
         return $def;

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveDefinitionTemplatesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveDefinitionTemplatesPassTest.php
@@ -139,6 +139,25 @@ class ResolveDefinitionTemplatesPassTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($def->getDecoratedService());
     }
 
+    public function testProcessDoesNotDropShared()
+    {
+        $container = new ContainerBuilder();
+
+        $container
+            ->register('parent')
+        ;
+
+        $container
+            ->setDefinition('child', new DefinitionDecorator('parent'))
+            ->setShared(false)
+        ;
+
+        $this->process($container);
+
+        $def = $container->getDefinition('child');
+        $this->assertFalse($def->isShared());
+    }
+
     public function testProcessHandlesMultipleInheritance()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveDefinitionTemplatesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveDefinitionTemplatesPassTest.php
@@ -101,6 +101,25 @@ class ResolveDefinitionTemplatesPassTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(ContainerInterface::SCOPE_CONTAINER, $def->getScope());
     }
 
+    public function testProcessDoesNotCopyShared()
+    {
+        $container = new ContainerBuilder();
+
+        $container
+            ->register('parent')
+            ->setShared(false)
+        ;
+
+        $container
+            ->setDefinition('child', new DefinitionDecorator('parent'))
+        ;
+
+        $this->process($container);
+
+        $def = $container->getDefinition('child');
+        $this->assertTrue($def->isShared());
+    }
+
     public function testProcessDoesNotCopyTags()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

While upgrading my applications from 2.7 and 2.8 I found out that the attribute "shared" gets lost when a parent is configured. I wrote a Test to confirm my assumption and added a bugfix
