### PR TITLE
[FrameworkBundle] Add APCu support for the Serializer

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
@@ -44,6 +44,12 @@
             </call>
         </service>
 
+        <service id="serializer.mapping.cache.apcu" class="Doctrine\Common\Cache\ApcuCache" public="false">
+            <call method="setNamespace">
+                <argument>%serializer.mapping.cache.prefix%</argument>
+            </call>
+        </service>
+
         <!-- Encoders -->
         <service id="serializer.encoder.xml" class="Symfony\Component\Serializer\Encoder\XmlEncoder" public="false">
             <tag name="serializer.encoder" />


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This PR configures support for the new APCu class from Doctrine Cache (doctrine/cache#115) for the Serializer service.
I'll open a similar PR for the validator service when #16822 will be merged.

I've opened it against master as a new feature, but maybe must it be merged in older versions (2.3?) and considered as a bug fix: APCu for PHP7 doesn't support the APC API anymore. So Symfony projects migrating to PHP7 will not be able to use metadata cache (mandatory in production) without APCu support or adding manually some services.
