### PR TITLE
[HttpKernel] added a setter for the headers property in the HttpException

### DIFF
--- a/src/Symfony/Component/HttpKernel/Exception/HttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/HttpException.php
@@ -38,4 +38,14 @@ class HttpException extends \RuntimeException implements HttpExceptionInterface
     {
         return $this->headers;
     }
+
+    /**
+     * Set response headers.
+     *
+     * @param array $headers Response headers.
+     */
+    public function setHeaders(array $headers)
+    {
+        $this->headers = $headers;
+    }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/AccessdeniedHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/AccessdeniedHttpExceptionTest.php
@@ -7,27 +7,8 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 /**
  * Test the AccessDeniedHttpException class.
  */
-class AccessDeniedHttpExceptionTest extends \PHPUnit_Framework_TestCase
+class AccessDeniedHttpExceptionTest extends HttpExceptionTest
 {
-    /**
-     * Provides header data for the tests.
-     *
-     * @return array
-     */
-    public function headerDataProvider()
-    {
-        return array(
-            array(array('X-Test' => 'Test')),
-            array(array('X-Test' => 1)),
-            array(
-                array(
-                    array('X-Test' => 'Test'),
-                    array('X-Test-2' => 'Test-2'),
-                ),
-            ),
-        );
-    }
-
     /**
      * Test that the default headers is an empty array.
      */

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/AccessdeniedHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/AccessdeniedHttpExceptionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Tests\Exception;
+
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+/**
+ * Test the AccessDeniedHttpException class.
+ */
+class AccessDeniedHttpExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Provides header data for the tests.
+     *
+     * @return array
+     */
+    public function headerDataProvider()
+    {
+        return array(
+            array(array('X-Test' => 'Test')),
+            array(array('X-Test' => 1)),
+            array(
+                array(
+                    array('X-Test' => 'Test'),
+                    array('X-Test-2' => 'Test-2'),
+                ),
+            ),
+        );
+    }
+
+    /**
+     * Test that the default headers is an empty array.
+     */
+    public function testHeadersDefault()
+    {
+        $exception = new AccessDeniedHttpException();
+        $this->assertSame(array(), $exception->getHeaders());
+    }
+
+    /**
+     * Test that setting the headers using the setter function
+     * is working as expected.
+     *
+     * @param array $headers The headers to set.
+     *
+     * @dataProvider headerDataProvider
+     */
+    public function testHeadersSetter($headers)
+    {
+        $exception = new AccessDeniedHttpException();
+        $exception->setHeaders($headers);
+        $this->assertSame($headers, $exception->getHeaders());
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/BadRequestHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/BadRequestHttpExceptionTest.php
@@ -7,27 +7,8 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 /**
  * Test the BadRequestHttpException class.
  */
-class BadRequestHttpExceptionTest extends \PHPUnit_Framework_TestCase
+class BadRequestHttpExceptionTest extends HttpExceptionTest
 {
-    /**
-     * Provides header data for the tests.
-     *
-     * @return array
-     */
-    public function headerDataProvider()
-    {
-        return array(
-            array(array('X-Test' => 'Test')),
-            array(array('X-Test' => 1)),
-            array(
-                array(
-                    array('X-Test' => 'Test'),
-                    array('X-Test-2' => 'Test-2'),
-                ),
-            ),
-        );
-    }
-
     /**
      * Test that the default headers is an empty array.
      */

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/BadRequestHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/BadRequestHttpExceptionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Tests\Exception;
+
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+/**
+ * Test the BadRequestHttpException class.
+ */
+class BadRequestHttpExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Provides header data for the tests.
+     *
+     * @return array
+     */
+    public function headerDataProvider()
+    {
+        return array(
+            array(array('X-Test' => 'Test')),
+            array(array('X-Test' => 1)),
+            array(
+                array(
+                    array('X-Test' => 'Test'),
+                    array('X-Test-2' => 'Test-2'),
+                ),
+            ),
+        );
+    }
+
+    /**
+     * Test that the default headers is an empty array.
+     */
+    public function testHeadersDefault()
+    {
+        $exception = new BadRequestHttpException();
+        $this->assertSame(array(), $exception->getHeaders());
+    }
+
+    /**
+     * Test that setting the headers using the setter function
+     * is working as expected.
+     *
+     * @param array $headers The headers to set.
+     *
+     * @dataProvider headerDataProvider
+     */
+    public function testHeadersSetter($headers)
+    {
+        $exception = new BadRequestHttpException();
+        $exception->setHeaders($headers);
+        $this->assertSame($headers, $exception->getHeaders());
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/ConflictHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/ConflictHttpExceptionTest.php
@@ -7,27 +7,8 @@ use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 /**
  * Test the ConflictHttpException class.
  */
-class ConflictHttpExceptionTest extends \PHPUnit_Framework_TestCase
+class ConflictHttpExceptionTest extends HttpExceptionTest
 {
-    /**
-     * Provides header data for the tests.
-     *
-     * @return array
-     */
-    public function headerDataProvider()
-    {
-        return array(
-            array(array('X-Test' => 'Test')),
-            array(array('X-Test' => 1)),
-            array(
-                array(
-                    array('X-Test' => 'Test'),
-                    array('X-Test-2' => 'Test-2'),
-                ),
-            ),
-        );
-    }
-
     /**
      * Test that the default headers is an empty array.
      */

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/ConflictHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/ConflictHttpExceptionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Tests\Exception;
+
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+
+/**
+ * Test the ConflictHttpException class.
+ */
+class ConflictHttpExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Provides header data for the tests.
+     *
+     * @return array
+     */
+    public function headerDataProvider()
+    {
+        return array(
+            array(array('X-Test' => 'Test')),
+            array(array('X-Test' => 1)),
+            array(
+                array(
+                    array('X-Test' => 'Test'),
+                    array('X-Test-2' => 'Test-2'),
+                ),
+            ),
+        );
+    }
+
+    /**
+     * Test that the default headers is an empty array.
+     */
+    public function testHeadersDefault()
+    {
+        $exception = new ConflictHttpException();
+        $this->assertSame(array(), $exception->getHeaders());
+    }
+
+    /**
+     * Test that setting the headers using the setter function
+     * is working as expected.
+     *
+     * @param array $headers The headers to set.
+     *
+     * @dataProvider headerDataProvider
+     */
+    public function testHeadersSetter($headers)
+    {
+        $exception = new ConflictHttpException();
+        $exception->setHeaders($headers);
+        $this->assertSame($headers, $exception->getHeaders());
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/GoneHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/GoneHttpExceptionTest.php
@@ -7,27 +7,8 @@ use Symfony\Component\HttpKernel\Exception\GoneHttpException;
 /**
  * Test the GoneHttpException class.
  */
-class GoneHttpExceptionTest extends \PHPUnit_Framework_TestCase
+class GoneHttpExceptionTest extends HttpExceptionTest
 {
-    /**
-     * Provides header data for the tests.
-     *
-     * @return array
-     */
-    public function headerDataProvider()
-    {
-        return array(
-            array(array('X-Test' => 'Test')),
-            array(array('X-Test' => 1)),
-            array(
-                array(
-                    array('X-Test' => 'Test'),
-                    array('X-Test-2' => 'Test-2'),
-                ),
-            ),
-        );
-    }
-
     /**
      * Test that the default headers is an empty array.
      */

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/GoneHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/GoneHttpExceptionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Tests\Exception;
+
+use Symfony\Component\HttpKernel\Exception\GoneHttpException;
+
+/**
+ * Test the GoneHttpException class.
+ */
+class GoneHttpExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Provides header data for the tests.
+     *
+     * @return array
+     */
+    public function headerDataProvider()
+    {
+        return array(
+            array(array('X-Test' => 'Test')),
+            array(array('X-Test' => 1)),
+            array(
+                array(
+                    array('X-Test' => 'Test'),
+                    array('X-Test-2' => 'Test-2'),
+                ),
+            ),
+        );
+    }
+
+    /**
+     * Test that the default headers is an empty array.
+     */
+    public function testHeadersDefault()
+    {
+        $exception = new GoneHttpException();
+        $this->assertSame(array(), $exception->getHeaders());
+    }
+
+    /**
+     * Test that setting the headers using the setter function
+     * is working as expected.
+     *
+     * @param array $headers The headers to set.
+     *
+     * @dataProvider headerDataProvider
+     */
+    public function testHeadersSetter($headers)
+    {
+        $exception = new GoneHttpException();
+        $exception->setHeaders($headers);
+        $this->assertSame($headers, $exception->getHeaders());
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/HttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/HttpExceptionTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Tests\Exception;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+/**
+ * Test the HttpException class.
+ */
+class HttpExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Provides header data for the tests.
+     *
+     * @return array
+     */
+    public function headerDataProvider()
+    {
+        return array(
+            array(array('X-Test' => 'Test')),
+            array(array('X-Test' => 1)),
+            array(
+                array(
+                    array('X-Test' => 'Test'),
+                    array('X-Test-2' => 'Test-2'),
+                ),
+            ),
+        );
+    }
+
+    /**
+     * Test that the default headers is an empty array.
+     */
+    public function testHeadersDefault()
+    {
+        $exception = new HttpException(200);
+        $this->assertSame(array(), $exception->getHeaders());
+    }
+
+    /**
+     * Test that setting the headers using the constructor parameter
+     * is working as expected.
+     *
+     * @param array $headers The headers to set.
+     *
+     * @dataProvider headerDataProvider
+     */
+    public function testHeadersConstructor($headers)
+    {
+        $exception = new HttpException(200, null, null, $headers);
+        $this->assertSame($headers, $exception->getHeaders());
+    }
+
+    /**
+     * Test that setting the headers using the setter function
+     * is working as expected.
+     *
+     * @param array $headers The headers to set.
+     *
+     * @dataProvider headerDataProvider
+     */
+    public function testHeadersSetter($headers)
+    {
+        $exception = new HttpException(200);
+        $exception->setHeaders($headers);
+        $this->assertSame($headers, $exception->getHeaders());
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/LengthRequiredHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/LengthRequiredHttpExceptionTest.php
@@ -7,27 +7,8 @@ use Symfony\Component\HttpKernel\Exception\LengthRequiredHttpException;
 /**
  * Test the LengthRequiredHttpException class.
  */
-class LengthRequiredHttpExceptionTest extends \PHPUnit_Framework_TestCase
+class LengthRequiredHttpExceptionTest extends HttpExceptionTest
 {
-    /**
-     * Provides header data for the tests.
-     *
-     * @return array
-     */
-    public function headerDataProvider()
-    {
-        return array(
-            array(array('X-Test' => 'Test')),
-            array(array('X-Test' => 1)),
-            array(
-                array(
-                    array('X-Test' => 'Test'),
-                    array('X-Test-2' => 'Test-2'),
-                ),
-            ),
-        );
-    }
-
     /**
      * Test that the default headers is an empty array.
      */

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/LengthRequiredHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/LengthRequiredHttpExceptionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Tests\Exception;
+
+use Symfony\Component\HttpKernel\Exception\LengthRequiredHttpException;
+
+/**
+ * Test the LengthRequiredHttpException class.
+ */
+class LengthRequiredHttpExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Provides header data for the tests.
+     *
+     * @return array
+     */
+    public function headerDataProvider()
+    {
+        return array(
+            array(array('X-Test' => 'Test')),
+            array(array('X-Test' => 1)),
+            array(
+                array(
+                    array('X-Test' => 'Test'),
+                    array('X-Test-2' => 'Test-2'),
+                ),
+            ),
+        );
+    }
+
+    /**
+     * Test that the default headers is an empty array.
+     */
+    public function testHeadersDefault()
+    {
+        $exception = new LengthRequiredHttpException();
+        $this->assertSame(array(), $exception->getHeaders());
+    }
+
+    /**
+     * Test that setting the headers using the setter function
+     * is working as expected.
+     *
+     * @param array $headers The headers to set.
+     *
+     * @dataProvider headerDataProvider
+     */
+    public function testHeadersSetter($headers)
+    {
+        $exception = new LengthRequiredHttpException();
+        $exception->setHeaders($headers);
+        $this->assertSame($headers, $exception->getHeaders());
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/MethodNotAllowedHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/MethodNotAllowedHttpExceptionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Tests\Exception;
+
+use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
+
+/**
+ * Test the MethodNotAllowedHttpException class.
+ */
+class MethodNotAllowedHttpExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Provides header data for the tests.
+     *
+     * @return array
+     */
+    public function headerDataProvider()
+    {
+        return array(
+            array(array('X-Test' => 'Test')),
+            array(array('X-Test' => 1)),
+            array(
+                array(
+                    array('X-Test' => 'Test'),
+                    array('X-Test-2' => 'Test-2'),
+                ),
+            ),
+        );
+    }
+
+    /**
+     * Test that the default headers is set as expected.
+     */
+    public function testHeadersDefault()
+    {
+        $exception = new MethodNotAllowedHttpException(array('GET', 'PUT'));
+        $this->assertSame(array('Allow' => 'GET, PUT'), $exception->getHeaders());
+    }
+
+    /**
+     * Test that setting the headers using the setter function
+     * is working as expected.
+     *
+     * @param array $headers The headers to set.
+     *
+     * @dataProvider headerDataProvider
+     */
+    public function testHeadersSetter($headers)
+    {
+        $exception = new MethodNotAllowedHttpException(array('GET'));
+        $exception->setHeaders($headers);
+        $this->assertSame($headers, $exception->getHeaders());
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/MethodNotAllowedHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/MethodNotAllowedHttpExceptionTest.php
@@ -7,27 +7,8 @@ use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 /**
  * Test the MethodNotAllowedHttpException class.
  */
-class MethodNotAllowedHttpExceptionTest extends \PHPUnit_Framework_TestCase
+class MethodNotAllowedHttpExceptionTest extends HttpExceptionTest
 {
-    /**
-     * Provides header data for the tests.
-     *
-     * @return array
-     */
-    public function headerDataProvider()
-    {
-        return array(
-            array(array('X-Test' => 'Test')),
-            array(array('X-Test' => 1)),
-            array(
-                array(
-                    array('X-Test' => 'Test'),
-                    array('X-Test-2' => 'Test-2'),
-                ),
-            ),
-        );
-    }
-
     /**
      * Test that the default headers is set as expected.
      */

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/NotAcceptableHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/NotAcceptableHttpExceptionTest.php
@@ -7,27 +7,8 @@ use Symfony\Component\HttpKernel\Exception\NotAcceptableHttpException;
 /**
  * Test the NotAcceptableHttpException class.
  */
-class NotAcceptableHttpExceptionTest extends \PHPUnit_Framework_TestCase
+class NotAcceptableHttpExceptionTest extends HttpExceptionTest
 {
-    /**
-     * Provides header data for the tests.
-     *
-     * @return array
-     */
-    public function headerDataProvider()
-    {
-        return array(
-            array(array('X-Test' => 'Test')),
-            array(array('X-Test' => 1)),
-            array(
-                array(
-                    array('X-Test' => 'Test'),
-                    array('X-Test-2' => 'Test-2'),
-                ),
-            ),
-        );
-    }
-
     /**
      * Test that the default headers is an empty array.
      */

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/NotAcceptableHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/NotAcceptableHttpExceptionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Tests\Exception;
+
+use Symfony\Component\HttpKernel\Exception\NotAcceptableHttpException;
+
+/**
+ * Test the NotAcceptableHttpException class.
+ */
+class NotAcceptableHttpExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Provides header data for the tests.
+     *
+     * @return array
+     */
+    public function headerDataProvider()
+    {
+        return array(
+            array(array('X-Test' => 'Test')),
+            array(array('X-Test' => 1)),
+            array(
+                array(
+                    array('X-Test' => 'Test'),
+                    array('X-Test-2' => 'Test-2'),
+                ),
+            ),
+        );
+    }
+
+    /**
+     * Test that the default headers is an empty array.
+     */
+    public function testHeadersDefault()
+    {
+        $exception = new NotAcceptableHttpException();
+        $this->assertSame(array(), $exception->getHeaders());
+    }
+
+    /**
+     * Test that setting the headers using the setter function
+     * is working as expected.
+     *
+     * @param array $headers The headers to set.
+     *
+     * @dataProvider headerDataProvider
+     */
+    public function testHeadersSetter($headers)
+    {
+        $exception = new NotAcceptableHttpException();
+        $exception->setHeaders($headers);
+        $this->assertSame($headers, $exception->getHeaders());
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/NotFoundHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/NotFoundHttpExceptionTest.php
@@ -7,27 +7,8 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 /**
  * Test the NotFoundHttpException class.
  */
-class NotFoundHttpExceptionTest extends \PHPUnit_Framework_TestCase
+class NotFoundHttpExceptionTest extends HttpExceptionTest
 {
-    /**
-     * Provides header data for the tests.
-     *
-     * @return array
-     */
-    public function headerDataProvider()
-    {
-        return array(
-            array(array('X-Test' => 'Test')),
-            array(array('X-Test' => 1)),
-            array(
-                array(
-                    array('X-Test' => 'Test'),
-                    array('X-Test-2' => 'Test-2'),
-                ),
-            ),
-        );
-    }
-
     /**
      * Test that the default headers is an empty array.
      */

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/NotFoundHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/NotFoundHttpExceptionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Tests\Exception;
+
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Test the NotFoundHttpException class.
+ */
+class NotFoundHttpExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Provides header data for the tests.
+     *
+     * @return array
+     */
+    public function headerDataProvider()
+    {
+        return array(
+            array(array('X-Test' => 'Test')),
+            array(array('X-Test' => 1)),
+            array(
+                array(
+                    array('X-Test' => 'Test'),
+                    array('X-Test-2' => 'Test-2'),
+                ),
+            ),
+        );
+    }
+
+    /**
+     * Test that the default headers is an empty array.
+     */
+    public function testHeadersDefault()
+    {
+        $exception = new NotFoundHttpException();
+        $this->assertSame(array(), $exception->getHeaders());
+    }
+
+    /**
+     * Test that setting the headers using the setter function
+     * is working as expected.
+     *
+     * @param array $headers The headers to set.
+     *
+     * @dataProvider headerDataProvider
+     */
+    public function testHeadersSetter($headers)
+    {
+        $exception = new NotFoundHttpException();
+        $exception->setHeaders($headers);
+        $this->assertSame($headers, $exception->getHeaders());
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/PreconditionFailedHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/PreconditionFailedHttpExceptionTest.php
@@ -7,27 +7,8 @@ use Symfony\Component\HttpKernel\Exception\PreconditionFailedHttpException;
 /**
  * Test the PreconditionFailedHttpException class.
  */
-class PreconditionFailedHttpExceptionTest extends \PHPUnit_Framework_TestCase
+class PreconditionFailedHttpExceptionTest extends HttpExceptionTest
 {
-    /**
-     * Provides header data for the tests.
-     *
-     * @return array
-     */
-    public function headerDataProvider()
-    {
-        return array(
-            array(array('X-Test' => 'Test')),
-            array(array('X-Test' => 1)),
-            array(
-                array(
-                    array('X-Test' => 'Test'),
-                    array('X-Test-2' => 'Test-2'),
-                ),
-            ),
-        );
-    }
-
     /**
      * Test that the default headers is an empty array.
      */

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/PreconditionFailedHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/PreconditionFailedHttpExceptionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Tests\Exception;
+
+use Symfony\Component\HttpKernel\Exception\PreconditionFailedHttpException;
+
+/**
+ * Test the PreconditionFailedHttpException class.
+ */
+class PreconditionFailedHttpExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Provides header data for the tests.
+     *
+     * @return array
+     */
+    public function headerDataProvider()
+    {
+        return array(
+            array(array('X-Test' => 'Test')),
+            array(array('X-Test' => 1)),
+            array(
+                array(
+                    array('X-Test' => 'Test'),
+                    array('X-Test-2' => 'Test-2'),
+                ),
+            ),
+        );
+    }
+
+    /**
+     * Test that the default headers is an empty array.
+     */
+    public function testHeadersDefault()
+    {
+        $exception = new PreconditionFailedHttpException();
+        $this->assertSame(array(), $exception->getHeaders());
+    }
+
+    /**
+     * Test that setting the headers using the setter function
+     * is working as expected.
+     *
+     * @param array $headers The headers to set.
+     *
+     * @dataProvider headerDataProvider
+     */
+    public function testHeadersSetter($headers)
+    {
+        $exception = new PreconditionFailedHttpException();
+        $exception->setHeaders($headers);
+        $this->assertSame($headers, $exception->getHeaders());
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/PreconditionRequiredHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/PreconditionRequiredHttpExceptionTest.php
@@ -7,27 +7,8 @@ use Symfony\Component\HttpKernel\Exception\PreconditionRequiredHttpException;
 /**
  * Test the PreconditionRequiredHttpException class.
  */
-class PreconditionRequiredHttpExceptionTest extends \PHPUnit_Framework_TestCase
+class PreconditionRequiredHttpExceptionTest extends HttpExceptionTest
 {
-    /**
-     * Provides header data for the tests.
-     *
-     * @return array
-     */
-    public function headerDataProvider()
-    {
-        return array(
-            array(array('X-Test' => 'Test')),
-            array(array('X-Test' => 1)),
-            array(
-                array(
-                    array('X-Test' => 'Test'),
-                    array('X-Test-2' => 'Test-2'),
-                ),
-            ),
-        );
-    }
-
     /**
      * Test that the default headers is an empty array.
      */

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/PreconditionRequiredHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/PreconditionRequiredHttpExceptionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Tests\Exception;
+
+use Symfony\Component\HttpKernel\Exception\PreconditionRequiredHttpException;
+
+/**
+ * Test the PreconditionRequiredHttpException class.
+ */
+class PreconditionRequiredHttpExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Provides header data for the tests.
+     *
+     * @return array
+     */
+    public function headerDataProvider()
+    {
+        return array(
+            array(array('X-Test' => 'Test')),
+            array(array('X-Test' => 1)),
+            array(
+                array(
+                    array('X-Test' => 'Test'),
+                    array('X-Test-2' => 'Test-2'),
+                ),
+            ),
+        );
+    }
+
+    /**
+     * Test that the default headers is an empty array.
+     */
+    public function testHeadersDefault()
+    {
+        $exception = new PreconditionRequiredHttpException();
+        $this->assertSame(array(), $exception->getHeaders());
+    }
+
+    /**
+     * Test that setting the headers using the setter function
+     * is working as expected.
+     *
+     * @param array $headers The headers to set.
+     *
+     * @dataProvider headerDataProvider
+     */
+    public function testHeadersSetter($headers)
+    {
+        $exception = new PreconditionRequiredHttpException();
+        $exception->setHeaders($headers);
+        $this->assertSame($headers, $exception->getHeaders());
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/ServiceUnavailableHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/ServiceUnavailableHttpExceptionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Tests\Exception;
+
+use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
+
+/**
+ * Test the ServiceUnavailableHttpException class.
+ */
+class ServiceUnavailableHttpExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Provides header data for the tests.
+     *
+     * @return array
+     */
+    public function headerDataProvider()
+    {
+        return array(
+            array(array('X-Test' => 'Test')),
+            array(array('X-Test' => 1)),
+            array(
+                array(
+                    array('X-Test' => 'Test'),
+                    array('X-Test-2' => 'Test-2'),
+                ),
+            ),
+        );
+    }
+
+    /**
+     * Test that the default headers is an empty array.
+     */
+    public function testHeadersDefault()
+    {
+        $exception = new ServiceUnavailableHttpException();
+        $this->assertSame(array(), $exception->getHeaders());
+    }
+
+    /**
+     * Test that setting the headers using the setter function
+     * is working as expected.
+     *
+     * @param array $headers The headers to set.
+     *
+     * @dataProvider headerDataProvider
+     */
+    public function testHeadersSetter($headers)
+    {
+        $exception = new ServiceUnavailableHttpException(10);
+        $exception->setHeaders($headers);
+        $this->assertSame($headers, $exception->getHeaders());
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/ServiceUnavailableHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/ServiceUnavailableHttpExceptionTest.php
@@ -7,27 +7,8 @@ use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 /**
  * Test the ServiceUnavailableHttpException class.
  */
-class ServiceUnavailableHttpExceptionTest extends \PHPUnit_Framework_TestCase
+class ServiceUnavailableHttpExceptionTest extends HttpExceptionTest
 {
-    /**
-     * Provides header data for the tests.
-     *
-     * @return array
-     */
-    public function headerDataProvider()
-    {
-        return array(
-            array(array('X-Test' => 'Test')),
-            array(array('X-Test' => 1)),
-            array(
-                array(
-                    array('X-Test' => 'Test'),
-                    array('X-Test-2' => 'Test-2'),
-                ),
-            ),
-        );
-    }
-
     /**
      * Test that the default headers is an empty array.
      */
@@ -35,6 +16,16 @@ class ServiceUnavailableHttpExceptionTest extends \PHPUnit_Framework_TestCase
     {
         $exception = new ServiceUnavailableHttpException();
         $this->assertSame(array(), $exception->getHeaders());
+    }
+
+    /**
+     * Test that the default headers are set correctly
+     * when the retryAfter parameter is set.
+     */
+    public function testHeadersDefaultRetryAfter()
+    {
+        $exception = new ServiceUnavailableHttpException(10);
+        $this->assertSame(array('Retry-After' => 10), $exception->getHeaders());
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/TooManyRequestsHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/TooManyRequestsHttpExceptionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Tests\Exception;
+
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+
+/**
+ * Test the TooManyRequestsHttpException class.
+ */
+class TooManyRequestsHttpExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Provides header data for the tests.
+     *
+     * @return array
+     */
+    public function headerDataProvider()
+    {
+        return array(
+            array(array('X-Test' => 'Test')),
+            array(array('X-Test' => 1)),
+            array(
+                array(
+                    array('X-Test' => 'Test'),
+                    array('X-Test-2' => 'Test-2'),
+                ),
+            ),
+        );
+    }
+
+    /**
+     * Test that the default headers is an empty array.
+     */
+    public function testHeadersDefault()
+    {
+        $exception = new TooManyRequestsHttpException();
+        $this->assertSame(array(), $exception->getHeaders());
+    }
+
+    /**
+     * Test that setting the headers using the setter function
+     * is working as expected.
+     *
+     * @param array $headers The headers to set.
+     *
+     * @dataProvider headerDataProvider
+     */
+    public function testHeadersSetter($headers)
+    {
+        $exception = new TooManyRequestsHttpException(10);
+        $exception->setHeaders($headers);
+        $this->assertSame($headers, $exception->getHeaders());
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/TooManyRequestsHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/TooManyRequestsHttpExceptionTest.php
@@ -7,27 +7,8 @@ use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
 /**
  * Test the TooManyRequestsHttpException class.
  */
-class TooManyRequestsHttpExceptionTest extends \PHPUnit_Framework_TestCase
+class TooManyRequestsHttpExceptionTest extends HttpExceptionTest
 {
-    /**
-     * Provides header data for the tests.
-     *
-     * @return array
-     */
-    public function headerDataProvider()
-    {
-        return array(
-            array(array('X-Test' => 'Test')),
-            array(array('X-Test' => 1)),
-            array(
-                array(
-                    array('X-Test' => 'Test'),
-                    array('X-Test-2' => 'Test-2'),
-                ),
-            ),
-        );
-    }
-
     /**
      * Test that the default headers is an empty array.
      */
@@ -35,6 +16,16 @@ class TooManyRequestsHttpExceptionTest extends \PHPUnit_Framework_TestCase
     {
         $exception = new TooManyRequestsHttpException();
         $this->assertSame(array(), $exception->getHeaders());
+    }
+
+    /**
+     * Test that the default headers are set correctly
+     * when the retryAfter parameter is set.
+     */
+    public function testHeadersDefaultRertyAfter()
+    {
+        $exception = new TooManyRequestsHttpException(10);
+        $this->assertSame(array('Retry-After' => 10), $exception->getHeaders());
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/UnauthorizedHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/UnauthorizedHttpExceptionTest.php
@@ -7,27 +7,8 @@ use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 /**
  * Test the UnauthorizedHttpException class.
  */
-class UnauthorizedHttpExceptionTest extends \PHPUnit_Framework_TestCase
+class UnauthorizedHttpExceptionTest extends HttpExceptionTest
 {
-    /**
-     * Provides header data for the tests.
-     *
-     * @return array
-     */
-    public function headerDataProvider()
-    {
-        return array(
-            array(array('X-Test' => 'Test')),
-            array(array('X-Test' => 1)),
-            array(
-                array(
-                    array('X-Test' => 'Test'),
-                    array('X-Test-2' => 'Test-2'),
-                ),
-            ),
-        );
-    }
-
     /**
      * Test that the default headers is set as expected.
      */

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/UnauthorizedHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/UnauthorizedHttpExceptionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Tests\Exception;
+
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+
+/**
+ * Test the UnauthorizedHttpException class.
+ */
+class UnauthorizedHttpExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Provides header data for the tests.
+     *
+     * @return array
+     */
+    public function headerDataProvider()
+    {
+        return array(
+            array(array('X-Test' => 'Test')),
+            array(array('X-Test' => 1)),
+            array(
+                array(
+                    array('X-Test' => 'Test'),
+                    array('X-Test-2' => 'Test-2'),
+                ),
+            ),
+        );
+    }
+
+    /**
+     * Test that the default headers is set as expected.
+     */
+    public function testHeadersDefault()
+    {
+        $exception = new UnauthorizedHttpException('Challenge');
+        $this->assertSame(array('WWW-Authenticate' => 'Challenge'), $exception->getHeaders());
+    }
+
+    /**
+     * Test that setting the headers using the setter function
+     * is working as expected.
+     *
+     * @param array $headers The headers to set.
+     *
+     * @dataProvider headerDataProvider
+     */
+    public function testHeadersSetter($headers)
+    {
+        $exception = new UnauthorizedHttpException('Challenge');
+        $exception->setHeaders($headers);
+        $this->assertSame($headers, $exception->getHeaders());
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/UnprocessableEntityHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/UnprocessableEntityHttpExceptionTest.php
@@ -7,27 +7,8 @@ use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 /**
  * Test the UnprocessableEntityHttpException class.
  */
-class UnprocessableEntityHttpExceptionTest extends \PHPUnit_Framework_TestCase
+class UnprocessableEntityHttpExceptionTest extends HttpExceptionTest
 {
-    /**
-     * Provides header data for the tests.
-     *
-     * @return array
-     */
-    public function headerDataProvider()
-    {
-        return array(
-            array(array('X-Test' => 'Test')),
-            array(array('X-Test' => 1)),
-            array(
-                array(
-                    array('X-Test' => 'Test'),
-                    array('X-Test-2' => 'Test-2'),
-                ),
-            ),
-        );
-    }
-
     /**
      * Test that the default headers is an empty array.
      */

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/UnprocessableEntityHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/UnprocessableEntityHttpExceptionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Tests\Exception;
+
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+
+/**
+ * Test the UnprocessableEntityHttpException class.
+ */
+class UnprocessableEntityHttpExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Provides header data for the tests.
+     *
+     * @return array
+     */
+    public function headerDataProvider()
+    {
+        return array(
+            array(array('X-Test' => 'Test')),
+            array(array('X-Test' => 1)),
+            array(
+                array(
+                    array('X-Test' => 'Test'),
+                    array('X-Test-2' => 'Test-2'),
+                ),
+            ),
+        );
+    }
+
+    /**
+     * Test that the default headers is an empty array.
+     */
+    public function testHeadersDefault()
+    {
+        $exception = new UnprocessableEntityHttpException();
+        $this->assertSame(array(), $exception->getHeaders());
+    }
+
+    /**
+     * Test that setting the headers using the setter function
+     * is working as expected.
+     *
+     * @param array $headers The headers to set.
+     *
+     * @dataProvider headerDataProvider
+     */
+    public function testHeadersSetter($headers)
+    {
+        $exception = new UnprocessableEntityHttpException(10);
+        $exception->setHeaders($headers);
+        $this->assertSame($headers, $exception->getHeaders());
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/UnsupportedMediaTypeHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/UnsupportedMediaTypeHttpExceptionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Tests\Exception;
+
+use Symfony\Component\HttpKernel\Exception\UnsupportedMediaTypeHttpException;
+
+/**
+ * Test the UnsupportedMediaTypeHttpException class.
+ */
+class UnsupportedMediaTypeHttpExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Provides header data for the tests.
+     *
+     * @return array
+     */
+    public function headerDataProvider()
+    {
+        return array(
+            array(array('X-Test' => 'Test')),
+            array(array('X-Test' => 1)),
+            array(
+                array(
+                    array('X-Test' => 'Test'),
+                    array('X-Test-2' => 'Test-2'),
+                ),
+            ),
+        );
+    }
+
+    /**
+     * Test that the default headers is an empty array.
+     */
+    public function testHeadersDefault()
+    {
+        $exception = new UnsupportedMediaTypeHttpException();
+        $this->assertSame(array(), $exception->getHeaders());
+    }
+
+    /**
+     * Test that setting the headers using the setter function
+     * is working as expected.
+     *
+     * @param array $headers The headers to set.
+     *
+     * @dataProvider headerDataProvider
+     */
+    public function testHeadersSetter($headers)
+    {
+        $exception = new UnsupportedMediaTypeHttpException(10);
+        $exception->setHeaders($headers);
+        $this->assertSame($headers, $exception->getHeaders());
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/UnsupportedMediaTypeHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/UnsupportedMediaTypeHttpExceptionTest.php
@@ -7,27 +7,8 @@ use Symfony\Component\HttpKernel\Exception\UnsupportedMediaTypeHttpException;
 /**
  * Test the UnsupportedMediaTypeHttpException class.
  */
-class UnsupportedMediaTypeHttpExceptionTest extends \PHPUnit_Framework_TestCase
+class UnsupportedMediaTypeHttpExceptionTest extends HttpExceptionTest
 {
-    /**
-     * Provides header data for the tests.
-     *
-     * @return array
-     */
-    public function headerDataProvider()
-    {
-        return array(
-            array(array('X-Test' => 'Test')),
-            array(array('X-Test' => 1)),
-            array(
-                array(
-                    array('X-Test' => 'Test'),
-                    array('X-Test-2' => 'Test-2'),
-                ),
-            ),
-        );
-    }
-
     /**
      * Test that the default headers is an empty array.
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | symfony/symfony-docs#6076 |

Added this setter, because it's now impossible to use those handy, meaningful, already implemented exceptions (like NotFound...) if one wants to set some custom headers. This PR solves this problem.
It's a backward compatible solution in this way, but maybe it would be better if the `HttpExceptionInterface` would contain the `setHeaders` function as well. Of course this would be a BC break, that's why it is missing now.

TODO:
- [x] submit changes to the documentation
