### PR TITLE
Mark all internal classes as final

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/IdReader.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/IdReader.php
@@ -24,7 +24,7 @@ use Symfony\Component\Form\Exception\RuntimeException;
  *
  * @internal This class is meant for internal use only.
  */
-class IdReader
+final class IdReader
 {
     /**
      * @var ObjectManager

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -25,7 +25,7 @@ use Symfony\Component\Routing\RouteCollection;
  *
  * @internal
  */
-class JsonDescriptor extends Descriptor
+final class JsonDescriptor extends Descriptor
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -25,7 +25,7 @@ use Symfony\Component\Routing\RouteCollection;
  *
  * @internal
  */
-class MarkdownDescriptor extends Descriptor
+final class MarkdownDescriptor extends Descriptor
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -27,7 +27,7 @@ use Symfony\Component\Routing\RouteCollection;
  *
  * @internal
  */
-class TextDescriptor extends Descriptor
+final class TextDescriptor extends Descriptor
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -25,7 +25,7 @@ use Symfony\Component\Routing\RouteCollection;
  *
  * @internal
  */
-class XmlDescriptor extends Descriptor
+final class XmlDescriptor extends Descriptor
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Helper/DescriptorHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Helper/DescriptorHelper.php
@@ -22,7 +22,7 @@ use Symfony\Component\Console\Helper\DescriptorHelper as BaseDescriptorHelper;
  *
  * @internal
  */
-class DescriptorHelper extends BaseDescriptorHelper
+final class DescriptorHelper extends BaseDescriptorHelper
 {
     /**
      * Constructor.

--- a/src/Symfony/Component/Console/Descriptor/ApplicationDescription.php
+++ b/src/Symfony/Component/Console/Descriptor/ApplicationDescription.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Exception\CommandNotFoundException;
  *
  * @internal
  */
-class ApplicationDescription
+final class ApplicationDescription
 {
     const GLOBAL_NAMESPACE = '_global';
 

--- a/src/Symfony/Component/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/JsonDescriptor.php
@@ -24,7 +24,7 @@ use Symfony\Component\Console\Input\InputOption;
  *
  * @internal
  */
-class JsonDescriptor extends Descriptor
+final class JsonDescriptor extends Descriptor
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/MarkdownDescriptor.php
@@ -24,7 +24,7 @@ use Symfony\Component\Console\Input\InputOption;
  *
  * @internal
  */
-class MarkdownDescriptor extends Descriptor
+final class MarkdownDescriptor extends Descriptor
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
@@ -24,7 +24,7 @@ use Symfony\Component\Console\Input\InputOption;
  *
  * @internal
  */
-class TextDescriptor extends Descriptor
+final class TextDescriptor extends Descriptor
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/XmlDescriptor.php
@@ -24,7 +24,7 @@ use Symfony\Component\Console\Input\InputOption;
  *
  * @internal
  */
-class XmlDescriptor extends Descriptor
+final class XmlDescriptor extends Descriptor
 {
     /**
      * @param InputDefinition $definition

--- a/src/Symfony/Component/CssSelector/Node/AttributeNode.php
+++ b/src/Symfony/Component/CssSelector/Node/AttributeNode.php
@@ -21,7 +21,7 @@ namespace Symfony\Component\CssSelector\Node;
  *
  * @internal
  */
-class AttributeNode extends AbstractNode
+final class AttributeNode extends AbstractNode
 {
     /**
      * @var NodeInterface

--- a/src/Symfony/Component/CssSelector/Node/ClassNode.php
+++ b/src/Symfony/Component/CssSelector/Node/ClassNode.php
@@ -21,7 +21,7 @@ namespace Symfony\Component\CssSelector\Node;
  *
  * @internal
  */
-class ClassNode extends AbstractNode
+final class ClassNode extends AbstractNode
 {
     /**
      * @var NodeInterface

--- a/src/Symfony/Component/CssSelector/Node/CombinedSelectorNode.php
+++ b/src/Symfony/Component/CssSelector/Node/CombinedSelectorNode.php
@@ -21,7 +21,7 @@ namespace Symfony\Component\CssSelector\Node;
  *
  * @internal
  */
-class CombinedSelectorNode extends AbstractNode
+final class CombinedSelectorNode extends AbstractNode
 {
     /**
      * @var NodeInterface

--- a/src/Symfony/Component/CssSelector/Node/ElementNode.php
+++ b/src/Symfony/Component/CssSelector/Node/ElementNode.php
@@ -21,7 +21,7 @@ namespace Symfony\Component\CssSelector\Node;
  *
  * @internal
  */
-class ElementNode extends AbstractNode
+final class ElementNode extends AbstractNode
 {
     /**
      * @var string|null

--- a/src/Symfony/Component/CssSelector/Node/FunctionNode.php
+++ b/src/Symfony/Component/CssSelector/Node/FunctionNode.php
@@ -23,7 +23,7 @@ use Symfony\Component\CssSelector\Parser\Token;
  *
  * @internal
  */
-class FunctionNode extends AbstractNode
+final class FunctionNode extends AbstractNode
 {
     /**
      * @var NodeInterface

--- a/src/Symfony/Component/CssSelector/Node/HashNode.php
+++ b/src/Symfony/Component/CssSelector/Node/HashNode.php
@@ -21,7 +21,7 @@ namespace Symfony\Component\CssSelector\Node;
  *
  * @internal
  */
-class HashNode extends AbstractNode
+final class HashNode extends AbstractNode
 {
     /**
      * @var NodeInterface

--- a/src/Symfony/Component/CssSelector/Node/NegationNode.php
+++ b/src/Symfony/Component/CssSelector/Node/NegationNode.php
@@ -21,7 +21,7 @@ namespace Symfony\Component\CssSelector\Node;
  *
  * @internal
  */
-class NegationNode extends AbstractNode
+final class NegationNode extends AbstractNode
 {
     /**
      * @var NodeInterface

--- a/src/Symfony/Component/CssSelector/Node/PseudoNode.php
+++ b/src/Symfony/Component/CssSelector/Node/PseudoNode.php
@@ -21,7 +21,7 @@ namespace Symfony\Component\CssSelector\Node;
  *
  * @internal
  */
-class PseudoNode extends AbstractNode
+final class PseudoNode extends AbstractNode
 {
     /**
      * @var NodeInterface

--- a/src/Symfony/Component/CssSelector/Node/SelectorNode.php
+++ b/src/Symfony/Component/CssSelector/Node/SelectorNode.php
@@ -21,7 +21,7 @@ namespace Symfony\Component\CssSelector\Node;
  *
  * @internal
  */
-class SelectorNode extends AbstractNode
+final class SelectorNode extends AbstractNode
 {
     /**
      * @var NodeInterface

--- a/src/Symfony/Component/CssSelector/Node/Specificity.php
+++ b/src/Symfony/Component/CssSelector/Node/Specificity.php
@@ -23,7 +23,7 @@ namespace Symfony\Component\CssSelector\Node;
  *
  * @internal
  */
-class Specificity
+final class Specificity
 {
     const A_FACTOR = 100;
     const B_FACTOR = 10;

--- a/src/Symfony/Component/CssSelector/Parser/Handler/CommentHandler.php
+++ b/src/Symfony/Component/CssSelector/Parser/Handler/CommentHandler.php
@@ -24,7 +24,7 @@ use Symfony\Component\CssSelector\Parser\TokenStream;
  *
  * @internal
  */
-class CommentHandler implements HandlerInterface
+final class CommentHandler implements HandlerInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/CssSelector/Parser/Handler/HashHandler.php
+++ b/src/Symfony/Component/CssSelector/Parser/Handler/HashHandler.php
@@ -27,7 +27,7 @@ use Symfony\Component\CssSelector\Parser\Tokenizer\TokenizerPatterns;
  *
  * @internal
  */
-class HashHandler implements HandlerInterface
+final class HashHandler implements HandlerInterface
 {
     /**
      * @var TokenizerPatterns

--- a/src/Symfony/Component/CssSelector/Parser/Handler/NumberHandler.php
+++ b/src/Symfony/Component/CssSelector/Parser/Handler/NumberHandler.php
@@ -26,7 +26,7 @@ use Symfony\Component\CssSelector\Parser\Tokenizer\TokenizerPatterns;
  *
  * @internal
  */
-class NumberHandler implements HandlerInterface
+final class NumberHandler implements HandlerInterface
 {
     /**
      * @var TokenizerPatterns

--- a/src/Symfony/Component/CssSelector/Parser/Handler/StringHandler.php
+++ b/src/Symfony/Component/CssSelector/Parser/Handler/StringHandler.php
@@ -29,7 +29,7 @@ use Symfony\Component\CssSelector\Parser\Tokenizer\TokenizerPatterns;
  *
  * @internal
  */
-class StringHandler implements HandlerInterface
+final class StringHandler implements HandlerInterface
 {
     /**
      * @var TokenizerPatterns

--- a/src/Symfony/Component/CssSelector/Parser/Handler/WhitespaceHandler.php
+++ b/src/Symfony/Component/CssSelector/Parser/Handler/WhitespaceHandler.php
@@ -25,7 +25,7 @@ use Symfony\Component\CssSelector\Parser\TokenStream;
  *
  * @internal
  */
-class WhitespaceHandler implements HandlerInterface
+final class WhitespaceHandler implements HandlerInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/CssSelector/Parser/Parser.php
+++ b/src/Symfony/Component/CssSelector/Parser/Parser.php
@@ -25,7 +25,7 @@ use Symfony\Component\CssSelector\Parser\Tokenizer\Tokenizer;
  *
  * @internal
  */
-class Parser implements ParserInterface
+final class Parser implements ParserInterface
 {
     /**
      * @var Tokenizer

--- a/src/Symfony/Component/CssSelector/Parser/Reader.php
+++ b/src/Symfony/Component/CssSelector/Parser/Reader.php
@@ -21,7 +21,7 @@ namespace Symfony\Component\CssSelector\Parser;
  *
  * @internal
  */
-class Reader
+final class Reader
 {
     /**
      * @var string

--- a/src/Symfony/Component/CssSelector/Parser/Shortcut/ClassParser.php
+++ b/src/Symfony/Component/CssSelector/Parser/Shortcut/ClassParser.php
@@ -26,7 +26,7 @@ use Symfony\Component\CssSelector\Parser\ParserInterface;
  *
  * @internal
  */
-class ClassParser implements ParserInterface
+final class ClassParser implements ParserInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/CssSelector/Parser/Shortcut/ElementParser.php
+++ b/src/Symfony/Component/CssSelector/Parser/Shortcut/ElementParser.php
@@ -25,7 +25,7 @@ use Symfony\Component\CssSelector\Parser\ParserInterface;
  *
  * @internal
  */
-class ElementParser implements ParserInterface
+final class ElementParser implements ParserInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/CssSelector/Parser/Shortcut/EmptyStringParser.php
+++ b/src/Symfony/Component/CssSelector/Parser/Shortcut/EmptyStringParser.php
@@ -29,7 +29,7 @@ use Symfony\Component\CssSelector\Parser\ParserInterface;
  *
  * @internal
  */
-class EmptyStringParser implements ParserInterface
+final class EmptyStringParser implements ParserInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/CssSelector/Parser/Shortcut/HashParser.php
+++ b/src/Symfony/Component/CssSelector/Parser/Shortcut/HashParser.php
@@ -26,7 +26,7 @@ use Symfony\Component\CssSelector\Parser\ParserInterface;
  *
  * @internal
  */
-class HashParser implements ParserInterface
+final class HashParser implements ParserInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/CssSelector/Parser/Token.php
+++ b/src/Symfony/Component/CssSelector/Parser/Token.php
@@ -21,7 +21,7 @@ namespace Symfony\Component\CssSelector\Parser;
  *
  * @internal
  */
-class Token
+final class Token
 {
     const TYPE_FILE_END = 'eof';
     const TYPE_DELIMITER = 'delimiter';

--- a/src/Symfony/Component/CssSelector/Parser/TokenStream.php
+++ b/src/Symfony/Component/CssSelector/Parser/TokenStream.php
@@ -24,7 +24,7 @@ use Symfony\Component\CssSelector\Exception\SyntaxErrorException;
  *
  * @internal
  */
-class TokenStream
+final class TokenStream
 {
     /**
      * @var Token[]

--- a/src/Symfony/Component/CssSelector/Parser/Tokenizer/Tokenizer.php
+++ b/src/Symfony/Component/CssSelector/Parser/Tokenizer/Tokenizer.php
@@ -26,7 +26,7 @@ use Symfony\Component\CssSelector\Parser\TokenStream;
  *
  * @internal
  */
-class Tokenizer
+final class Tokenizer
 {
     /**
      * @var Handler\HandlerInterface[]

--- a/src/Symfony/Component/CssSelector/Parser/Tokenizer/TokenizerEscaping.php
+++ b/src/Symfony/Component/CssSelector/Parser/Tokenizer/TokenizerEscaping.php
@@ -21,7 +21,7 @@ namespace Symfony\Component\CssSelector\Parser\Tokenizer;
  *
  * @internal
  */
-class TokenizerEscaping
+final class TokenizerEscaping
 {
     /**
      * @var TokenizerPatterns

--- a/src/Symfony/Component/CssSelector/Parser/Tokenizer/TokenizerPatterns.php
+++ b/src/Symfony/Component/CssSelector/Parser/Tokenizer/TokenizerPatterns.php
@@ -21,7 +21,7 @@ namespace Symfony\Component\CssSelector\Parser\Tokenizer;
  *
  * @internal
  */
-class TokenizerPatterns
+final class TokenizerPatterns
 {
     /**
      * @var string

--- a/src/Symfony/Component/CssSelector/XPath/Extension/AttributeMatchingExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/AttributeMatchingExtension.php
@@ -24,7 +24,7 @@ use Symfony\Component\CssSelector\XPath\XPathExpr;
  *
  * @internal
  */
-class AttributeMatchingExtension extends AbstractExtension
+final class AttributeMatchingExtension extends AbstractExtension
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/CssSelector/XPath/Extension/CombinationExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/CombinationExtension.php
@@ -23,7 +23,7 @@ use Symfony\Component\CssSelector\XPath\XPathExpr;
  *
  * @internal
  */
-class CombinationExtension extends AbstractExtension
+final class CombinationExtension extends AbstractExtension
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/CssSelector/XPath/Extension/FunctionExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/FunctionExtension.php
@@ -28,7 +28,7 @@ use Symfony\Component\CssSelector\XPath\XPathExpr;
  *
  * @internal
  */
-class FunctionExtension extends AbstractExtension
+final class FunctionExtension extends AbstractExtension
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/CssSelector/XPath/Extension/HtmlExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/HtmlExtension.php
@@ -26,7 +26,7 @@ use Symfony\Component\CssSelector\XPath\XPathExpr;
  *
  * @internal
  */
-class HtmlExtension extends AbstractExtension
+final class HtmlExtension extends AbstractExtension
 {
     /**
      * Constructor.

--- a/src/Symfony/Component/CssSelector/XPath/Extension/NodeExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/NodeExtension.php
@@ -25,7 +25,7 @@ use Symfony\Component\CssSelector\XPath\XPathExpr;
  *
  * @internal
  */
-class NodeExtension extends AbstractExtension
+final class NodeExtension extends AbstractExtension
 {
     const ELEMENT_NAME_IN_LOWER_CASE = 1;
     const ATTRIBUTE_NAME_IN_LOWER_CASE = 2;

--- a/src/Symfony/Component/CssSelector/XPath/Extension/PseudoClassExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/PseudoClassExtension.php
@@ -24,7 +24,7 @@ use Symfony\Component\CssSelector\XPath\XPathExpr;
  *
  * @internal
  */
-class PseudoClassExtension extends AbstractExtension
+final class PseudoClassExtension extends AbstractExtension
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/CssSelector/XPath/Translator.php
+++ b/src/Symfony/Component/CssSelector/XPath/Translator.php
@@ -28,7 +28,7 @@ use Symfony\Component\CssSelector\Parser\ParserInterface;
  *
  * @internal
  */
-class Translator implements TranslatorInterface
+final class Translator implements TranslatorInterface
 {
     /**
      * @var ParserInterface

--- a/src/Symfony/Component/CssSelector/XPath/XPathExpr.php
+++ b/src/Symfony/Component/CssSelector/XPath/XPathExpr.php
@@ -21,7 +21,7 @@ namespace Symfony\Component\CssSelector\XPath;
  *
  * @internal
  */
-class XPathExpr
+final class XPathExpr
 {
     /**
      * @var string

--- a/src/Symfony/Component/ExpressionLanguage/Node/ArgumentsNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/ArgumentsNode.php
@@ -18,7 +18,7 @@ use Symfony\Component\ExpressionLanguage\Compiler;
  *
  * @internal
  */
-class ArgumentsNode extends ArrayNode
+final class ArgumentsNode extends ArrayNode
 {
     public function compile(Compiler $compiler)
     {

--- a/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
@@ -18,7 +18,7 @@ use Symfony\Component\ExpressionLanguage\Compiler;
  *
  * @internal
  */
-class BinaryNode extends Node
+final class BinaryNode extends Node
 {
     private static $operators = array(
         '~' => '.',

--- a/src/Symfony/Component/ExpressionLanguage/Node/ConditionalNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/ConditionalNode.php
@@ -18,7 +18,7 @@ use Symfony\Component\ExpressionLanguage\Compiler;
  *
  * @internal
  */
-class ConditionalNode extends Node
+final class ConditionalNode extends Node
 {
     public function __construct(Node $expr1, Node $expr2, Node $expr3)
     {

--- a/src/Symfony/Component/ExpressionLanguage/Node/ConstantNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/ConstantNode.php
@@ -18,7 +18,7 @@ use Symfony\Component\ExpressionLanguage\Compiler;
  *
  * @internal
  */
-class ConstantNode extends Node
+final class ConstantNode extends Node
 {
     public function __construct($value)
     {

--- a/src/Symfony/Component/ExpressionLanguage/Node/FunctionNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/FunctionNode.php
@@ -18,7 +18,7 @@ use Symfony\Component\ExpressionLanguage\Compiler;
  *
  * @internal
  */
-class FunctionNode extends Node
+final class FunctionNode extends Node
 {
     public function __construct($name, Node $arguments)
     {

--- a/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
@@ -18,7 +18,7 @@ use Symfony\Component\ExpressionLanguage\Compiler;
  *
  * @internal
  */
-class GetAttrNode extends Node
+final class GetAttrNode extends Node
 {
     const PROPERTY_CALL = 1;
     const METHOD_CALL = 2;

--- a/src/Symfony/Component/ExpressionLanguage/Node/NameNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/NameNode.php
@@ -18,7 +18,7 @@ use Symfony\Component\ExpressionLanguage\Compiler;
  *
  * @internal
  */
-class NameNode extends Node
+final class NameNode extends Node
 {
     public function __construct($name)
     {

--- a/src/Symfony/Component/ExpressionLanguage/Node/UnaryNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/UnaryNode.php
@@ -18,7 +18,7 @@ use Symfony\Component\ExpressionLanguage\Compiler;
  *
  * @internal
  */
-class UnaryNode extends Node
+final class UnaryNode extends Node
 {
     private static $operators = array(
         '!' => '!',

--- a/src/Symfony/Component/Intl/Data/Bundle/Compiler/GenrbCompiler.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Compiler/GenrbCompiler.php
@@ -20,7 +20,7 @@ use Symfony\Component\Intl\Exception\RuntimeException;
  *
  * @internal
  */
-class GenrbCompiler implements BundleCompilerInterface
+final class GenrbCompiler implements BundleCompilerInterface
 {
     /**
      * @var string The path to the "genrb" executable.

--- a/src/Symfony/Component/Intl/Data/Bundle/Reader/BufferedBundleReader.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Reader/BufferedBundleReader.php
@@ -18,7 +18,7 @@ use Symfony\Component\Intl\Data\Util\RingBuffer;
  *
  * @internal
  */
-class BufferedBundleReader implements BundleReaderInterface
+final class BufferedBundleReader implements BundleReaderInterface
 {
     /**
      * @var BundleReaderInterface

--- a/src/Symfony/Component/Intl/Data/Bundle/Reader/BundleEntryReader.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Reader/BundleEntryReader.php
@@ -26,7 +26,7 @@ use Symfony\Component\Intl\Data\Util\RecursiveArrayAccess;
  *
  * @internal
  */
-class BundleEntryReader implements BundleEntryReaderInterface
+final class BundleEntryReader implements BundleEntryReaderInterface
 {
     /**
      * @var BundleReaderInterface

--- a/src/Symfony/Component/Intl/Data/Bundle/Reader/IntlBundleReader.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Reader/IntlBundleReader.php
@@ -21,7 +21,7 @@ use Symfony\Component\Intl\Data\Util\ArrayAccessibleResourceBundle;
  *
  * @internal
  */
-class IntlBundleReader implements BundleReaderInterface
+final class IntlBundleReader implements BundleReaderInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Intl/Data/Bundle/Reader/JsonBundleReader.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Reader/JsonBundleReader.php
@@ -21,7 +21,7 @@ use Symfony\Component\Intl\Exception\RuntimeException;
  *
  * @internal
  */
-class JsonBundleReader implements BundleReaderInterface
+final class JsonBundleReader implements BundleReaderInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Intl/Data/Bundle/Reader/PhpBundleReader.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Reader/PhpBundleReader.php
@@ -21,7 +21,7 @@ use Symfony\Component\Intl\Exception\RuntimeException;
  *
  * @internal
  */
-class PhpBundleReader implements BundleReaderInterface
+final class PhpBundleReader implements BundleReaderInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Intl/Data/Bundle/Writer/JsonBundleWriter.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Writer/JsonBundleWriter.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Intl\Data\Bundle\Writer;
  *
  * @internal
  */
-class JsonBundleWriter implements BundleWriterInterface
+final class JsonBundleWriter implements BundleWriterInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Intl/Data/Bundle/Writer/PhpBundleWriter.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Writer/PhpBundleWriter.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Intl\Data\Bundle\Writer;
  *
  * @internal
  */
-class PhpBundleWriter implements BundleWriterInterface
+final class PhpBundleWriter implements BundleWriterInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Intl/Data/Bundle/Writer/TextBundleWriter.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Writer/TextBundleWriter.php
@@ -26,7 +26,7 @@ use Symfony\Component\Intl\Exception\UnexpectedTypeException;
  *
  * @internal
  */
-class TextBundleWriter implements BundleWriterInterface
+final class TextBundleWriter implements BundleWriterInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Intl/Data/Generator/CurrencyDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/CurrencyDataGenerator.php
@@ -23,7 +23,7 @@ use Symfony\Component\Intl\Data\Util\LocaleScanner;
  *
  * @internal
  */
-class CurrencyDataGenerator extends AbstractDataGenerator
+final class CurrencyDataGenerator extends AbstractDataGenerator
 {
     const UNKNOWN_CURRENCY_ID = 'XXX';
 

--- a/src/Symfony/Component/Intl/Data/Generator/GeneratorConfig.php
+++ b/src/Symfony/Component/Intl/Data/Generator/GeneratorConfig.php
@@ -20,7 +20,7 @@ use Symfony\Component\Intl\Data\Bundle\Writer\BundleWriterInterface;
  *
  * @internal
  */
-class GeneratorConfig
+final class GeneratorConfig
 {
     /**
      * @var string

--- a/src/Symfony/Component/Intl/Data/Generator/LanguageDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/LanguageDataGenerator.php
@@ -24,7 +24,7 @@ use Symfony\Component\Intl\Data\Bundle\Compiler\GenrbCompiler;
  *
  * @internal
  */
-class LanguageDataGenerator extends AbstractDataGenerator
+final class LanguageDataGenerator extends AbstractDataGenerator
 {
     /**
      * Source: http://www-01.sil.org/iso639-3/codes.asp.

--- a/src/Symfony/Component/Intl/Data/Generator/LocaleDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/LocaleDataGenerator.php
@@ -27,7 +27,7 @@ use Symfony\Component\Intl\Locale;
  *
  * @internal
  */
-class LocaleDataGenerator
+final class LocaleDataGenerator
 {
     /**
      * @var string

--- a/src/Symfony/Component/Intl/Data/Generator/RegionDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/RegionDataGenerator.php
@@ -25,7 +25,7 @@ use Symfony\Component\Intl\Data\Util\LocaleScanner;
  *
  * @internal
  */
-class RegionDataGenerator extends AbstractDataGenerator
+final class RegionDataGenerator extends AbstractDataGenerator
 {
     const UNKNOWN_REGION_ID = 'ZZ';
 

--- a/src/Symfony/Component/Intl/Data/Generator/ScriptDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/ScriptDataGenerator.php
@@ -22,7 +22,7 @@ use Symfony\Component\Intl\Data\Util\LocaleScanner;
  *
  * @internal
  */
-class ScriptDataGenerator extends AbstractDataGenerator
+final class ScriptDataGenerator extends AbstractDataGenerator
 {
     /**
      * Collects all available language codes.

--- a/src/Symfony/Component/Intl/Data/Provider/ScriptDataProvider.php
+++ b/src/Symfony/Component/Intl/Data/Provider/ScriptDataProvider.php
@@ -21,7 +21,7 @@ use Symfony\Component\Intl\Locale;
  *
  * @internal
  */
-class ScriptDataProvider
+final class ScriptDataProvider
 {
     /**
      * @var string

--- a/src/Symfony/Component/Intl/Data/Util/ArrayAccessibleResourceBundle.php
+++ b/src/Symfony/Component/Intl/Data/Util/ArrayAccessibleResourceBundle.php
@@ -23,7 +23,7 @@ use Symfony\Component\Intl\Exception\BadMethodCallException;
  *
  * @internal
  */
-class ArrayAccessibleResourceBundle implements \ArrayAccess, \IteratorAggregate, \Countable
+final class ArrayAccessibleResourceBundle implements \ArrayAccess, \IteratorAggregate, \Countable
 {
     private $bundleImpl;
 

--- a/src/Symfony/Component/Intl/Data/Util/LocaleScanner.php
+++ b/src/Symfony/Component/Intl/Data/Util/LocaleScanner.php
@@ -28,7 +28,7 @@ namespace Symfony\Component\Intl\Data\Util;
  *
  * @internal
  */
-class LocaleScanner
+final class LocaleScanner
 {
     /**
      * Returns all locales found in the given directory.

--- a/src/Symfony/Component/Intl/Data/Util/RecursiveArrayAccess.php
+++ b/src/Symfony/Component/Intl/Data/Util/RecursiveArrayAccess.php
@@ -18,7 +18,7 @@ use Symfony\Component\Intl\Exception\OutOfBoundsException;
  *
  * @internal
  */
-class RecursiveArrayAccess
+final class RecursiveArrayAccess
 {
     public static function get($array, array $indices)
     {

--- a/src/Symfony/Component/Intl/Data/Util/RingBuffer.php
+++ b/src/Symfony/Component/Intl/Data/Util/RingBuffer.php
@@ -24,7 +24,7 @@ use Symfony\Component\Intl\Exception\OutOfBoundsException;
  *
  * @internal
  */
-class RingBuffer implements \ArrayAccess
+final class RingBuffer implements \ArrayAccess
 {
     private $values = array();
 

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/AmPmTransformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/AmPmTransformer.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Intl\DateFormatter\DateFormat;
  *
  * @internal
  */
-class AmPmTransformer extends Transformer
+final class AmPmTransformer extends Transformer
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/DayOfWeekTransformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/DayOfWeekTransformer.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Intl\DateFormatter\DateFormat;
  *
  * @internal
  */
-class DayOfWeekTransformer extends Transformer
+final class DayOfWeekTransformer extends Transformer
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/DayOfYearTransformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/DayOfYearTransformer.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Intl\DateFormatter\DateFormat;
  *
  * @internal
  */
-class DayOfYearTransformer extends Transformer
+final class DayOfYearTransformer extends Transformer
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/DayTransformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/DayTransformer.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Intl\DateFormatter\DateFormat;
  *
  * @internal
  */
-class DayTransformer extends Transformer
+final class DayTransformer extends Transformer
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/FullTransformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/FullTransformer.php
@@ -21,7 +21,7 @@ use Symfony\Component\Intl\Globals\IntlGlobals;
  *
  * @internal
  */
-class FullTransformer
+final class FullTransformer
 {
     private $quoteMatch = "'(?:[^']+|'')*'";
     private $implementedChars = 'MLydQqhDEaHkKmsz';

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/Hour1200Transformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/Hour1200Transformer.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Intl\DateFormatter\DateFormat;
  *
  * @internal
  */
-class Hour1200Transformer extends HourTransformer
+final class Hour1200Transformer extends HourTransformer
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/Hour1201Transformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/Hour1201Transformer.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Intl\DateFormatter\DateFormat;
  *
  * @internal
  */
-class Hour1201Transformer extends HourTransformer
+final class Hour1201Transformer extends HourTransformer
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/Hour2400Transformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/Hour2400Transformer.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Intl\DateFormatter\DateFormat;
  *
  * @internal
  */
-class Hour2400Transformer extends HourTransformer
+final class Hour2400Transformer extends HourTransformer
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/Hour2401Transformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/Hour2401Transformer.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Intl\DateFormatter\DateFormat;
  *
  * @internal
  */
-class Hour2401Transformer extends HourTransformer
+final class Hour2401Transformer extends HourTransformer
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/MinuteTransformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/MinuteTransformer.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Intl\DateFormatter\DateFormat;
  *
  * @internal
  */
-class MinuteTransformer extends Transformer
+final class MinuteTransformer extends Transformer
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/MonthTransformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/MonthTransformer.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Intl\DateFormatter\DateFormat;
  *
  * @internal
  */
-class MonthTransformer extends Transformer
+final class MonthTransformer extends Transformer
 {
     /**
      * @var array

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/QuarterTransformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/QuarterTransformer.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Intl\DateFormatter\DateFormat;
  *
  * @internal
  */
-class QuarterTransformer extends Transformer
+final class QuarterTransformer extends Transformer
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/SecondTransformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/SecondTransformer.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Intl\DateFormatter\DateFormat;
  *
  * @internal
  */
-class SecondTransformer extends Transformer
+final class SecondTransformer extends Transformer
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/TimeZoneTransformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/TimeZoneTransformer.php
@@ -20,7 +20,7 @@ use Symfony\Component\Intl\Exception\NotImplementedException;
  *
  * @internal
  */
-class TimeZoneTransformer extends Transformer
+final class TimeZoneTransformer extends Transformer
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/YearTransformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/YearTransformer.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Intl\DateFormatter\DateFormat;
  *
  * @internal
  */
-class YearTransformer extends Transformer
+final class YearTransformer extends Transformer
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Intl/ResourceBundle/CurrencyBundle.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/CurrencyBundle.php
@@ -23,7 +23,7 @@ use Symfony\Component\Intl\Exception\MissingResourceException;
  *
  * @internal
  */
-class CurrencyBundle extends CurrencyDataProvider implements CurrencyBundleInterface
+final class CurrencyBundle extends CurrencyDataProvider implements CurrencyBundleInterface
 {
     /**
      * @var LocaleDataProvider

--- a/src/Symfony/Component/Intl/ResourceBundle/LanguageBundle.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/LanguageBundle.php
@@ -24,7 +24,7 @@ use Symfony\Component\Intl\Exception\MissingResourceException;
  *
  * @internal
  */
-class LanguageBundle extends LanguageDataProvider implements LanguageBundleInterface
+final class LanguageBundle extends LanguageDataProvider implements LanguageBundleInterface
 {
     /**
      * @var LocaleDataProvider

--- a/src/Symfony/Component/Intl/ResourceBundle/LocaleBundle.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/LocaleBundle.php
@@ -21,7 +21,7 @@ use Symfony\Component\Intl\Exception\MissingResourceException;
  *
  * @internal
  */
-class LocaleBundle extends LocaleDataProvider implements LocaleBundleInterface
+final class LocaleBundle extends LocaleDataProvider implements LocaleBundleInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Intl/ResourceBundle/RegionBundle.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/RegionBundle.php
@@ -23,7 +23,7 @@ use Symfony\Component\Intl\Exception\MissingResourceException;
  *
  * @internal
  */
-class RegionBundle extends RegionDataProvider implements RegionBundleInterface
+final class RegionBundle extends RegionDataProvider implements RegionBundleInterface
 {
     /**
      * @var LocaleDataProvider

--- a/src/Symfony/Component/Intl/Resources/stubs/Collator.php
+++ b/src/Symfony/Component/Intl/Resources/stubs/Collator.php
@@ -15,7 +15,9 @@ use Symfony\Component\Intl\Collator\Collator as IntlCollator;
  * Stub implementation for the Collator class of the intl extension.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @internal
  */
-class Collator extends IntlCollator
+final class Collator extends IntlCollator
 {
 }

--- a/src/Symfony/Component/Ldap/Exception/ConnectionException.php
+++ b/src/Symfony/Component/Ldap/Exception/ConnectionException.php
@@ -18,6 +18,6 @@ namespace Symfony\Component\Ldap\Exception;
  *
  * @internal
  */
-class ConnectionException extends \RuntimeException
+final class ConnectionException extends \RuntimeException
 {
 }

--- a/src/Symfony/Component/Ldap/Exception/LdapException.php
+++ b/src/Symfony/Component/Ldap/Exception/LdapException.php
@@ -18,6 +18,6 @@ namespace Symfony\Component\Ldap\Exception;
  *
  * @internal
  */
-class LdapException extends \RuntimeException
+final class LdapException extends \RuntimeException
 {
 }

--- a/src/Symfony/Component/Ldap/LdapClient.php
+++ b/src/Symfony/Component/Ldap/LdapClient.php
@@ -21,7 +21,7 @@ use Symfony\Component\Ldap\Exception\LdapException;
  *
  * @internal
  */
-class LdapClient implements LdapClientInterface
+final class LdapClient implements LdapClientInterface
 {
     private $host;
     private $port;

--- a/src/Symfony/Component/Process/Pipes/UnixPipes.php
+++ b/src/Symfony/Component/Process/Pipes/UnixPipes.php
@@ -20,7 +20,7 @@ use Symfony\Component\Process\Process;
  *
  * @internal
  */
-class UnixPipes extends AbstractPipes
+final class UnixPipes extends AbstractPipes
 {
     /** @var bool */
     private $ttyMode;

--- a/src/Symfony/Component/Process/Pipes/WindowsPipes.php
+++ b/src/Symfony/Component/Process/Pipes/WindowsPipes.php
@@ -24,7 +24,7 @@ use Symfony\Component\Process\Exception\RuntimeException;
  *
  * @internal
  */
-class WindowsPipes extends AbstractPipes
+final class WindowsPipes extends AbstractPipes
 {
     /** @var array */
     private $files = array();

--- a/src/Symfony/Component/Routing/Matcher/Dumper/DumperPrefixCollection.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/DumperPrefixCollection.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Routing\Matcher\Dumper;
  *
  * @internal
  */
-class DumperPrefixCollection extends DumperCollection
+final class DumperPrefixCollection extends DumperCollection
 {
     /**
      * @var string

--- a/src/Symfony/Component/Routing/Matcher/Dumper/DumperRoute.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/DumperRoute.php
@@ -20,7 +20,7 @@ use Symfony\Component\Routing\Route;
  *
  * @internal
  */
-class DumperRoute
+final class DumperRoute
 {
     /**
      * @var string

--- a/src/Symfony/Component/Serializer/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassMetadata.php
@@ -15,8 +15,10 @@ namespace Symfony\Component\Serializer\Mapping;
  * {@inheritdoc}
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @internal
  */
-class ClassMetadata implements ClassMetadataInterface
+final class ClassMetadata implements ClassMetadataInterface
 {
     /**
      * @var string

--- a/src/Symfony/Component/Validator/Context/ExecutionContext.php
+++ b/src/Symfony/Component/Validator/Context/ExecutionContext.php
@@ -35,7 +35,7 @@ use Symfony\Component\Validator\Violation\ConstraintViolationBuilder;
  * @internal You should not instantiate or use this class. Code against
  *           {@link ExecutionContextInterface} instead.
  */
-class ExecutionContext implements ExecutionContextInterface
+final class ExecutionContext implements ExecutionContextInterface
 {
     /**
      * @var ValidatorInterface

--- a/src/Symfony/Component/Validator/Context/ExecutionContextFactory.php
+++ b/src/Symfony/Component/Validator/Context/ExecutionContextFactory.php
@@ -24,7 +24,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  * @internal You should not instantiate or use this class. Code against
  *           {@link ExecutionContextFactoryInterface} instead.
  */
-class ExecutionContextFactory implements ExecutionContextFactoryInterface
+final class ExecutionContextFactory implements ExecutionContextFactoryInterface
 {
     /**
      * @var TranslatorInterface

--- a/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilder.php
+++ b/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilder.php
@@ -27,7 +27,7 @@ use Symfony\Component\Validator\Util\PropertyPath;
  * @internal You should not instantiate or use this class. Code against
  *           {@link ConstraintViolationBuilderInterface} instead.
  */
-class ConstraintViolationBuilder implements ConstraintViolationBuilderInterface
+final class ConstraintViolationBuilder implements ConstraintViolationBuilderInterface
 {
     /**
      * @var ConstraintViolationList

--- a/src/Symfony/Component/Yaml/Escaper.php
+++ b/src/Symfony/Component/Yaml/Escaper.php
@@ -19,7 +19,7 @@ namespace Symfony\Component\Yaml;
  *
  * @internal
  */
-class Escaper
+final class Escaper
 {
     // Characters that would cause a dumped string to require double quoting.
     const REGEX_CHARACTER_TO_ESCAPE = "[\\x00-\\x1f]|\xc2\x85|\xc2\xa0|\xe2\x80\xa8|\xe2\x80\xa9";

--- a/src/Symfony/Component/Yaml/Unescaper.php
+++ b/src/Symfony/Component/Yaml/Unescaper.php
@@ -21,7 +21,7 @@ use Symfony\Component\Yaml\Exception\ParseException;
  *
  * @internal
  */
-class Unescaper
+final class Unescaper
 {
     /**
      * Regex fragment that matches an escaped character in a double quoted string.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | technically, no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This PR marks all internal classes as final (except those ones with children like `Symfony\Component\ExpressionLanguage\Node\ArrayNode`). See #15233 for reasoning. Also I found out that it already was suggested some time ago: #16211.

Technically, it isn't a BC break as classes are internal.
