### PR TITLE
Added getter and setter of QuestionHelper to SymfonyStyle

### DIFF
--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Helper\SymfonyQuestionHelper;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
@@ -353,6 +354,22 @@ class SymfonyStyle extends OutputStyle
     {
         parent::write($messages, $newline, $type);
         $this->bufferedOutput->write($this->reduceBuffer($messages), $newline, $type);
+    }
+
+    /**
+     * @return QuestionHelper|null
+     */
+    public function getQuestionHelper()
+    {
+        return $this->questionHelper;
+    }
+
+    /**
+     * @param QuestionHelper $questionHelper
+     */
+    public function setQuestionHelper(QuestionHelper $questionHelper)
+    {
+        $this->questionHelper = $questionHelper;
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Current SymfonyStyle implementation disallow to test interactively input  of command according [docs](http://symfony.com/doc/current/components/console/helpers/questionhelper.html#testing-a-command-that-expects-input).
