### PR TITLE
[Security] Verify if a password encoded with bcrypt is no longer than 72 characters

### DIFF
--- a/src/Symfony/Component/Security/Core/Encoder/BCryptPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/BCryptPasswordEncoder.php
@@ -19,6 +19,8 @@ use Symfony\Component\Security\Core\Exception\BadCredentialsException;
  */
 class BCryptPasswordEncoder extends BasePasswordEncoder
 {
+    const MAX_PASSWORD_LENGTH = 72;
+
     /**
      * @var string
      */

--- a/src/Symfony/Component/Security/Core/Encoder/BasePasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/BasePasswordEncoder.php
@@ -95,6 +95,6 @@ abstract class BasePasswordEncoder implements PasswordEncoderInterface
      */
     protected function isPasswordTooLong($password)
     {
-        return strlen($password) > self::MAX_PASSWORD_LENGTH;
+        return strlen($password) > static::MAX_PASSWORD_LENGTH;
     }
 }

--- a/src/Symfony/Component/Security/Tests/Core/Encoder/BCryptPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Encoder/BCryptPasswordEncoderTest.php
@@ -45,9 +45,6 @@ class BCryptPasswordEncoderTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    /**
-     * @requires PHP 5.3.7
-     */
     public function testResultLength()
     {
         $encoder = new BCryptPasswordEncoder(self::VALID_COST);
@@ -55,9 +52,6 @@ class BCryptPasswordEncoderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(60, strlen($result));
     }
 
-    /**
-     * @requires PHP 5.3.7
-     */
     public function testValidation()
     {
         $encoder = new BCryptPasswordEncoder(self::VALID_COST);

--- a/src/Symfony/Component/Security/Tests/Core/Encoder/BCryptPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Encoder/BCryptPasswordEncoderTest.php
@@ -73,13 +73,15 @@ class BCryptPasswordEncoderTest extends \PHPUnit_Framework_TestCase
     {
         $encoder = new BCryptPasswordEncoder(self::VALID_COST);
 
-        $encoder->encodePassword(str_repeat('a', 5000), 'salt');
+        $encoder->encodePassword(str_repeat('a', 73), 'salt');
     }
 
     public function testCheckPasswordLength()
     {
         $encoder = new BCryptPasswordEncoder(self::VALID_COST);
+        $result = $encoder->encodePassword(str_repeat('a', 72), null);
 
-        $this->assertFalse($encoder->isPasswordValid('encoded', str_repeat('a', 5000), 'salt'));
+        $this->assertFalse($encoder->isPasswordValid($result, str_repeat('a', 73), 'salt'));
+        $this->assertTrue($encoder->isPasswordValid($result, str_repeat('a', 72), 'salt'));
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17047 |
| License | MIT |
| Doc PR | - |

From the [password_hash() docs](http://php.net/password_hash):

> Caution Using the PASSWORD_BCRYPT as the algorithm, will result in the password parameter being truncated to a maximum length of 72 characters.
