### PR TITLE
Webprofiler add status code to search form

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -216,6 +216,7 @@ class ProfilerController
         if (null === $session = $request->getSession()) {
             $ip =
             $method =
+            $statusCode =
             $url =
             $start =
             $end =
@@ -224,6 +225,7 @@ class ProfilerController
         } else {
             $ip = $request->query->get('ip', $session->get('_profiler_search_ip'));
             $method = $request->query->get('method', $session->get('_profiler_search_method'));
+            $statusCode = $request->query->get('status_code', $session->get('_profiler_search_status_code'));
             $url = $request->query->get('url', $session->get('_profiler_search_url'));
             $start = $request->query->get('start', $session->get('_profiler_search_start'));
             $end = $request->query->get('end', $session->get('_profiler_search_end'));
@@ -236,6 +238,7 @@ class ProfilerController
                 'token' => $token,
                 'ip' => $ip,
                 'method' => $method,
+                'status_code' => $statusCode,
                 'url' => $url,
                 'start' => $start,
                 'end' => $end,
@@ -269,6 +272,7 @@ class ProfilerController
 
         $ip = $request->query->get('ip');
         $method = $request->query->get('method');
+        $statusCode = $request->query->get('status_code');
         $url = $request->query->get('url');
         $start = $request->query->get('start', null);
         $end = $request->query->get('end', null);
@@ -278,9 +282,10 @@ class ProfilerController
             'request' => $request,
             'token' => $token,
             'profile' => $profile,
-            'tokens' => $this->profiler->find($ip, $url, $limit, $method, $start, $end),
+            'tokens' => $this->profiler->find($ip, $url, $limit, $method, $start, $end, $statusCode),
             'ip' => $ip,
             'method' => $method,
+            'status_code' => $statusCode,
             'url' => $url,
             'start' => $start,
             'end' => $end,
@@ -308,6 +313,7 @@ class ProfilerController
 
         $ip = preg_replace('/[^:\d\.]/', '', $request->query->get('ip'));
         $method = $request->query->get('method');
+        $statusCode = $request->query->get('status_code');
         $url = $request->query->get('url');
         $start = $request->query->get('start', null);
         $end = $request->query->get('end', null);
@@ -317,6 +323,7 @@ class ProfilerController
         if (null !== $session = $request->getSession()) {
             $session->set('_profiler_search_ip', $ip);
             $session->set('_profiler_search_method', $method);
+            $session->set('_profiler_search_status_code', $statusCode);
             $session->set('_profiler_search_url', $url);
             $session->set('_profiler_search_start', $start);
             $session->set('_profiler_search_end', $end);
@@ -328,12 +335,13 @@ class ProfilerController
             return new RedirectResponse($this->generator->generate('_profiler', array('token' => $token)), 302, array('Content-Type' => 'text/html'));
         }
 
-        $tokens = $this->profiler->find($ip, $url, $limit, $method, $start, $end);
+        $tokens = $this->profiler->find($ip, $url, $limit, $method, $start, $end, $statusCode);
 
         return new RedirectResponse($this->generator->generate('_profiler_search_results', array(
             'token' => $tokens ? $tokens[0]['token'] : 'empty',
             'ip' => $ip,
             'method' => $method,
+            'status_code' => $statusCode,
             'url' => $url,
             'start' => $start,
             'end' => $end,

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/search.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/search.html.twig
@@ -16,6 +16,11 @@
         </div>
 
         <div class="form-group">
+            <label for="status_code">Status</label>
+            <input type="number" name="status_code" id="status_code" value="{{ status_code }}">
+        </div>
+
+        <div class="form-group">
             <label for="url">URL</label>
             <input type="text" name="url" id="url" value="{{ url }}">
         </div>

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
@@ -123,6 +123,7 @@ class ProfilerControllerTest extends \PHPUnit_Framework_TestCase
                 'tokens' => $tokens,
                 'ip' => '127.0.0.1',
                 'method' => 'GET',
+                'status_code' => null,
                 'url' => 'http://example.com/',
                 'start' => null,
                 'end' => null,

--- a/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
@@ -49,7 +49,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
     /**
      * {@inheritdoc}
      */
-    public function find($ip, $url, $limit, $method, $start = null, $end = null)
+    public function find($ip, $url, $limit, $method, $start = null, $end = null, $statusCode = null)
     {
         $file = $this->getIndexFilename();
 
@@ -63,12 +63,10 @@ class FileProfilerStorage implements ProfilerStorageInterface
         $result = array();
         while (count($result) < $limit && $line = $this->readLineFromFile($file)) {
             $values = str_getcsv($line);
-            list($csvToken, $csvIp, $csvMethod, $csvUrl, $csvTime, $csvParent) = $values;
-            $csvStatusCode = isset($values[6]) ? $values[6] : null;
-
+            list($csvToken, $csvIp, $csvMethod, $csvUrl, $csvTime, $csvParent, $csvStatusCode) = $values;
             $csvTime = (int) $csvTime;
 
-            if ($ip && false === strpos($csvIp, $ip) || $url && false === strpos($csvUrl, $url) || $method && false === strpos($csvMethod, $method)) {
+            if ($ip && false === strpos($csvIp, $ip) || $url && false === strpos($csvUrl, $url) || $method && false === strpos($csvMethod, $method) || $statusCode && false === strpos($csvStatusCode, $statusCode)) {
                 continue;
             }
 
@@ -154,6 +152,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
             'method' => $profile->getMethod(),
             'url' => $profile->getUrl(),
             'time' => $profile->getTime(),
+            'status_code' => $profile->getStatusCode(),
         );
 
         if (false === file_put_contents($file, serialize($data))) {
@@ -261,6 +260,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
         $profile->setMethod($data['method']);
         $profile->setUrl($data['url']);
         $profile->setTime($data['time']);
+        $profile->setStatusCode($data['status_code']);
         $profile->setCollectors($data['data']);
 
         if (!$parent && $data['parent']) {

--- a/src/Symfony/Component/HttpKernel/Profiler/Profile.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profile.php
@@ -287,6 +287,6 @@ class Profile
 
     public function __sleep()
     {
-        return array('token', 'parent', 'children', 'collectors', 'ip', 'method', 'url', 'time');
+        return array('token', 'parent', 'children', 'collectors', 'ip', 'method', 'url', 'time', 'statusCode');
     }
 }

--- a/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
@@ -134,20 +134,21 @@ class Profiler
     /**
      * Finds profiler tokens for the given criteria.
      *
-     * @param string $ip     The IP
-     * @param string $url    The URL
-     * @param string $limit  The maximum number of tokens to return
-     * @param string $method The request method
-     * @param string $start  The start date to search from
-     * @param string $end    The end date to search to
+     * @param string $ip         The IP
+     * @param string $url        The URL
+     * @param string $limit      The maximum number of tokens to return
+     * @param string $method     The request method
+     * @param string $start      The start date to search from
+     * @param string $end        The end date to search to
+     * @param string $statusCode The request status code
      *
      * @return array An array of tokens
      *
      * @see http://php.net/manual/en/datetime.formats.php for the supported date/time formats
      */
-    public function find($ip, $url, $limit, $method, $start, $end)
+    public function find($ip, $url, $limit, $method, $start, $end, $statusCode = null)
     {
-        return $this->storage->find($ip, $url, $limit, $method, $this->getTimestamp($start), $this->getTimestamp($end));
+        return $this->storage->find($ip, $url, $limit, $method, $this->getTimestamp($start), $this->getTimestamp($end), $statusCode);
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/FileProfilerStorageTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/FileProfilerStorageTest.php
@@ -127,6 +127,20 @@ class FileProfilerStorageTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(0, $this->storage->find('127.0._.1', '', 10, 'GET'), '->find() does not interpret a "_" as a wildcard in the IP');
     }
 
+    public function testRetrieveByStatusCode()
+    {
+        $profile200 = new Profile('statuscode200');
+        $profile200->setStatusCode(200);
+        $this->storage->write($profile200);
+
+        $profile404 = new Profile('statuscode404');
+        $profile404->setStatusCode(404);
+        $this->storage->write($profile404);
+
+        $this->assertCount(1, $this->storage->find(null, null, 10, null, null, null, '200'), '->find() retrieve a record by Status code 200');
+        $this->assertCount(1, $this->storage->find(null, null, 10, null, null, null, '404'), '->find() retrieve a record by Status code 404');
+    }
+
     public function testRetrieveByUrl()
     {
         $profile = new Profile('simple_quote');

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/ProfilerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/ProfilerTest.php
@@ -59,6 +59,13 @@ class ProfilerTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(0, $profiler->find(null, null, null, null, 'some string', ''));
     }
 
+    public function testFindWorksWithStatusCode()
+    {
+        $profiler = new Profiler($this->storage);
+
+        $this->assertCount(0, $profiler->find(null, null, null, null, null, null, '204'));
+    }
+
     protected function setUp()
     {
         $this->tmp = tempnam(sys_get_temp_dir(), 'sf2_profiler');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/pull/13034 |
| License | MIT |

With this PR, in the web profiler, you can filter by HTTP status codes.

_Before filter_
![image](https://i.gyazo.com/8cb99295b12489cc9024ccc07fabf805.png)

_After filter_
![image](https://i.gyazo.com/4caaf032b56ccfe84198a230dbb211a2.png)
