### PR TITLE
[appveyor] Exit with failing status code

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,9 +55,10 @@ install:
 
 test_script:
     - cd c:\projects\symfony
+    - Setlocal EnableDelayedExpansion
     - SET X=0
     - copy /Y c:\php\php.ini-min c:\php\php.ini
-    - php phpunit symfony --exclude-group benchmark,intl-data || SET X=1
+    - php phpunit symfony --exclude-group benchmark,intl-data || SET X=!errorlevel!
     - copy /Y c:\php\php.ini-max c:\php\php.ini
-    - php phpunit symfony --exclude-group benchmark,intl-data || SET X=1
+    - php phpunit symfony --exclude-group benchmark,intl-data || SET X=!errorlevel!
     - exit %X%

--- a/phpunit
+++ b/phpunit
@@ -162,7 +162,7 @@ if (isset($argv[1]) && 'symfony' === $argv[1]) {
 
             // Fail on any individual component failures but ignore STATUS_STACK_BUFFER_OVERRUN (-1073740791) on Windows when APCu is enabled
             if ($procStatus && ('\\' !== DIRECTORY_SEPARATOR || !extension_loaded('apcu') || !ini_get('apc.enable_cli') || -1073740791 !== $procStatus)) {
-                $exit = 1;
+                $exit = $procStatus;
                 echo "\033[41mKO\033[0m $component\n\n";
             } else {
                 echo "\033[32mOK\033[0m $component\n\n";


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

[Sometimes](https://ci.appveyor.com/project/fabpot/symfony/build/1.0.4272#L1103), tests fail on appveyor and I'd like to see the exit code. This does it.
