### PR TITLE
[FrameworkBundle] Added the assets helper again

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
@@ -34,8 +34,7 @@
 
         <service id="templating.helper.assets" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\AssetsHelper">
             <tag name="templating.helper" alias="assets" />
-            <argument /> <!-- default package -->
-            <argument type="collection" /> <!-- named packages -->
+            <argument /> <!-- packages -->
         </service>
 
         <service id="templating.helper.actions" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\ActionsHelper">

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/AssetsHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/AssetsHelper.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Templating\Helper;
+
+use Symfony\Component\Asset\Packages;
+use Symfony\Component\Templating\Helper\Helper;
+
+/**
+ * AssetsHelper helps manage asset URLs.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class AssetsHelper extends Helper
+{
+    private $packages;
+
+    public function __construct(Packages $packages)
+    {
+        $this->packages = $packages;
+    }
+
+    /**
+     * Returns the public url/path of an asset.
+     *
+     * If the package used to generate the path is an instance of
+     * UrlPackage, you will always get a URL and not a path.
+     *
+     * @param string $path        A public path
+     * @param string $packageName The name of the asset package to use
+     *
+     * @return string The public path of the asset
+     */
+    public function getUrl($path, $packageName = null)
+    {
+        return $this->packages->getUrl($path, $packageName);
+    }
+
+    /**
+     * Returns the version of an asset.
+     *
+     * @param string $path        A public path
+     * @param string $packageName The name of the asset package to use
+     *
+     * @return string The asset version
+     */
+    public function getVersion($path, $packageName = null)
+    {
+        return $this->packages->getVersion($path, $packageName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'assets';
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/AssetsHelperTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/AssetsHelperTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Templating\Helper;
+
+use Symfony\Bundle\FrameworkBundle\Templating\Helper\AssetsHelper;
+use Symfony\Component\Asset\Package;
+use Symfony\Component\Asset\Packages;
+use Symfony\Component\Asset\VersionStrategy\StaticVersionStrategy;
+
+class AssetsHelperTest extends \PHPUnit_Framework_TestCase
+{
+    private $helper;
+
+    protected function setUp()
+    {
+        $fooPackage = new Package(new StaticVersionStrategy('42', '%s?v=%s'));
+        $barPackage = new Package(new StaticVersionStrategy('22', '%s?%s'));
+
+        $packages = new Packages($fooPackage, ['bar' => $barPackage]);
+
+        $this->helper = new AssetsHelper($packages);
+    }
+
+    public function testGetUrl()
+    {
+        $this->assertEquals('me.png?v=42', $this->helper->getUrl('me.png'));
+        $this->assertEquals('me.png?22', $this->helper->getUrl('me.png', 'bar'));
+    }
+
+    public function testGetVersion()
+    {
+        $this->assertEquals('42', $this->helper->getVersion('/'));
+        $this->assertEquals('22', $this->helper->getVersion('/', 'bar'));
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

This PR is a follow up of #14972, we deprecated and removed the AssetsHelper in 2.7/3.0 doing impossible to use the Asset component and the PHP templates together, I've submitted this PR to be merged in 3.0 because IMO this is a bug fix, but we documented the deprecation and removal of the helper, what we should do here? (https://github.com/symfony/symfony/blob/3.0/UPGRADE-3.0.md#frameworkbundle and https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.7.md#frameworkbundle)

cc/ @WouterJ 
