### PR TITLE
Recursive denormalize with property info

### DIFF
--- a/src/Symfony/Component/Serializer/Annotation/Groups.php
+++ b/src/Symfony/Component/Serializer/Annotation/Groups.php
@@ -35,7 +35,7 @@ class Groups
      */
     public function __construct(array $data)
     {
-        if (!isset($data['value']) || !$data['value']) {
+        if (empty($data['value'])) {
             throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" cannot be empty.', get_class($this)));
         }
 

--- a/src/Symfony/Component/Serializer/Annotation/MaxDepth.php
+++ b/src/Symfony/Component/Serializer/Annotation/MaxDepth.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Annotation;
+
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+
+/**
+ * Annotation class for @MaxDepth().
+ *
+ * @Annotation
+ * @Target({"PROPERTY", "METHOD"})
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class MaxDepth
+{
+    /**
+     * @var int
+     */
+    private $maxDepth;
+
+    public function __construct(array $data)
+    {
+        if (!isset($data['value']) || !$data['value']) {
+            throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" cannot be empty.', get_class($this)));
+        }
+
+        if (!is_int($data['value'])) {
+            throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" must be an int.', get_class($this)));
+        }
+
+        $this->maxDepth = $data['value'];
+    }
+
+    public function getMaxDepth()
+    {
+        return $this->maxDepth;
+    }
+}

--- a/src/Symfony/Component/Serializer/Annotation/MaxDepth.php
+++ b/src/Symfony/Component/Serializer/Annotation/MaxDepth.php
@@ -38,6 +38,10 @@ class MaxDepth
             throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" must be an int.', get_class($this)));
         }
 
+        if ($data['value'] <= 0) {
+            throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" must be greater than 0.', get_class($this)));
+        }
+
         $this->maxDepth = $data['value'];
     }
 

--- a/src/Symfony/Component/Serializer/Annotation/MaxDepth.php
+++ b/src/Symfony/Component/Serializer/Annotation/MaxDepth.php
@@ -30,7 +30,7 @@ class MaxDepth
 
     public function __construct(array $data)
     {
-        if (!isset($data['value']) || !$data['value']) {
+        if (empty($data['value'])) {
             throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" cannot be empty.', get_class($this)));
         }
 

--- a/src/Symfony/Component/Serializer/Annotation/MaxDepth.php
+++ b/src/Symfony/Component/Serializer/Annotation/MaxDepth.php
@@ -34,12 +34,8 @@ class MaxDepth
             throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" cannot be empty.', get_class($this)));
         }
 
-        if (!is_int($data['value'])) {
-            throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" must be an int.', get_class($this)));
-        }
-
-        if ($data['value'] <= 0) {
-            throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" must be greater than 0.', get_class($this)));
+        if (!is_int($data['value']) || $data['value'] <= 0) {
+            throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" must be a positive integer.', get_class($this)));
         }
 
         $this->maxDepth = $data['value'];

--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
@@ -37,6 +37,15 @@ class AttributeMetadata implements AttributeMetadataInterface
     public $groups = array();
 
     /**
+     * @var int|null
+     *
+     * @internal This property is public in order to reduce the size of the
+     *           class' serialized representation. Do not access it. Use
+     *           {@link getMaxDepth()} instead.
+     */
+    public $maxDepth;
+
+    /**
      * Constructs a metadata for the given attribute.
      *
      * @param string $name
@@ -75,10 +84,31 @@ class AttributeMetadata implements AttributeMetadataInterface
     /**
      * {@inheritdoc}
      */
+    public function setMaxDepth($maxDepth)
+    {
+        $this->maxDepth = $maxDepth;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMaxDepth()
+    {
+        return $this->maxDepth;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function merge(AttributeMetadataInterface $attributeMetadata)
     {
         foreach ($attributeMetadata->getGroups() as $group) {
             $this->addGroup($group);
+        }
+
+        // Overwrite only if not defined
+        if (null === $this->maxDepth) {
+            $this->maxDepth = $attributeMetadata->getMaxDepth();
         }
     }
 
@@ -89,6 +119,6 @@ class AttributeMetadata implements AttributeMetadataInterface
      */
     public function __sleep()
     {
-        return array('name', 'groups');
+        return array('name', 'groups', 'maxDepth');
     }
 }

--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
@@ -42,6 +42,20 @@ interface AttributeMetadataInterface
     public function getGroups();
 
     /**
+     * Sets the serialization max depth for this attribute.
+     *
+     * @param int|null $maxDepth
+     */
+    public function setMaxDepth($maxDepth);
+
+    /**
+     * Gets the serialization max depth for this attribute.
+     *
+     * @return int|null
+     */
+    public function getMaxDepth();
+
+    /**
      * Merges an {@see AttributeMetadataInterface} with in the current one.
      *
      * @param AttributeMetadataInterface $attributeMetadata

--- a/src/Symfony/Component/Serializer/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassMetadata.php
@@ -28,7 +28,7 @@ class ClassMetadata implements ClassMetadataInterface
     public $name;
 
     /**
-     * @var AttributeMetadataInterface[]
+     * @var array
      *
      * @internal This property is public in order to reduce the size of the
      *           class' serialized representation. Do not access it. Use

--- a/src/Symfony/Component/Serializer/Mapping/ClassMetadataInterface.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassMetadataInterface.php
@@ -39,7 +39,7 @@ interface ClassMetadataInterface
     /**
      * Gets the list of {@link AttributeMetadataInterface}.
      *
-     * @return AttributeMetadataInterface[]
+     * @return array An array containing the attribute name as key and the related instance of AttributeMetadataInterface as value.
      */
     public function getAttributesMetadata();
 

--- a/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
@@ -61,9 +61,7 @@ class AnnotationLoader implements LoaderInterface
                         foreach ($annotation->getGroups() as $group) {
                             $attributesMetadata[$property->name]->addGroup($group);
                         }
-                    }
-
-                    if ($annotation instanceof MaxDepth) {
+                    } elseif ($annotation instanceof MaxDepth) {
                         $attributesMetadata[$property->name]->setMaxDepth($annotation->getMaxDepth());
                     }
 

--- a/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
@@ -98,9 +98,7 @@ class AnnotationLoader implements LoaderInterface
                     foreach ($annotation->getGroups() as $group) {
                         $attributeMetadata->addGroup($group);
                     }
-                }
-
-                if ($annotation instanceof MaxDepth) {
+                } elseif ($annotation instanceof MaxDepth) {
                     if (!$accessorOrMutator) {
                         throw new MappingException(sprintf('MaxDepth on "%s::%s" cannot be added. MaxDepth can only be added on methods beginning with "get", "is", "has" or "set".', $className, $method->name));
                     }

--- a/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Serializer\Mapping\Loader;
 
 use Doctrine\Common\Annotations\Reader;
 use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Annotation\MaxDepth;
 use Symfony\Component\Serializer\Exception\MappingException;
 use Symfony\Component\Serializer\Mapping\AttributeMetadata;
 use Symfony\Component\Serializer\Mapping\ClassMetadataInterface;
@@ -55,11 +56,15 @@ class AnnotationLoader implements LoaderInterface
             }
 
             if ($property->getDeclaringClass()->name === $className) {
-                foreach ($this->reader->getPropertyAnnotations($property) as $groups) {
-                    if ($groups instanceof Groups) {
-                        foreach ($groups->getGroups() as $group) {
+                foreach ($this->reader->getPropertyAnnotations($property) as $annotation) {
+                    if ($annotation instanceof Groups) {
+                        foreach ($annotation->getGroups() as $group) {
                             $attributesMetadata[$property->name]->addGroup($group);
                         }
+                    }
+
+                    if ($annotation instanceof MaxDepth) {
+                        $attributesMetadata[$property->name]->setMaxDepth($annotation->getMaxDepth());
                     }
 
                     $loaded = true;
@@ -68,29 +73,40 @@ class AnnotationLoader implements LoaderInterface
         }
 
         foreach ($reflectionClass->getMethods() as $method) {
-            if ($method->getDeclaringClass()->name === $className) {
-                foreach ($this->reader->getMethodAnnotations($method) as $groups) {
-                    if ($groups instanceof Groups) {
-                        if (preg_match('/^(get|is|has|set)(.+)$/i', $method->name, $matches)) {
-                            $attributeName = lcfirst($matches[2]);
+            if ($method->getDeclaringClass()->name !== $className) {
+                continue;
+            }
 
-                            if (isset($attributesMetadata[$attributeName])) {
-                                $attributeMetadata = $attributesMetadata[$attributeName];
-                            } else {
-                                $attributesMetadata[$attributeName] = $attributeMetadata = new AttributeMetadata($attributeName);
-                                $classMetadata->addAttributeMetadata($attributeMetadata);
-                            }
+            $accessorOrMutator = preg_match('/^(get|is|has|set)(.+)$/i', $method->name, $matches);
+            $attributeName = lcfirst($matches[2]);
 
-                            foreach ($groups->getGroups() as $group) {
-                                $attributeMetadata->addGroup($group);
-                            }
-                        } else {
-                            throw new MappingException(sprintf('Groups on "%s::%s" cannot be added. Groups can only be added on methods beginning with "get", "is", "has" or "set".', $className, $method->name));
-                        }
+            if (isset($attributesMetadata[$attributeName])) {
+                $attributeMetadata = $attributesMetadata[$attributeName];
+            } else {
+                $attributesMetadata[$attributeName] = $attributeMetadata = new AttributeMetadata($attributeName);
+                $classMetadata->addAttributeMetadata($attributeMetadata);
+            }
+
+            foreach ($this->reader->getMethodAnnotations($method) as $annotation) {
+                if ($annotation instanceof Groups) {
+                    if (!$accessorOrMutator) {
+                        throw new MappingException(sprintf('Groups on "%s::%s" cannot be added. Groups can only be added on methods beginning with "get", "is", "has" or "set".', $className, $method->name));
                     }
 
-                    $loaded = true;
+                    foreach ($annotation->getGroups() as $group) {
+                        $attributeMetadata->addGroup($group);
+                    }
                 }
+
+                if ($annotation instanceof MaxDepth) {
+                    if (!$accessorOrMutator) {
+                        throw new MappingException(sprintf('MaxDepth on "%s::%s" cannot be added. MaxDepth can only be added on methods beginning with "get", "is", "has" or "set".', $className, $method->name));
+                    }
+
+                    $attributeMetadata->setMaxDepth($annotation->getMaxDepth());
+                }
+
+                $loaded = true;
             }
         }
 

--- a/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
@@ -78,13 +78,15 @@ class AnnotationLoader implements LoaderInterface
             }
 
             $accessorOrMutator = preg_match('/^(get|is|has|set)(.+)$/i', $method->name, $matches);
-            $attributeName = lcfirst($matches[2]);
+            if ($accessorOrMutator) {
+                $attributeName = lcfirst($matches[2]);
 
-            if (isset($attributesMetadata[$attributeName])) {
-                $attributeMetadata = $attributesMetadata[$attributeName];
-            } else {
-                $attributesMetadata[$attributeName] = $attributeMetadata = new AttributeMetadata($attributeName);
-                $classMetadata->addAttributeMetadata($attributeMetadata);
+                if (isset($attributesMetadata[$attributeName])) {
+                    $attributeMetadata = $attributesMetadata[$attributeName];
+                } else {
+                    $attributesMetadata[$attributeName] = $attributeMetadata = new AttributeMetadata($attributeName);
+                    $classMetadata->addAttributeMetadata($attributeMetadata);
+                }
             }
 
             foreach ($this->reader->getMethodAnnotations($method) as $annotation) {

--- a/src/Symfony/Component/Serializer/Mapping/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/XmlFileLoader.php
@@ -62,6 +62,10 @@ class XmlFileLoader extends FileLoader
                 foreach ($attribute->group as $group) {
                     $attributeMetadata->addGroup((string) $group);
                 }
+
+                if (isset($attribute['max-depth'])) {
+                    $attributeMetadata->setMaxDepth((int) $attribute['max-depth']);
+                }
             }
 
             return true;

--- a/src/Symfony/Component/Serializer/Mapping/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/YamlFileLoader.php
@@ -65,6 +65,7 @@ class YamlFileLoader extends FileLoader
 
             if (isset($yaml['attributes']) && is_array($yaml['attributes'])) {
                 $attributesMetadata = $classMetadata->getAttributesMetadata();
+
                 foreach ($yaml['attributes'] as $attribute => $data) {
                     if (isset($attributesMetadata[$attribute])) {
                         $attributeMetadata = $attributesMetadata[$attribute];
@@ -75,8 +76,12 @@ class YamlFileLoader extends FileLoader
 
                     if (isset($data['groups'])) {
                         foreach ($data['groups'] as $group) {
-                            $attributeMetadata->addGroup($group);
+                            $attributeMetadata->addGroup((string) $group);
                         }
+                    }
+
+                    if (isset($data['max_depth'])) {
+                        $attributeMetadata->setMaxDepth((int) $data['max_depth']);
                     }
                 }
             }

--- a/src/Symfony/Component/Serializer/Mapping/Loader/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd
@@ -47,10 +47,11 @@
         Contains serialization groups for a attributes. The name of the attribute should be given in the "name" option.
       ]]></xsd:documentation>
         </xsd:annotation>
-        <xsd:sequence>
+        <xsd:sequence minOccurs="0">
             <xsd:element name="group" type="xsd:string" maxOccurs="unbounded" />
         </xsd:sequence>
         <xsd:attribute name="name" type="xsd:string" use="required" />
+        <xsd:attribute name="max-depth" type="xsd:int" />
     </xsd:complexType>
 
 </xsd:schema>

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -318,7 +318,7 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
      *
      * @return array
      */
-    protected function setAttribute($data, $attribute, $attributeValue)
+    protected function setAttribute(array $data, $attribute, $attributeValue)
     {
         if ($this->nameConverter) {
             $attribute = $this->nameConverter->normalize($attribute);

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -32,8 +32,6 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
     const ENABLE_MAX_DEPTH = 'enable_max_depth';
     const DEPTH_KEY_PATTERN = 'depth_%s::%s';
 
-    public static $n;
-
     /**
      * @var int
      */
@@ -396,14 +394,6 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
             ++$context[$key];
         } else {
             $context[$key] = 1;
-        }
-
-        if ($attribute === 'foo') {
-            if (null === self::$n) {
-                self::$n = 0;
-            } else {
-                ++self::$n;
-            }
         }
 
         return false;

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -341,7 +341,7 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
         }
 
         foreach ($types as $type) {
-            if (empty($data) && !$type->isNullable()) {
+            if ($data === null && $type->isNullable()) {
                 return $data;
             }
 

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -266,62 +266,93 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
         }
 
         $constructor = $reflectionClass->getConstructor();
-        if ($constructor) {
-            $constructorParameters = $constructor->getParameters();
-
-            $params = array();
-            foreach ($constructorParameters as $constructorParameter) {
-                $paramName = $constructorParameter->name;
-                $key = $this->nameConverter ? $this->nameConverter->normalize($paramName) : $paramName;
-
-                $allowed = $allowedAttributes === false || in_array($paramName, $allowedAttributes);
-                $ignored = in_array($paramName, $this->ignoredAttributes);
-                if (method_exists($constructorParameter, 'isVariadic') && $constructorParameter->isVariadic()) {
-                    if ($allowed && !$ignored && (isset($data[$key]) || array_key_exists($key, $data))) {
-                        if (!is_array($data[$paramName])) {
-                            throw new RuntimeException(sprintf('Cannot create an instance of %s from serialized data because the variadic parameter %s can only accept an array.', $class, $constructorParameter->name));
-                        }
-
-                        $params = array_merge($params, $data[$paramName]);
-                    }
-                } elseif ($allowed && !$ignored && (isset($data[$key]) || array_key_exists($key, $data))) {
-                    if ($this->propertyInfoExtractor) {
-                        $types = $this->propertyInfoExtractor->getTypes($class, $key);
-
-                        foreach ($types as $type) {
-                            if ($type && $type->getClassName() && (!empty($data[$key]) || !$type->isNullable())) {
-                                if (!$this->serializer instanceof DenormalizerInterface) {
-                                    throw new RuntimeException(sprintf('Cannot denormalize attribute "%s" because injected serializer is not a denormalizer', $key));
-                                }
-
-                                $value = $data[$paramName];
-                                $data[$paramName] = $this->serializer->denormalize($value, $type->getClassName(), $format, $context);
-
-                                break;
-                            }
-                        }
-                    }
-
-                    $params[] = $data[$key];
-                    // don't run set for a parameter passed to the constructor
-                    unset($data[$key]);
-                } elseif ($constructorParameter->isDefaultValueAvailable()) {
-                    $params[] = $constructorParameter->getDefaultValue();
-                } else {
-                    throw new RuntimeException(
-                        sprintf(
-                            'Cannot create an instance of %s from serialized data because its constructor requires parameter "%s" to be present.',
-                            $class,
-                            $constructorParameter->name
-                        )
-                    );
-                }
-            }
-
-            return $reflectionClass->newInstanceArgs($params);
+        if (!$constructor) {
+            return new $class();
         }
 
-        return new $class();
+        $constructorParameters = $constructor->getParameters();
+
+        $params = array();
+        foreach ($constructorParameters as $constructorParameter) {
+            $paramName = $constructorParameter->name;
+            $key = $this->nameConverter ? $this->nameConverter->normalize($paramName) : $paramName;
+
+            $allowed = $allowedAttributes === false || in_array($paramName, $allowedAttributes);
+            $ignored = in_array($paramName, $this->ignoredAttributes);
+
+            if (!$allowed || $ignored) {
+                continue;
+            }
+
+            $missing = !isset($data[$key]) && !array_key_exists($key, $data);
+            $variadic = method_exists($constructorParameter, 'isVariadic') && $constructorParameter->isVariadic();
+
+            if ($variadic && !$missing && !is_array($data[$paramName])) {
+                $message = 'Cannot create an instance of %s from serialized data because the variadic parameter %s can only accept an array.';
+                throw new RuntimeException(sprintf($message, $class, $constructorParameter->name));
+            }
+
+            if ($variadic && !$missing) {
+                $params = array_merge($params, $data[$paramName]);
+
+                continue;
+            }
+
+            if ($missing && !$variadic && !$constructorParameter->isDefaultValueAvailable()) {
+                $message = 'Cannot create an instance of %s from serialized data because its constructor requires parameter "%s" to be present.';
+                throw new RuntimeException(sprintf($message, $class, $constructorParameter->name));
+            }
+
+            if ($missing && $constructorParameter->isDefaultValueAvailable()) {
+                $params[] = $constructorParameter->getDefaultValue();
+
+                continue;
+            }
+
+            if (!$missing) {
+                $params[] = $this->denormalizeProperty($data[$key], $class, $key, $format, $context);
+
+                unset($data[$key]);
+            }
+        }
+
+        return $reflectionClass->newInstanceArgs($params);
+    }
+
+    /**
+     * @param mixed  $data
+     * @param string $class
+     * @param string $name
+     * @param string $format
+     * @param array  $context
+     *
+     * @return mixed|object
+     */
+    protected function denormalizeProperty($data, $class, $name, $format = null, array $context = array())
+    {
+        if (!$this->propertyInfoExtractor) {
+            return $data;
+        }
+
+        $types = $this->propertyInfoExtractor->getTypes($class, $name);
+
+        if (empty($types)) {
+            return $data;
+        }
+
+        foreach ($types as $type) {
+            if (empty($data) && !$type->isNullable()) {
+                return $data;
+            }
+
+            if (!$this->serializer instanceof DenormalizerInterface) {
+                $message = 'Cannot denormalize attribute "%s" because injected serializer is not a denormalizer';
+                throw new RuntimeException(sprintf($message, $name));
+            }
+
+            return $this->serializer->denormalize($data, $type->getClassName(), $format, $context);
+        }
+
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -140,9 +140,18 @@ class GetSetMethodNormalizer extends AbstractNormalizer
                         }
                     }
 
-                    $object->$setter($value);
-                }
+            if (!$allowed || $ignored) {
+                continue;
             }
+
+            $setter = 'set'.ucfirst($attribute);
+            if (!in_array($setter, $classMethods)) {
+                continue;
+            }
+
+            $value = $this->denormalizeProperty($value, $class, $attribute, $format, $context);
+
+            $object->$setter($value);
         }
 
         return $object;

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -76,7 +76,7 @@ class GetSetMethodNormalizer extends AbstractNormalizer
                 $attributeValue = call_user_func($this->callbacks[$attributeName], $attributeValue);
             }
 
-            // Recursive call are done at the end of the process to allow @MaxDepth to work
+            // Recursive calls are done at the end of the process to allow @MaxDepth to work
             if (null !== $attributeValue && !is_scalar($attributeValue)) {
                 $stack[$attributeName] = $attributeValue;
                 continue;

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -15,7 +15,6 @@ use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Serializer\Exception\CircularReferenceException;
-use Symfony\Component\Serializer\Exception\LogicException;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 
@@ -60,10 +59,11 @@ class ObjectNormalizer extends AbstractNormalizer
         }
 
         $data = array();
+        $stack = array();
         $attributes = $this->getAttributes($object, $context);
 
         foreach ($attributes as $attribute) {
-            if (in_array($attribute, $this->ignoredAttributes)) {
+            if (!$this->isAttributeToNormalize($object, $attribute, $context)) {
                 continue;
             }
 
@@ -73,22 +73,16 @@ class ObjectNormalizer extends AbstractNormalizer
                 $attributeValue = call_user_func($this->callbacks[$attribute], $attributeValue);
             }
 
+            // Recursive call are done at the end of the process to allow @MaxDepth to work
             if (null !== $attributeValue && !is_scalar($attributeValue)) {
-                if (!$this->serializer instanceof NormalizerInterface) {
-                    throw new LogicException(sprintf('Cannot normalize attribute "%s" because injected serializer is not a normalizer', $attribute));
-                }
-
-                $attributeValue = $this->serializer->normalize($attributeValue, $format, $context);
+                $stack[$attribute] = $attributeValue;
+                continue;
             }
 
-            if ($this->nameConverter) {
-                $attribute = $this->nameConverter->normalize($attribute);
-            }
-
-            $data[$attribute] = $attributeValue;
+            $data = $this->setAttribute($data, $attribute, $attributeValue);
         }
 
-        return $data;
+        return $this->normalizeComplexTypes($data, $stack, $format, $context);
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -73,7 +73,7 @@ class ObjectNormalizer extends AbstractNormalizer
                 $attributeValue = call_user_func($this->callbacks[$attribute], $attributeValue);
             }
 
-            // Recursive call are done at the end of the process to allow @MaxDepth to work
+            // Recursive calls are done at the end of the process to allow @MaxDepth to work
             if (null !== $attributeValue && !is_scalar($attributeValue)) {
                 $stack[$attribute] = $attributeValue;
                 continue;

--- a/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
@@ -69,7 +69,7 @@ class PropertyNormalizer extends AbstractNormalizer
                 $attributeValue = call_user_func($this->callbacks[$property->name], $attributeValue);
             }
 
-            // Recursive call are done at the end of the process to allow @MaxDepth to work
+            // Recursive calls are done at the end of the process to allow @MaxDepth to work
             if (null !== $attributeValue && !is_scalar($attributeValue)) {
                 $stack[$property->name] = $attributeValue;
                 continue;

--- a/src/Symfony/Component/Serializer/Tests/Annotation/MaxDepthTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Annotation/MaxDepthTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Annotation;
+
+use Symfony\Component\Serializer\Annotation\MaxDepth;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class MaxDepthTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \Symfony\Component\Serializer\Exception\InvalidArgumentException
+     */
+    public function testNotAnIntMaxDepthParameter()
+    {
+        new MaxDepth(array('value' => 'coopTilleuls'));
+    }
+
+    public function testMaxDepthParameters()
+    {
+        $validData = 3;
+
+        $groups = new MaxDepth(array('value' => 3));
+        $this->assertEquals($validData, $groups->getMaxDepth());
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Annotation/MaxDepthTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Annotation/MaxDepthTest.php
@@ -23,7 +23,7 @@ class MaxDepthTest extends \PHPUnit_Framework_TestCase
      */
     public function testNotAnIntMaxDepthParameter()
     {
-        new MaxDepth(array('value' => 'coopTilleuls'));
+        new MaxDepth(array('value' => 'foo'));
     }
 
     public function testMaxDepthParameters()

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/MaxDepthDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/MaxDepthDummy.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Annotation\MaxDepth;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class MaxDepthDummy
+{
+    /**
+     * @MaxDepth(2)
+     */
+    public $foo;
+
+    public $bar;
+
+    /**
+     * @var self
+     */
+    public $child;
+
+    /**
+     * @MaxDepth(3)
+     */
+    public function getBar()
+    {
+        return $this->bar;
+    }
+
+    public function getChild()
+    {
+        return $this->child;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.xml
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.xml
@@ -15,4 +15,9 @@
         </attribute>
     </class>
 
+    <class name="Symfony\Component\Serializer\Tests\Fixtures\MaxDepthDummy">
+        <attribute name="foo" max-depth="2" />
+        <attribute name="bar" max-depth="3" />
+    </class>
+
 </serializer>

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.yml
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.yml
@@ -1,6 +1,12 @@
-Symfony\Component\Serializer\Tests\Fixtures\GroupDummy:
+'Symfony\Component\Serializer\Tests\Fixtures\GroupDummy':
   attributes:
     foo:
       groups: ['group1', 'group2']
     bar:
       groups: ['group2']
+'Symfony\Component\Serializer\Tests\Fixtures\MaxDepthDummy':
+  attributes:
+    foo:
+      max_depth: 2
+    bar:
+      max_depth: 3

--- a/src/Symfony/Component/Serializer/Tests/Mapping/AttributeMetadataTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/AttributeMetadataTest.php
@@ -40,6 +40,14 @@ class AttributeMetadataTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('a', 'b'), $attributeMetadata->getGroups());
     }
 
+    public function testMaxDepth()
+    {
+        $attributeMetadata = new AttributeMetadata('name');
+        $attributeMetadata->setMaxDepth(69);
+
+        $this->assertEquals(69, $attributeMetadata->getMaxDepth());
+    }
+
     public function testMerge()
     {
         $attributeMetadata1 = new AttributeMetadata('a1');
@@ -49,10 +57,12 @@ class AttributeMetadataTest extends \PHPUnit_Framework_TestCase
         $attributeMetadata2 = new AttributeMetadata('a2');
         $attributeMetadata2->addGroup('a');
         $attributeMetadata2->addGroup('c');
+        $attributeMetadata2->setMaxDepth(2);
 
         $attributeMetadata1->merge($attributeMetadata2);
 
         $this->assertEquals(array('a', 'b', 'c'), $attributeMetadata1->getGroups());
+        $this->assertEquals(2, $attributeMetadata1->getMaxDepth());
     }
 
     public function testSerialize()
@@ -60,6 +70,7 @@ class AttributeMetadataTest extends \PHPUnit_Framework_TestCase
         $attributeMetadata = new AttributeMetadata('attribute');
         $attributeMetadata->addGroup('a');
         $attributeMetadata->addGroup('b');
+        $attributeMetadata->setMaxDepth(3);
 
         $serialized = serialize($attributeMetadata);
         $this->assertEquals($attributeMetadata, unserialize($serialized));

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTest.php
@@ -43,12 +43,22 @@ class AnnotationLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->loader->loadClassMetadata($classMetadata));
     }
 
-    public function testLoadClassMetadata()
+    public function testLoadGroups()
     {
         $classMetadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\GroupDummy');
         $this->loader->loadClassMetadata($classMetadata);
 
         $this->assertEquals(TestClassMetadataFactory::createClassMetadata(), $classMetadata);
+    }
+
+    public function testLoadMaxDepth()
+    {
+        $classMetadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\MaxDepthDummy');
+        $this->loader->loadClassMetadata($classMetadata);
+
+        $attributesMetadata = $classMetadata->getAttributesMetadata();
+        $this->assertEquals(2, $attributesMetadata['foo']->getMaxDepth());
+        $this->assertEquals(3, $attributesMetadata['bar']->getMaxDepth());
     }
 
     public function testLoadClassMetadataAndMerge()

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
@@ -51,4 +51,14 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(TestClassMetadataFactory::createXmlCLassMetadata(), $this->metadata);
     }
+
+    public function testMaxDepth()
+    {
+        $classMetadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\MaxDepthDummy');
+        $this->loader->loadClassMetadata($classMetadata);
+
+        $attributesMetadata = $classMetadata->getAttributesMetadata();
+        $this->assertEquals(2, $attributesMetadata['foo']->getMaxDepth());
+        $this->assertEquals(3, $attributesMetadata['bar']->getMaxDepth());
+    }
 }

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
@@ -66,4 +66,14 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(TestClassMetadataFactory::createXmlCLassMetadata(), $this->metadata);
     }
+
+    public function testMaxDepth()
+    {
+        $classMetadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\MaxDepthDummy');
+        $this->loader->loadClassMetadata($classMetadata);
+
+        $attributesMetadata = $classMetadata->getAttributesMetadata();
+        $this->assertEquals(2, $attributesMetadata['foo']->getMaxDepth());
+        $this->assertEquals(3, $attributesMetadata['bar']->getMaxDepth());
+    }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Tests\Fixtures\CircularReferenceDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\MaxDepthDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\SiblingHolder;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
@@ -494,6 +495,46 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
     {
         $obj = $this->normalizer->denormalize(array('foo' => 'foobar'), __NAMESPACE__.'\ObjectWithPrivateSetterDummy');
         $this->assertEquals('bar', $obj->getFoo());
+    }
+
+    public function testMaxDepth()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $this->normalizer = new GetSetMethodNormalizer($classMetadataFactory);
+        $serializer = new Serializer(array($this->normalizer));
+        $this->normalizer->setSerializer($serializer);
+
+        $level1 = new MaxDepthDummy();
+        $level1->bar = 'level1';
+
+        $level2 = new MaxDepthDummy();
+        $level2->bar = 'level2';
+        $level1->child = $level2;
+
+        $level3 = new MaxDepthDummy();
+        $level3->bar = 'level3';
+        $level2->child = $level3;
+
+        $level4 = new MaxDepthDummy();
+        $level4->bar = 'level4';
+        $level3->child = $level4;
+
+        $result = $serializer->normalize($level1, null, array(GetSetMethodNormalizer::ENABLE_MAX_DEPTH => true));
+
+        $expected = array(
+            'bar' => 'level1',
+            'child' => array(
+                    'bar' => 'level2',
+                    'child' => array(
+                            'bar' => 'level3',
+                            'child' => array(
+                                    'child' => null,
+                                ),
+                        ),
+                ),
+            );
+
+        $this->assertEquals($expected, $result);
     }
 }
 

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -19,9 +19,11 @@
         "php": ">=5.5.9"
     },
     "require-dev": {
-        "symfony/yaml": "~2.8|~3.0",
-        "symfony/config": "~2.8|~3.0",
-        "symfony/property-access": "~2.8|~3.0",
+        "symfony/phpunit-bridge": "~2.7|~3.0.0",
+        "symfony/yaml": "~2.0,>=2.0.5|~3.0.0",
+        "symfony/config": "~2.2|~3.0.0",
+        "symfony/property-access": "~2.3|~3.0.0",
+        "symfony/property-info": "~2.8|~3.0",
         "doctrine/annotations": "~1.0",
         "doctrine/cache": "~1.0"
     },

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -32,7 +32,8 @@
         "doctrine/cache": "For using the default cached annotation reader and metadata cache.",
         "symfony/yaml": "For using the default YAML mapping loader.",
         "symfony/config": "For using the XML mapping loader.",
-        "symfony/property-access": "For using the ObjectNormalizer."
+        "symfony/property-access": "For using the ObjectNormalizer.",
+        "symfony/property-info": "For using recursive denormalizations"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Serializer\\": "" },


### PR DESCRIPTION
[2.7][Serializer] Feature using `PropertyInfo` to recursively denormalize values before calling the setter.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | n/a |

Refactored #14844 "Denormalize with typehinting":
- Now using (optional) PropertyInfo to extract type information
- Updated tests
- Updated composer.json

This PR replaces #16143.
