### PR TITLE
[Yaml] cast arrays to objects after parsing has finished

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -240,10 +240,6 @@ class Parser
                 if ($isRef) {
                     $this->refs[$isRef] = $data[$key];
                 }
-
-                if ($objectForMap && !is_object($data)) {
-                    $data = (object) $data;
-                }
             } else {
                 // multiple documents are not supported
                 if ('---' === $this->currentLine) {
@@ -305,6 +301,10 @@ class Parser
 
         if (isset($mbEncoding)) {
             mb_internal_encoding($mbEncoding);
+        }
+
+        if ($objectForMap && !is_object($data)) {
+            $data = (object) $data;
         }
 
         return empty($data) ? null : $data;
@@ -574,7 +574,7 @@ class Parser
             $previousLineIndented = false;
             $previousLineBlank = false;
 
-            for ($i = 0; $i < count($blockLines); $i++) {
+            for ($i = 0; $i < count($blockLines); ++$i) {
                 if ('' === $blockLines[$i]) {
                     $text .= "\n";
                     $previousLineIndented = false;

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -460,6 +460,15 @@ EOF;
         $this->assertEquals('cat', $result->fiz);
     }
 
+    public function testObjectForMapIsAppliedAfterParsing()
+    {
+        $expected = new \stdClass();
+        $expected->foo = 'bar';
+        $expected->baz = 'foobar';
+
+        $this->assertEquals($expected, $this->parser->parse("foo: bar\nbaz: foobar", false, false, true));
+    }
+
     /**
      * @expectedException \Symfony\Component\Yaml\Exception\ParseException
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17190 |
| License | MIT |
| Doc PR |  |

Casting arrays to objects must happen after the complete YAML string has
been parsed to avoid errors when parsing subsequent lines.
