### PR TITLE
update php/object tag syntax

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -105,7 +105,7 @@ class Inline
                 return 'null';
             case is_object($value):
                 if ($objectSupport) {
-                    return '!!php/object:'.serialize($value);
+                    return '!php/object:'.serialize($value);
                 }
 
                 if ($exceptionOnInvalidType) {
@@ -477,8 +477,11 @@ class Inline
                     case 0 === strpos($scalar, '! '):
                         return (int) self::parseScalar(substr($scalar, 2));
                     case 0 === strpos($scalar, '!!php/object:'):
+                        trigger_error('!!php/object is deprecated use !php/object instead', E_USER_DEPRECATED);
+                        $scalar = substr($scalar, 1);
+                    case 0 === strpos($scalar, '!php/object:'):
                         if (self::$objectSupport) {
-                            return unserialize(substr($scalar, 13));
+                            return unserialize(substr($scalar, 12));
                         }
 
                         if (self::$exceptionOnInvalidType) {

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -477,7 +477,7 @@ class Inline
                     case 0 === strpos($scalar, '! '):
                         return (int) self::parseScalar(substr($scalar, 2));
                     case 0 === strpos($scalar, '!!php/object:'):
-                        trigger_error('!!php/object is deprecated use !php/object instead', E_USER_DEPRECATED);
+                        @trigger_error('!!php/object is deprecated since version 3.0 and will be removed in 4.0. Use !php/object instead.', E_USER_DEPRECATED);
                         $scalar = substr($scalar, 1);
                     case 0 === strpos($scalar, '!php/object:'):
                         if (self::$objectSupport) {

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -180,7 +180,7 @@ EOF;
     {
         $dump = $this->dumper->dump(array('foo' => new A(), 'bar' => 1), 0, 0, false, true);
 
-        $this->assertEquals('{ foo: !!php/object:O:30:"Symfony\Component\Yaml\Tests\A":1:{s:1:"a";s:3:"foo";}, bar: 1 }', $dump, '->dump() is able to dump objects');
+        $this->assertEquals('{ foo: !php/object:O:30:"Symfony\Component\Yaml\Tests\A":1:{s:1:"a";s:3:"foo";}, bar: 1 }', $dump, '->dump() is able to dump objects');
     }
 
     public function testObjectSupportDisabledButNoExceptions()

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -422,7 +422,7 @@ EOF;
     public function testObjectSupportEnabled()
     {
         $input = <<<EOF
-foo: !!php/object:O:30:"Symfony\Component\Yaml\Tests\B":1:{s:1:"b";s:3:"foo";}
+foo: !php/object:O:30:"Symfony\Component\Yaml\Tests\B":1:{s:1:"b";s:3:"foo";}
 bar: 1
 EOF;
         $this->assertEquals(array('foo' => new B(), 'bar' => 1), $this->parser->parse($input, false, true), '->parse() is able to parse objects');
@@ -431,7 +431,7 @@ EOF;
     public function testObjectSupportDisabledButNoExceptions()
     {
         $input = <<<EOF
-foo: !!php/object:O:30:"Symfony\Tests\Component\Yaml\B":1:{s:1:"b";s:3:"foo";}
+foo: !php/object:O:30:"Symfony\Tests\Component\Yaml\B":1:{s:1:"b";s:3:"foo";}
 bar: 1
 EOF;
 
@@ -443,7 +443,29 @@ EOF;
      */
     public function testObjectsSupportDisabledWithExceptions()
     {
+        $this->parser->parse('foo: !php/object:O:30:"Symfony\Tests\Component\Yaml\B":1:{s:1:"b";s:3:"foo";}', true, false);
+    }
+
+    /**
+     * @expectedException PHPUnit_Framework_Exception
+     * @expectedExceptionMessage !!php/object is deprecated use !php/object instead
+     */
+    public function testDeprecatedObjectNotation()
+    {
         $this->parser->parse('foo: !!php/object:O:30:"Symfony\Tests\Component\Yaml\B":1:{s:1:"b";s:3:"foo";}', true, false);
+    }
+
+    public function testDeprecatedObjectNotationWithErrorsSuppressed()
+    {
+        $input = <<<EOF
+foo: !!php/object:O:30:"Symfony\Component\Yaml\Tests\B":1:{s:1:"b";s:3:"foo";}
+bar: 1
+EOF;
+
+        $previous = error_reporting(E_ALL & ~E_USER_DEPRECATED);
+        $actual = $this->parser->parse($input, false, true);
+        error_reporting($previous);
+        $this->assertEquals(array('foo' => new B(), 'bar' => 1), $actual, '->parse() is able to parse objects');
     }
 
     /**

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -452,7 +452,7 @@ EOF;
      */
     public function testDeprecatedObjectNotation()
     {
-        $this->parser->parse('foo: !!php/object:O:30:"Symfony\Tests\Component\Yaml\B":1:{s:1:"b";s:3:"foo";}', true, false);
+        $this->parser->parse('foo: !!php/object:O:30:"Symfony\Tests\Component\Yaml\B":1:{s:1:"b";s:3:"foo";}', true, true);
     }
 
     public function testDeprecatedObjectNotationWithErrorsSuppressed()

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -446,26 +446,25 @@ EOF;
         $this->parser->parse('foo: !php/object:O:30:"Symfony\Tests\Component\Yaml\B":1:{s:1:"b";s:3:"foo";}', true, false);
     }
 
-    /**
-     * @expectedException PHPUnit_Framework_Exception
-     * @expectedExceptionMessage !!php/object is deprecated use !php/object instead
-     */
     public function testDeprecatedObjectNotation()
-    {
-        $this->parser->parse('foo: !!php/object:O:30:"Symfony\Tests\Component\Yaml\B":1:{s:1:"b";s:3:"foo";}', true, true);
-    }
-
-    public function testDeprecatedObjectNotationWithErrorsSuppressed()
     {
         $input = <<<EOF
 foo: !!php/object:O:30:"Symfony\Component\Yaml\Tests\B":1:{s:1:"b";s:3:"foo";}
 bar: 1
 EOF;
 
-        $previous = error_reporting(E_ALL & ~E_USER_DEPRECATED);
-        $actual = $this->parser->parse($input, false, true);
-        error_reporting($previous);
+        $actual = $this->parser->parse($input, true, true);
+
+        $lastError = error_get_last();
+        unset($lastError['file'], $lastError['line']);
+
+        $xError = array(
+            'type' => E_USER_DEPRECATED,
+            'message' => '!!php/object is deprecated since version 3.0 and will be removed in 4.0. Use !php/object instead.',
+        );
+
         $this->assertEquals(array('foo' => new B(), 'bar' => 1), $actual, '->parse() is able to parse objects');
+        $this->assertSame($xError, $lastError);
     }
 
     /**


### PR DESCRIPTION
[Yaml] deprecate old php/object syntax

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #16877 |
| License | MIT |

the old syntax (double exclamation mark) is to represent native YAML
types, a single exclamation mark represent a local tag.
an E_USER_DEPRECATED error is triggered for old tags.
