### PR TITLE
Missing ctype extension as requirement

### DIFF
--- a/src/Symfony/Component/Yaml/composer.json
+++ b/src/Symfony/Component/Yaml/composer.json
@@ -16,7 +16,8 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9"
+        "php": ">=5.5.9",
+        "ext-ctype": "*"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Yaml\\": "" },


### PR DESCRIPTION
PHP Fatal error:  Call to undefined function Symfony\Component\Yaml\ctype_digit() in .../vendor/symfony/yaml/Inline.php on line 494
