### PR TITLE
fix UrlPackage.php:119 TypeError return float but chooseBaseUrl() is …

### DIFF
--- a/src/Symfony/Component/Asset/UrlPackage.php
+++ b/src/Symfony/Component/Asset/UrlPackage.php
@@ -112,11 +112,11 @@ class UrlPackage extends Package
      *
      * @param string $path
      *
-     * @return float The base URL for the given path
+     * @return int The base URL for the given path
      */
     protected function chooseBaseUrl($path)
     {
-        return fmod(hexdec(substr(hash('sha256', $path), 0, 10)), count($this->baseUrls));
+        return (int) fmod(hexdec(substr(hash('sha256', $path), 0, 10)), count($this->baseUrls));
     }
 
     private function getSslUrls($urls)

--- a/src/Symfony/Component/Asset/UrlPackage.php
+++ b/src/Symfony/Component/Asset/UrlPackage.php
@@ -112,7 +112,7 @@ class UrlPackage extends Package
      *
      * @param string $path
      *
-     * @return string The base URL for the given path
+     * @return float The base URL for the given path
      */
     protected function chooseBaseUrl($path)
     {


### PR DESCRIPTION
Hi,

This PR fixes documentation issue 
src/Symfony/Component/Asset/UrlPackage.php:119 TypeError return float but chooseBaseUrl() is declared to return string

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
