### PR TITLE
[HttpFoundation] Do not append "private" to "no-cache" in the Cache-Control header

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
@@ -288,7 +288,7 @@ class ResponseHeaderBag extends HeaderBag
         }
 
         $header = $this->getCacheControlHeader();
-        if (isset($this->cacheControl['public']) || isset($this->cacheControl['private'])) {
+        if (isset($this->cacheControl['public']) || isset($this->cacheControl['private']) || isset($this->cacheControl['no-cache'])) {
             return $header;
         }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
@@ -37,6 +37,10 @@ class ResponseHeaderBagTest extends \PHPUnit_Framework_TestCase
                 array('fOo' => array('BAR'), 'Cache-Control' => array('no-cache')),
             ),
             array(
+                array('fOo' => 'BAR', 'Cache-Control' => array('no-cache')),
+                array('fOo' => array('BAR'), 'Cache-Control' => array('no-cache')),
+            ),
+            array(
                 array('ETag' => 'xyzzy'),
                 array('ETag' => array('xyzzy'), 'Cache-Control' => array('private, must-revalidate')),
             ),
@@ -61,6 +65,14 @@ class ResponseHeaderBagTest extends \PHPUnit_Framework_TestCase
                 array('X-XSS-Protection' => array('1; mode=block'), 'Cache-Control' => array('no-cache')),
             ),
         );
+    }
+
+    public function testHeadersArePreserved()
+    {
+        $bag1 = new ResponseHeaderBag(array('test'));
+        $bag2 = new ResponseHeaderBag($bag1->allPreserveCase());
+
+        $this->assertEquals($bag1->allPreserveCase(), $bag2->allPreserveCase());
     }
 
     public function testCacheControlHeader()

--- a/src/Symfony/Component/HttpFoundation/Tests/StreamedResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/StreamedResponseTest.php
@@ -34,7 +34,7 @@ class StreamedResponseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('1.1', $response->getProtocolVersion());
         $this->assertNotEquals('chunked', $response->headers->get('Transfer-Encoding'), 'Apache assumes responses with a Transfer-Encoding header set to chunked to already be encoded.');
-        $this->assertEquals('no-cache, private', $response->headers->get('Cache-Control'));
+        $this->assertEquals('no-cache', $response->headers->get('Cache-Control'));
     }
 
     public function testPrepareWith10Protocol()
@@ -47,7 +47,7 @@ class StreamedResponseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('1.0', $response->getProtocolVersion());
         $this->assertNull($response->headers->get('Transfer-Encoding'));
-        $this->assertEquals('no-cache, private', $response->headers->get('Cache-Control'));
+        $this->assertEquals('no-cache', $response->headers->get('Cache-Control'));
     }
 
     public function testPrepareWithHeadRequest()

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
@@ -1107,7 +1107,8 @@ class HttpCacheTest extends HttpCacheTestCase
         $this->assertEquals('Hello World! My name is Bobby.', $this->response->getContent());
         $this->assertNull($this->response->getTtl());
         $this->assertTrue($this->response->mustRevalidate());
-        $this->assertTrue($this->response->headers->hasCacheControlDirective('private'));
+        $this->assertFalse($this->response->headers->hasCacheControlDirective('private'));
+        $this->assertTrue($this->response->headers->hasCacheControlDirective('must-revalidate'));
         $this->assertTrue($this->response->headers->hasCacheControlDirective('no-cache'));
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16171 |
| License | MIT |
| Doc PR | - |

Replaces #16307 with a simpler approach.
