### PR TITLE
[DomCrawler] Revert previous restriction, allow selection of every DOMNode object 

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -695,7 +695,7 @@ class Crawler extends \SplObjectStorage
      *
      * @return Link A Link instance
      *
-     * @throws \InvalidArgumentException If the current node list is empty or contains non DOMElement instances
+     * @throws \InvalidArgumentException If the current node list is empty or contains non-DOMElement instances
      */
     public function link($method = 'get')
     {
@@ -717,7 +717,7 @@ class Crawler extends \SplObjectStorage
      *
      * @return Link[] An array of Link instances
      *
-     * @throws \InvalidArgumentException If the current node list contains non DOMElement instances
+     * @throws \InvalidArgumentException If the current node list contains non-DOMElement instances
      */
     public function links()
     {
@@ -741,7 +741,7 @@ class Crawler extends \SplObjectStorage
      *
      * @return Form A Form instance
      *
-     * @throws \InvalidArgumentException If the current node list is empty or contains non DOMElement instances
+     * @throws \InvalidArgumentException If the current node list is empty or contains non-DOMElement instances
      */
     public function form(array $values = null, $method = null)
     {

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -695,7 +695,7 @@ class Crawler extends \SplObjectStorage
      *
      * @return Link A Link instance
      *
-     * @throws \InvalidArgumentException If the current node list is empty or contains non-DOMElement instances
+     * @throws \InvalidArgumentException If the current node list is empty or the selected node is not instance of DOMElement
      */
     public function link($method = 'get')
     {
@@ -706,7 +706,7 @@ class Crawler extends \SplObjectStorage
         $node = $this->getNode(0);
 
         if (!$node instanceof \DOMElement) {
-            throw new \InvalidArgumentException(sprintf('The current node list should contain only DOMElement instances, "%s" found.', get_class($node)));
+            throw new \InvalidArgumentException(sprintf('The selected node should be instance of DOMElement, got "%s".', get_class($node)));
         }
 
         return new Link($node, $this->baseHref, $method);
@@ -741,7 +741,7 @@ class Crawler extends \SplObjectStorage
      *
      * @return Form A Form instance
      *
-     * @throws \InvalidArgumentException If the current node list is empty or contains non-DOMElement instances
+     * @throws \InvalidArgumentException If the current node list is empty or the selected node is not instance of DOMElement
      */
     public function form(array $values = null, $method = null)
     {
@@ -752,7 +752,7 @@ class Crawler extends \SplObjectStorage
         $node = $this->getNode(0);
 
         if (!$node instanceof \DOMElement) {
-            throw new \InvalidArgumentException(sprintf('The current node list should contain only DOMElement instances, "%s" found.', get_class($node)));
+            throw new \InvalidArgumentException(sprintf('The selected node should be instance of DOMElement, got "%s".', get_class($node)));
         }
 
         $form = new Form($node, $this->uri, $method, $this->baseHref);

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\DomCrawler;
 use Symfony\Component\CssSelector\CssSelectorConverter;
 
 /**
- * Crawler eases navigation of a list of \DOMElement objects.
+ * Crawler eases navigation of a list of \DOMNode objects.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
@@ -288,10 +288,6 @@ class Crawler extends \SplObjectStorage
     {
         if ($node instanceof \DOMDocument) {
             $node = $node->documentElement;
-        }
-
-        if (!$node instanceof \DOMElement) {
-            throw new \InvalidArgumentException(sprintf('Nodes set in a Crawler must be DOMElement or DOMDocument instances, "%s" given.', get_class($node)));
         }
 
         if (null !== $this->document && $this->document !== $node->ownerDocument) {
@@ -699,7 +695,7 @@ class Crawler extends \SplObjectStorage
      *
      * @return Link A Link instance
      *
-     * @throws \InvalidArgumentException If the current node list is empty
+     * @throws \InvalidArgumentException If the current node list is empty or contains non DOMElement instances
      */
     public function link($method = 'get')
     {
@@ -709,6 +705,10 @@ class Crawler extends \SplObjectStorage
 
         $node = $this->getNode(0);
 
+        if (!$node instanceof \DOMElement) {
+            throw new \InvalidArgumentException(sprintf("The current node list should contain only DOMElement instances, '%s' found.", get_class($node)));
+        }
+
         return new Link($node, $this->baseHref, $method);
     }
 
@@ -716,11 +716,17 @@ class Crawler extends \SplObjectStorage
      * Returns an array of Link objects for the nodes in the list.
      *
      * @return Link[] An array of Link instances
+     *
+     * @throws \InvalidArgumentException If the current node list contains non DOMElement instances
      */
     public function links()
     {
         $links = array();
         foreach ($this as $node) {
+            if (!$node instanceof \DOMElement) {
+                throw new \InvalidArgumentException(sprintf("The current node list should contain only DOMElement instances, '%s' found.", get_class($node)));
+            }
+
             $links[] = new Link($node, $this->baseHref, 'get');
         }
 
@@ -735,7 +741,7 @@ class Crawler extends \SplObjectStorage
      *
      * @return Form A Form instance
      *
-     * @throws \InvalidArgumentException If the current node list is empty
+     * @throws \InvalidArgumentException If the current node list is empty or contains non DOMElement instances
      */
     public function form(array $values = null, $method = null)
     {
@@ -743,7 +749,13 @@ class Crawler extends \SplObjectStorage
             throw new \InvalidArgumentException('The current node list is empty.');
         }
 
-        $form = new Form($this->getNode(0), $this->uri, $method, $this->baseHref);
+        $node = $this->getNode(0);
+
+        if (!$node instanceof \DOMElement) {
+            throw new \InvalidArgumentException(sprintf("The current node list should contain only DOMElement instances, '%s' found.", get_class($node)));
+        }
+
+        $form = new Form($node, $this->uri, $method, $this->baseHref);
 
         if (null !== $values) {
             $form->setValues($values);
@@ -965,12 +977,7 @@ class Crawler extends \SplObjectStorage
 
         foreach ($this as $node) {
             $domxpath = $this->createDOMXPath($node->ownerDocument, $prefixes);
-
-            foreach ($domxpath->query($xpath, $node) as $subNode) {
-                if ($subNode->nodeType === 1) {
-                    $crawler->add($subNode);
-                }
-            }
+            $crawler->add($domxpath->query($xpath, $node));
         }
 
         return $crawler;

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -706,7 +706,7 @@ class Crawler extends \SplObjectStorage
         $node = $this->getNode(0);
 
         if (!$node instanceof \DOMElement) {
-            throw new \InvalidArgumentException(sprintf("The current node list should contain only DOMElement instances, '%s' found.", get_class($node)));
+            throw new \InvalidArgumentException(sprintf('The current node list should contain only DOMElement instances, "%s" found.', get_class($node)));
         }
 
         return new Link($node, $this->baseHref, $method);
@@ -724,7 +724,7 @@ class Crawler extends \SplObjectStorage
         $links = array();
         foreach ($this as $node) {
             if (!$node instanceof \DOMElement) {
-                throw new \InvalidArgumentException(sprintf("The current node list should contain only DOMElement instances, '%s' found.", get_class($node)));
+                throw new \InvalidArgumentException(sprintf('The current node list should contain only DOMElement instances, "%s" found.', get_class($node)));
             }
 
             $links[] = new Link($node, $this->baseHref, 'get');
@@ -752,7 +752,7 @@ class Crawler extends \SplObjectStorage
         $node = $this->getNode(0);
 
         if (!$node instanceof \DOMElement) {
-            throw new \InvalidArgumentException(sprintf("The current node list should contain only DOMElement instances, '%s' found.", get_class($node)));
+            throw new \InvalidArgumentException(sprintf('The current node list should contain only DOMElement instances, "%s" found.', get_class($node)));
         }
 
         $form = new Form($node, $this->uri, $method, $this->baseHref);

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -47,7 +47,7 @@ class CrawlerTest extends \PHPUnit_Framework_TestCase
 
         $crawler = new Crawler();
         $crawler->add($this->createNodeList()->item(0));
-        $this->assertEquals('foo', $crawler->filterXPath('//div')->attr('class'), '->add() adds nodes from a \DOMElement');
+        $this->assertEquals('foo', $crawler->filterXPath('//div')->attr('class'), '->add() adds nodes from an \DOMNode');
 
         $crawler = new Crawler();
         $crawler->add('<html><body>Foo</body></html>');
@@ -64,13 +64,12 @@ class CrawlerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Nodes set in a Crawler must be DOMElement or DOMDocument instances, "DOMNode" given.
+     * @group legacy
      */
-    public function testAddInvalidNode()
+    public function testAddMultipleDocumentNode()
     {
-        $crawler = new Crawler();
-        $crawler->add(new \DOMNode());
+        $crawler = $this->createTestCrawler();
+        $crawler->addHtmlContent('<html><div class="foo"></html>', 'UTF-8');
     }
 
     public function testAddHtmlContent()
@@ -264,7 +263,7 @@ EOF
         $crawler = new Crawler();
         $crawler->addNode($this->createNodeList()->item(0));
 
-        $this->assertEquals('foo', $crawler->filterXPath('//div')->attr('class'), '->addNode() adds nodes from a \DOMElement');
+        $this->assertEquals('foo', $crawler->filterXPath('//div')->attr('class'), '->addNode() adds nodes from an \DOMNode');
     }
 
     public function testClear()
@@ -527,7 +526,7 @@ EOF
 
     public function testFilterXPathWithAttributeAxisAfterElementAxis()
     {
-        $this->assertCount(0, $this->createTestCrawler()->filterXPath('//form/button/attribute::*'), '->filterXPath() handles attribute axes properly when they are preceded by an element filtering axis');
+        $this->assertCount(3, $this->createTestCrawler()->filterXPath('//form/button/attribute::*'), '->filterXPath() handles attribute axes properly when they are preceded by an element filtering axis');
     }
 
     public function testFilterXPathWithChildAxis()
@@ -745,6 +744,26 @@ HTML;
         }
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessageRegExp /^The current node list should contain only DOMElement instances/
+     */
+    public function testInvalidLink()
+    {
+        $crawler = $this->createTestCrawler('http://example.com/bar/');
+        $crawler->filterXPath('//li/text()')->link();
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessageRegExp /^The current node list should contain only DOMElement instances/
+     */
+    public function testInvalidLinks()
+    {
+        $crawler = $this->createTestCrawler('http://example.com/bar/');
+        $crawler->filterXPath('//li/text()')->link();
+    }
+
     public function testSelectLinkAndLinkFiltered()
     {
         $html = <<<HTML
@@ -815,6 +834,16 @@ HTML;
         } catch (\InvalidArgumentException $e) {
             $this->assertTrue(true, '->form() throws an \InvalidArgumentException if the node list is empty');
         }
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessageRegExp /^The current node list should contain only DOMElement instances/
+     */
+    public function testInvalidForm()
+    {
+        $crawler = $this->createTestCrawler('http://example.com/bar/');
+        $crawler->filterXPath('//li/text()')->form();
     }
 
     public function testLast()

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -737,7 +737,7 @@ HTML;
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The current node list should contain only DOMElement instances
+     * @expectedExceptionMessage The selected node should be instance of DOMElement
      */
     public function testInvalidLink()
     {
@@ -747,7 +747,7 @@ HTML;
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The current node list should contain only DOMElement instances
+     * @expectedExceptionMessage The selected node should be instance of DOMElement
      */
     public function testInvalidLinks()
     {
@@ -829,7 +829,7 @@ HTML;
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The current node list should contain only DOMElement instances
+     * @expectedExceptionMessage The selected node should be instance of DOMElement
      */
     public function testInvalidForm()
     {

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -746,7 +746,7 @@ HTML;
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /^The current node list should contain only DOMElement instances/
+     * @expectedExceptionMessage The current node list should contain only DOMElement instances
      */
     public function testInvalidLink()
     {
@@ -756,7 +756,7 @@ HTML;
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /^The current node list should contain only DOMElement instances/
+     * @expectedExceptionMessage The current node list should contain only DOMElement instances
      */
     public function testInvalidLinks()
     {
@@ -838,7 +838,7 @@ HTML;
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /^The current node list should contain only DOMElement instances/
+     * @expectedExceptionMessage The current node list should contain only DOMElement instances
      */
     public function testInvalidForm()
     {

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -47,7 +47,7 @@ class CrawlerTest extends \PHPUnit_Framework_TestCase
 
         $crawler = new Crawler();
         $crawler->add($this->createNodeList()->item(0));
-        $this->assertEquals('foo', $crawler->filterXPath('//div')->attr('class'), '->add() adds nodes from an \DOMNode');
+        $this->assertEquals('foo', $crawler->filterXPath('//div')->attr('class'), '->add() adds nodes from a \DOMNode');
 
         $crawler = new Crawler();
         $crawler->add('<html><body>Foo</body></html>');
@@ -263,7 +263,7 @@ EOF
         $crawler = new Crawler();
         $crawler->addNode($this->createNodeList()->item(0));
 
-        $this->assertEquals('foo', $crawler->filterXPath('//div')->attr('class'), '->addNode() adds nodes from an \DOMNode');
+        $this->assertEquals('foo', $crawler->filterXPath('//div')->attr('class'), '->addNode() adds nodes from a \DOMNode');
     }
 
     public function testClear()

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -63,15 +63,6 @@ class CrawlerTest extends \PHPUnit_Framework_TestCase
         $crawler->add(1);
     }
 
-    /**
-     * @group legacy
-     */
-    public function testAddMultipleDocumentNode()
-    {
-        $crawler = $this->createTestCrawler();
-        $crawler->addHtmlContent('<html><div class="foo"></html>', 'UTF-8');
-    }
-
     public function testAddHtmlContent()
     {
         $crawler = new Crawler();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes, revert to previous behaviour |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16933 |
| License | MIT |
| Doc PR |  |

This is a backport of PR https://github.com/symfony/symfony/pull/17021
