### PR TITLE
[FrameworkBundle] Set the kernel.name properly after a cache warmup

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -144,9 +144,18 @@ EOF
         }
 
         // fix references to kernel/container related classes
-        $search = $tempKernel->getName().ucfirst($tempKernel->getEnvironment());
-        $replace = $realKernel->getName().ucfirst($realKernel->getEnvironment());
-        foreach (Finder::create()->files()->name($search.'*')->in($warmupDir) as $file) {
+        $fileSearch = $tempKernel->getName().ucfirst($tempKernel->getEnvironment()).'*';
+        $search = array(
+            $tempKernel->getName().ucfirst($tempKernel->getEnvironment()),
+            sprintf('\'kernel.name\' => \'%s\'', $tempKernel->getName()),
+            sprintf('key="kernel.name">%s<', $tempKernel->getName()),
+        );
+        $replace = array(
+            $realKernel->getName().ucfirst($realKernel->getEnvironment()),
+            sprintf('\'kernel.name\' => \'%s\'', $realKernel->getName()),
+            sprintf('key="kernel.name">%s<', $realKernel->getName()),
+        );
+        foreach (Finder::create()->files()->name($fileSearch)->in($warmupDir) as $file) {
             $content = str_replace($search, $replace, file_get_contents($file));
             file_put_contents(str_replace($search, $replace, $file), $content);
             unlink($file);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/CacheClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/CacheClearCommandTest.php
@@ -83,5 +83,6 @@ class CacheClearCommandTest extends TestCase
             }
         }
         $this->assertTrue($found, 'Kernel file should present as resource');
+        $this->assertRegExp(sprintf('/\'kernel.name\'\s*=>\s*\'%s\'/', $this->kernel->getName()), file_get_contents($containerFile), 'kernel.name is properly set on the dumped container');
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16180 |
| License | MIT |
| Doc PR | - |
