### PR TITLE
Asset fix phan type error

### DIFF
--- a/src/Symfony/Component/Asset/UrlPackage.php
+++ b/src/Symfony/Component/Asset/UrlPackage.php
@@ -112,7 +112,7 @@ class UrlPackage extends Package
      *
      * @param string $path
      *
-     * @return string The base URL for the given path
+     * @return float The base URL for the given path
      */
     protected function chooseBaseUrl($path)
     {

--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -332,7 +332,7 @@ class Table
             $columns[] = $this->getNumberOfColumns($row);
         }
 
-        return $this->numberOfColumns = max($columns);
+        $this->numberOfColumns = max($columns);
     }
 
     private function buildTableRows($rows)
@@ -487,7 +487,7 @@ class Table
      *
      * @param array $row
      *
-     * @return array()
+     * @return array
      */
     private function getRowColumns($row)
     {
@@ -528,8 +528,6 @@ class Table
 
     /**
      * Gets column width.
-     *
-     * @param int $column
      *
      * @return int
      */


### PR DESCRIPTION
Hi,

This PR fixes documentation issue 
src/Symfony/Component/Asset/UrlPackage.php:119 TypeError return float but chooseBaseUrl() is declared to return string

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
