### PR TITLE
[Validator] Fix test error for AnnotationLoader

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/AnnotationLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/AnnotationLoaderTest.php
@@ -148,6 +148,9 @@ class AnnotationLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testLoadGroupSequenceProviderAnnotation()
     {
+        // Autoload GroupSequenceProvider annotation
+        $this->assertTrue(class_exists('Symfony\Component\Validator\Constraints\GroupSequenceProvider'));
+
         $loader = new AnnotationLoader(new AnnotationReader());
 
         $metadata = new ClassMetadata('Symfony\Component\Validator\Tests\Fixtures\GroupSequenceProviderEntity');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

When running the tests for the Validator Component alone, The test `AnnotationLoaderTest::testLoadGroupSequenceProviderAnnotation` fails because the class for the `GroupSequenceProvider` annotation isn't loaded yet and the AnnotationReader doesn't autoload Annotation classes.

This ensures the class is auto-loaded.

AppVeyor failing tests are related to the HttpFoundation Component.
HHVM failing tests are related to the Process Component.
In both case, it's unrelated to this PR.
