### PR TITLE
[OptionsResolver] support array of instance validation

### DIFF
--- a/src/Symfony/Component/OptionsResolver/CHANGELOG.md
+++ b/src/Symfony/Component/OptionsResolver/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.8.0
+-----
+
+ * Added typed array support as allowed type
+
 2.6.0
 -----
 

--- a/src/Symfony/Component/OptionsResolver/CHANGELOG.md
+++ b/src/Symfony/Component/OptionsResolver/CHANGELOG.md
@@ -1,7 +1,7 @@
 CHANGELOG
 =========
 
-2.8.0
+3.1.0
 -----
 
  * Added typed array support as allowed type

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -895,29 +895,28 @@ class OptionsResolver implements Options
      */
     private function verifyAllowedType($type, $value)
     {
-        $valid = false;
+        if (substr($type, -2) === '[]') {
+            //allowed type is typed array
+            if (!is_array($value)) {
+                return false;
+            }
+            $subType = substr($type, 0, -2);
+            foreach ($value as $v) {
+                //recursive call -> check subtype
+                if (!$this->verifyAllowedType($subType, $v)) {
+                    return false;
+                }
+            }
+            //value was array, subtypes all matched -> allowed type OK
+            return true;
+        }
 
         $type = isset(self::$typeAliases[$type]) ? self::$typeAliases[$type] : $type;
 
-        if (substr($type, -2) === '[]') {
-            if (is_array($value)) {
-                $subType = substr($type, 0, -2);
-                foreach ($value as $v) {
-                    $valid = $this->verifyAllowedType($subType, $v);
-                    if (!$valid) {
-                        break;
-                    }
-                }
-            }
-        } elseif (function_exists($isFunction = 'is_'.$type)) {
-            if ($isFunction($value)) {
-                $valid = true;
-            }
-        } elseif ($value instanceof $type) {
-            $valid = true;
+        if (function_exists($isFunction = 'is_'.$type)) {
+            return $isFunction($value);
         }
-
-        return $valid;
+        return ($value instanceof $type);
     }
 
     /**

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -1007,7 +1007,7 @@ class OptionsResolver implements Options
     }
 
     /**
-     * Returns a string represnetation of the complex type of the value.
+     * Returns a string representation of the complex type of the value.
      *
      * This method should be called in formatTypeOf, if there is a complex allowed type
      * for an array value defined to get a more explicit exception message

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -916,6 +916,7 @@ class OptionsResolver implements Options
         if (function_exists($isFunction = 'is_'.$type)) {
             return $isFunction($value);
         }
+
         return ($value instanceof $type);
     }
 

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -993,9 +993,9 @@ class OptionsResolver implements Options
      *
      * @return string The type of the value
      */
-    private function formatTypeOf($value, $option)
+    private function formatTypeOf($value, $option = null)
     {
-        if (is_array($value)) {
+        if (is_array($value) && $option) {
             foreach ($this->allowedTypes[$option] as $type) {
                 if (substr($type, -2) === '[]') {
                     return $this->formatComplexTypeOf($value, $type);
@@ -1031,12 +1031,21 @@ class OptionsResolver implements Options
             $suffix .= '[]';
         }
         if (is_array($value)) {
-            $value = array_shift($value);//get first element
+            $subTypes = array();
+            foreach ($value as $v) {
+                $v = $this->formatTypeOf($v);
+                if (!isset($subTypes[$v])) {
+                    $subTypes[$v] = $v;//build unique map from the off
+                }
+            }
+            $vType = implode('|', $subTypes);
+        } else {
+            $vType = is_object($value) ? get_class($value) : gettype($value);
         }
 
         return sprintf(
             '%s%s',
-            is_object($value) ? get_class($value) : gettype($value),
+            $vType,
             $suffix
         );
     }

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -909,11 +909,11 @@ class OptionsResolver implements Options
                     }
                 }
             }
-        } else if (function_exists($isFunction = 'is_'.$type)) {
+        } elseif (function_exists($isFunction = 'is_'.$type)) {
             if ($isFunction($value)) {
                 $valid = true;
             }
-        } else if ($value instanceof $type) {
+        } elseif ($value instanceof $type) {
             $valid = true;
         }
 

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -903,7 +903,7 @@ class OptionsResolver implements Options
             if (is_array($value)) {
                 $subType = substr($type, 0, -2);
                 foreach ($value as $v) {
-                    $valid = $this->validateType($subType, $v);
+                    $valid = $this->verifyAllowedType($subType, $v);
                     if (!$valid) {
                         break;
                     }

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -794,19 +794,8 @@ class OptionsResolver implements Options
             $valid = false;
 
             foreach ($this->allowedTypes[$option] as $type) {
-                $type = isset(self::$typeAliases[$type]) ? self::$typeAliases[$type] : $type;
-
-                if (function_exists($isFunction = 'is_'.$type)) {
-                    if ($isFunction($value)) {
-                        $valid = true;
-                        break;
-                    }
-
-                    continue;
-                }
-
-                if ($value instanceof $type) {
-                    $valid = true;
+                $valid = $this->verifyAllowedType($type, $value);
+                if ($valid) {
                     break;
                 }
             }
@@ -818,7 +807,7 @@ class OptionsResolver implements Options
                     $option,
                     $this->formatValue($value),
                     implode('" or "', $this->allowedTypes[$option]),
-                    $this->formatTypeOf($value)
+                    $this->formatTypeOf($value, $offendingType)
                 ));
             }
         }
@@ -893,6 +882,44 @@ class OptionsResolver implements Options
         $this->resolved[$option] = $value;
 
         return $value;
+    }
+
+    /**
+     * Verify value is of the allowed type. Recursive method to support
+     * typed array notation like ClassName[], or scalar arrays (int[])
+     *
+     * @param string $type the required allowedType string
+     *
+     * @param mixed $value the value
+     *
+     * @return bool Whether or not $value if of the allowed type
+     *
+     */
+    private function verifyAllowedType($type, $value)
+    {
+        $valid = false;
+
+        $type = isset(self::$typeAliases[$type]) ? self::$typeAliases[$type] : $type;
+
+        if (substr($type, -2) === '[]') {
+            if (is_array($value)) {
+                $subType = substr($type, 0, -2);
+                foreach ($value as $v) {
+                    $valid = $this->validateType($subType, $v);
+                    if (!$valid) {
+                        break;
+                    }
+                }
+            }
+        } else if (function_exists($isFunction = 'is_'.$type)) {
+            if ($isFunction($value)) {
+                $valid = true;
+            }
+        } else if ($value instanceof $type) {
+            $valid = true;
+        }
+
+        return $valid;
     }
 
     /**

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -988,7 +988,7 @@ class OptionsResolver implements Options
      * parameters should usually not be included in messages aimed at
      * non-technical people.
      *
-     * @param mixed $value The value to return the type of
+     * @param mixed  $value  The value to return the type of
      * @param string $option The option that holds the value
      *
      * @return string The type of the value
@@ -1002,17 +1002,18 @@ class OptionsResolver implements Options
                 }
             }
         }
+
         return is_object($value) ? get_class($value) : gettype($value);
     }
 
     /**
-     * Returns a string represnetation of the complex type of the value
+     * Returns a string represnetation of the complex type of the value.
      *
      * This method should be called in formatTypeOf, if there is a complex allowed type
      * for an array value defined to get a more explicit exception message
      *
-     * @param array $value The value to return the complex type of
-     * @param string $type the expected type
+     * @param array  $value The value to return the complex type of
+     * @param string $type  the expected type
      *
      * @return string the complex type of the value
      */
@@ -1032,6 +1033,7 @@ class OptionsResolver implements Options
         if (is_array($value)) {
             $value = array_shift($value);//get first element
         }
+
         return sprintf(
             '%s%s',
             is_object($value) ? get_class($value) : gettype($value),

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -895,12 +895,12 @@ class OptionsResolver implements Options
      */
     private function verifyAllowedType($type, $value)
     {
-        if (substr($type, -2) === '[]') {
+        if (mb_substr($type, -2) === '[]') {
             //allowed type is typed array
             if (!is_array($value)) {
                 return false;
             }
-            $subType = substr($type, 0, -2);
+            $subType = mb_substr($type, 0, -2);
             foreach ($value as $v) {
                 //recursive call -> check subtype
                 if (!$this->verifyAllowedType($subType, $v)) {
@@ -997,7 +997,7 @@ class OptionsResolver implements Options
     {
         if (is_array($value) && $option) {
             foreach ($this->allowedTypes[$option] as $type) {
-                if (substr($type, -2) === '[]') {
+                if (mb_substr($type, -2) === '[]') {
                     return $this->formatComplexTypeOf($value, $type);
                 }
             }
@@ -1020,14 +1020,14 @@ class OptionsResolver implements Options
     private function formatComplexTypeOf(array $value, $type)
     {
         $suffix = '[]';
-        $type = substr($type, 0, -2);
-        while (substr($type, -2) === '[]') {
+        $type = mb_substr($type, 0, -2);
+        while (mb_substr($type, -2) === '[]') {
             $value = array_shift($value);
             if (!is_array($value)) {
                 //expected a nested array, but we've already hit a scalar
                 break;
             }
-            $type = substr($type, 0, -2);
+            $type = mb_substr($type, 0, -2);
             $suffix .= '[]';
         }
         if (is_array($value)) {

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -891,7 +891,7 @@ class OptionsResolver implements Options
      * @param string $type  the required allowedType string
      * @param mixed  $value the value
      *
-     * @return bool Whether or not $value if of the allowed type
+     * @return bool Whether the $value is of the allowed type
      */
     private function verifyAllowedType($type, $value)
     {

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -886,14 +886,12 @@ class OptionsResolver implements Options
 
     /**
      * Verify value is of the allowed type. Recursive method to support
-     * typed array notation like ClassName[], or scalar arrays (int[])
+     * typed array notation like ClassName[], or scalar arrays (int[]).
      *
-     * @param string $type the required allowedType string
-     *
-     * @param mixed $value the value
+     * @param string $type  the required allowedType string
+     * @param mixed  $value the value
      *
      * @return bool Whether or not $value if of the allowed type
-     *
      */
     private function verifyAllowedType($type, $value)
     {

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -807,7 +807,7 @@ class OptionsResolver implements Options
                     $option,
                     $this->formatValue($value),
                     implode('" or "', $this->allowedTypes[$option]),
-                    $this->formatTypeOf($value)
+                    $this->formatTypeOf($value, $option)
                 ));
             }
         }
@@ -989,12 +989,54 @@ class OptionsResolver implements Options
      * non-technical people.
      *
      * @param mixed $value The value to return the type of
+     * @param string $option The option that holds the value
      *
      * @return string The type of the value
      */
-    private function formatTypeOf($value)
+    private function formatTypeOf($value, $option)
     {
+        if (is_array($value)) {
+            foreach ($this->allowedTypes[$option] as $type) {
+                if (substr($type, -2) === '[]') {
+                    return $this->formatComplexTypeOf($value, $type);
+                }
+            }
+        }
         return is_object($value) ? get_class($value) : gettype($value);
+    }
+
+    /**
+     * Returns a string represnetation of the complex type of the value
+     *
+     * This method should be called in formatTypeOf, if there is a complex allowed type
+     * for an array value defined to get a more explicit exception message
+     *
+     * @param array $value The value to return the complex type of
+     * @param string $type the expected type
+     *
+     * @return string the complex type of the value
+     */
+    private function formatComplexTypeOf(array $value, $type)
+    {
+        $suffix = '[]';
+        $type = substr($type, 0, -2);
+        while (substr($type, -2) === '[]') {
+            $value = array_shift($value);
+            if (!is_array($value)) {
+                //expected a nested array, but we've already hit a scalar
+                break;
+            }
+            $type = substr($type, 0, -2);
+            $suffix .= '[]';
+        }
+        if (is_array($value)) {
+            $value = array_shift($value);//get first element
+        }
+        return sprintf(
+            '%s%s',
+            is_object($value) ? get_class($value) : gettype($value),
+            $suffix
+        );
     }
 
     /**

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -807,7 +807,7 @@ class OptionsResolver implements Options
                     $option,
                     $this->formatValue($value),
                     implode('" or "', $this->allowedTypes[$option]),
-                    $this->formatTypeOf($value, $offendingType)
+                    $this->formatTypeOf($value)
                 ));
             }
         }

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -571,10 +571,10 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
         $this->resolver->setAllowedTypes('foo', array('null', '\DateTime[]'));
 
         $data = array(
-            'foo'   => array(
+            'foo' => array(
                 new \DateTime(),
                 new \DateTime(),
-            )
+            ),
         );
         $result = $this->resolver->resolve($data);
         $this->assertEquals($data, $result);

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -513,6 +513,24 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider provideInvalidTypes
      * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedExceptionMessage The option "foo" with value array is expected to be of type "int[][]", but is of type "double[][]".
+     */
+    public function testResolveFailsWithCorrectLevelsButWrongScalar()
+    {
+        $this->resolver->setDefined('foo');
+        $this->resolver->setAllowedTypes('foo', 'int[][]');
+
+        $this->resolver->resolve(
+            array(
+                'foo'   => array(
+                    array(1.2),
+                ),
+            )
+        );
+    }
+ 
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
      * @expectedExceptionMessage The option "foo" with value array is expected to be of type "int[]", but is of type "integer|stdClass|array|DateTime[]".
      */
     public function testResolveFailsIfTypedArrayContainsInvalidTypes()

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -499,7 +499,21 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedExceptionMessage The option "foo" with value array is expected to be of type "int[]", but is of type "array".
+     */
+    public function testResolveFailsIfInvalidTypedArray()
+    {
+        $this->resolver->setDefined('foo');
+        $this->resolver->setAllowedTypes('foo', 'int[]');
+
+        $this->resolver->resolve(array('foo' => array(new \DateTime)));
+    }
+
+    /**
      * @dataProvider provideInvalidTypes
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedExceptionMessage The option "foo" with value 42 is expected to be of type "string", but is of type "integer".
      */
     public function testResolveFailsIfInvalidType($actualType, $allowedType, $exceptionMessage)
     {

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -520,7 +520,7 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
         $this->resolver->setDefined('foo');
         $this->resolver->setAllowedTypes('foo', 'int[]');
         $values = range(1, 5);
-        $values[] = new \stdClass;
+        $values[] = new \stdClass();
         $values[] = array();
         $values[] = new \DateTime();
         $values[] = 123;

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -565,6 +565,46 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEmpty($this->resolver->resolve());
     }
 
+    public function testResolveSucceedsIfTypedArray()
+    {
+        $this->resolver->setDefault('foo', null);
+        $this->resolver->setAllowedTypes('foo', array('null', '\DateTime[]'));
+
+        $data = array(
+            'foo'   => array(
+                new \DateTime(),
+                new \DateTime(),
+            )
+        );
+        $result = $this->resolver->resolve($data);
+        $this->assertEquals($data, $result);
+    }
+
+    public function testResolveSucceedsNestedTypedArray()
+    {
+        $this->resolver->setDefault('foo', null);
+        $this->resolver->setAllowedTypes('foo', 'int[][]');
+
+        $expect = array(
+            'foo' => array(
+                range(1, 10),
+            ),
+        );
+        $result = $this->resolver->resolve($expect);
+        $this->assertEquals($expect, $result);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testResolveFailsIfNotInstanceOfClass()
+    {
+        $this->resolver->setDefault('foo', 'bar');
+        $this->resolver->setAllowedTypes('foo', '\stdClass');
+
+        $this->resolver->resolve();
+    }
+
     public function testResolveSucceedsIfInstanceOfClass()
     {
         $this->resolver->setDefault('foo', new \stdClass());

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -507,7 +507,7 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
         $this->resolver->setDefined('foo');
         $this->resolver->setAllowedTypes('foo', 'int[]');
 
-        $this->resolver->resolve(array('foo' => array(new \DateTime)));
+        $this->resolver->resolve(array('foo' => array(new \DateTime())));
     }
 
     /**

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -500,7 +500,7 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     * @expectedExceptionMessage The option "foo" with value array is expected to be of type "int[]", but is of type "array".
+     * @expectedExceptionMessage The option "foo" with value array is expected to be of type "int[]", but is of type "DateTime[]".
      */
     public function testResolveFailsIfInvalidTypedArray()
     {

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -511,7 +511,6 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider provideInvalidTypes
      * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
      * @expectedExceptionMessage The option "foo" with value array is expected to be of type "int[][]", but is of type "double[][]".
      */
@@ -547,8 +546,7 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     * @expectedExceptionMessage The option "foo" with value 42 is expected to be of type "string", but is of type "integer".
+     * @dataProvider provideInvalidTypes
      */
     public function testResolveFailsIfInvalidType($actualType, $allowedType, $exceptionMessage)
     {

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -513,6 +513,23 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider provideInvalidTypes
      * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedExceptionMessage The option "foo" with value array is expected to be of type "int[]", but is of type "integer|stdClass|array|DateTime[]".
+     */
+    public function testResolveFailsIfTypedArrayContainsInvalidTypes()
+    {
+        $this->resolver->setDefined('foo');
+        $this->resolver->setAllowedTypes('foo', 'int[]');
+        $values = range(1, 5);
+        $values[] = new \stdClass;
+        $values[] = array();
+        $values[] = new \DateTime();
+        $values[] = 123;
+
+        $this->resolver->resolve(array('foo' => $values));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
      * @expectedExceptionMessage The option "foo" with value 42 is expected to be of type "string", but is of type "integer".
      */
     public function testResolveFailsIfInvalidType($actualType, $allowedType, $exceptionMessage)

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -522,13 +522,13 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
 
         $this->resolver->resolve(
             array(
-                'foo'   => array(
+                'foo' => array(
                     array(1.2),
                 ),
             )
         );
     }
- 
+
     /**
      * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
      * @expectedExceptionMessage The option "foo" with value array is expected to be of type "int[]", but is of type "integer|stdClass|array|DateTime[]".


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15524 |
| License | MIT |
| Doc PR | symfony/symfony-docs#6048 |

A suggested approach to add support for typed-arrays as allowed types, using a simple recursive method.

Closing [PR 15671](https://github.com/symfony/symfony/pull/15671).
