### PR TITLE
[Security] [SimplePreAuthenticatorInterface] Remove divert deprecation message

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/SimplePreAuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/SimplePreAuthenticatorInterface.php
@@ -11,14 +11,13 @@
 
 namespace Symfony\Component\Security\Core\Authentication;
 
-use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Http\Authentication\SimplePreAuthenticatorInterface as BaseSimplePreAuthenticatorInterface;
 
 /**
  * @deprecated Since version 2.8, to be removed in 3.0. Use the same interface from Security\Http\Authentication instead.
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
-interface SimplePreAuthenticatorInterface extends SimpleAuthenticatorInterface
+interface SimplePreAuthenticatorInterface extends BaseSimplePreAuthenticatorInterface
 {
-    public function createToken(Request $request, $providerKey);
 }

--- a/src/Symfony/Component/Security/Http/Authentication/SimplePreAuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Http/Authentication/SimplePreAuthenticatorInterface.php
@@ -11,11 +11,13 @@
 
 namespace Symfony\Component\Security\Http\Authentication;
 
-use Symfony\Component\Security\Core\Authentication\SimplePreAuthenticatorInterface as BaseSimplePreAuthenticatorInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\SimpleAuthenticatorInterface;
 
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
-interface SimplePreAuthenticatorInterface extends BaseSimplePreAuthenticatorInterface
+interface SimplePreAuthenticatorInterface extends SimpleAuthenticatorInterface
 {
+    public function createToken(Request $request, $providerKey);
 }

--- a/src/Symfony/Component/Security/Http/Firewall/SimplePreAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SimplePreAuthenticationListener.php
@@ -15,7 +15,7 @@ use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterfac
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Security\Core\Authentication\SimplePreAuthenticatorInterface;
+use Symfony\Component\Security\Http\Authentication\SimplePreAuthenticatorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Even if you use Security\Http\Authentication\SimplePreAuthenticatorInterface (as deprecation of Security\Core\Authentication\SimplePreAuthenticatorInterface says) it anyway show that message.
