### PR TITLE
[Serializer] Make metadata interfaces internal

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
@@ -16,6 +16,8 @@ namespace Symfony\Component\Serializer\Mapping;
  *
  * Primarily, the metadata stores serialization groups.
  *
+ * @internal
+ *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
 interface AttributeMetadataInterface

--- a/src/Symfony/Component/Serializer/Mapping/ClassMetadataInterface.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassMetadataInterface.php
@@ -18,6 +18,8 @@ namespace Symfony\Component\Serializer\Mapping;
  *
  * There may only exist one metadata for each attribute according to its name.
  *
+ * @internal
+ *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
 interface ClassMetadataInterface


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/pull/17113#discussion_r48291776 |
| License | MIT |
| Doc PR | n/a |

Introducing such interfaces was a (my) mistake. Serializer metadata are value objects. Nobody will (nor should) implement these interfaces. Composition is better for "extending" metadata.

They were not marked as `@api` and should now be marked as `@internal` (or even deprecated but it will cause some maintenance headaches).
