### PR TITLE
[FrameworkBundle] minor: fix property_info service name in composer.json

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -58,7 +58,7 @@
         "symfony/serializer": "For using the serializer service",
         "symfony/validator": "For using validation",
         "symfony/yaml": "For using the debug:config and lint:yaml commands",
-        "symfony/property-info": "For using the property_info_extractor service",
+        "symfony/property-info": "For using the property_info service",
         "symfony/process": "For using the server:run, server:start, server:stop, and server:status commands"
     },
     "autoload": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |
