### PR TITLE
bug #14246 [Filesystem] dumpFile() non atomic

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -477,9 +477,9 @@ class Filesystem
             throw new IOException(sprintf('Failed to write file "%s".', $filename));
         }
 
-        $this->rename($tmpFile, $filename, true);
         if (null !== $mode) {
-            $this->chmod($filename, $mode);
+            $this->chmod($tmpFile, $mode);
         }
+        $this->rename($tmpFile, $filename, true);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14246 |
| License | MIT |
| Doc PR | none |

Remove race condition where `dumpFile` has written the resulting file but has not given access yet.
