### PR TITLE
[PhpUnitBridge] Replace "weak-verbose" by "deprecations upper bound" mode

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -19,14 +19,28 @@ namespace Symfony\Bridge\PhpUnit;
 class DeprecationErrorHandler
 {
     const MODE_WEAK = 'weak';
-    const MODE_WEAK_VERBOSE = 'weak-verbose';
 
     private static $isRegistered = false;
 
-    public static function register($mode = false)
+    /**
+     * Registers and configures the deprecation handler.
+     *
+     * The following reporting modes are supported:
+     * - use "weak" to hide the deprecation report but keep a global count;
+     * - use "/some-regexp/" to stop the test suite whenever a deprecation
+     *   message matches the given regular expression;
+     * - use a number to define the upper bound of allowed deprecations,
+     *   making the test suite fail whenever more notices are trigerred.
+     *
+     * @param int|string|false $mode The reporting mode. Defaults to not allowing any deprecations.
+     */
+    public static function register($mode = 0)
     {
         if (self::$isRegistered) {
             return;
+        }
+        if (self::MODE_WEAK !== $mode && (!isset($mode[0]) || '/' !== $mode[0])) {
+            $mode = preg_match('/^[1-9][0-9]*$/', $mode) ? (int) $mode : 0;
         }
         $deprecations = array(
             'unsilencedCount' => 0,
@@ -147,7 +161,7 @@ class DeprecationErrorHandler
                 if (!empty($notices)) {
                     echo "\n";
                 }
-                if (DeprecationErrorHandler::MODE_WEAK !== $mode && DeprecationErrorHandler::MODE_WEAK_VERBOSE !== $mode && ($deprecations['unsilenced'] || $deprecations['remaining'] || $deprecations['other'])) {
+                if (DeprecationErrorHandler::MODE_WEAK !== $mode && $mode < $deprecations['unsilencedCount'] + $deprecations['remainingCount'] + $deprecations['otherCount']) {
                     exit(1);
                 }
             });

--- a/src/Symfony/Bridge/PhpUnit/README.md
+++ b/src/Symfony/Bridge/PhpUnit/README.md
@@ -12,11 +12,11 @@ It comes with the following features:
  * display the stack trace of a deprecation on-demand.
 
 By default any non-legacy-tagged or any non-@-silenced deprecation notices will
-make tests fail.
-This can be changed by setting the `SYMFONY_DEPRECATIONS_HELPER` environment
-variable to `weak` or `weak-verbose`. This will make the bridge ignore
-deprecation notices and is useful to projects that must use deprecated interfaces
-for backward compatibility reasons.
+make tests fail. This can be changed by setting the `SYMFONY_DEPRECATIONS_HELPER`
+environment variable to the maximum number of deprecations that are allowed to be
+triggered before making the test suite fail. Alternatively, setting it to `weak`
+will make the bridge ignore any deprecation notices and is useful to projects
+that must use deprecated interfaces for backward compatibility reasons.
 
 A summary of deprecation notices is displayed at the end of the test suite:
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16789, #14475 |
| License | MIT |
| Doc PR | - |

This is a "new feature" that replaces a "new feature" not yet released but merged into 2.8.1. See #16789.
It is way more flexible to be able to specify the upper bound of remaining deprecation notices that you allow in your test suite. This allows lowering this number while deprecations are removed, step after step.

ping @WouterJ @Tobion @craue @fabpot @stof 
