### PR TITLE
[HttpKernel] Kernel name generation based on class name

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -268,7 +268,8 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     public function getName()
     {
         if (null === $this->name) {
-            $this->name = preg_replace('/[^a-zA-Z0-9_]+/', '', basename($this->rootDir));
+            $classParts = explode('\\', get_class($this));
+            $this->name = strtolower(str_replace('Kernel', '', array_pop($classParts)));
         }
 
         return $this->name;

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -323,7 +323,7 @@ EOF;
     {
         $kernel = new KernelForTest('test', true);
 
-        $this->assertEquals('Fixtures', $kernel->getName());
+        $this->assertEquals('fortest', $kernel->getName());
     }
 
     public function testOverrideGetName()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

with the _rise of the MicroKernel_ it makes sense to decouple the Kernel-Name-Generation from the Directory it is inside. Now the Kernel Name is generated with the Class Name. That makes it possible to use the same Cache Directory for all Kernels and have different cached Routers/UrlMatcher/UrlGenerator/...

the current Generation Strategy was choosen to avoid BC Breaks...
