### PR TITLE
Overriding profiler position in CSS breaks JS positioning

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -416,9 +416,6 @@
     .sf-toolbar-block .sf-toolbar-icon svg {
         top: 6px;
     }
-    .sf-toolbar-block-config:hover .sf-toolbar-info {
-        right: 0;
-    }
     .sf-toolbar-block-time .sf-toolbar-icon svg,
     .sf-toolbar-block-memory .sf-toolbar-icon svg {
         display: none;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The positioning of a profiler info block (open to the left or right) is [calculated using Javascript](https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig#L35). Since Symfony 2.8, the config/version panel is right-aligned and opens to the left. If another panel is added to the right of it, the panel cannot open correctly.

Styles are unset in https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig#L46-L47 but that means it is set back to the stylesheet settings, which results in `right:0, left:0` on the element.

Manual testing is fairly easy: Just add a CSS class `sf-toolbar-block-right` on one or multiple panels (e.g. Doctrine) that result in the Config panel to have enough room to open to the right.

Here's a screenshot of the problem:
![bildschirmfoto 2015-12-11 um 10 27 55](https://cloud.githubusercontent.com/assets/1073273/11740305/e2c94cfc-9ff1-11e5-86ae-1fd94ec5a93e.png)

The other option would be to set the position in javascript to `right: auto` instead of unsetting, but I prefer to fix invalid CSS ;-)
