### PR TITLE
Increases the debug toolbar z-index

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -38,7 +38,7 @@
     position: fixed;
     right: 0;
     text-align: left;
-    z-index: 99999;
+    z-index: 100001;
 }
 .sf-toolbarreset abbr {
     border: dashed #777;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The vardumper is using a z-index of 100,000. In order to not be hidden the debug toolbar by a content dumped in a template using the `dump()` function, the debug toolbar must have an higher z-index.
