### PR TITLE
CSS min-height and min-width should not be "auto"

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -276,8 +276,8 @@ table tbody ul {
 }
 
 .metrics-horizontal .metric {
-    min-height: auto;
-    min-width: auto;
+    min-height: 0;
+    min-width: 0;
 }
 .metrics-horizontal .metric .value,
 .metrics-horizontal .metric .label {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Setting `min-width` and `min-height` to `auto` does not work in Safari and IE. The `auto` property has been removed from the standard meanwhile (see https://developer.mozilla.org/en-US/docs/Web/CSS/min-height).

Correct is to set a minimum of zero, which is actually "no minimum height".

This is what the web profiler looks like before and after on latest Safari:

![bildschirmfoto 2015-12-11 um 11 02 31](https://cloud.githubusercontent.com/assets/1073273/11741083/f17357fc-9ff6-11e5-8b59-239b38d37b2a.png)

![bildschirmfoto 2015-12-11 um 11 02 25](https://cloud.githubusercontent.com/assets/1073273/11741089/f6fb6656-9ff6-11e5-946f-f6c9f936c17f.png)
