### PR TITLE
[Routing] Skip PhpGeneratorDumperTest::testDumpWithTooManyRoutes on HHVM

### DIFF
--- a/src/Symfony/Component/Routing/Tests/Generator/Dumper/PhpGeneratorDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/Dumper/PhpGeneratorDumperTest.php
@@ -85,6 +85,10 @@ class PhpGeneratorDumperTest extends \PHPUnit_Framework_TestCase
 
     public function testDumpWithTooManyRoutes()
     {
+        if (defined('HHVM_VERSION_ID')) {
+            $this->markTestSkipped('HHVM consumes too much memory on this test.');
+        }
+
         $this->routeCollection->add('Test', new Route('/testing/{foo}'));
         for ($i = 0; $i < 32769; ++$i) {
             $this->routeCollection->add('route_'.$i, new Route('/route_'.$i));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15617 |
| License | MIT |
| Doc PR | - |

phpunit reports:
- before: `Memory: 430.91Mb`
- after: `Memory: 21.26Mb`
