### PR TITLE
[DependencyInjection] Introduce a new ParameterResolver

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBagInterface.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBagInterface.php
@@ -91,7 +91,11 @@ interface ParameterBagInterface
      *
      * @param mixed $value A value
      *
-     * @throws ParameterNotFoundException if a placeholder references a parameter that does not exist
+     * @return mixed The resolved value
+     *
+     * @throws ParameterNotFoundException          if a placeholder references a parameter that does not exist
+     * @throws ParameterCircularReferenceException if a circular reference is detected
+     * @throws RuntimeException                    when a given parameter has a type problem.
      */
     public function resolveValue($value);
 

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterResolverTrait.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterResolverTrait.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\ParameterBag;
+
+use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
+use Symfony\Component\DependencyInjection\Exception\ParameterCircularReferenceException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+
+/**
+ * Implementation of {@link ParameterResolverInterface}.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Guilhem N. <egetick@gmail.com>
+ */
+trait ParameterResolverTrait
+{
+    /**
+     * Replaces parameter placeholders (%name%) by their values.
+     *
+     * @param mixed $value A value
+     *
+     * @return mixed The resolved value
+     *
+     * @throws ParameterNotFoundException          if a placeholder references a parameter that does not exist
+     * @throws ParameterCircularReferenceException if a circular reference is detected
+     * @throws RuntimeException                    when a given parameter has a type problem.
+     */
+    public function resolveValue($value, array $resolving = array())
+    {
+        if (is_array($value)) {
+            $args = array();
+            foreach ($value as $k => $v) {
+                $args[$this->resolveValue($k, $resolving)] = $this->resolveValue($v, $resolving);
+            }
+
+            return $args;
+        }
+
+        if (!is_string($value)) {
+            return $value;
+        }
+
+        // we do this to deal with non string values (Boolean, integer, ...)
+        // as the preg_replace_callback throw an exception when trying
+        // a non-string in a parameter value
+        if (preg_match('/^%([^%\s]+)%$/', $value, $match)) {
+            $key = $match[1];
+            $lcKey = strtolower($key);
+
+            if (isset($resolving[$lcKey])) {
+                throw new ParameterCircularReferenceException(array_keys($resolving));
+            }
+
+            $resolving[$lcKey] = true;
+
+            return $this->getParameter($key, $resolving);
+        }
+
+        return preg_replace_callback('/%%|%([^%\s]+)%/', function ($match) use ($resolving, $value) {
+            // skip %%
+            if (!isset($match[1])) {
+                return '%%';
+            }
+
+            $key = $match[1];
+            $lcKey = strtolower($key);
+            if (isset($resolving[$lcKey])) {
+                throw new ParameterCircularReferenceException(array_keys($resolving));
+            }
+
+            $resolving[$lcKey] = true;
+            $resolved = $this->getParameter($key, $resolving);
+
+            if (!is_string($resolved) && !is_numeric($resolved)) {
+                throw new RuntimeException(sprintf('A string value must be composed of strings and/or numbers, but found parameter "%s" of type %s inside string value "%s".', $key, gettype($resolved), $value));
+            }
+
+            return (string) $resolved;
+        }, $value);
+    }
+
+    /**
+     * Gets a parameter.
+     *
+     * @param string $name      The parameter name
+     * @param array  $resolving used internally to detect circular references
+     *
+     * @return mixed The parameter value
+     *
+     * @throws ParameterNotFoundException if the parameter is not defined
+     */
+    abstract protected function getParameter($name, $resolving = array());
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
@@ -13,8 +13,6 @@ namespace Symfony\Component\DependencyInjection\Tests\ParameterBag;
 
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
-use Symfony\Component\DependencyInjection\Exception\ParameterCircularReferenceException;
-use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 
 class ParameterBagTest extends \PHPUnit_Framework_TestCase
 {
@@ -107,73 +105,6 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($bag->has('bar'), '->has() returns false if a parameter is not defined');
     }
 
-    public function testResolveValue()
-    {
-        $bag = new ParameterBag(array());
-        $this->assertEquals('foo', $bag->resolveValue('foo'), '->resolveValue() returns its argument unmodified if no placeholders are found');
-
-        $bag = new ParameterBag(array('foo' => 'bar'));
-        $this->assertEquals('I\'m a bar', $bag->resolveValue('I\'m a %foo%'), '->resolveValue() replaces placeholders by their values');
-        $this->assertEquals(array('bar' => 'bar'), $bag->resolveValue(array('%foo%' => '%foo%')), '->resolveValue() replaces placeholders in keys and values of arrays');
-        $this->assertEquals(array('bar' => array('bar' => array('bar' => 'bar'))), $bag->resolveValue(array('%foo%' => array('%foo%' => array('%foo%' => '%foo%')))), '->resolveValue() replaces placeholders in nested arrays');
-        $this->assertEquals('I\'m a %%foo%%', $bag->resolveValue('I\'m a %%foo%%'), '->resolveValue() supports % escaping by doubling it');
-        $this->assertEquals('I\'m a bar %%foo bar', $bag->resolveValue('I\'m a %foo% %%foo %foo%'), '->resolveValue() supports % escaping by doubling it');
-        $this->assertEquals(array('foo' => array('bar' => array('ding' => 'I\'m a bar %%foo %%bar'))), $bag->resolveValue(array('foo' => array('bar' => array('ding' => 'I\'m a bar %%foo %%bar')))), '->resolveValue() supports % escaping by doubling it');
-
-        $bag = new ParameterBag(array('foo' => true));
-        $this->assertTrue($bag->resolveValue('%foo%'), '->resolveValue() replaces arguments that are just a placeholder by their value without casting them to strings');
-        $bag = new ParameterBag(array('foo' => null));
-        $this->assertNull($bag->resolveValue('%foo%'), '->resolveValue() replaces arguments that are just a placeholder by their value without casting them to strings');
-
-        $bag = new ParameterBag(array('foo' => 'bar', 'baz' => '%%%foo% %foo%%% %%foo%% %%%foo%%%'));
-        $this->assertEquals('%%bar bar%% %%foo%% %%bar%%', $bag->resolveValue('%baz%'), '->resolveValue() replaces params placed besides escaped %');
-
-        $bag = new ParameterBag(array('baz' => '%%s?%%s'));
-        $this->assertEquals('%%s?%%s', $bag->resolveValue('%baz%'), '->resolveValue() is not replacing greedily');
-
-        $bag = new ParameterBag(array());
-        try {
-            $bag->resolveValue('%foobar%');
-            $this->fail('->resolveValue() throws an InvalidArgumentException if a placeholder references a non-existent parameter');
-        } catch (ParameterNotFoundException $e) {
-            $this->assertEquals('You have requested a non-existent parameter "foobar".', $e->getMessage(), '->resolveValue() throws a ParameterNotFoundException if a placeholder references a non-existent parameter');
-        }
-
-        try {
-            $bag->resolveValue('foo %foobar% bar');
-            $this->fail('->resolveValue() throws a ParameterNotFoundException if a placeholder references a non-existent parameter');
-        } catch (ParameterNotFoundException $e) {
-            $this->assertEquals('You have requested a non-existent parameter "foobar".', $e->getMessage(), '->resolveValue() throws a ParameterNotFoundException if a placeholder references a non-existent parameter');
-        }
-
-        $bag = new ParameterBag(array('foo' => 'a %bar%', 'bar' => array()));
-        try {
-            $bag->resolveValue('%foo%');
-            $this->fail('->resolveValue() throws a RuntimeException when a parameter embeds another non-string parameter');
-        } catch (RuntimeException $e) {
-            $this->assertEquals('A string value must be composed of strings and/or numbers, but found parameter "bar" of type array inside string value "a %bar%".', $e->getMessage(), '->resolveValue() throws a RuntimeException when a parameter embeds another non-string parameter');
-        }
-
-        $bag = new ParameterBag(array('foo' => '%bar%', 'bar' => '%foobar%', 'foobar' => '%foo%'));
-        try {
-            $bag->resolveValue('%foo%');
-            $this->fail('->resolveValue() throws a ParameterCircularReferenceException when a parameter has a circular reference');
-        } catch (ParameterCircularReferenceException $e) {
-            $this->assertEquals('Circular reference detected for parameter "foo" ("foo" > "bar" > "foobar" > "foo").', $e->getMessage(), '->resolveValue() throws a ParameterCircularReferenceException when a parameter has a circular reference');
-        }
-
-        $bag = new ParameterBag(array('foo' => 'a %bar%', 'bar' => 'a %foobar%', 'foobar' => 'a %foo%'));
-        try {
-            $bag->resolveValue('%foo%');
-            $this->fail('->resolveValue() throws a ParameterCircularReferenceException when a parameter has a circular reference');
-        } catch (ParameterCircularReferenceException $e) {
-            $this->assertEquals('Circular reference detected for parameter "foo" ("foo" > "bar" > "foobar" > "foo").', $e->getMessage(), '->resolveValue() throws a ParameterCircularReferenceException when a parameter has a circular reference');
-        }
-
-        $bag = new ParameterBag(array('host' => 'foo.bar', 'port' => 1337));
-        $this->assertEquals('foo.bar:1337', $bag->resolveValue('%host%:%port%'));
-    }
-
     public function testResolveIndicatesWhyAParameterIsNeeded()
     {
         $bag = new ParameterBag(array('foo' => '%bar%'));
@@ -221,6 +152,7 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider stringsWithSpacesProvider
+     * @group legacy
      */
     public function testResolveStringWithSpacesReturnsString($expected, $test, $description)
     {

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterResolverTraitTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterResolverTraitTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\ParameterBag;
+
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\DependencyInjection\Exception\ParameterCircularReferenceException;
+use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+
+class ParameterResolverTraitTest extends \PHPUnit_Framework_TestCase
+{
+    public function testResolveValue()
+    {
+        $bag = new ParameterBag(array());
+        $this->assertEquals('foo', $bag->resolveValue('foo'), '->resolveValue() returns its argument unmodified if no placeholders are found');
+
+        $bag = new ParameterBag(array('foo' => 'bar'));
+        $this->assertEquals('I\'m a bar', $bag->resolveValue('I\'m a %foo%'), '->resolveValue() replaces placeholders by their values');
+        $this->assertEquals(array('bar' => 'bar'), $bag->resolveValue(array('%foo%' => '%foo%')), '->resolveValue() replaces placeholders in keys and values of arrays');
+        $this->assertEquals(array('bar' => array('bar' => array('bar' => 'bar'))), $bag->resolveValue(array('%foo%' => array('%foo%' => array('%foo%' => '%foo%')))), '->resolveValue() replaces placeholders in nested arrays');
+        $this->assertEquals('I\'m a %%foo%%', $bag->resolveValue('I\'m a %%foo%%'), '->resolveValue() supports % escaping by doubling it');
+        $this->assertEquals('I\'m a bar %%foo bar', $bag->resolveValue('I\'m a %foo% %%foo %foo%'), '->resolveValue() supports % escaping by doubling it');
+        $this->assertEquals(array('foo' => array('bar' => array('ding' => 'I\'m a bar %%foo %%bar'))), $bag->resolveValue(array('foo' => array('bar' => array('ding' => 'I\'m a bar %%foo %%bar')))), '->resolveValue() supports % escaping by doubling it');
+
+        $bag = new ParameterBag(array('foo' => true));
+        $this->assertTrue($bag->resolveValue('%foo%'), '->resolveValue() replaces arguments that are just a placeholder by their value without casting them to strings');
+        $bag = new ParameterBag(array('foo' => null));
+        $this->assertNull($bag->resolveValue('%foo%'), '->resolveValue() replaces arguments that are just a placeholder by their value without casting them to strings');
+
+        $bag = new ParameterBag(array('foo' => 'bar', 'baz' => '%%%foo% %foo%%% %%foo%% %%%foo%%%'));
+        $this->assertEquals('%%bar bar%% %%foo%% %%bar%%', $bag->resolveValue('%baz%'), '->resolveValue() replaces params placed besides escaped %');
+
+        $bag = new ParameterBag(array('baz' => '%%s?%%s'));
+        $this->assertEquals('%%s?%%s', $bag->resolveValue('%baz%'), '->resolveValue() is not replacing greedily');
+
+        $bag = new ParameterBag(array());
+        try {
+            $bag->resolveValue('%foobar%');
+            $this->fail('->resolveValue() throws an InvalidArgumentException if a placeholder references a non-existent parameter');
+        } catch (ParameterNotFoundException $e) {
+            $this->assertEquals('You have requested a non-existent parameter "foobar".', $e->getMessage(), '->resolveValue() throws a ParameterNotFoundException if a placeholder references a non-existent parameter');
+        }
+
+        try {
+            $bag->resolveValue('foo %foobar% bar');
+            $this->fail('->resolveValue() throws a ParameterNotFoundException if a placeholder references a non-existent parameter');
+        } catch (ParameterNotFoundException $e) {
+            $this->assertEquals('You have requested a non-existent parameter "foobar".', $e->getMessage(), '->resolveValue() throws a ParameterNotFoundException if a placeholder references a non-existent parameter');
+        }
+
+        $bag = new ParameterBag(array('foo' => 'a %bar%', 'bar' => array()));
+        try {
+            $bag->resolveValue('%foo%');
+            $this->fail('->resolveValue() throws a RuntimeException when a parameter embeds another non-string parameter');
+        } catch (RuntimeException $e) {
+            $this->assertEquals('A string value must be composed of strings and/or numbers, but found parameter "bar" of type array inside string value "a %bar%".', $e->getMessage(), '->resolveValue() throws a RuntimeException when a parameter embeds another non-string parameter');
+        }
+
+        $bag = new ParameterBag(array('foo' => '%bar%', 'bar' => '%foobar%', 'foobar' => '%foo%'));
+        try {
+            $bag->resolveValue('%foo%');
+            $this->fail('->resolveValue() throws a ParameterCircularReferenceException when a parameter has a circular reference');
+        } catch (ParameterCircularReferenceException $e) {
+            $this->assertEquals('Circular reference detected for parameter "foo" ("foo" > "bar" > "foobar" > "foo").', $e->getMessage(), '->resolveValue() throws a ParameterCircularReferenceException when a parameter has a circular reference');
+        }
+
+        $bag = new ParameterBag(array('foo' => 'a %bar%', 'bar' => 'a %foobar%', 'foobar' => 'a %foo%'));
+        try {
+            $bag->resolveValue('%foo%');
+            $this->fail('->resolveValue() throws a ParameterCircularReferenceException when a parameter has a circular reference');
+        } catch (ParameterCircularReferenceException $e) {
+            $this->assertEquals('Circular reference detected for parameter "foo" ("foo" > "bar" > "foobar" > "foo").', $e->getMessage(), '->resolveValue() throws a ParameterCircularReferenceException when a parameter has a circular reference');
+        }
+
+        $bag = new ParameterBag(array('host' => 'foo.bar', 'port' => 1337));
+        $this->assertEquals('foo.bar:1337', $bag->resolveValue('%host%:%port%'));
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #17160 |
| License | MIT |
| Doc PR |  |

> Actually, to resolve a value we can use [`ParameterBag::resolveValue()`](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php#L170) which is accessible [in the `Container`](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/DependencyInjection/Container.php#L113).
> This works fine but the problem is when we want to resolve a value at runtime and we have a custom `ContainerInterface` instance.
> 
> So I would like to have a trait or a class which would allow to resolve values without an access to a `ParameterBag` instance.
> 
> You can find [an example of use case in `FOSRestBundle`](https://github.com/FriendsOfSymfony/FOSRestBundle/blob/master/Request/ParamFetcher.php#L139) where we need to resolve values at runtime.
> We actually use [a trait](https://github.com/FriendsOfSymfony/FOSRestBundle/blob/master/Util/ResolverTrait.php#L21) but I'd prefer to use something from the core. 

[As suggested by @xabbuh](https://github.com/symfony/symfony/issues/17160#issuecomment-167758740), this PR creates a new `ParameterResolver` used internally by the `ParameterBag`.
