### PR TITLE
[FrameworkBundle][HttpKernel] Remove remaining $triggerDeprecation flag

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -13,7 +13,6 @@
             <argument type="service" id="event_dispatcher" />
             <argument type="service" id="controller_resolver" />
             <argument type="service" id="request_stack" />
-            <argument>false</argument>
         </service>
 
         <service id="request_stack" class="Symfony\Component\HttpFoundation\RequestStack" />


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets | n/a |
| License | MIT |

Introduced in #14665, this flag controlled the deprecation notice triggering when using the `ContainerAwareHttpKernel`, in order to avoid triggering it when using this class in the Symfony framework. This class no longer exists now, neither the flag.
