### PR TITLE
[Routing] Reduce memory usage of a high consuming test case

### DIFF
--- a/src/Symfony/Component/Routing/Tests/Generator/Dumper/PhpGeneratorDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/Dumper/PhpGeneratorDumperTest.php
@@ -91,10 +91,10 @@ class PhpGeneratorDumperTest extends \PHPUnit_Framework_TestCase
         }
         $this->routeCollection->add('Test2', new Route('/testing2'));
 
-        $data = $this->generatorDumper->dump(array(
+        file_put_contents($this->largeTestTmpFilepath, $this->generatorDumper->dump(array(
             'class' => 'ProjectLargeUrlGenerator',
-        ));
-        file_put_contents($this->largeTestTmpFilepath, $data);
+        )));
+        $this->routeCollection = $this->generatorDumper = null;
         include $this->largeTestTmpFilepath;
 
         $projectUrlGenerator = new \ProjectLargeUrlGenerator(new RequestContext('/app.php'));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15617 |
| License | MIT |
| Doc PR | - |

Tests fail transiently on hhvm because of the high memory usage of this test case.
This patch cuts it by two.

See this blackfire comparison graph on the Memory dimension:
https://blackfire.io/profiles/compare/fd72ee66-e4d0-4ac2-92bf-16dd3849ef4c/graph?settings%5Bdimension%5D=pmu
