### PR TITLE
[Security] skip bcrypt tests on incompatible platforms

### DIFF
--- a/src/Symfony/Component/Security/Tests/Core/Encoder/BCryptPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Encoder/BCryptPasswordEncoderTest.php
@@ -45,19 +45,21 @@ class BCryptPasswordEncoderTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     * @requires PHP 5.3.7
+     */
     public function testResultLength()
     {
-        $this->skipIfPhpVersionIsNotSupported();
-
         $encoder = new BCryptPasswordEncoder(self::VALID_COST);
         $result = $encoder->encodePassword(self::PASSWORD, null);
         $this->assertEquals(60, strlen($result));
     }
 
+    /**
+     * @requires PHP 5.3.7
+     */
     public function testValidation()
     {
-        $this->skipIfPhpVersionIsNotSupported();
-
         $encoder = new BCryptPasswordEncoder(self::VALID_COST);
         $result = $encoder->encodePassword(self::PASSWORD, null);
         $this->assertTrue($encoder->isPasswordValid($result, self::PASSWORD, null));
@@ -74,21 +76,15 @@ class BCryptPasswordEncoderTest extends \PHPUnit_Framework_TestCase
         $encoder->encodePassword(str_repeat('a', 73), 'salt');
     }
 
+    /**
+     * @requires PHP 5.3.7
+     */
     public function testCheckPasswordLength()
     {
-        $this->skipIfPhpVersionIsNotSupported();
-
         $encoder = new BCryptPasswordEncoder(self::VALID_COST);
         $result = $encoder->encodePassword(str_repeat('a', 72), null);
 
         $this->assertFalse($encoder->isPasswordValid($result, str_repeat('a', 73), 'salt'));
         $this->assertTrue($encoder->isPasswordValid($result, str_repeat('a', 72), 'salt'));
-    }
-
-    private function skipIfPhpVersionIsNotSupported()
-    {
-        if (PHP_VERSION_ID < 50307 && !\PasswordCompat\binary\check()) {
-            $this->markTestSkipped('Skipping test as this PHP version is not compatible with the ircmaxell/password-compat library.');
-        }
     }
 }

--- a/src/Symfony/Component/Security/Tests/Core/Encoder/BCryptPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Encoder/BCryptPasswordEncoderTest.php
@@ -47,6 +47,8 @@ class BCryptPasswordEncoderTest extends \PHPUnit_Framework_TestCase
 
     public function testResultLength()
     {
+        $this->skipIfPhpVersionIsNotSupported();
+
         $encoder = new BCryptPasswordEncoder(self::VALID_COST);
         $result = $encoder->encodePassword(self::PASSWORD, null);
         $this->assertEquals(60, strlen($result));
@@ -54,6 +56,8 @@ class BCryptPasswordEncoderTest extends \PHPUnit_Framework_TestCase
 
     public function testValidation()
     {
+        $this->skipIfPhpVersionIsNotSupported();
+
         $encoder = new BCryptPasswordEncoder(self::VALID_COST);
         $result = $encoder->encodePassword(self::PASSWORD, null);
         $this->assertTrue($encoder->isPasswordValid($result, self::PASSWORD, null));
@@ -72,10 +76,19 @@ class BCryptPasswordEncoderTest extends \PHPUnit_Framework_TestCase
 
     public function testCheckPasswordLength()
     {
+        $this->skipIfPhpVersionIsNotSupported();
+
         $encoder = new BCryptPasswordEncoder(self::VALID_COST);
         $result = $encoder->encodePassword(str_repeat('a', 72), null);
 
         $this->assertFalse($encoder->isPasswordValid($result, str_repeat('a', 73), 'salt'));
         $this->assertTrue($encoder->isPasswordValid($result, str_repeat('a', 72), 'salt'));
+    }
+
+    private function skipIfPhpVersionIsNotSupported()
+    {
+        if (PHP_VERSION_ID < 50307 && !\PasswordCompat\binary\check()) {
+            $this->markTestSkipped('Skipping test as this PHP version is not compatible with the ircmaxell/password-compat library.');
+        }
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17055 |
| License | MIT |
| Doc PR |  |

Not all PHP versions before 5.3.7 have backported fixes that make it
possible to use `password_hash()` function. Therefore, we have to skip
tests on not supported platforms.
