### PR TITLE
Fix constraint validator alias being required

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddConstraintValidatorsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddConstraintValidatorsPass.php
@@ -27,6 +27,8 @@ class AddConstraintValidatorsPass implements CompilerPassInterface
             if (isset($attributes[0]['alias'])) {
                 $validators[$attributes[0]['alias']] = $id;
             }
+
+            $validators[$container->getDefinition($id)->getClass()] = $id;
         }
 
         $container->getDefinition('validator.validator_factory')->replaceArgument(1, $validators);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddConstraintValidatorsPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddConstraintValidatorsPassTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddConstraintValidatorsPass;
+
+class AddConstraintValidatorsPassTest extends \PHPUnit_Framework_TestCase
+{
+    public function testThatConstraintValidatorServicesAreProcessed()
+    {
+        $services = array(
+            'my_constraint_validator_service1' => array(0 => array('alias' => 'my_constraint_validator_alias1')),
+            'my_constraint_validator_service2' => array(),
+        );
+
+        $validatorFactoryDefinition = $this->getMock('Symfony\Component\DependencyInjection\Definition');
+        $container = $this->getMock(
+            'Symfony\Component\DependencyInjection\ContainerBuilder',
+            array('findTaggedServiceIds', 'getDefinition', 'hasDefinition')
+        );
+
+        $validatorDefinition1 = $this->getMock('Symfony\Component\DependencyInjection\Definition', array('getClass'));
+        $validatorDefinition2 = $this->getMock('Symfony\Component\DependencyInjection\Definition', array('getClass'));
+
+        $validatorDefinition1->expects($this->atLeastOnce())
+            ->method('getClass')
+            ->willReturn('My\Fully\Qualified\Class\Named\Validator1');
+        $validatorDefinition2->expects($this->atLeastOnce())
+            ->method('getClass')
+            ->willReturn('My\Fully\Qualified\Class\Named\Validator2');
+
+        $container->expects($this->any())
+            ->method('getDefinition')
+            ->with($this->anything())
+            ->will($this->returnValueMap(array(
+                array('my_constraint_validator_service1', $validatorDefinition1),
+                array('my_constraint_validator_service2', $validatorDefinition2),
+                array('validator.validator_factory', $validatorFactoryDefinition),
+            )));
+
+        $container->expects($this->atLeastOnce())
+            ->method('findTaggedServiceIds')
+            ->will($this->returnValue($services));
+        $container->expects($this->atLeastOnce())
+            ->method('hasDefinition')
+            ->with('validator.validator_factory')
+            ->will($this->returnValue(true));
+
+        $validatorFactoryDefinition->expects($this->once())
+            ->method('replaceArgument')
+            ->with(1, array(
+                'My\Fully\Qualified\Class\Named\Validator1' => 'my_constraint_validator_service1',
+                'my_constraint_validator_alias1' => 'my_constraint_validator_service1',
+                'My\Fully\Qualified\Class\Named\Validator2' => 'my_constraint_validator_service2',
+            ));
+
+        $addConstraintValidatorsPass = new AddConstraintValidatorsPass();
+        $addConstraintValidatorsPass->process($container);
+    }
+
+    public function testThatCompilerPassIsIgnoredIfThereIsNoConstraintValidatorFactoryDefinition()
+    {
+        $definition = $this->getMock('Symfony\Component\DependencyInjection\Definition');
+        $container = $this->getMock(
+            'Symfony\Component\DependencyInjection\ContainerBuilder',
+            array('hasDefinition', 'findTaggedServiceIds', 'getDefinition')
+        );
+
+        $container->expects($this->never())->method('findTaggedServiceIds');
+        $container->expects($this->never())->method('getDefinition');
+        $container->expects($this->atLeastOnce())
+            ->method('hasDefinition')
+            ->with('validator.validator_factory')
+            ->will($this->returnValue(false));
+        $definition->expects($this->never())->method('replaceArgument');
+
+        $addConstraintValidatorsPass = new AddConstraintValidatorsPass();
+        $addConstraintValidatorsPass->process($container);
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16805 |
| License | MIT |
| Doc PR | symfony/symfony-docs#6055 |

This is my first contribution, so everything might not be in perfect order.

Follow-up of #16841 on the right branch.
