### PR TITLE
[Bridge/Doctrine] Fix test case

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -1194,15 +1194,18 @@ class EntityTypeTest extends TypeTestCase
             'property3' => 2,
         ));
 
-        $choiceList1 = $form->get('property1')->getConfig()->getOption('choice_list');
-        $choiceList2 = $form->get('property2')->getConfig()->getOption('choice_list');
-        $choiceList3 = $form->get('property3')->getConfig()->getOption('choice_list');
+        $choiceLoader1 = $form->get('property1')->getConfig()->getOption('choice_loader');
+        $choiceLoader2 = $form->get('property2')->getConfig()->getOption('choice_loader');
+        $choiceLoader3 = $form->get('property3')->getConfig()->getOption('choice_loader');
 
-        $this->assertInstanceOf('Symfony\Component\Form\ChoiceList\ChoiceListInterface', $choiceList1);
-        $this->assertSame($choiceList1, $choiceList2);
-        $this->assertSame($choiceList1, $choiceList3);
+        $this->assertInstanceOf('Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface', $choiceLoader1);
+        $this->assertSame($choiceLoader1, $choiceLoader2);
+        $this->assertSame($choiceLoader1, $choiceLoader3);
     }
 
+    /**
+     * @group legacy
+     */
     public function testCacheChoiceLists()
     {
         $entity1 = new SingleIntIdEntity(1, 'Foo');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The choice_list vs choice_loader change is already applied on 3.0,
the `@group legacy` tags a test case that has been already removed in 3.0.
@webmozart or anyone else could you please have a quick look here and confirm it's ok?
