### PR TITLE
[Filesystem] fix tests on 2.3

### DIFF
--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -492,7 +492,7 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
 
         $this->filesystem->chmod($directory, 0753, 0000, true);
 
-        $this->assertFilePermissions(753, $subdirectory);
+        $this->assertEquals(753, $this->getFilePermissions($subdirectory));
     }
 
     public function testChown()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16797 |
| License | MIT |
| Doc PR |  |

The test introduced in #16797 used the `assertFilePermissions()` method
to test for the expected result. This worked quite well for the PR as it
was submitted for the `master` branch. However, the tests now fail on
2.3 as the `FilesystemTestCase` class which contains this method was
introduced with Symfony 2.4.
