### PR TITLE
[Validator] Target aware class constraints

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.1.0
+-----
+
+ * added Target Aware Constraints and its support in loaders for class constraints
+
 2.8.0
 -----
 

--- a/src/Symfony/Component/Validator/Constraints/TargetAwareConstraintInterface.php
+++ b/src/Symfony/Component/Validator/Constraints/TargetAwareConstraintInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+/**
+ * This interface is to be implemented by constraints that need to be
+ * aware of the exact target they have been declared on.
+ *
+ * This interface only makes sense for class constraints. Which could be
+ * attached to multiple classes because of class inheritance.
+ *
+ * @since 3.1
+ *
+ * @author Mathieu Lemoine <mlemoine@mlemoine.name>
+ */
+interface TargetAwareConstraintInterface
+{
+    /*
+     * Since constraints are implemented using public properties,
+     * the interface is intended as a tag and declare no method.
+     */
+}

--- a/src/Symfony/Component/Validator/Constraints/TargetAwareConstraintTrait.php
+++ b/src/Symfony/Component/Validator/Constraints/TargetAwareConstraintTrait.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * This trait is intended as a helper for implementing TargetAwareConstraintInterface.
+ *
+ * Since the interface interface only makes sense for class constraints,
+ * the default targets is set to class constraint.
+ *
+ * @since 3.1
+ *
+ * @author Mathieu Lemoine <mlemoine@mlemoine.name>
+ */
+trait TargetAwareConstraintTrait
+{
+    public $target;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTargets()
+    {
+        return Constraint::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Symfony/Component/Validator/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/AnnotationLoader.php
@@ -16,6 +16,7 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Callback;
 use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\Constraints\GroupSequenceProvider;
+use Symfony\Component\Validator\Constraints\TargetAwareConstraintInterface;
 use Symfony\Component\Validator\Exception\MappingException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 
@@ -51,6 +52,10 @@ class AnnotationLoader implements LoaderInterface
             } elseif ($constraint instanceof GroupSequenceProvider) {
                 $metadata->setGroupSequenceProvider(true);
             } elseif ($constraint instanceof Constraint) {
+                if ($constraint instanceof TargetAwareConstraintInterface) {
+                    $constraint->target = $metadata->getClassName();
+                }
+
                 $metadata->addConstraint($constraint);
             }
 

--- a/src/Symfony/Component/Validator/Mapping/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/XmlFileLoader.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Mapping\Loader;
 
 use Symfony\Component\Config\Util\XmlUtils;
+use Symfony\Component\Validator\Constraints\TargetAwareConstraintInterface;
 use Symfony\Component\Validator\Exception\MappingException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 
@@ -201,6 +202,10 @@ class XmlFileLoader extends FileLoader
         }
 
         foreach ($this->parseConstraints($classDescription->constraint) as $constraint) {
+            if ($constraint instanceof TargetAwareConstraintInterface) {
+                $constraint->target = $metadata->getClassName();
+            }
+
             $metadata->addConstraint($constraint);
         }
 

--- a/src/Symfony/Component/Validator/Mapping/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/YamlFileLoader.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Mapping\Loader;
 
 use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Constraints\TargetAwareConstraintInterface;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Parser as YamlParser;
 
@@ -157,6 +158,10 @@ class YamlFileLoader extends FileLoader
 
         if (isset($classDescription['constraints']) && is_array($classDescription['constraints'])) {
             foreach ($this->parseNodes($classDescription['constraints']) as $constraint) {
+                if ($constraint instanceof TargetAwareConstraintInterface) {
+                    $constraint->target = $metadata->getClassName();
+                }
+
                 $metadata->addConstraint($constraint);
             }
         }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintD.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintD.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\TargetAwareConstraintInterface;
+use Symfony\Component\Validator\Constraints\TargetAwareConstraintTrait;
+
+/** @Annotation */
+class ConstraintD extends Constraint implements TargetAwareConstraintInterface
+{
+    use TargetAwareConstraintTrait;
+}

--- a/src/Symfony/Component/Validator/Tests/Fixtures/EntityParent.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/EntityParent.php
@@ -13,6 +13,9 @@ namespace Symfony\Component\Validator\Tests\Fixtures;
 
 use Symfony\Component\Validator\Constraints\NotNull;
 
+/**
+ * @Symfony\Component\Validator\Tests\Fixtures\ConstraintD
+ */
 class EntityParent
 {
     protected $firstName;

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/AnnotationLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/AnnotationLoaderTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\Validator\Constraints\IsTrue;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
+use Symfony\Component\Validator\Tests\Fixtures\ConstraintD;
 
 class AnnotationLoaderTest extends \PHPUnit_Framework_TestCase
 {
@@ -89,6 +90,7 @@ class AnnotationLoaderTest extends \PHPUnit_Framework_TestCase
         $loader->loadClassMetadata($parent_metadata);
 
         $expected_parent = new ClassMetadata('Symfony\Component\Validator\Tests\Fixtures\EntityParent');
+        $expected_parent->addConstraint(new ConstraintD(array('target' => 'Symfony\Component\Validator\Tests\Fixtures\EntityParent')));
         $expected_parent->addPropertyConstraint('other', new NotNull());
         $expected_parent->getReflectionClass();
 
@@ -113,6 +115,7 @@ class AnnotationLoaderTest extends \PHPUnit_Framework_TestCase
         $loader->loadClassMetadata($metadata);
 
         $expected_parent = new ClassMetadata('Symfony\Component\Validator\Tests\Fixtures\EntityParent');
+        $expected_parent->addConstraint(new ConstraintD(array('target' => 'Symfony\Component\Validator\Tests\Fixtures\EntityParent')));
         $expected_parent->addPropertyConstraint('other', new NotNull());
         $expected_parent->getReflectionClass();
 

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/YamlFileLoaderTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Loader\YamlFileLoader;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintB;
+use Symfony\Component\Validator\Tests\Fixtures\ConstraintD;
 
 class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
 {
@@ -93,6 +94,74 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $loader->loadClassMetadata($metadata);
 
         $expected = new ClassMetadata('Symfony\Component\Validator\Tests\Fixtures\Entity');
+        $expected->setGroupSequence(array('Foo', 'Entity'));
+        $expected->addConstraint(new ConstraintA());
+        $expected->addConstraint(new ConstraintB());
+        $expected->addConstraint(new Callback('validateMe'));
+        $expected->addConstraint(new Callback('validateMeStatic'));
+        $expected->addConstraint(new Callback(array('Symfony\Component\Validator\Tests\Fixtures\CallbackClass', 'callback')));
+        $expected->addPropertyConstraint('firstName', new NotNull());
+        $expected->addPropertyConstraint('firstName', new Range(array('min' => 3)));
+        $expected->addPropertyConstraint('firstName', new Choice(array('A', 'B')));
+        $expected->addPropertyConstraint('firstName', new All(array(new NotNull(), new Range(array('min' => 3)))));
+        $expected->addPropertyConstraint('firstName', new All(array('constraints' => array(new NotNull(), new Range(array('min' => 3))))));
+        $expected->addPropertyConstraint('firstName', new Collection(array('fields' => array(
+            'foo' => array(new NotNull(), new Range(array('min' => 3))),
+            'bar' => array(new Range(array('min' => 5))),
+        ))));
+        $expected->addPropertyConstraint('firstName', new Choice(array(
+            'message' => 'Must be one of %choices%',
+            'choices' => array('A', 'B'),
+        )));
+        $expected->addGetterConstraint('lastName', new NotNull());
+        $expected->addGetterConstraint('valid', new IsTrue());
+        $expected->addGetterConstraint('permissions', new IsTrue());
+
+        $this->assertEquals($expected, $metadata);
+    }
+
+    /**
+     * Test MetaData merge with parent annotation.
+     */
+    public function testLoadParentClassMetadata()
+    {
+        $loader = new YamlFileLoader(__DIR__.'/constraint-mapping.yml');
+
+        // Load Parent MetaData
+        $parent_metadata = new ClassMetadata('Symfony\Component\Validator\Tests\Fixtures\EntityParent');
+        $loader->loadClassMetadata($parent_metadata);
+
+        $expected_parent = new ClassMetadata('Symfony\Component\Validator\Tests\Fixtures\EntityParent');
+        $expected_parent->addConstraint(new ConstraintD(array('target' => 'Symfony\Component\Validator\Tests\Fixtures\EntityParent')));
+        $expected_parent->addPropertyConstraint('other', new NotNull());
+
+        $this->assertEquals($expected_parent, $parent_metadata);
+    }
+    /**
+     * Test MetaData merge with parent annotation.
+     */
+    public function testLoadClassMetadataAndMerge()
+    {
+        $loader = new YamlFileLoader(__DIR__.'/constraint-mapping.yml');
+
+        // Load Parent MetaData
+        $parent_metadata = new ClassMetadata('Symfony\Component\Validator\Tests\Fixtures\EntityParent');
+        $loader->loadClassMetadata($parent_metadata);
+
+        $metadata = new ClassMetadata('Symfony\Component\Validator\Tests\Fixtures\Entity');
+
+        // Merge parent metaData.
+        $metadata->mergeConstraints($parent_metadata);
+
+        $loader->loadClassMetadata($metadata);
+
+        $expected_parent = new ClassMetadata('Symfony\Component\Validator\Tests\Fixtures\EntityParent');
+        $expected_parent->addConstraint(new ConstraintD(array('target' => 'Symfony\Component\Validator\Tests\Fixtures\EntityParent')));
+        $expected_parent->addPropertyConstraint('other', new NotNull());
+
+        $expected = new ClassMetadata('Symfony\Component\Validator\Tests\Fixtures\Entity');
+        $expected->mergeConstraints($expected_parent);
+
         $expected->setGroupSequence(array('Foo', 'Entity'));
         $expected->addConstraint(new ConstraintA());
         $expected->addConstraint(new ConstraintB());

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping.xml
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping.xml
@@ -6,6 +6,15 @@
 
   <namespace prefix="custom">Symfony\Component\Validator\Tests\Fixtures\</namespace>
 
+  <class name="Symfony\Component\Validator\Tests\Fixtures\EntityParent">
+    <!-- Target aware constraint -->
+    <constraint name="Symfony\Component\Validator\Tests\Fixtures\ConstraintD" />
+
+      <property name="other">
+        <constraint name="NotNull" />
+      </property>
+  </class>
+
   <class name="Symfony\Component\Validator\Tests\Fixtures\Entity">
 
     <group-sequence>

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping.yml
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping.yml
@@ -1,6 +1,14 @@
 namespaces:
   custom: Symfony\Component\Validator\Tests\Fixtures\
 
+Symfony\Component\Validator\Tests\Fixtures\EntityParent:
+  constraints:
+    # Target aware constraint
+    - Symfony\Component\Validator\Tests\Fixtures\ConstraintD: ~
+  properties:
+    other:
+      - NotNull: ~
+
 Symfony\Component\Validator\Tests\Fixtures\Entity:
   group_sequence:
     - Foo


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | symfony/symfony-docs#6002 |

This PR is the first part of #16969

It basically creates a new `TargetAwareConstraintInterface` and a trait for its implementation.

The idea is that a constraint implementing this interface would need to be aware of its target (it makes sense only for Class Constraints). For class constraints, the target is the class the constraint was declared on.

It provides also support for YamlFileLoader, XmlFileLoader and AnnotationLoader (only for Class Constraints) with appropriate tests.

AppVeyor failing tests are related to the HttpFoundation Component.
HHVM failing tests are related to the Process Component.
In both case, it's unrelated to this PR.
