### PR TITLE
Sort commands with same name as namespace inside namespace

### DIFF
--- a/src/Symfony/Component/Console/Descriptor/ApplicationDescription.php
+++ b/src/Symfony/Component/Console/Descriptor/ApplicationDescription.php
@@ -149,7 +149,7 @@ class ApplicationDescription
         ksort($namespacedCommands);
         $namespacedCommands = array_merge($globalCommands, $namespacedCommands);
 
-        foreach ($namespacedCommands[self::GLOBAL_NAMESPACE] as $name => $command) {
+        foreach ($namespacedCommands[self::GLOBAL_NAMESPACE] as $name ==> $command) {
             if (array_key_exists($name, $namespacedCommands) && $name != self::GLOBAL_NAMESPACE) {
                 $namespacedCommands[$name][$name] = $command;
                 unset($namespacedCommands[self::GLOBAL_NAMESPACE][$name]);

--- a/src/Symfony/Component/Console/Descriptor/ApplicationDescription.php
+++ b/src/Symfony/Component/Console/Descriptor/ApplicationDescription.php
@@ -149,10 +149,12 @@ class ApplicationDescription
         ksort($namespacedCommands);
         $namespacedCommands = array_merge($globalCommands, $namespacedCommands);
 
-        foreach ($namespacedCommands[self::GLOBAL_NAMESPACE] as $name ==> $command) {
-            if (array_key_exists($name, $namespacedCommands) && $name != self::GLOBAL_NAMESPACE) {
-                $namespacedCommands[$name][$name] = $command;
-                unset($namespacedCommands[self::GLOBAL_NAMESPACE][$name]);
+        if (array_key_exists(self::GLOBAL_NAMESPACE, $namespacedCommands)) {
+            foreach ($namespacedCommands[self::GLOBAL_NAMESPACE] as $name ==> $command) {
+                if (array_key_exists($name, $namespacedCommands) && $name != self::GLOBAL_NAMESPACE) {
+                    $namespacedCommands[$name][$name] = $command;
+                    unset($namespacedCommands[self::GLOBAL_NAMESPACE][$name]);
+                }
             }
         }
 

--- a/src/Symfony/Component/Console/Descriptor/ApplicationDescription.php
+++ b/src/Symfony/Component/Console/Descriptor/ApplicationDescription.php
@@ -150,8 +150,8 @@ class ApplicationDescription
         $namespacedCommands = array_merge($globalCommands, $namespacedCommands);
 
         if (array_key_exists(self::GLOBAL_NAMESPACE, $namespacedCommands)) {
-            foreach ($namespacedCommands[self::GLOBAL_NAMESPACE] as $name ==> $command) {
-                if (array_key_exists($name, $namespacedCommands) && $name != self::GLOBAL_NAMESPACE) {
+            foreach ($namespacedCommands[self::GLOBAL_NAMESPACE] as $name => $command) {
+                if (array_key_exists($name, $namespacedCommands) && $name !== self::GLOBAL_NAMESPACE) {
                     $namespacedCommands[$name][$name] = $command;
                     unset($namespacedCommands[self::GLOBAL_NAMESPACE][$name]);
                 }

--- a/src/Symfony/Component/Console/Descriptor/ApplicationDescription.php
+++ b/src/Symfony/Component/Console/Descriptor/ApplicationDescription.php
@@ -141,13 +141,20 @@ class ApplicationDescription
         foreach ($commands as $name => $command) {
             $key = $this->application->extractNamespace($name, 1);
             if (!$key) {
-                $globalCommands['_global'][$name] = $command;
+                $globalCommands[self::GLOBAL_NAMESPACE][$name] = $command;
             } else {
                 $namespacedCommands[$key][$name] = $command;
             }
         }
         ksort($namespacedCommands);
         $namespacedCommands = array_merge($globalCommands, $namespacedCommands);
+
+        foreach ($namespacedCommands[self::GLOBAL_NAMESPACE] as $name => $command) {
+            if (array_key_exists($name, $namespacedCommands) && $name != self::GLOBAL_NAMESPACE) {
+                $namespacedCommands[$name][$name] = $command;
+                unset($namespacedCommands[self::GLOBAL_NAMESPACE][$name]);
+            }
+        }
 
         foreach ($namespacedCommands as &$commandsSet) {
             ksort($commandsSet);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| License | MIT |
| Doc PR |  |

Sorts commands that have the same name as a namespace inside that namespace in the ApplicationDescription.

Before:

``` bash
Available commands:
  help        Displays help for a command
  list        Lists commands
  tpl         Create a new project from a template
 tpl
  tpl:add     Add a new template
  tpl:delete  Remove a template [This will not delete any files]
  tpl:dir     Set the template directory
  tpl:list    List all templates
```

After:

``` bash
Available commands:
  help        Displays help for a command
  list        Lists commands
 tpl
  tpl         Create a new project from a template
  tpl:add     Add a new template
  tpl:delete  Remove a template [This will not delete any files]
  tpl:dir     Set the template directory
  tpl:list    List all templates
```
