### PR TITLE
[DoctrineBridge] [PropertyInfo] Catch Doctrine\ORM\Mapping\MappingException

### DIFF
--- a/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
+++ b/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
@@ -43,7 +43,6 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
     {
         try {
             $metadata = $this->classMetadataFactory->getMetadataFor($class);
-
         } catch (MappingException $exception) {
             return;
         } catch (OrmMappingException $exception) {

--- a/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
+++ b/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
@@ -14,6 +14,7 @@ namespace Symfony\Bridge\Doctrine\PropertyInfo;
 use Doctrine\Common\Persistence\Mapping\ClassMetadataFactory;
 use Doctrine\Common\Persistence\Mapping\MappingException;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\MappingException as OrmMappingException;
 use Symfony\Component\PropertyInfo\PropertyListExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\PropertyInfo\Type;
@@ -42,7 +43,10 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
     {
         try {
             $metadata = $this->classMetadataFactory->getMetadataFor($class);
+
         } catch (MappingException $exception) {
+            return;
+        } catch (OrmMappingException $exception) {
             return;
         }
 
@@ -57,6 +61,8 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
         try {
             $metadata = $this->classMetadataFactory->getMetadataFor($class);
         } catch (MappingException $exception) {
+            return;
+        } catch (OrmMappingException $exception) {
             return;
         }
 

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
@@ -81,4 +81,14 @@ class DoctrineExtractorTest extends \PHPUnit_Framework_TestCase
             array('notMapped', null),
         );
     }
+
+    public function testGetPropertiesCatchException()
+    {
+        $this->assertNull($this->extractor->getProperties('Not\Exist'));
+    }
+
+    public function testGetTypesCatchException()
+    {
+        $this->assertNull($this->extractor->getTypes('Not\Exist', 'baz'));
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Sometimes the Doctrine ORM `ClassMetadataFactory` throws a `Doctrine\Common\Persistence\Mapping\MappingException` exception, sometime a `Doctrine\ORM\Mapping\MappingException`.
This PR catch both.

Port of dunglas/php-property-info#10.
