### PR TITLE
[Serializer] Remove normalizer cache in Serializer class

### DIFF
--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -237,7 +237,6 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
         foreach ($this->normalizers as $normalizer) {
             if ($normalizer instanceof NormalizerInterface
                 && $normalizer->supportsNormalization($object, $format)) {
-                $this->normalizerCache[$class][$format] = $normalizer;
 
                 return $normalizer->normalize($object, $format, $context);
             }
@@ -272,7 +271,6 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
         foreach ($this->normalizers as $normalizer) {
             if ($normalizer instanceof DenormalizerInterface
                 && $normalizer->supportsDenormalization($data, $class, $format)) {
-                $this->denormalizerCache[$class][$format] = $normalizer;
 
                 return $normalizer->denormalize($data, $class, $format, $context);
             }

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -73,6 +73,50 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->serializer->denormalize(json_encode($data), 'stdClass', 'json'));
     }
 
+    public function testNormalizeWithSupportOnData()
+    {
+        $normalizer1 = $this->getMock('Symfony\Component\Serializer\Normalizer\NormalizerInterface');
+        $normalizer1->method('supportsNormalization')
+            ->willReturnCallback(function ($data, $format) {
+                return isset($data->test);
+            });
+        $normalizer1->method('normalize')->willReturn('test1');
+
+        $normalizer2 = $this->getMock('Symfony\Component\Serializer\Normalizer\NormalizerInterface');
+        $normalizer2->method('supportsNormalization')
+            ->willReturn(true);
+        $normalizer2->method('normalize')->willReturn('test2');
+
+        $serializer = new Serializer(array($normalizer1, $normalizer2));
+
+        $data = new \stdClass();
+        $data->test = true;
+        $this->assertEquals('test1', $serializer->normalize($data));
+
+        $this->assertEquals('test2', $serializer->normalize(new \stdClass()));
+    }
+
+    public function testDenormalizeWithSupportOnData()
+    {
+        $denormalizer1 = $this->getMock('Symfony\Component\Serializer\Normalizer\DenormalizerInterface');
+        $denormalizer1->method('supportsDenormalization')
+            ->willReturnCallback(function ($data, $type, $format) {
+                return isset($data['test1']);
+            });
+        $denormalizer1->method('denormalize')->willReturn('test1');
+
+        $denormalizer2 = $this->getMock('Symfony\Component\Serializer\Normalizer\DenormalizerInterface');
+        $denormalizer2->method('supportsDenormalization')
+            ->willReturn(true);
+        $denormalizer2->method('denormalize')->willReturn('test2');
+
+        $serializer = new Serializer(array($denormalizer1, $denormalizer2));
+
+        $this->assertEquals('test1', $serializer->denormalize(array('test1' => true), 'test'));
+
+        $this->assertEquals('test2', $serializer->denormalize(array(), 'test'));
+    }
+
     public function testSerialize()
     {
         $this->serializer = new Serializer(array(new GetSetMethodNormalizer()), array('json' => new JsonEncoder()));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The serializer cache the normalizer/denormalizer to use based only on the class and format. But the supportsNormalization and supportDenormalization methods can decide based on the data passed leading to hard to find bugs when the serializer used a cached normalizer it shouldn't use.
