### PR TITLE
Release v2.3.36

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -7,6 +7,34 @@ in 2.3 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.3.0...v2.3.1
 
+* 2.3.36 (2015-12-26)
+
+ * bug #16864 [Yaml] fix indented line handling in folded blocks (xabbuh)
+ * bug #16826 Embedded identifier support (mihai-stancu)
+ * bug #17129 [Config] Fix array sort on normalization in edge case (romainneutron)
+ * bug #17094 [Process] More robustness and deterministic tests (nicolas-grekas)
+ * bug #17112 [PropertyAccess] Reorder elements array after PropertyPathBuilder::replace (alekitto)
+ * bug #16797 [Filesystem] Recursivly widen non-executable directories (Slamdunk)
+ * bug #17040 [Console] Avoid extra blank lines when rendering exceptions (ogizanagi)
+ * bug #17055 [Security] Verify if a password encoded with bcrypt is no longer than 72 characters (jakzal)
+ * bug #16959 [Form] fix #15544 when a collection type attribute "required" is false, "prototype" should too (HeahDude)
+ * bug #16860 [Yaml] do not remove "comments" in scalar blocks (xabbuh)
+ * bug #16971 [HttpFoundation] Added the ability of using BinaryFileResponse with stream wrappers (jakzal, Sander-Toonen)
+ * bug #17048 Fix the logout path when not using the router (stof)
+ * bug #17057 [FrameworkBundle][HttpKernel] the finder is required to discover bundle commands (xabbuh)
+ * bug #16915 [Process] Enhance compatiblity with --enable-sigchild (nicolas-grekas)
+ * bug #16829 [FrameworkBundle] prevent cache:clear creating too long paths (Tobion)
+ * bug #16870 [FrameworkBundle] Disable the server:run command when Process component is missing (gnugat, xabbuh)
+ * bug #16799 Improve error message for undefined DIC aliases (mpdude)
+ * bug #16772 Refactoring EntityUserProvider::__construct() to not do work, cause cache warm error (weaverryan)
+ * bug #16753 [Process] Fix signaling/stopping logic on Windows (nicolas-grekas)
+ * bug #16733 [Console] do not encode backslashes in console default description (Tobion)
+ * bug #16312 [HttpKernel] clearstatcache() so the Cache sees when a .lck file has been released (mpdude)
+ * bug #16695 [SecurityBundle] disable the init:acl command if ACL is not used (Tobion)
+ * bug #16676 [HttpFoundation] Workaround HHVM rewriting HTTP response line (nicolas-grekas)
+ * bug #16668 [ClassLoader] Fix parsing namespace when token_get_all() is missing (nicolas-grekas)
+ * bug #16386 Bug #16343 [Router] Too many Routes ? (jelte)
+
 * 2.3.35 (2015-11-23)
 
  * security #16631 CVE-2015-8124: Session Fixation in the "Remember Me" Login Feature (xabbuh)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,8 +13,8 @@ Symfony is the result of the work of many people who made the code better
  - Christophe Coevoet (stof)
  - Johannes S (johannes)
  - Kris Wallsmith (kriswallsmith)
- - Jakub Zalas (jakubzalas)
  - Christian Flothmann (xabbuh)
+ - Jakub Zalas (jakubzalas)
  - Ryan Weaver (weaverryan)
  - Pascal Borreli (pborreli)
  - Hugo Hamon (hhamon)
@@ -30,8 +30,8 @@ Symfony is the result of the work of many people who made the code better
  - Martin Hasoň (hason)
  - Wouter De Jong (wouterj)
  - Eriksen Costa (eriksencosta)
- - Grégoire Pineau (lyrixx)
  - Javier Eguiluz (javier.eguiluz)
+ - Grégoire Pineau (lyrixx)
  - Kévin Dunglas (dunglas)
  - Jonathan Wage (jwage)
  - Alexandre Salomé (alexandresalome)
@@ -49,17 +49,17 @@ Symfony is the result of the work of many people who made the code better
  - Konstantin Kudryashov (everzet)
  - Bilal Amarni (bamarni)
  - Florin Patan (florinpatan)
+ - Maxime Steinhausser (ogizanagi)
  - Eric Clemmons (ericclemmons)
  - Andrej Hudec (pulzarraider)
- - Maxime Steinhausser (ogizanagi)
  - Deni
  - Henrik Westphal (snc)
  - Dariusz Górecki (canni)
  - Gábor Egyed (1ed)
  - Christian Raue
+ - Michel Weimerskirch (mweimerskirch)
  - Arnout Boks (aboks)
  - Kevin Bond (kbond)
- - Michel Weimerskirch (mweimerskirch)
  - Douglas Greenshields (shieldo)
  - Lee McDermott
  - Brandon Turner
@@ -67,11 +67,11 @@ Symfony is the result of the work of many people who made the code better
  - Daniel Holmes (dholmes)
  - Bart van den Burg (burgov)
  - Jordan Alliot (jalliot)
+ - Matthias Pigulla (mpdude)
  - John Wards (johnwards)
  - Fran Moreno (franmomu)
  - Antoine Hérault (herzult)
  - Toni Uebernickel (havvg)
- - Matthias Pigulla (mpdude)
  - Arnaud Le Blanc (arnaud-lb)
  - Tim Nagel (merk)
  - Brice BERNARD (brikou)
@@ -80,21 +80,21 @@ Symfony is the result of the work of many people who made the code better
  - lenar
  - Graham Campbell (graham)
  - Włodzimierz Gajda (gajdaw)
+ - Michal Piotrowski (eventhorizon)
  - Florian Voutzinos (florianv)
+ - Peter Rehm (rpet)
  - Colin Frei
  - Adrien Brault (adrienbrault)
  - excelwebzone
  - Jacob Dreesen (jdreesen)
- - Michal Piotrowski (eventhorizon)
+ - Dariusz Ruminski
  - Peter Kokot (maastermedia)
  - Fabien Pennequin (fabienpennequin)
- - Peter Rehm (rpet)
  - Pierre du Plessis (pierredup)
  - Alexander Schwenn (xelaris)
  - Gordon Franke (gimler)
  - Robert Schönthal (digitalkaoz)
  - Jérémy DERUSSÉ (jderusse)
- - Dariusz Ruminski
  - Joshua Thijssen
  - Stefano Sala (stefano.sala)
  - David Buchmann (dbu)
@@ -112,12 +112,15 @@ Symfony is the result of the work of many people who made the code better
  - Sebastiaan Stok (sstok)
  - Rafael Dohms (rdohms)
  - Arnaud Kleinpeter (nanocom)
+ - Alexander M. Turek (derrabus)
  - Tigran Azatyan (tigranazatyan)
  - Richard Shank (iampersistent)
+ - Charles Sarrazin (csarrazi)
  - Clemens Tolboom
  - Helmer Aaviksoo
  - Baptiste Clavié (talus)
  - Tugdual Saunier (tucksaun)
+ - Andréia Bohner (andreia)
  - Hiromi Hishida (77web)
  - Matthieu Ouellette-Vachon (maoueh)
  - Michał Pipa (michal.pipa)
@@ -125,9 +128,7 @@ Symfony is the result of the work of many people who made the code better
  - Jonathan Ingram (jonathaningram)
  - Artur Kotyrba
  - Rouven Weßling (realityking)
- - Charles Sarrazin (csarrazi)
  - Warnar Boekkooi (boekkooi)
- - Andréia Bohner (andreia)
  - Dmitrii Chekaliuk (lazyhammer)
  - Clément JOBEILI (dator)
  - Dorian Villet (gnutix)
@@ -135,19 +136,19 @@ Symfony is the result of the work of many people who made the code better
  - Richard Miller (mr_r_miller)
  - hacfi (hifi)
  - Mario A. Alvarez Garcia (nomack84)
+ - Thomas Rabaix (rande)
  - Dennis Benkert (denderello)
- - Alexander M. Turek (derrabus)
  - Konstantin Myakshin (koc)
  - Benjamin Dulau (dbenjamin)
  - Andreas Hucks (meandmymonkey)
  - Mikael Pajunen
  - Noel Guilbert (noel)
  - Joel Wurtz (brouznouf)
+ - Evgeniy (ewgraf)
  - bronze1man
  - sun (sun)
  - Larry Garfield (crell)
  - Martin Schuhfuß (usefulthink)
- - Thomas Rabaix (rande)
  - Matthieu Bontemps (mbontemps)
  - Pierre Minnieur (pminnieur)
  - fivestar
@@ -163,7 +164,6 @@ Symfony is the result of the work of many people who made the code better
  - Lars Strojny (lstrojny)
  - Daniel Wehner
  - Rui Marinho (ruimarinho)
- - Evgeniy (ewgraf)
  - Julien Brochet (mewt)
  - Sergey Linnik (linniksa)
  - Jáchym Toušek
@@ -244,6 +244,7 @@ Symfony is the result of the work of many people who made the code better
  - Julien Galenski (ruian)
  - Bongiraud Dominique
  - janschoenherr
+ - Jannik Zschiesche (apfelbox)
  - Thomas Schulz (king2500)
  - Marco Pivetta (ocramius)
  - Ricard Clau (ricardclau)
@@ -252,6 +253,7 @@ Symfony is the result of the work of many people who made the code better
  - Erin Millard
  - Matthew Lewinski (lewinski)
  - Antonio J. García Lagar (ajgarlag)
+ - Roumen Damianoff (roumen)
  - alquerci
  - Francesco Levorato
  - Vitaliy Zakharov (zakharovvi)
@@ -273,7 +275,9 @@ Symfony is the result of the work of many people who made the code better
  - Stéphane PY (steph_py)
  - Philipp Kräutli (pkraeutli)
  - Kirill chEbba Chebunin (chebba)
+ - Filippo Tessarotto
  - Greg Thornton (xdissent)
+ - jeremyFreeAgent (jeremyfreeagent)
  - Costin Bereveanu (schniper)
  - Loïc Chardonnet (gnusat)
  - Marek Kalnik (marekkalnik)
@@ -306,7 +310,6 @@ Symfony is the result of the work of many people who made the code better
  - Christophe L. (christophelau)
  - Massimiliano Arione (garak)
  - Anthon Pang (robocoder)
- - Jannik Zschiesche (apfelbox)
  - Emanuele Gaspari (inmarelibero)
  - Dariusz Rumiński
  - Brian King
@@ -321,9 +324,10 @@ Symfony is the result of the work of many people who made the code better
  - Markus Bachmann (baachi)
  - lancergr
  - Olivier Dolbeau (odolbeau)
- - Roumen Damianoff (roumen)
+ - Ben Davies (bendavies)
  - vagrant
  - Asier Illarramendi (doup)
+ - Artur Melo (restless)
  - Chris Sedlmayr (catchamonkey)
  - Seb Koelen
  - Christoph Mewes (xrstf)
@@ -348,10 +352,11 @@ Symfony is the result of the work of many people who made the code better
  - Sebastian Bergmann
  - Pablo Díez (pablodip)
  - Kevin McBride
+ - Ener-Getick (energetick)
  - Philipp Rieber (bicpi)
  - Manuel de Ruiter (manuel)
- - Jérémy Romey (jeremyfreeagent)
  - Eduardo Oliveira (entering)
+ - Eugene Wissner
  - Iker Ibarguren (ikerib)
  - Ricardo Oliveira (ricardolotr)
  - ondrowan
@@ -406,6 +411,7 @@ Symfony is the result of the work of many people who made the code better
  - Lenar Lõhmus
  - Benjamin Laugueux (yzalis)
  - Zach Badgett (zachbadgett)
+ - Loïc Faugeron
  - Aurélien Fredouelle
  - Pavel Campr (pcampr)
  - Johnny Robeson (johnny)
@@ -435,6 +441,7 @@ Symfony is the result of the work of many people who made the code better
  - Åsmund Garfors
  - Maxime Douailin
  - Gregor Harlan
+ - Michael Hirschler (mvhirsch)
  - Javier López (loalf)
  - Reinier Kip
  - Dustin Dobervich (dustin10)
@@ -465,7 +472,6 @@ Symfony is the result of the work of many people who made the code better
  - Sascha Grossenbacher
  - Szijarto Tamas
  - Benjamin Zikarsky (bzikarsky)
- - Ben Davies (bendavies)
  - Mickaël Andrieu (mickaelandrieu)
  - Simon Schick (simonsimcity)
  - redstar504
@@ -485,13 +491,13 @@ Symfony is the result of the work of many people who made the code better
  - Mark Sonnabaum
  - Alexander Obuhovich (aik099)
  - jochenvdv
- - Filippo Tessarotto
  - Arturas Smorgun (asarturas)
  - Alexander Volochnev (exelenz)
  - Michael Piecko
  - yclian
  - Sergio Santoro
  - Sebastian Grodzicki (sgrodzicki)
+ - Martin Hujer (martinhujer)
  - Pascal Helfenstein
  - Baldur Rensch (brensch)
  - Vladyslav Petrovych
@@ -521,6 +527,7 @@ Symfony is the result of the work of many people who made the code better
  - Benoit Lévêque (benoit_leveque)
  - Jeroen Fiege (fieg)
  - Krzysiek Łabuś
+ - Ilya Antipenko (aivus)
  - Nicolas Dewez (nicolas_dewez)
  - Xavier Lacot (xavier)
  - Olivier Maisonneuve (olineuve)
@@ -532,7 +539,6 @@ Symfony is the result of the work of many people who made the code better
  - fago
  - Harm van Tilborg
  - Jan Prieser
- - Artur Melo (restless)
  - James Michael DuPont
  - Tom Klingenberg
  - Christopher Hall (mythmakr)
@@ -628,6 +634,7 @@ Symfony is the result of the work of many people who made the code better
  - xaav
  - Jean-Christophe Cuvelier [Artack]
  - Mahmoud Mostafa (mahmoud)
+ - Pieter
  - Michael Tibben
  - Sander Marechal
  - Radosław Benkel
@@ -635,7 +642,6 @@ Symfony is the result of the work of many people who made the code better
  - Mei Gwilym (meigwilym)
  - Michael H. Arieli (excelwebzone)
  - Luciano Mammino (loige)
- - Michael Hirschler (mvhirsch)
  - fabios
  - Jérôme Vasseur
  - Sander Coolen (scoolen)
@@ -646,6 +652,7 @@ Symfony is the result of the work of many people who made the code better
  - Irmantas Šiupšinskas (irmantas)
  - Charles-Henri Bruyand
  - Danilo Silva
+ - Konstantin S. M. Möllers (ksmmoellers)
  - Zachary Tong (polyfractal)
  - Hryhorii Hrebiniuk
  - dantleech
@@ -748,7 +755,6 @@ Symfony is the result of the work of many people who made the code better
  - Brooks Boyd
  - Roger Webb
  - Dmitriy Simushev
- - Martin Hujer (martinhujer)
  - Max Voloshin (maxvoloshin)
  - Nicolas Fabre (nfabre)
  - Raul Rodriguez (raul782)
@@ -765,6 +771,7 @@ Symfony is the result of the work of many people who made the code better
  - Philipp Strube
  - Christian Sciberras
  - Anton Bakai
+ - Chad Sikorra (chadsikorra)
  - Clement Herreman (clemherreman)
  - Nyro (nyro)
  - Trent Steel (trsteel88)
@@ -779,6 +786,8 @@ Symfony is the result of the work of many people who made the code better
  - Jakub Kulhan
  - Mo Di (modi)
  - Jeroen van den Enden (stoefke)
+ - Christian Wahler
+ - Jelte Steijaert (jelte)
  - Quique Porta (quiqueporta)
  - Tomasz Szymczyk (karion)
  - ConneXNL
@@ -796,6 +805,7 @@ Symfony is the result of the work of many people who made the code better
  - Sebastian Göttschkes (sgoettschkes)
  - Tatsuya Tsuruoka
  - Ross Tuck
+ - Zander Baldwin
  - Kévin Gomez (kevin)
  - azine
  - Dawid Sajdak
@@ -835,11 +845,14 @@ Symfony is the result of the work of many people who made the code better
  - m.chwedziak
  - Philip Frank
  - Lance McNearney
+ - Dominik Ritter (dritter)
  - Frank Neff (fneff)
+ - Roman Lapin (memphys)
  - Giorgio Premi
  - caponica
  - Matt Daum (daum)
  - Alberto Pirovano (geezmo)
+ - Jules Pietri (heah)
  - Pete Mitchell (peterjmit)
  - Tom Corrigan (tomcorrigan)
  - Martin Pärtel
@@ -868,6 +881,7 @@ Symfony is the result of the work of many people who made the code better
  - Adrien Samson (adriensamson)
  - Samuel Gordalina (gordalina)
  - Max Romanovsky (maxromanovsky)
+ - Dariusz Ruminski
  - Mathieu Morlon
  - Daniel Tschinder
  - Rafał Muszyński (rafmus90)
@@ -948,6 +962,7 @@ Symfony is the result of the work of many people who made the code better
  - 2manypeople
  - Wing
  - Thomas Bibb
+ - Alessandro Chitolina
  - Matt Farmer
  - catch
  - Alexandre Segura
@@ -977,6 +992,7 @@ Symfony is the result of the work of many people who made the code better
  - nuncanada
  - flack
  - František Bereň
+ - Almog Baku (almogbaku)
  - Christoph Nissle (derstoffel)
  - Ionel Scutelnicu (ionelscutelnicu)
  - Nicolas Tallefourtané (nicolab)
@@ -1046,6 +1062,7 @@ Symfony is the result of the work of many people who made the code better
  - Drew Butler
  - J Bruni
  - Alexey Prilipko
+ - Oleg Voronkovich
  - bertillon
  - Victor Bocharsky (bocharsky_bw)
  - Luca Genuzio (genuzio)
@@ -1092,6 +1109,7 @@ Symfony is the result of the work of many people who made the code better
  - Alex Pods
  - hadriengem
  - timaschew
+ - Jelle Kapitein
  - Ian Phillips
  - Haritz
  - Matthieu Prat
@@ -1104,6 +1122,7 @@ Symfony is the result of the work of many people who made the code better
  - David Windell
  - Gabriel Birke
  - skafandri
+ - NothingWeAre
  - Alan Chen
  - Maerlyn
  - Even André Fiskvik
@@ -1112,6 +1131,7 @@ Symfony is the result of the work of many people who made the code better
  - Lenar Lõhmus
  - Cristian Gonzalez
  - AlberT
+ - hainey
  - Juan M Martínez
  - Gilles Gauthier
  - ddebree
@@ -1121,6 +1141,7 @@ Symfony is the result of the work of many people who made the code better
  - possum
  - Rafał
  - Adria Lopez (adlpz)
+ - Andreas Schempp (aschempp)
  - Rosio (ben-rosio)
  - Simon Paarlberg (blamh)
  - Jeroen Thora (bolle)
@@ -1147,7 +1168,9 @@ Symfony is the result of the work of many people who made the code better
  - Pablo Monterde Perez (plebs)
  - Jimmy Leger (redpanda)
  - Pavel Batanov (scaytrase)
+ - Simone Di  Maulo (toretto460)
  - Cyrille Jouineau (tuxosaurus)
+ - Sander Toonen (xatoo)
  - Yorkie Chadwick (yorkie76)
  - Yanick Witschi
  - Ondrej Mirtes
@@ -1197,6 +1220,7 @@ Symfony is the result of the work of many people who made the code better
  - Vladimir Sazhin
  - lol768
  - jamogon
+ - Antoine LA
  - Vyacheslav Slinko
  - Johannes
  - Jörg Rühl
@@ -1219,7 +1243,6 @@ Symfony is the result of the work of many people who made the code better
  - Sam Williams
  - Adrian Philipp
  - James Michael DuPont
- - Eugene Wissner
  - Kasperki
  - Tammy D
  - Ondrej Slinták
@@ -1237,6 +1260,7 @@ Symfony is the result of the work of many people who made the code better
  - Pierre-Louis LAUNAY
  - djama
  - Eduardo Conceição
+ - Sébastien Santoro
  - Jon Cave
  - Sébastien HOUZE
  - Abdulkadir N. A.
@@ -1248,6 +1272,7 @@ Symfony is the result of the work of many people who made the code better
  - Norman Soetbeer
  - Benjamin Long
  - Matt Janssen
+ - Jeremy Benoist
  - Peter Gribanov
  - kwiateusz
  - David Soria Parra
@@ -1267,6 +1292,7 @@ Symfony is the result of the work of many people who made the code better
  - Dawid Nowak
  - Richard Quadling
  - Karolis Daužickas
+ - Baptiste Lafontaine
  - tirnanog06
  - phc
  - Дмитрий Пацура
@@ -1314,6 +1340,7 @@ Symfony is the result of the work of many people who made the code better
  - Ismail Faizi (kanafghan)
  - Sébastien Armand (khepin)
  - Krzysztof Menżyk (krymen)
+ - Krzysztof Piasecki (krzysztek)
  - samuel laulhau (lalop)
  - Laurent Bachelier (laurentb)
  - Jérôme Parmentier (lctrs)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -58,12 +58,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '2.3.36-DEV';
+    const VERSION = '2.3.36';
     const VERSION_ID = 20336;
     const MAJOR_VERSION = 2;
     const MINOR_VERSION = 3;
     const RELEASE_VERSION = 36;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     /**
      * Constructor.


### PR DESCRIPTION
Changes since last release: https://github.com/symfony/symfony/compare/v2.3.35...b7362dc

**Changelog**
- bug #16864 [Yaml] fix indented line handling in folded blocks (@xabbuh)
- bug #17052  Fixed flatten exception recursion with errors (@GrahamCampbell)
- bug #16826 Embedded identifier support (@mihai-stancu)
- bug #17129 [Config] Fix array sort on normalization in edge case (@romainneutron)
- bug #17094 [Process] More robustness and deterministic tests (@nicolas-grekas)
- bug #17112 [PropertyAccess] Reorder elements array after PropertyPathBuilder::replace (@alekitto)
- bug #16797 [Filesystem] Recursivly widen non-executable directories (@Slamdunk)
- bug #17040 [Console] Avoid extra blank lines when rendering exceptions (@ogizanagi)
- bug #17055 [Security] Verify if a password encoded with bcrypt is no longer than 72 characters (@jakzal)
- bug #16959 [Form] fix #15544 when a collection type attribute "required" is false, "prototype" should too (@HeahDude)
- bug #16860 [Yaml] do not remove "comments" in scalar blocks (@xabbuh)
- bug #16971 [HttpFoundation] Added the ability of using BinaryFileResponse with stream wrappers (@jakzal, @Sander-Toonen)
- bug #17048 Fix the logout path when not using the router (@stof)
- bug #17057 [FrameworkBundle][HttpKernel] the finder is required to discover bundle commands (@xabbuh)
- bug #16915 [Process] Enhance compatiblity with --enable-sigchild (@nicolas-grekas)
- bug #16829 [FrameworkBundle] prevent cache:clear creating too long paths (@Tobion)
- bug #16870 [FrameworkBundle] Disable the server:run command when Process component is missing (@gnugat, @xabbuh)
- minor #16850 [MonologBridge] Added a test case for the Logger class (@derrabus)
- bug #16799 Improve error message for undefined DIC aliases (@mpdude)
- bug #16772 Refactoring EntityUserProvider::__construct() to not do work, cause cache warm error (@weaverryan)
- bug #16753 [Process] Fix signaling/stopping logic on Windows (@nicolas-grekas)
- bug #16733 [Console] do not encode backslashes in console default description (@Tobion)
- bug #16312 [HttpKernel] clearstatcache() so the Cache sees when a .lck file has been released (@mpdude)
- bug #16695 [SecurityBundle] disable the init:acl command if ACL is not used (@Tobion)
- bug #16676 [HttpFoundation] Workaround HHVM rewriting HTTP response line (@nicolas-grekas)
- bug #16668 [ClassLoader] Fix parsing namespace when token_get_all() is missing (@nicolas-grekas)
- bug #16386 Bug #16343 [Router] Too many Routes ? (@jelte)
