### PR TITLE
[Security][Guard] checkCredentials() should have a @return annotation

### DIFF
--- a/src/Symfony/Component/Security/Guard/GuardAuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Guard/GuardAuthenticatorInterface.php
@@ -83,6 +83,8 @@ interface GuardAuthenticatorInterface extends AuthenticationEntryPointInterface
      *
      * @param mixed         $credentials
      * @param UserInterface $user
+     * 
+     * @return bool
      *
      * @throws AuthenticationException
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

According to its documentation, an implementation of the `GuardAuthenticatorInterface::checkCredentials()` method should return `true` on success. I've added a `@return` annotation to the PHPDoc block to reflect the fact that this method should actually return something.
