### PR TITLE
[Form] Allow usage of immutable collection

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -325,7 +325,11 @@ class Form implements \IteratorAggregate, FormInterface
         }
 
         if (is_object($modelData) && !$this->config->getByReference()) {
-            $modelData = clone $modelData;
+            if ($modelData instanceof \Traversable) {
+                $modelData = iterator_to_array($modelData);
+            } else {
+                $modelData = clone $modelData;
+            }
         }
 
         if ($this->lockSetData) {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\Tests\Fixtures\Author;
+use Symfony\Component\Form\Tests\Fixtures\NotesContainer;
 
 class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 {
@@ -315,5 +316,29 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
         $this->assertFalse($form->createView()->vars['required'], 'collection is not required');
         $this->assertFalse($form->createView()->vars['prototype']->vars['required'], '"prototype" should not be required');
+    }
+
+    public function testDeleteDoesNotUseOffsetUnset()
+    {
+        $data = new NotesContainer();
+        $data->addNote('foo@bar.com');
+        $data->addNote('bar@bar.com');
+
+        $builder = $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType', $data, array(
+            'data_class' => 'Symfony\Component\Form\Tests\Fixtures\NotesContainer',
+        ));
+        $builder->add('notes', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', array(
+            'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+            'allow_delete' => true,
+            'by_reference' => false,
+        ));
+
+        $form = $builder->getForm();
+        $form->submit(array(
+            'notes' => array('bar@bar.com'),
+        ));
+
+        $this->assertEquals(1, $form->getData()->getNotes()->count());
+        $this->assertEquals('bar@bar.com', $form->getData()->getNotes()->first());
     }
 }

--- a/src/Symfony/Component/Form/Tests/Fixtures/ArrayCollectionWithoutOffsetUnset.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/ArrayCollectionWithoutOffsetUnset.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+class ArrayCollectionWithoutOffsetUnset extends ArrayCollection
+{
+    public function offsetUnset($offset)
+    {
+        throw new \Exception('The offsetUnset method should not be called on this class.');
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/NotesContainer.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/NotesContainer.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+class NotesContainer
+{
+    private $notes;
+
+    public function __construct()
+    {
+        $this->notes = new ArrayCollectionWithoutOffsetUnset();
+    }
+
+    public function getNotes()
+    {
+        return $this->notes;
+    }
+
+    public function addNote($note)
+    {
+        $this->notes->add($note);
+    }
+
+    public function removeNote($note)
+    {
+        $this->notes->removeElement($note);
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | unsure |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

It's a commonly known good practice to use adder and remover methods instead of directly modifying the underlying collection when using a OneToMany/ManyToMany relation between entities. In Nette community we have taken this approach one step further using an [immutable collection](https://github.com/Kdyby/Doctrine/blob/master/src/Kdyby/Doctrine/Collections/ReadOnlyCollectionWrapper.php) to ensure that the collection can't be modified without using adder/remover methods. The typical usage looks like this:

``` php
class Article
{
    private $comments;
    public function __construct() {
        $this->comments = new ArrayCollection;
    }
    public function getComments() {
        return new ReadOnlyCollectionWrapper($this->comments);
    }
    public function addComment(Comment $comment) {
        $this->comments->add($comment);
    }
    public function removeComment(Comment $comment) {
        $this->comments-removeElement($comment);
    }
}
```

This however currently doesn't work with Symfony/Form. The reason is that even when using the by_reference false option Symfony actually calls both the `Collection::remove()` as well as the proper remover method like `Article::removeComment()`. I can elaborate how exactly this works if needed.

After this commit it seems to work just fine even with immutable collections. I don't know what side-effects it could have though. Not quite sure which branch I should target with this nor whether to consider this a bug fix or a new feature.
