### PR TITLE
[PropertyAccess] Reorder elements array after PropertyPathBuilder::replace

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyPathBuilder.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPathBuilder.php
@@ -142,6 +142,7 @@ class PropertyPathBuilder
             $this->elements[$offset + $i] = $path->getElement($pathOffset + $i);
             $this->isIndex[$offset + $i] = $path->isIndex($pathOffset + $i);
         }
+        ksort($this->elements);
     }
 
     /**

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyPathBuilderTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyPathBuilderTest.php
@@ -252,6 +252,17 @@ class PropertyPathBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($path, $builder->getPropertyPath());
     }
 
+    public function testReplaceWithLongerPathKeepsOrder()
+    {
+        $path = new PropertyPath('new1.new2.new3');
+        $expected = new PropertyPath('new1.new2.new3.old2');
+
+        $builder = new PropertyPathBuilder(new PropertyPath('old1.old2'));
+        $builder->replace(0, 1, $path);
+
+        $this->assertEquals($expected, $builder->getPropertyPath());
+    }
+
     public function testRemove()
     {
         $this->builder->remove(3);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17102 |
| License | MIT |
| Doc PR |  |
