### PR TITLE
[Yaml] recognize when a block scalar is left

### DIFF
--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -737,7 +737,9 @@ EOF;
 
     public function getCommentLikeStringInScalarBlockData()
     {
-        $yaml1 = <<<'EOT'
+        $tests = array();
+
+        $yaml = <<<'EOT'
 pages:
     -
         title: some title
@@ -752,7 +754,7 @@ pages:
 
             footer # comment3
 EOT;
-        $expected1 = array(
+        $expected = array(
             'pages' => array(
                 array(
                     'title' => 'some title',
@@ -771,8 +773,9 @@ EOT
                 ),
             ),
         );
+        $tests[] = array($yaml, $expected);
 
-        $yaml2 = <<<'EOT'
+        $yaml = <<<'EOT'
 test: |
     foo
     # bar
@@ -787,7 +790,7 @@ collection:
         # bar
         baz
 EOT;
-        $expected2 = array(
+        $expected = array(
             'test' => <<<'EOT'
 foo
 # bar
@@ -814,11 +817,47 @@ EOT
                 ),
             ),
         );
+        $tests[] = array($yaml, $expected);
 
-        return array(
-            array($yaml1, $expected1),
-            array($yaml2, $expected2),
+        $yaml = <<<EOT
+foo:
+  bar:
+    scalar-block: >
+      line1
+      line2>
+  baz:
+# comment
+    foobar: ~
+EOT;
+        $expected = array(
+            'foo' => array(
+                'bar' => array(
+                    'scalar-block' => 'line1 line2>',
+                ),
+                'baz' => array(
+                    'foobar' => null,
+                ),
+            ),
         );
+        $tests[] = array($yaml, $expected);
+
+        $yaml = <<<'EOT'
+a:
+    b: hello
+#    c: |
+#        first row
+#        second row
+    d: hello
+EOT;
+        $expected = array(
+            'a' => array(
+                'b' => 'hello',
+                'd' => 'hello',
+            ),
+        );
+        $tests[] = array($yaml, $expected);
+
+        return $tests;
     }
 
     public function testBlankLinesAreParsedAsNewLinesInFoldedBlocks()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17116 |
| License | MIT |
| Doc PR |  |

The parser did not recognize when the block scalar was completely parsed
and thus treated following comments as they need to be kept leading to
parse errors on the following lines.
