### PR TITLE
[Form] Fix casting regression in DoctrineChoiceLoader

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/DoctrineChoiceLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/DoctrineChoiceLoader.php
@@ -156,7 +156,7 @@ class DoctrineChoiceLoader implements ChoiceLoaderInterface
             // "INDEX BY" clause to the Doctrine query in the loader,
             // but I'm not sure whether that's doable in a generic fashion.
             foreach ($unorderedObjects as $object) {
-                $objectsById[$this->idReader->getIdValue($object)] = $object;
+                $objectsById[(string) $this->idReader->getIdValue($object)] = $object;
             }
 
             foreach ($values as $i => $id) {

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/SingleStringCastableIdEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/SingleStringCastableIdEntity.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+
+/** @Entity */
+class SingleStringCastableIdEntity
+{
+    /**
+     * @Id
+     * @Column(type="string")
+     * @GeneratedValue(strategy="NONE")
+     */
+    protected $id;
+
+    /** @Column(type="string", nullable=true) */
+    public $name;
+
+    public function __construct($id, $name)
+    {
+        $this->id = new StringCastableObjectIdentity($id);
+        $this->name = $name;
+    }
+
+    public function __toString()
+    {
+        return (string) $this->name;
+    }
+}
+
+class StringCastableObjectIdentity
+{
+    protected $id;
+
+    public function __construct($id)
+    {
+        $this->id = $id;
+    }
+
+    public function __toString()
+    {
+        return (string) $this->id;
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

In symfony 2.7, the [DoctrineChoiceLoader](https://github.com/symfony/symfony/blob/9543b36a34221aaca9f2f3cfe34112e8468a591a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/DoctrineChoiceLoader.php) and [IdReader](https://github.com/symfony/symfony/blob/9543b36a34221aaca9f2f3cfe34112e8468a591a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/IdReader.php) were introduce to replace the deprecated [EntityChoiceList](https://github.com/symfony/symfony/blob/9543b36a34221aaca9f2f3cfe34112e8468a591a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php)

There appears to have been a change in behaviour in the refactor, as the old `EntityChoiceList` [casts ID to strings](https://github.com/symfony/symfony/blob/9543b36a34221aaca9f2f3cfe34112e8468a591a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php#L248), whereas the new `DoctrineChoiceLoader` [does not](https://github.com/symfony/symfony/blob/2.7/src/Symfony/Bridge/Doctrine/Form/ChoiceList/DoctrineChoiceLoader.php#L159). The casting behavior was [maintained elsewhere](https://github.com/symfony/symfony/blob/2.7/src/Symfony/Bridge/Doctrine/Form/ChoiceList/DoctrineChoiceLoader.php#L122), however.

Since the new `DoctrineChoiceLoader` deprecated `EntityChoiceList`, i'm calling this a regression.
