### PR TITLE
prefer phpunit 5.x on hhvm

### DIFF
--- a/phpunit
+++ b/phpunit
@@ -18,8 +18,8 @@ use Symfony\Component\Process\ProcessUtils;
 error_reporting(-1);
 require __DIR__.'/src/Symfony/Component/Process/ProcessUtils.php';
 
-// PHPUnit 4.8 does not support PHP 7, while 5.0 requires PHP 5.6+
-$PHPUNIT_VERSION = PHP_VERSION_ID >= 50600 ? '5.0' : '4.8';
+// PHPUnit 4.8 does not support PHP 7, while 5.1 requires PHP 5.6+
+$PHPUNIT_VERSION = PHP_VERSION_ID >= 50600 ? '5.1' : '4.8';
 $PHPUNIT_DIR = __DIR__.'/.phpunit';
 $PHP = defined('PHP_BINARY') ? PHP_BINARY : 'php';
 $PHP = ProcessUtils::escapeArgument($PHP);

--- a/phpunit
+++ b/phpunit
@@ -19,7 +19,7 @@ error_reporting(-1);
 require __DIR__.'/src/Symfony/Component/Process/ProcessUtils.php';
 
 // PHPUnit 4.8 does not support PHP 7, while 5.0 requires PHP 5.6+
-$PHPUNIT_VERSION = ((PHP_VERSION_ID >= 70000) or (PHP_VERSION_ID >= 50600)) ? '5.0' : '4.8';
+$PHPUNIT_VERSION = PHP_VERSION_ID >= 50600 ? '5.0' : '4.8';
 $PHPUNIT_DIR = __DIR__.'/.phpunit';
 $PHP = defined('PHP_BINARY') ? PHP_BINARY : 'php';
 $PHP = ProcessUtils::escapeArgument($PHP);

--- a/phpunit
+++ b/phpunit
@@ -19,7 +19,7 @@ error_reporting(-1);
 require __DIR__.'/src/Symfony/Component/Process/ProcessUtils.php';
 
 // PHPUnit 4.8 does not support PHP 7, while 5.0 requires PHP 5.6+
-$PHPUNIT_VERSION = PHP_VERSION_ID >= 70000 ? '5.0' : '4.8';
+$PHPUNIT_VERSION = ((PHP_VERSION_ID >= 70000) or (PHP_VERSION_ID >= 50600)) ? '5.0' : '4.8';
 $PHPUNIT_DIR = __DIR__.'/.phpunit';
 $PHP = defined('PHP_BINARY') ? PHP_BINARY : 'php';
 $PHP = ProcessUtils::escapeArgument($PHP);


### PR DESCRIPTION
Hi,

HHVM is identified as PHP 5.6 compiler. There are some unsolved problems with tests on hhvm, but using a recent phpunit should be a good start point. How about using 5.1?

Best regards,
Michal

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
