### PR TITLE
Upgrade for 2.8: ContainerAware was deprecated in favour of ContainerAwareTrait

### DIFF
--- a/UPGRADE-2.8.md
+++ b/UPGRADE-2.8.md
@@ -374,6 +374,10 @@ DependencyInjection
    </services>
    ```
 
+ * `Symfony\Component\DependencyInjection\ContainerAware` has been deprecated, use 
+   `Symfony\Component\DependencyInjection\ContainerAwareTrait` or implement 
+   `Symfony\Component\DependencyInjection\ContainerAwareInterface` manually
+
 WebProfiler
 -----------
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
