### PR TITLE
[DependencyInjection] Make YamlFileLoader raise a deprecation notice if a service definition contains unsupported keywords.

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/legacy_invalid_definition.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/legacy_invalid_definition.yml
@@ -1,0 +1,10 @@
+services:
+    # This definition is valid and should not raise any deprecation notice
+    foo:
+        class: stdClass
+        arguments: [ 'foo', 'bar' ]
+
+    # This definition is invalid and must raise a deprecation notice
+    bar:
+        class: stdClass
+        private: true        # the "private" keyword is invalid

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -293,4 +293,14 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($container->getDefinition('bar_service')->isAutowired());
     }
+
+    /**
+     * @group legacy
+     */
+    public function testServiceDefinitionContainsUnsupportedKeywords()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('legacy_invalid_definition.yml');
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

Merry Christmas Symfony!!!
