### PR TITLE
Fix the logout path when not using the router

### DIFF
--- a/src/Symfony/Component/Security/Http/Logout/LogoutUrlGenerator.php
+++ b/src/Symfony/Component/Security/Http/Logout/LogoutUrlGenerator.php
@@ -121,7 +121,7 @@ class LogoutUrlGenerator
 
             $request = $this->requestStack->getCurrentRequest();
 
-            $url = UrlGeneratorInterface::ABSOLUTE_URL === $referenceType ? $request->getUriForPath($logoutPath) : $request->getBasePath().$logoutPath;
+            $url = UrlGeneratorInterface::ABSOLUTE_URL === $referenceType ? $request->getUriForPath($logoutPath) : $request->getBaseUrl().$logoutPath;
 
             if (!empty($parameters)) {
                 $url .= '?'.http_build_query($parameters);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17029 |
| License | MIT |
| Doc PR | n/a |

This needs to use the base url, not the base path, so that it goes through the front controller when not using url rewriting.

Similar to #17048, but in the new code location
