### PR TITLE
[WIP][RFC][Validator] Dynamic Validation Groups

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/DynamicGroups.php
+++ b/src/Symfony/Component/Validator/Constraints/DynamicGroups.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ * @Target({"CLASS", "ANNOTATION"})
+ */
+class DynamicGroups extends Constraint
+{
+    public $groupProvider;
+
+    public function getRequiredOptions()
+    {
+        return array('groupProvider');
+    }
+
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/DynamicGroupsValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DynamicGroupsValidator.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * @Annotation
+ * @Target({"CLASS", "ANNOTATION"})
+ */
+class DynamicGroupsValidator extends ConstraintValidator
+{
+    /**
+     * @var PropertyAccessor
+     */
+    private $propertyAccessor;
+
+    public function __construct()
+    {
+        $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
+    }
+
+    /**
+     * @param object|array|null $value
+     * @param Constraint        $constraint
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (null === $value) {
+            return;
+        }
+
+        /** @var DynamicValidationGroup $constraint */
+        $groups = $this->propertyAccessor->getValue($value, $constraint->groupProvider);
+
+        if (is_array($groups)) {
+            $this->context
+                ->getValidator()
+                ->inContext($this->context)
+                ->atPath('')
+                ->validate($value, null, $groups);
+        }
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Since the cascade_validation option has been deprecated for forms it makes sense to provide a generic solution for validation groups based on populated entity data.

This is based on the discussion I had with @stof a while ago and the gist he provided. https://gist.github.com/stof/d21838b00d08858ae6bb

``` php
/**
 * @DynamicGroups(groupProvider="dynamicGroups")
 */
class Customer
{
    /**
     * @Assert\NotBlank()
     */
    private $customerType; // Customer or Person

    /**
     * @Assert\NotBlank(groups={"Company"})
     */
    private $companyName;

    /**
     * @Assert\NotBlank(groups={"Person"})
     */
    private $lastName;

    public function getDynamicGroups()
    {
        return [$this->customerType];
    }
}
```

By default the entity will be validated against the Default constraint (or the constraint specified in the validator) and if the DynamicGroups constraint is part of that validation the validation will be cascaded to the dynamic groups.

The PR is just the RFC to see if that functionality is wanted, then I would complete it with tests and documentation. This gives a generic solution where the validation is configured is only in the entity and the validation_groups option in form types then can and should only be used for partial validation.
