### PR TITLE
[WIP] [Form] fix BC break introduced with prototype_data option

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -28,7 +28,7 @@ class CollectionType extends AbstractType
     {
         if ($options['allow_add'] && $options['prototype']) {
             $prototypeOptions = array_replace(array(
-                'label' => $options['prototype_name'] . 'label__',
+                'label' => $options['prototype_name'].'label__',
             ), $options['options']);
 
             if ($options['prototype_data'] !== null) {

--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -27,11 +27,15 @@ class CollectionType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         if ($options['allow_add'] && $options['prototype']) {
-            $prototype = $builder->create($options['prototype_name'], $options['entry_type'], array_replace(array(
-                'label' => $options['prototype_name'].'label__',
-            ), $options['entry_options'], array(
-                'data' => $options['prototype_data'],
-            )));
+            $prototypeOptions = array_replace(array(
+                'label' => $options['prototype_name'] . 'label__',
+            ), $options['options']);
+
+            if ($options['prototype_data'] !== null) {
+                $prototypeOptions['data'] = $options['prototype_data'];
+            }
+
+            $prototype = $builder->create($options['prototype_name'], $options['entry_type'], $prototypeOptions);
             $builder->setAttribute('prototype', $prototype->getForm());
         }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -316,4 +316,20 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
         $this->assertSame('foo', $form->createView()->vars['prototype']->vars['value']);
     }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyPrototypeData()
+    {
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', array(), array(
+            'allow_add' => true,
+            'prototype' => true,
+            'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+            'entry_options' => array(
+                'data' => 'bar',
+            ),
+        ));
+        $this->assertSame('bar', $form->createView()->vars['prototype']->vars['value']);
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [yes] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [no] |
| Fixed tickets | [#15707] |
| License | MIT |
| Doc PR | [] |

This fixes the BC break introduced with prototype_data option in collection type. At the moment whether option is set or not it overwrites prototype data but it has different behaviour before and prototype data was taken from the mapped form data/entity.
- [ ] make the test work (can't figure yet how to test that prototype without prototype_data option has default values)
