### PR TITLE
[WCM][DoctrineBridge] Fix UniqueEntity interaction with inheritance

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -26,3 +26,9 @@ Yaml
 
  * The `!!php/object` tag to indicate dumped PHP objects was removed in favor of
    the `!php/object` tag.
+
+Doctrine Bridge
+---
+
+ * The `UniqueEntity` constraints now requires a `target` property when loaded
+   with the `StaticMethodLoader`.

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+3.2.0
+-----
+
+ * fixed `UniqueEntity` interaction with inheritance
+ * deprecated `UniqueEntity` constraints without a target (possible only if
+   `StaticMethodLoader` or a custom constraint loader is used)
+
 3.1.0
 -----
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/ChildEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/ChildEntity.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+
+/** @Entity */
+class ChildEntity extends SingleIntIdEntity
+{
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/HighestEntity/GoodEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/HighestEntity/GoodEntity.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures\HighestEntity;
+
+use Doctrine\ORM\Mapping\Entity;
+
+/**
+ * @Entity
+ */
+class GoodEntity extends UpperTransient
+{
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/HighestEntity/InstanceEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/HighestEntity/InstanceEntity.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures\HighestEntity;
+
+use Doctrine\ORM\Mapping\Entity;
+
+/**
+ * @Entity
+ */
+class InstanceEntity extends LowerEntity
+{
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/HighestEntity/LowerEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/HighestEntity/LowerEntity.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures\HighestEntity;
+
+use Doctrine\ORM\Mapping\Entity;
+
+/**
+ * @Entity
+ */
+class LowerEntity extends LowerTransient
+{
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/HighestEntity/LowerMappedSuperClass.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/HighestEntity/LowerMappedSuperClass.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures\HighestEntity;
+
+use Doctrine\ORM\Mapping\MappedSuperclass;
+
+/** @MappedSuperclass */
+class LowerMappedSuperClass extends GoodEntity
+{
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/HighestEntity/LowerTransient.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/HighestEntity/LowerTransient.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures\HighestEntity;
+
+class LowerTransient extends LowerMappedSuperClass
+{
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/HighestEntity/SideEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/HighestEntity/SideEntity.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures\HighestEntity;
+
+use Doctrine\ORM\Mapping\Entity;
+
+/**
+ * @Entity
+ */
+class SideEntity extends SideTransient
+{
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/HighestEntity/SideMappedSuperClass.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/HighestEntity/SideMappedSuperClass.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures\HighestEntity;
+
+use Doctrine\ORM\Mapping\MappedSuperclass;
+
+/** @MappedSuperclass */
+class SideMappedSuperClass extends GoodEntity
+{
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/HighestEntity/SideTransient.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/HighestEntity/SideTransient.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures\HighestEntity;
+
+class SideTransient extends SideMappedSuperClass
+{
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/HighestEntity/TargetMappedSuperClass.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/HighestEntity/TargetMappedSuperClass.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures\HighestEntity;
+
+use Doctrine\ORM\Mapping\MappedSuperclass;
+
+/** @MappedSuperclass */
+class TargetMappedSuperClass extends TopEntity
+{
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/HighestEntity/TargetTransient.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/HighestEntity/TargetTransient.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures\HighestEntity;
+
+class TargetTransient extends TargetMappedSuperClass
+{
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/HighestEntity/TopEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/HighestEntity/TopEntity.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures\HighestEntity;
+
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\DiscriminatorColumn;
+use Doctrine\ORM\Mapping\DiscriminatorMap;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\InheritanceType;
+
+/**
+ * @Entity
+ * @InheritanceType("SINGLE_TABLE")
+ * @DiscriminatorColumn(name="discr", type="string")
+ * @DiscriminatorMap({
+ *     "top"  = "TopEntity",
+ *     "good" = "GoodEntity",
+ *     "low"  = "LowEntity",
+ *     "side" = "SideEntity",
+ *     "inst" = "InstanceEntity",
+ * })
+ *
+ * The point of this hierarchy is to test the selection of the repository
+ * by the UniqueEntityValidator. This hierarchy provides:
+ *  - A top entity which is too high in the inheritance chain to be selected
+ *  - Both a transient and a mapped super class targets
+ *  - Upper mapped super and transient classes which should not be selected
+ *  - A good Entity which is intended to provide the repo
+ *  - A side branch including one of each Entity, Mapped Super and Transient
+ *  - A lower part including one of each Entity, Mapped Super and Transient
+ *    which are not intended to be selected since they lower than the GoodEntity
+ *  - An InstanceEntity which is intended to be validated
+ */
+class TopEntity
+{
+    /** @Id @Column(type="integer") */
+    protected $id;
+
+    /** @Column(type="string", nullable=true) */
+    public $name;
+
+    public function __construct($id, $name)
+    {
+        $this->id = $id;
+        $this->name = $name;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/HighestEntity/UpperMappedSuperClass.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/HighestEntity/UpperMappedSuperClass.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures\HighestEntity;
+
+use Doctrine\ORM\Mapping\MappedSuperclass;
+
+/** @MappedSuperclass */
+class UpperMappedSuperClass extends TargetTransient
+{
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/HighestEntity/UpperTransient.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/HighestEntity/UpperTransient.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures\HighestEntity;
+
+class UpperTransient extends UpperMappedSuperClass
+{
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/SingleIntIdEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/SingleIntIdEntity.php
@@ -13,9 +13,17 @@ namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
 
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\DiscriminatorColumn;
+use Doctrine\ORM\Mapping\DiscriminatorMap;
 use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\InheritanceType;
 
-/** @Entity */
+/**
+ * @Entity
+ * @InheritanceType("SINGLE_TABLE")
+ * @DiscriminatorColumn(name="discr", type="string")
+ * @DiscriminatorMap({"parent" = "SingleIntIdEntity", "child" = "ChildEntity"})
+ */
 class SingleIntIdEntity
 {
     /** @Id @Column(type="integer") */

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
@@ -12,6 +12,8 @@
 namespace Symfony\Bridge\Doctrine\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\TargetAwareConstraintInterface;
+use Symfony\Component\Validator\Constraints\TargetAwareConstraintTrait;
 
 /**
  * Constraint for the Unique Entity validator.
@@ -21,8 +23,10 @@ use Symfony\Component\Validator\Constraint;
  *
  * @author Benjamin Eberlei <kontakt@beberlei.de>
  */
-class UniqueEntity extends Constraint
+class UniqueEntity extends Constraint implements TargetAwareConstraintInterface
 {
+    use TargetAwareConstraintTrait;
+
     public $message = 'This value is already used.';
     public $service = 'doctrine.orm.validator.unique';
     public $em = null;
@@ -44,14 +48,6 @@ class UniqueEntity extends Constraint
     public function validatedBy()
     {
         return $this->service;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getTargets()
-    {
-        return self::CLASS_CONSTRAINT;
     }
 
     public function getDefaultOption()

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.1.0
+-----
+
+ * added Target Aware Constraints and its support in loaders for class constraints
+
 2.8.0
 -----
 

--- a/src/Symfony/Component/Validator/Constraints/TargetAwareConstraintInterface.php
+++ b/src/Symfony/Component/Validator/Constraints/TargetAwareConstraintInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+/**
+ * This interface is to be implemented by constraints that need to be
+ * aware of the exact target they have been declared on.
+ *
+ * This interface only makes sense for class constraints. Which could be
+ * attached to multiple classes because of class inheritance.
+ *
+ * @since 3.1
+ *
+ * @author Mathieu Lemoine <mlemoine@mlemoine.name>
+ */
+interface TargetAwareConstraintInterface
+{
+    /*
+     * Since constraints are implemented using public properties,
+     * the interface is intended as a tag and declare no method.
+     */
+}

--- a/src/Symfony/Component/Validator/Constraints/TargetAwareConstraintTrait.php
+++ b/src/Symfony/Component/Validator/Constraints/TargetAwareConstraintTrait.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * This trait is intended as a helper for implementing TargetAwareConstraintInterface.
+ *
+ * Since the interface interface only makes sense for class constraints,
+ * the default targets is set to class constraint.
+ *
+ * @since 3.1
+ *
+ * @author Mathieu Lemoine <mlemoine@mlemoine.name>
+ */
+trait TargetAwareConstraintTrait
+{
+    public $target;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTargets()
+    {
+        return Constraint::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Symfony/Component/Validator/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/AnnotationLoader.php
@@ -16,6 +16,7 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Callback;
 use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\Constraints\GroupSequenceProvider;
+use Symfony\Component\Validator\Constraints\TargetAwareConstraintInterface;
 use Symfony\Component\Validator\Exception\MappingException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 
@@ -51,6 +52,10 @@ class AnnotationLoader implements LoaderInterface
             } elseif ($constraint instanceof GroupSequenceProvider) {
                 $metadata->setGroupSequenceProvider(true);
             } elseif ($constraint instanceof Constraint) {
+                if ($constraint instanceof TargetAwareConstraintInterface) {
+                    $constraint->target = $metadata->getClassName();
+                }
+
                 $metadata->addConstraint($constraint);
             }
 

--- a/src/Symfony/Component/Validator/Mapping/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/XmlFileLoader.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Mapping\Loader;
 
 use Symfony\Component\Config\Util\XmlUtils;
+use Symfony\Component\Validator\Constraints\TargetAwareConstraintInterface;
 use Symfony\Component\Validator\Exception\MappingException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 
@@ -201,6 +202,10 @@ class XmlFileLoader extends FileLoader
         }
 
         foreach ($this->parseConstraints($classDescription->constraint) as $constraint) {
+            if ($constraint instanceof TargetAwareConstraintInterface) {
+                $constraint->target = $metadata->getClassName();
+            }
+
             $metadata->addConstraint($constraint);
         }
 

--- a/src/Symfony/Component/Validator/Mapping/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/YamlFileLoader.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Mapping\Loader;
 
 use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Constraints\TargetAwareConstraintInterface;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Parser as YamlParser;
 
@@ -157,6 +158,10 @@ class YamlFileLoader extends FileLoader
 
         if (isset($classDescription['constraints']) && is_array($classDescription['constraints'])) {
             foreach ($this->parseNodes($classDescription['constraints']) as $constraint) {
+                if ($constraint instanceof TargetAwareConstraintInterface) {
+                    $constraint->target = $metadata->getClassName();
+                }
+
                 $metadata->addConstraint($constraint);
             }
         }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintD.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintD.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\TargetAwareConstraintInterface;
+use Symfony\Component\Validator\Constraints\TargetAwareConstraintTrait;
+
+/** @Annotation */
+class ConstraintD extends Constraint implements TargetAwareConstraintInterface
+{
+    use TargetAwareConstraintTrait;
+}

--- a/src/Symfony/Component/Validator/Tests/Fixtures/EntityParent.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/EntityParent.php
@@ -13,6 +13,9 @@ namespace Symfony\Component\Validator\Tests\Fixtures;
 
 use Symfony\Component\Validator\Constraints\NotNull;
 
+/**
+ * @Symfony\Component\Validator\Tests\Fixtures\ConstraintD
+ */
 class EntityParent
 {
     protected $firstName;

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/AnnotationLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/AnnotationLoaderTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\Validator\Constraints\IsTrue;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
+use Symfony\Component\Validator\Tests\Fixtures\ConstraintD;
 
 class AnnotationLoaderTest extends \PHPUnit_Framework_TestCase
 {
@@ -89,6 +90,7 @@ class AnnotationLoaderTest extends \PHPUnit_Framework_TestCase
         $loader->loadClassMetadata($parent_metadata);
 
         $expected_parent = new ClassMetadata('Symfony\Component\Validator\Tests\Fixtures\EntityParent');
+        $expected_parent->addConstraint(new ConstraintD(array('target' => 'Symfony\Component\Validator\Tests\Fixtures\EntityParent')));
         $expected_parent->addPropertyConstraint('other', new NotNull());
         $expected_parent->getReflectionClass();
 
@@ -113,6 +115,7 @@ class AnnotationLoaderTest extends \PHPUnit_Framework_TestCase
         $loader->loadClassMetadata($metadata);
 
         $expected_parent = new ClassMetadata('Symfony\Component\Validator\Tests\Fixtures\EntityParent');
+        $expected_parent->addConstraint(new ConstraintD(array('target' => 'Symfony\Component\Validator\Tests\Fixtures\EntityParent')));
         $expected_parent->addPropertyConstraint('other', new NotNull());
         $expected_parent->getReflectionClass();
 

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/YamlFileLoaderTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Loader\YamlFileLoader;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintB;
+use Symfony\Component\Validator\Tests\Fixtures\ConstraintD;
 
 class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
 {
@@ -93,6 +94,74 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $loader->loadClassMetadata($metadata);
 
         $expected = new ClassMetadata('Symfony\Component\Validator\Tests\Fixtures\Entity');
+        $expected->setGroupSequence(array('Foo', 'Entity'));
+        $expected->addConstraint(new ConstraintA());
+        $expected->addConstraint(new ConstraintB());
+        $expected->addConstraint(new Callback('validateMe'));
+        $expected->addConstraint(new Callback('validateMeStatic'));
+        $expected->addConstraint(new Callback(array('Symfony\Component\Validator\Tests\Fixtures\CallbackClass', 'callback')));
+        $expected->addPropertyConstraint('firstName', new NotNull());
+        $expected->addPropertyConstraint('firstName', new Range(array('min' => 3)));
+        $expected->addPropertyConstraint('firstName', new Choice(array('A', 'B')));
+        $expected->addPropertyConstraint('firstName', new All(array(new NotNull(), new Range(array('min' => 3)))));
+        $expected->addPropertyConstraint('firstName', new All(array('constraints' => array(new NotNull(), new Range(array('min' => 3))))));
+        $expected->addPropertyConstraint('firstName', new Collection(array('fields' => array(
+            'foo' => array(new NotNull(), new Range(array('min' => 3))),
+            'bar' => array(new Range(array('min' => 5))),
+        ))));
+        $expected->addPropertyConstraint('firstName', new Choice(array(
+            'message' => 'Must be one of %choices%',
+            'choices' => array('A', 'B'),
+        )));
+        $expected->addGetterConstraint('lastName', new NotNull());
+        $expected->addGetterConstraint('valid', new IsTrue());
+        $expected->addGetterConstraint('permissions', new IsTrue());
+
+        $this->assertEquals($expected, $metadata);
+    }
+
+    /**
+     * Test MetaData merge with parent annotation.
+     */
+    public function testLoadParentClassMetadata()
+    {
+        $loader = new YamlFileLoader(__DIR__.'/constraint-mapping.yml');
+
+        // Load Parent MetaData
+        $parent_metadata = new ClassMetadata('Symfony\Component\Validator\Tests\Fixtures\EntityParent');
+        $loader->loadClassMetadata($parent_metadata);
+
+        $expected_parent = new ClassMetadata('Symfony\Component\Validator\Tests\Fixtures\EntityParent');
+        $expected_parent->addConstraint(new ConstraintD(array('target' => 'Symfony\Component\Validator\Tests\Fixtures\EntityParent')));
+        $expected_parent->addPropertyConstraint('other', new NotNull());
+
+        $this->assertEquals($expected_parent, $parent_metadata);
+    }
+    /**
+     * Test MetaData merge with parent annotation.
+     */
+    public function testLoadClassMetadataAndMerge()
+    {
+        $loader = new YamlFileLoader(__DIR__.'/constraint-mapping.yml');
+
+        // Load Parent MetaData
+        $parent_metadata = new ClassMetadata('Symfony\Component\Validator\Tests\Fixtures\EntityParent');
+        $loader->loadClassMetadata($parent_metadata);
+
+        $metadata = new ClassMetadata('Symfony\Component\Validator\Tests\Fixtures\Entity');
+
+        // Merge parent metaData.
+        $metadata->mergeConstraints($parent_metadata);
+
+        $loader->loadClassMetadata($metadata);
+
+        $expected_parent = new ClassMetadata('Symfony\Component\Validator\Tests\Fixtures\EntityParent');
+        $expected_parent->addConstraint(new ConstraintD(array('target' => 'Symfony\Component\Validator\Tests\Fixtures\EntityParent')));
+        $expected_parent->addPropertyConstraint('other', new NotNull());
+
+        $expected = new ClassMetadata('Symfony\Component\Validator\Tests\Fixtures\Entity');
+        $expected->mergeConstraints($expected_parent);
+
         $expected->setGroupSequence(array('Foo', 'Entity'));
         $expected->addConstraint(new ConstraintA());
         $expected->addConstraint(new ConstraintB());

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping.xml
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping.xml
@@ -6,6 +6,15 @@
 
   <namespace prefix="custom">Symfony\Component\Validator\Tests\Fixtures\</namespace>
 
+  <class name="Symfony\Component\Validator\Tests\Fixtures\EntityParent">
+    <!-- Target aware constraint -->
+    <constraint name="Symfony\Component\Validator\Tests\Fixtures\ConstraintD" />
+
+      <property name="other">
+        <constraint name="NotNull" />
+      </property>
+  </class>
+
   <class name="Symfony\Component\Validator\Tests\Fixtures\Entity">
 
     <group-sequence>

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping.yml
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping.yml
@@ -1,6 +1,14 @@
 namespaces:
   custom: Symfony\Component\Validator\Tests\Fixtures\
 
+Symfony\Component\Validator\Tests\Fixtures\EntityParent:
+  constraints:
+    # Target aware constraint
+    - Symfony\Component\Validator\Tests\Fixtures\ConstraintD: ~
+  properties:
+    other:
+      - NotNull: ~
+
 Symfony\Component\Validator\Tests\Fixtures\Entity:
   group_sequence:
     - Foo


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes, only if `StaticMethodLoader` or a custom Constraint Loader is used to load `UniqueEntity` constraints |
| Tests pass? | yes |
| Fixed tickets | #16969, #4087, #12573 |
| Dependens on | #16978 |
| License | MIT |
| Doc PR | N/A |

This is the second half of #16969 with the actual fix.

This version of the code is ready for code review. However, since I'm dependent on #16978, I'm leaving the PR as a WIP until the dependence is merged and I rebase the current one on master.

Since I introduce deprecations, I updated `UPGRADE-4.0.md`.
- [x] ~~Manage the case where `@UniqueEntity` is attached to a non-Entity class~~
