### PR TITLE
[Profiler] Exit impersonation links

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -37,6 +37,13 @@
             <div class="sf-toolbar-info-piece">
                 <b>Actions</b>
                 <span><a href="{{ collector.logoutUrl }}">Logout</a></span>
+                {% if 'ROLE_PREVIOUS_ADMIN' in collector.roles %}
+                    - <span>
+                        <a href="{{ path(profile.getcollector('request').requestattributes.get('_route'), {'_switch_user': '_exit'}) }}">
+                            Exit impersonation
+                        </a>
+                    </span>
+                {% endif %}
             </div>
             {% endif %}
         {% elseif collector.enabled %}
@@ -110,6 +117,21 @@
                 {% endif %}
             </tbody>
         </table>
+        
+        {% if collector.logoutUrl %}
+            <div>
+                <b>Actions:</b>
+                <span><a href="{{ collector.logoutUrl }}">Logout</a></span>
+                {% if 'ROLE_PREVIOUS_ADMIN' in collector.roles %}
+                    - <span>
+                        <a href="{{ path(profile.getcollector('request').requestattributes.get('_route'), {'_switch_user': '_exit'}) }}">
+                            Exit impersonation
+                        </a>
+                    </span>
+                {% endif %}
+            </div>
+        {% endif %}
+        
     {% elseif collector.enabled %}
         <div class="empty">
             <p>There is no security token.</p>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
#14378 did introduce the logout link in the profiler toolbar as I saw in [the DX post](http://symfony.com/blog/new-in-symfony-2-8-dx-improvements#added-a-logout-shortcut-in-the-toolbar), and also spoke about user impersonation. This PR adds an "Exit impersionation" link when that specific role is available, and also adds those two links to the actual security panel.
