### PR TITLE
[HttpFoundation] allows delaying session write/close when using NativeSessionStorage

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -91,6 +91,8 @@ class NativeSessionStorage implements SessionStorageInterface
      * upload_progress.min-freq, "1"
      * url_rewriter.tags, "a=href,area=href,frame=src,form=,fieldset="
      *
+     * register_shutdown, true. Should session_register_shutdown() be called? (This is not a Session option)
+     *
      * @param array                                                            $options Session configuration options.
      * @param AbstractProxy|NativeSessionHandler|\SessionHandlerInterface|null $handler
      * @param MetadataBag                                                      $metaBag MetadataBag.
@@ -100,7 +102,10 @@ class NativeSessionStorage implements SessionStorageInterface
         session_cache_limiter(''); // disable by default because it's managed by HeaderBag (if used)
         ini_set('session.use_cookies', 1);
 
-        session_register_shutdown();
+        if (!isset($options['register_shutdown']) || $options['register_shutdown']) {
+            session_register_shutdown();
+        }
+        unset($options['register_shutdown']);
 
         $this->setMetadataBag($metaBag);
         $this->setOptions($options);


### PR DESCRIPTION
An application that needs to write to the session during PHP's shutdown cycle should set the `register_shutdown` option to `false` and manually call `session_write_close()` at the end of the request. Otherwise the session may be prematurely closed if `NativeSessionStorage` is instantiated early in the request.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | n/a |
