### PR TITLE
[HttpFoundation] add missing symfony/polyfill-php55 dependency

### DIFF
--- a/src/Symfony/Component/HttpFoundation/composer.json
+++ b/src/Symfony/Component/HttpFoundation/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": ">=5.3.9",
-        "symfony/polyfill-php54": "~1.0"
+        "symfony/polyfill-php54": "~1.0",
+        "symfony/polyfill-php55": "~1.0"
     },
     "require-dev": {
         "symfony/expression-language": "~2.4|~3.0.0"


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16317 |
| License | MIT |
| Doc PR |  |

The `json_last_error_msg()` function used in the `JsonResponse` class
requires PHP 5.5.
