### PR TITLE
[Bridge] [Doctrine] [Validator] Added support \IteratorAggregate for UniqueEntityValidator

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -114,6 +114,10 @@ class UniqueEntityValidator extends ConstraintValidator
         $repository = $em->getRepository(get_class($entity));
         $result = $repository->{$constraint->repositoryMethod}($criteria);
 
+        if ($result instanceof \IteratorAggregate) {
+            $result = $result->getIterator();
+        }
+
         /* If the result is a MongoCursor, it must be advanced to the first
          * element. Rewinding should have no ill effect if $result is another
          * iterator implementation.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Expand the list of supported types of results returned from the repositories.
Added processing of type \IteratorAggregate (and as a consequence doctrine Collection)
