### PR TITLE
Make property accessor aliases available by runtime.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
@@ -55,7 +55,7 @@
         </service>
 
         <!-- CoreExtension -->
-        <service id="form.property_accessor" alias="property_accessor" public="false" />
+        <service id="form.property_accessor" alias="property_accessor" />
 
         <service id="form.type.form" class="Symfony\Component\Form\Extension\Core\Type\FormType">
             <argument type="service" id="form.property_accessor" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
@@ -17,7 +17,7 @@
             <argument type="collection" />
         </service>
 
-        <service id="serializer.property_accessor" alias="property_accessor" public="false" />
+        <service id="serializer.property_accessor" alias="property_accessor" />
 
         <!-- Normalizer -->
         <service id="serializer.normalizer.object" class="Symfony\Component\Serializer\Normalizer\ObjectNormalizer" public="false">


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14989 |
| License | MIT |
| Doc PR | - |

Sometimes we need getting `form.property_accessor` at runtime, for example in SonataAdminBundle https://github.com/sonata-project/SonataAdminBundle/pull/3488/files#diff-ed85ead40da3b862ecc9ba97a2e62ac2R243
