### PR TITLE
CS: use nowdoc instead of heredoc

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -24,5 +24,7 @@ return Symfony\CS\Config\Config::create()
             ->notPath('src/Symfony/Component/Yaml/Tests/Fixtures/sfTests.yml')
             // test template
             ->notPath('src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/Resources/Custom/_name_entry_label.html.php')
+            // explicit heredoc test
+            ->notPath('src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Resources/views/translation.html.php')
     )
 ;

--- a/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
@@ -37,7 +37,7 @@ class AssetsInstallCommand extends ContainerAwareCommand
             ->addOption('symlink', null, InputOption::VALUE_NONE, 'Symlinks the assets instead of copying it')
             ->addOption('relative', null, InputOption::VALUE_NONE, 'Make relative symlinks')
             ->setDescription('Installs bundles web assets under a public web directory')
-            ->setHelp(<<<EOT
+            ->setHelp(<<<'EOT'
 The <info>%command.name%</info> command installs bundle assets into a given
 directory (e.g. the <comment>web</comment> directory).
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -37,7 +37,7 @@ class CacheClearCommand extends ContainerAwareCommand
                 new InputOption('no-optional-warmers', '', InputOption::VALUE_NONE, 'Skip optional cache warmers (faster)'),
             ))
             ->setDescription('Clears the cache')
-            ->setHelp(<<<EOF
+            ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command clears the application cache for a given environment
 and debug mode:
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheWarmupCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheWarmupCommand.php
@@ -33,7 +33,7 @@ class CacheWarmupCommand extends ContainerAwareCommand
                 new InputOption('no-optional-warmers', '', InputOption::VALUE_NONE, 'Skip optional cache warmers (faster)'),
             ))
             ->setDescription('Warms up an empty cache')
-            ->setHelp(<<<EOF
+            ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command warms up the cache.
 
 Before running this command, the cache must be empty.

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
@@ -35,7 +35,7 @@ class ConfigDumpReferenceCommand extends ContainerDebugCommand
                 new InputArgument('name', InputArgument::OPTIONAL, 'The Bundle or extension alias'),
             ))
             ->setDescription('Dumps default configuration for an extension')
-            ->setHelp(<<<EOF
+            ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command dumps the default configuration for an extension/bundle.
 
 The extension alias or bundle name can be used:

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -49,7 +49,7 @@ class ContainerDebugCommand extends ContainerAwareCommand
                 new InputOption('parameters', null, InputOption::VALUE_NONE, 'Displays parameters for an application'),
             ))
             ->setDescription('Displays current services for an application')
-            ->setHelp(<<<EOF
+            ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command displays all configured <comment>public</comment> services:
 
   <info>php %command.full_name%</info>

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterApacheDumperCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterApacheDumperCommand.php
@@ -53,7 +53,7 @@ class RouterApacheDumperCommand extends ContainerAwareCommand
                 new InputOption('base-uri', null, InputOption::VALUE_REQUIRED, 'The base URI'),
             ))
             ->setDescription('Dumps all routes as Apache rewrite rules')
-            ->setHelp(<<<EOF
+            ->setHelp(<<<'EOF'
 The <info>%command.name%</info> dumps all routes as Apache rewrite rules.
 These can then be used with the ApacheUrlMatcher to use Apache for route
 matching.

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -51,7 +51,7 @@ class RouterDebugCommand extends ContainerAwareCommand
                 new InputArgument('name', InputArgument::OPTIONAL, 'A route name'),
             ))
             ->setDescription('Displays current routes for an application')
-            ->setHelp(<<<EOF
+            ->setHelp(<<<'EOF'
 The <info>%command.name%</info> displays the configured routes:
 
   <info>php %command.full_name%</info>

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
@@ -52,7 +52,7 @@ class RouterMatchCommand extends ContainerAwareCommand
                 new InputArgument('path_info', InputArgument::REQUIRED, 'A path info'),
             ))
             ->setDescription('Helps debug routes by simulating a path info match')
-            ->setHelp(<<<EOF
+            ->setHelp(<<<'EOF'
 The <info>%command.name%</info> simulates a path info match:
 
   <info>php %command.full_name% /foo</info>

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
@@ -54,7 +54,7 @@ class ServerRunCommand extends ContainerAwareCommand
             ))
             ->setName('server:run')
             ->setDescription('Runs PHP built-in web server')
-            ->setHelp(<<<EOF
+            ->setHelp(<<<'EOF'
 The <info>%command.name%</info> runs PHP built-in web server:
 
   <info>%command.full_name%</info>

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -43,7 +43,7 @@ class TranslationUpdateCommand extends ContainerAwareCommand
                 new InputOption('clean', null, InputOption::VALUE_NONE, 'Should clean not found messages'),
             ))
             ->setDescription('Updates the translation file')
-            ->setHelp(<<<EOF
+            ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command extract translation strings from templates
 of a given bundle. It can display them or merge the new ones into the translation files.
 When new translation strings are found it can automatically add a prefix to the translation

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
@@ -108,9 +108,9 @@ class Translator extends BaseTranslator
                 $fallbackSuffix = ucfirst(preg_replace($replacementPattern, '_', $fallback));
                 $currentSuffix = ucfirst(preg_replace($replacementPattern, '_', $current));
 
-                $fallbackContent .= sprintf(<<<EOF
-\$catalogue%s = new MessageCatalogue('%s', %s);
-\$catalogue%s->addFallbackCatalogue(\$catalogue%s);
+                $fallbackContent .= sprintf(<<<'EOF'
+$catalogue%s = new MessageCatalogue('%s', %s);
+$catalogue%s->addFallbackCatalogue($catalogue%s);
 
 
 EOF

--- a/src/Symfony/Bundle/SecurityBundle/Command/InitAclCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/InitAclCommand.php
@@ -43,7 +43,7 @@ class InitAclCommand extends ContainerAwareCommand
         $this
             ->setName('init:acl')
             ->setDescription('Mounts ACL tables in the database')
-            ->setHelp(<<<EOF
+            ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command mounts ACL tables in the database.
 
   <info>php %command.full_name%</info>

--- a/src/Symfony/Bundle/TwigBundle/Command/LintCommand.php
+++ b/src/Symfony/Bundle/TwigBundle/Command/LintCommand.php
@@ -29,7 +29,7 @@ class LintCommand extends ContainerAwareCommand
             ->setName('twig:lint')
             ->setDescription('Lints a template and outputs encountered errors')
             ->addArgument('filename')
-            ->setHelp(<<<EOF
+            ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command lints a template and outputs to stdout
 the first encountered syntax error.
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Command/ExportCommand.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Command/ExportCommand.php
@@ -53,7 +53,7 @@ class ExportCommand extends Command
             ->setDefinition(array(
                 new InputArgument('token', InputArgument::REQUIRED, 'The profile token'),
             ))
-            ->setHelp(<<<EOF
+            ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command exports a profile to the standard output:
 
   <info>php %command.full_name% profile_token</info>

--- a/src/Symfony/Bundle/WebProfilerBundle/Command/ImportCommand.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Command/ImportCommand.php
@@ -53,7 +53,7 @@ class ImportCommand extends Command
             ->setDefinition(array(
                 new InputArgument('filename', InputArgument::OPTIONAL, 'The profile path'),
             ))
-            ->setHelp(<<<EOF
+            ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command imports a profile:
 
   <info>php %command.full_name% profile_filepath</info>

--- a/src/Symfony/Component/ClassLoader/Tests/ClassCollectionLoaderTest.php
+++ b/src/Symfony/Component/ClassLoader/Tests/ClassCollectionLoaderTest.php
@@ -241,26 +241,26 @@ class ClassCollectionLoaderTest extends \PHPUnit_Framework_TestCase
 
         spl_autoload_unregister($r);
 
-        $this->assertEquals(<<<EOF
+        $this->assertEquals(<<<'EOF'
 namespace Namespaced
 {
 class WithComments
 {
-public static \$loaded = true;
+public static $loaded = true;
 }
-\$string ='string should not be   modified {\$string}';
-\$heredoc = (<<<HD
+$string ='string should not be   modified {$string}';
+$heredoc = (<<<HD
 
 
-Heredoc should not be   modified {\$string}
+Heredoc should not be   modified {$string}
 
 
 HD
 );
-\$nowdoc =<<<'ND'
+$nowdoc =<<<'ND'
 
 
-Nowdoc should not be   modified {\$string}
+Nowdoc should not be   modified {$string}
 
 
 ND
@@ -270,7 +270,7 @@ namespace
 {
 class Pearlike_WithComments
 {
-public static \$loaded = true;
+public static $loaded = true;
 }
 }
 EOF

--- a/src/Symfony/Component/Config/Tests/Definition/ReferenceDumperTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ReferenceDumperTest.php
@@ -26,7 +26,7 @@ class ReferenceDumperTest extends \PHPUnit_Framework_TestCase
 
     private function getConfigurationAsString()
     {
-        return <<<EOL
+        return <<<'EOL'
 root:
     boolean:              true
     scalar_empty:         ~

--- a/src/Symfony/Component/Console/Command/HelpCommand.php
+++ b/src/Symfony/Component/Console/Command/HelpCommand.php
@@ -42,7 +42,7 @@ class HelpCommand extends Command
                 new InputOption('raw', null, InputOption::VALUE_NONE, 'To output raw command help'),
             ))
             ->setDescription('Displays help for a command')
-            ->setHelp(<<<EOF
+            ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command displays help for a given command:
 
   <info>php %command.full_name% list</info>

--- a/src/Symfony/Component/Console/Command/ListCommand.php
+++ b/src/Symfony/Component/Console/Command/ListCommand.php
@@ -34,7 +34,7 @@ class ListCommand extends Command
             ->setName('list')
             ->setDefinition($this->createDefinition())
             ->setDescription('Lists commands')
-            ->setHelp(<<<EOF
+            ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command lists all commands:
 
   <info>php %command.full_name%</info>

--- a/src/Symfony/Component/Console/Shell.php
+++ b/src/Symfony/Component/Console/Shell.php
@@ -68,7 +68,7 @@ class Shell
         if ($this->processIsolation) {
             $finder = new PhpExecutableFinder();
             $php = $finder->find();
-            $this->output->writeln(<<<EOF
+            $this->output->writeln(<<<'EOF'
 <info>Running with process isolation, you should consider this:</info>
   * each command is executed as separate process,
   * commands don't support interactivity, all params must be passed explicitly,

--- a/src/Symfony/Component/Console/Tests/Command/ListCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/ListCommandTest.php
@@ -38,7 +38,7 @@ class ListCommandTest extends \PHPUnit_Framework_TestCase
         $application = new Application();
         $commandTester = new CommandTester($command = $application->get('list'));
         $commandTester->execute(array('command' => $command->getName(), '--raw' => true));
-        $output = <<<EOF
+        $output = <<<'EOF'
 help   Displays help for a command
 list   Lists commands
 
@@ -54,7 +54,7 @@ EOF;
         $application->add(new \FooCommand());
         $commandTester = new CommandTester($command = $application->get('list'));
         $commandTester->execute(array('command' => $command->getName(), 'namespace' => 'foo', '--raw' => true));
-        $output = <<<EOF
+        $output = <<<'EOF'
 foo:bar   The foo:bar command
 
 EOF;
@@ -69,7 +69,7 @@ EOF;
         $application->add(new \Foo6Command());
         $commandTester = new CommandTester($command = $application->get('list'));
         $commandTester->execute(array('command' => $command->getName()), array('decorated' => false));
-        $output = <<<EOF
+        $output = <<<'EOF'
 Console Tool
 
 Usage:
@@ -101,7 +101,7 @@ EOF;
         $application->add(new \Foo6Command());
         $commandTester = new CommandTester($command = $application->get('list'));
         $commandTester->execute(array('command' => $command->getName(), '--raw' => true));
-        $output = <<<EOF
+        $output = <<<'EOF'
 help       Displays help for a command
 list       Lists commands
 0foo:bar   0foo:bar command

--- a/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
@@ -220,7 +220,7 @@ class OutputFormatterTest extends \PHPUnit_Framework_TestCase
 \033[32m
 some text\033[0m
 EOF
-            , $formatter->format(<<<EOF
+            , $formatter->format(<<<'EOF'
 <info>
 some text</info>
 EOF
@@ -230,7 +230,7 @@ EOF
 \033[32msome text
 \033[0m
 EOF
-            , $formatter->format(<<<EOF
+            , $formatter->format(<<<'EOF'
 <info>some text
 </info>
 EOF
@@ -241,7 +241,7 @@ EOF
 some text
 \033[0m
 EOF
-            , $formatter->format(<<<EOF
+            , $formatter->format(<<<'EOF'
 <info>
 some text
 </info>
@@ -254,7 +254,7 @@ some text
 more text
 \033[0m
 EOF
-            , $formatter->format(<<<EOF
+            , $formatter->format(<<<'EOF'
 <info>
 some text
 more text

--- a/src/Symfony/Component/Console/Tests/Helper/TableHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableHelperTest.php
@@ -91,7 +91,7 @@ class TableHelperTest extends \PHPUnit_Framework_TestCase
                     array('80-902734-1-6', 'And Then There Were None', 'Agatha Christie'),
                 ),
                 TableHelper::LAYOUT_DEFAULT,
-<<<TABLE
+<<<'TABLE'
 +---------------+--------------------------+------------------+
 | ISBN          | Title                    | Author           |
 +---------------+--------------------------+------------------+
@@ -123,7 +123,7 @@ TABLE
                     array('80-902734-1-6', 'And Then There Were None', 'Agatha Christie'),
                 ),
                 TableHelper::LAYOUT_DEFAULT,
-<<<TABLE
+<<<'TABLE'
 +---------------+--------------------------+------------------+
 | ISBN          | Title                    |                  |
 +---------------+--------------------------+------------------+
@@ -144,7 +144,7 @@ TABLE
                     array('80-902734-1-6', 'And Then There Were None', 'Agatha Christie'),
                 ),
                 TableHelper::LAYOUT_DEFAULT,
-<<<TABLE
+<<<'TABLE'
 +---------------+--------------------------+------------------+
 | 99921-58-10-7 | Divine Comedy            | Dante Alighieri  |
 | 9971-5-0210-0 |                          |                  |
@@ -163,7 +163,7 @@ TABLE
                     array('960-425-059-0', 'The Lord of the Rings', "J. R. R.\nTolkien"),
                 ),
                 TableHelper::LAYOUT_DEFAULT,
-<<<TABLE
+<<<'TABLE'
 +---------------+----------------------------+-----------------+
 | ISBN          | Title                      | Author          |
 +---------------+----------------------------+-----------------+
@@ -183,7 +183,7 @@ TABLE
                 array('ISBN', 'Title'),
                 array(),
                 TableHelper::LAYOUT_DEFAULT,
-<<<TABLE
+<<<'TABLE'
 +------+-------+
 | ISBN | Title |
 +------+-------+
@@ -203,7 +203,7 @@ TABLE
                     array('9971-5-0210-0', 'A Tale of Two Cities', '<info>Charles Dickens</>'),
                 ),
                 TableHelper::LAYOUT_DEFAULT,
-<<<TABLE
+<<<'TABLE'
 +---------------+----------------------+-----------------+
 | ISBN          | Title                | Author          |
 +---------------+----------------------+-----------------+
@@ -220,7 +220,7 @@ TABLE
                     array('9971-5-0210-0', 'A Tale of Two Cities', 'Charles Dickens'),
                 ),
                 TableHelper::LAYOUT_DEFAULT,
-<<<TABLE
+<<<'TABLE'
 +----------------------------------+----------------------+-----------------+
 | ISBN                             | Title                | Author          |
 +----------------------------------+----------------------+-----------------+
@@ -247,7 +247,7 @@ TABLE
         $table->render($output = $this->getOutputStream());
 
         $expected =
-<<<TABLE
+<<<'TABLE'
 +------+
 | ■■   |
 +------+
@@ -273,7 +273,7 @@ TABLE;
         $table->render($output = $this->getOutputStream());
 
         $expected =
-            <<<TABLE
+            <<<'TABLE'
 +------------+
 | あいうえお |
 +------------+

--- a/src/Symfony/Component/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/Debug/ExceptionHandler.php
@@ -141,7 +141,7 @@ class ExceptionHandler
                     $ind = $count - $position + 1;
                     $class = $this->abbrClass($e['class']);
                     $message = nl2br(htmlspecialchars($e['message'], $flags, $this->charset));
-                    $content .= sprintf(<<<EOF
+                    $content .= sprintf(<<<'EOF'
                         <div class="block_exception clear_fix">
                             <h2><span>%d/%d</span> %s: %s</h2>
                         </div>
@@ -196,7 +196,7 @@ EOF;
      */
     public function getStylesheet(FlattenException $exception)
     {
-        return <<<EOF
+        return <<<'EOF'
             .sf-reset { font: 11px Verdana, Arial, sans-serif; color: #333 }
             .sf-reset .clear { clear:both; height:0; font-size:0; line-height:0; }
             .sf-reset .clear_fix:after { display:block; height:0; clear:both; visibility:hidden; }

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -558,7 +558,7 @@ class PhpDumper extends Dumper
 
         $doc = '';
         if (ContainerInterface::SCOPE_PROTOTYPE !== $scope) {
-            $doc .= <<<EOF
+            $doc .= <<<'EOF'
 
      *
      * This service is shared.
@@ -567,7 +567,7 @@ EOF;
         }
 
         if (!$definition->isPublic()) {
-            $doc .= <<<EOF
+            $doc .= <<<'EOF'
 
      *
      * This service is private.
@@ -804,7 +804,7 @@ EOF;
         $code .= $this->addMethodMap();
         $code .= $this->addAliases();
 
-        $code .= <<<EOF
+        $code .= <<<'EOF'
     }
 
 EOF;
@@ -834,11 +834,11 @@ EOF;
             $code .= "\n        \$this->parameters = \$this->getDefaultParameters();\n";
         }
 
-        $code .= <<<EOF
+        $code .= <<<'EOF'
 
-        \$this->services =
-        \$this->scopedServices =
-        \$this->scopeStacks = array();
+        $this->services =
+        $this->scopedServices =
+        $this->scopeStacks = array();
 EOF;
 
         $code .= "\n";
@@ -853,7 +853,7 @@ EOF;
         $code .= $this->addMethodMap();
         $code .= $this->addAliases();
 
-        $code .= <<<EOF
+        $code .= <<<'EOF'
     }
 
 EOF;
@@ -924,36 +924,36 @@ EOF;
 
         $code = '';
         if ($this->container->isFrozen()) {
-            $code .= <<<EOF
+            $code .= <<<'EOF'
 
     /**
      * {@inheritdoc}
      */
-    public function getParameter(\$name)
+    public function getParameter($name)
     {
-        \$name = strtolower(\$name);
+        $name = strtolower($name);
 
-        if (!(isset(\$this->parameters[\$name]) || array_key_exists(\$name, \$this->parameters))) {
-            throw new InvalidArgumentException(sprintf('The parameter "%s" must be defined.', \$name));
+        if (!(isset($this->parameters[$name]) || array_key_exists($name, $this->parameters))) {
+            throw new InvalidArgumentException(sprintf('The parameter "%s" must be defined.', $name));
         }
 
-        return \$this->parameters[\$name];
+        return $this->parameters[$name];
     }
 
     /**
      * {@inheritdoc}
      */
-    public function hasParameter(\$name)
+    public function hasParameter($name)
     {
-        \$name = strtolower(\$name);
+        $name = strtolower($name);
 
-        return isset(\$this->parameters[\$name]) || array_key_exists(\$name, \$this->parameters);
+        return isset($this->parameters[$name]) || array_key_exists($name, $this->parameters);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function setParameter(\$name, \$value)
+    public function setParameter($name, $value)
     {
         throw new LogicException('Impossible to call set() on a frozen ParameterBag.');
     }
@@ -963,11 +963,11 @@ EOF;
      */
     public function getParameterBag()
     {
-        if (null === \$this->parameterBag) {
-            \$this->parameterBag = new FrozenParameterBag(\$this->parameters);
+        if (null === $this->parameterBag) {
+            $this->parameterBag = new FrozenParameterBag($this->parameters);
         }
 
-        return \$this->parameterBag;
+        return $this->parameterBag;
     }
 EOF;
         }
@@ -1029,7 +1029,7 @@ EOF;
      */
     private function endClass()
     {
-        return <<<EOF
+        return <<<'EOF'
 }
 
 EOF;

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -117,7 +117,7 @@ class CrawlerTest extends \PHPUnit_Framework_TestCase
         $internalErrors = libxml_use_internal_errors(true);
 
         $crawler = new Crawler();
-        $crawler->addHtmlContent(<<<EOF
+        $crawler->addHtmlContent(<<<'EOF'
 <!DOCTYPE html>
 <html>
     <head>
@@ -158,7 +158,7 @@ EOF
         $internalErrors = libxml_use_internal_errors(true);
 
         $crawler = new Crawler();
-        $crawler->addXmlContent(<<<EOF
+        $crawler->addXmlContent(<<<'EOF'
 <!DOCTYPE html>
 <html>
     <head>
@@ -518,7 +518,7 @@ EOF
 
     public function testSelectButtonWithSingleQuotesInNameAttribute()
     {
-        $html = <<<HTML
+        $html = <<<'HTML'
 <!DOCTYPE html>
 <html lang="en">
 <body>
@@ -539,7 +539,7 @@ HTML;
 
     public function testSelectButtonWithDoubleQuotesInNameAttribute()
     {
-        $html = <<<HTML
+        $html = <<<'HTML'
 <!DOCTYPE html>
 <html lang="en">
 <body>
@@ -578,7 +578,7 @@ HTML;
 
     public function testSelectLinkAndLinkFiltered()
     {
-        $html = <<<HTML
+        $html = <<<'HTML'
 <!DOCTYPE html>
 <html lang="en">
 <body>

--- a/src/Symfony/Component/Intl/Data/Bundle/Writer/PhpBundleWriter.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Writer/PhpBundleWriter.php
@@ -25,7 +25,7 @@ class PhpBundleWriter implements BundleWriterInterface
      */
     public function write($path, $locale, $data)
     {
-        $template = <<<TEMPLATE
+        $template = <<<'TEMPLATE'
 <?php
 
 return %s;

--- a/src/Symfony/Component/Intl/Resources/bin/update-data.php
+++ b/src/Symfony/Component/Intl/Resources/bin/update-data.php
@@ -35,7 +35,7 @@ $argc = $_SERVER['argc'];
 $argv = $_SERVER['argv'];
 
 if ($argc > 3 || 2 === $argc && '-h' === $argv[1]) {
-    bailout(<<<MESSAGE
+    bailout(<<<'MESSAGE'
 Usage: php update-icu-component.php <path/to/icu/source> <path/to/icu/build>
 
 Updates the ICU data for Symfony to the latest version of ICU.

--- a/src/Symfony/Component/Process/Tests/PhpProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/PhpProcessTest.php
@@ -30,7 +30,7 @@ PHP
 
     public function testCommandLine()
     {
-        $process = new PhpProcess(<<<PHP
+        $process = new PhpProcess(<<<'PHP'
 <?php echo 'foobar';
 PHP
         );

--- a/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
+++ b/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
@@ -106,16 +106,16 @@ EOF;
      */
     private function generateGenerateMethod()
     {
-        return <<<EOF
-    public function generate(\$name, \$parameters = array(), \$referenceType = self::ABSOLUTE_PATH)
+        return <<<'EOF'
+    public function generate($name, $parameters = array(), $referenceType = self::ABSOLUTE_PATH)
     {
-        if (!isset(self::\$declaredRoutes[\$name])) {
-            throw new RouteNotFoundException(sprintf('Unable to generate a URL for the named route "%s" as such route does not exist.', \$name));
+        if (!isset(self::$declaredRoutes[$name])) {
+            throw new RouteNotFoundException(sprintf('Unable to generate a URL for the named route "%s" as such route does not exist.', $name));
         }
 
-        list(\$variables, \$defaults, \$requirements, \$tokens, \$hostTokens) = self::\$declaredRoutes[\$name];
+        list($variables, $defaults, $requirements, $tokens, $hostTokens) = self::$declaredRoutes[$name];
 
-        return \$this->doGenerate(\$variables, \$defaults, \$requirements, \$tokens, \$parameters, \$name, \$referenceType, \$hostTokens);
+        return $this->doGenerate($variables, $defaults, $requirements, $tokens, $parameters, $name, $referenceType, $hostTokens);
     }
 EOF;
     }

--- a/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
@@ -367,7 +367,7 @@ FINDCHILDREN;
      */
     protected function getSelectObjectIdentityIdSql(ObjectIdentityInterface $oid)
     {
-        $query = <<<QUERY
+        $query = <<<'QUERY'
             SELECT o.id
             FROM %s o
             INNER JOIN %s c ON c.id = o.class_id

--- a/src/Symfony/Component/Security/Acl/Dbal/MutableAclProvider.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/MutableAclProvider.php
@@ -433,7 +433,7 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
      */
     protected function getInsertAccessControlEntrySql($classId, $objectIdentityId, $field, $aceOrder, $securityIdentityId, $strategy, $mask, $granting, $auditSuccess, $auditFailure)
     {
-        $query = <<<QUERY
+        $query = <<<'QUERY'
             INSERT INTO %s (
                 class_id,
                 object_identity_id,
@@ -510,7 +510,7 @@ QUERY;
      */
     protected function getInsertObjectIdentitySql($identifier, $classId, $entriesInheriting)
     {
-        $query = <<<QUERY
+        $query = <<<'QUERY'
               INSERT INTO %s (class_id, object_identifier, entries_inheriting)
               VALUES (%d, %s, %s)
 QUERY;

--- a/src/Symfony/Component/Validator/Tests/ConstraintViolationListTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintViolationListTest.php
@@ -110,7 +110,7 @@ class ConstraintViolationListTest extends \PHPUnit_Framework_TestCase
             $this->getViolation('Error 5', '', '[baz]'),
         ));
 
-        $expected = <<<EOF
+        $expected = <<<'EOF'
 Root:
     Error 1
 Root.foo.bar:

--- a/src/Symfony/Component/Validator/Tests/ConstraintViolationTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintViolationTest.php
@@ -26,7 +26,7 @@ class ConstraintViolationTest extends \PHPUnit_Framework_TestCase
             null
         );
 
-        $expected = <<<EOF
+        $expected = <<<'EOF'
 Root.property.path:
     Array
 EOF;
@@ -45,7 +45,7 @@ EOF;
             null
         );
 
-        $expected = <<<EOF
+        $expected = <<<'EOF'
 Array.some_value:
     42 cannot be used here
 EOF;

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -54,7 +54,7 @@ class DumperTest extends \PHPUnit_Framework_TestCase
     {
         $this->dumper->setIndentation(7);
 
-        $expected = <<<EOF
+        $expected = <<<'EOF'
 '': bar
 foo: '#bar'
 'foo''bar': {  }
@@ -104,13 +104,13 @@ EOF;
 
     public function testInlineLevel()
     {
-        $expected = <<<EOF
+        $expected = <<<'EOF'
 { '': bar, foo: '#bar', 'foo''bar': {  }, bar: [1, foo], foobar: { foo: bar, bar: [1, foo], foobar: { foo: bar, bar: [1, foo] } } }
 EOF;
         $this->assertEquals($expected, $this->dumper->dump($this->array, -10), '->dump() takes an inline level argument');
         $this->assertEquals($expected, $this->dumper->dump($this->array, 0), '->dump() takes an inline level argument');
 
-        $expected = <<<EOF
+        $expected = <<<'EOF'
 '': bar
 foo: '#bar'
 'foo''bar': {  }
@@ -120,7 +120,7 @@ foobar: { foo: bar, bar: [1, foo], foobar: { foo: bar, bar: [1, foo] } }
 EOF;
         $this->assertEquals($expected, $this->dumper->dump($this->array, 1), '->dump() takes an inline level argument');
 
-        $expected = <<<EOF
+        $expected = <<<'EOF'
 '': bar
 foo: '#bar'
 'foo''bar': {  }
@@ -135,7 +135,7 @@ foobar:
 EOF;
         $this->assertEquals($expected, $this->dumper->dump($this->array, 2), '->dump() takes an inline level argument');
 
-        $expected = <<<EOF
+        $expected = <<<'EOF'
 '': bar
 foo: '#bar'
 'foo''bar': {  }
@@ -154,7 +154,7 @@ foobar:
 EOF;
         $this->assertEquals($expected, $this->dumper->dump($this->array, 3), '->dump() takes an inline level argument');
 
-        $expected = <<<EOF
+        $expected = <<<'EOF'
 '': bar
 foo: '#bar'
 'foo''bar': {  }

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -90,7 +90,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
 
     public function testEndOfTheDocumentMarker()
     {
-        $yaml = <<<EOF
+        $yaml = <<<'EOF'
 --- %YAML:1.0
 foo
 ...
@@ -473,7 +473,7 @@ EOF;
      */
     public function testUnindentedCollectionException()
     {
-        $yaml = <<<EOF
+        $yaml = <<<'EOF'
 
 collection:
 -item1
@@ -490,7 +490,7 @@ EOF;
      */
     public function testShortcutKeyUnindentedCollectionException()
     {
-        $yaml = <<<EOF
+        $yaml = <<<'EOF'
 
 collection:
 -  key: foo
@@ -507,7 +507,7 @@ EOF;
      */
     public function testMultipleDocumentsNotSupportedException()
     {
-        Yaml::parse(<<<EOL
+        Yaml::parse(<<<'EOL'
 # Ranking of 1998 home runs
 ---
 - Mark McGwire
@@ -527,7 +527,7 @@ EOL
      */
     public function testSequenceInAMapping()
     {
-        Yaml::parse(<<<EOF
+        Yaml::parse(<<<'EOF'
 yaml:
   hash: me
   - array stuff
@@ -540,7 +540,7 @@ EOF
      */
     public function testMappingInASequence()
     {
-        Yaml::parse(<<<EOF
+        Yaml::parse(<<<'EOF'
 yaml:
   - array stuff
   hash: me
@@ -550,7 +550,7 @@ EOF
 
     public function testEmptyValue()
     {
-        $input = <<<EOF
+        $input = <<<'EOF'
 hash:
 EOF;
 
@@ -568,7 +568,7 @@ EOF;
                     'class' => 'Bar',
                 ),
             ),
-        ), Yaml::parse(<<<EOF
+        ), Yaml::parse(<<<'EOF'
 # comment 1
 services:
 # comment 2
@@ -585,7 +585,7 @@ EOF
 
     public function testStringBlockWithComments()
     {
-        $this->assertEquals(array('content' => <<<EOT
+        $this->assertEquals(array('content' => <<<'EOT'
 # comment 1
 header
 
@@ -596,7 +596,7 @@ header
 
 footer # comment3
 EOT
-        ), Yaml::parse(<<<EOF
+        ), Yaml::parse(<<<'EOF'
 content: |
     # comment 1
     header
@@ -613,7 +613,7 @@ EOF
 
     public function testFoldedStringBlockWithComments()
     {
-        $this->assertEquals(array(array('content' => <<<EOT
+        $this->assertEquals(array(array('content' => <<<'EOT'
 # comment 1
 header
 
@@ -624,7 +624,7 @@ header
 
 footer # comment3
 EOT
-        )), Yaml::parse(<<<EOF
+        )), Yaml::parse(<<<'EOF'
 -
     content: |
         # comment 1
@@ -644,7 +644,7 @@ EOF
     {
         $this->assertEquals(array(array(
             'title' => 'some title',
-            'content' => <<<EOT
+            'content' => <<<'EOT'
 # comment 1
 header
 
@@ -655,7 +655,7 @@ header
 
 footer # comment3
 EOT
-        )), Yaml::parse(<<<EOF
+        )), Yaml::parse(<<<'EOF'
 -
     title: some title
     content: |
@@ -684,7 +684,7 @@ EOF
             'map' => array('key' => 'var-value'),
             'list_in_map' => array('key' => array('var-value')),
             'map_in_map' => array('foo' => array('bar' => 'var-value')),
-        ), Yaml::parse(<<<EOF
+        ), Yaml::parse(<<<'EOF'
 var:  &var var-value
 scalar: *var
 list: [ *var ]
@@ -700,7 +700,7 @@ EOF
 
     public function testYamlDirective()
     {
-        $yaml = <<<EOF
+        $yaml = <<<'EOF'
 %YAML 1.2
 ---
 foo: 1
@@ -711,7 +711,7 @@ EOF;
 
     public function testFloatKeys()
     {
-        $yaml = <<<EOF
+        $yaml = <<<'EOF'
 foo:
     1.2: "bar"
     1.3: "baz"
@@ -737,7 +737,7 @@ EOF;
 
     public function getCommentLikeStringInScalarBlockData()
     {
-        $yaml1 = <<<EOT
+        $yaml1 = <<<'EOT'
 pages:
     -
         title: some title
@@ -756,7 +756,7 @@ EOT;
             'pages' => array(
                 array(
                     'title' => 'some title',
-                    'content' => <<<EOT
+                    'content' => <<<'EOT'
 # comment 1
 header
 
@@ -772,7 +772,7 @@ EOT
             ),
         );
 
-        $yaml2 = <<<EOT
+        $yaml2 = <<<'EOT'
 test: |
     foo
     # bar
@@ -788,7 +788,7 @@ collection:
         baz
 EOT;
         $expected2 = array(
-            'test' => <<<EOT
+            'test' => <<<'EOT'
 foo
 # bar
 baz
@@ -797,7 +797,7 @@ EOT
             ,
             'collection' => array(
                 array(
-                    'one' => <<<EOT
+                    'one' => <<<'EOT'
 foo
 # bar
 baz
@@ -805,7 +805,7 @@ EOT
                     ,
                 ),
                 array(
-                    'two' => <<<EOT
+                    'two' => <<<'EOT'
 foo
 # bar
 baz


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | — |
| License | MIT |
| Doc PR | — |

if this is accepted, we could add the fixer to symfony level of php-cs-fixer: https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/1580
