### PR TITLE
[Security] Run tests on all PHP versions

### DIFF
--- a/src/Symfony/Component/Security/Core/Tests/Encoder/BCryptPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/BCryptPasswordEncoderTest.php
@@ -45,9 +45,6 @@ class BCryptPasswordEncoderTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    /**
-     * @requires PHP 5.3.7
-     */
     public function testResultLength()
     {
         $encoder = new BCryptPasswordEncoder(self::VALID_COST);
@@ -55,9 +52,6 @@ class BCryptPasswordEncoderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(60, strlen($result));
     }
 
-    /**
-     * @requires PHP 5.3.7
-     */
     public function testValidation()
     {
         $encoder = new BCryptPasswordEncoder(self::VALID_COST);
@@ -76,9 +70,6 @@ class BCryptPasswordEncoderTest extends \PHPUnit_Framework_TestCase
         $encoder->encodePassword(str_repeat('a', 73), 'salt');
     }
 
-    /**
-     * @requires PHP 5.3.7
-     */
     public function testCheckPasswordLength()
     {
         $encoder = new BCryptPasswordEncoder(self::VALID_COST);


### PR DESCRIPTION
Symfony 2.7 supports PHP >= 5.3.9. Since #17073 was merged to 2.7 now, we need to remove the checks for 5.3.7 again.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
