### PR TITLE
[Twig][Translation] added support for namespaced translation keys.

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
@@ -14,9 +14,11 @@ namespace Symfony\Bridge\Twig\Extension;
 use Symfony\Bridge\Twig\TokenParser\TransTokenParser;
 use Symfony\Bridge\Twig\TokenParser\TransChoiceTokenParser;
 use Symfony\Bridge\Twig\TokenParser\TransDefaultDomainTokenParser;
+use Symfony\Bridge\Twig\TokenParser\TransNamespaceTokenParser;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Bridge\Twig\NodeVisitor\TranslationNodeVisitor;
 use Symfony\Bridge\Twig\NodeVisitor\TranslationDefaultDomainNodeVisitor;
+use Symfony\Bridge\Twig\NodeVisitor\TranslationNamespaceNodeVisitor;
 
 /**
  * Provides integration of the Translation component with Twig.
@@ -72,6 +74,9 @@ class TranslationExtension extends \Twig_Extension
 
             // {% trans_default_domain "foobar" %}
             new TransDefaultDomainTokenParser(),
+
+            // {% trans_namespace "foo" %}
+            new TransNamespaceTokenParser(),
         );
     }
 
@@ -80,7 +85,7 @@ class TranslationExtension extends \Twig_Extension
      */
     public function getNodeVisitors()
     {
-        return array($this->translationNodeVisitor, new TranslationDefaultDomainNodeVisitor());
+        return array($this->translationNodeVisitor, new TranslationDefaultDomainNodeVisitor(), new TranslationNamespaceNodeVisitor());
     }
 
     public function getTranslationNodeVisitor()

--- a/src/Symfony/Bridge/Twig/Node/TransNamespaceNode.php
+++ b/src/Symfony/Bridge/Twig/Node/TransNamespaceNode.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\Node;
+
+/**
+ * @author Abdellatif Ait boudad <a.aitboudad@gmail.com>
+ */
+class TransNamespaceNode extends \Twig_Node
+{
+    public function __construct(\Twig_Node_Expression $expr, $lineno = 0, $tag = null)
+    {
+        parent::__construct(array('expr' => $expr), array(), $lineno, $tag);
+    }
+
+    /**
+     * Compiles the node to PHP.
+     *
+     * @param \Twig_Compiler $compiler A Twig_Compiler instance
+     */
+    public function compile(\Twig_Compiler $compiler)
+    {
+        // noop as this node is just a marker for TransNamespaceTokenParser
+    }
+}

--- a/src/Symfony/Bridge/Twig/NodeVisitor/TranslationNamespaceNodeVisitor.php
+++ b/src/Symfony/Bridge/Twig/NodeVisitor/TranslationNamespaceNodeVisitor.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\NodeVisitor;
+
+use Symfony\Bridge\Twig\Node\TransNode;
+use Symfony\Bridge\Twig\Node\TransNamespaceNode;
+
+/**
+ * @author Abdellatif Ait boudad <a.aitboudad@gmail.com>
+ */
+class TranslationNamespaceNodeVisitor extends \Twig_BaseNodeVisitor
+{
+    /**
+     * @var Scope
+     */
+    private $scope;
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->scope = new Scope();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doEnterNode(\Twig_Node $node, \Twig_Environment $env)
+    {
+        if ($node instanceof \Twig_Node_Block || $node instanceof \Twig_Node_Module) {
+            $this->scope = $this->scope->enter();
+        }
+
+        if ($node instanceof TransNamespaceNode) {
+            if ($node->getNode('expr') instanceof \Twig_Node_Expression_Constant) {
+                $this->scope->set('namespace', $node->getNode('expr'));
+
+                return $node;
+            } else {
+                $var = $env->getParser()->getVarName();
+                $name = new \Twig_Node_Expression_AssignName($var, $node->getLine());
+                $this->scope->set('namespace', new \Twig_Node_Expression_Name($var, $node->getLine()));
+
+                return new \Twig_Node_Set(false, new \Twig_Node(array($name)), new \Twig_Node(array($node->getNode('expr'))), $node->getLine());
+            }
+        }
+
+        if (!$this->scope->has('namespace')) {
+            return $node;
+        }
+
+        $namespace = $this->scope->get('namespace')->getAttribute('value');
+        if ($node instanceof \Twig_Node_Expression_Filter && in_array($node->getNode('filter')->getAttribute('value'), array('trans', 'transchoice'))) {
+            $message = $node->getNode('node')->getAttribute('value');
+            $node->getNode('node')->setAttribute('value', $namespace.$message);
+        } elseif ($node instanceof TransNode) {
+            $message = $node->getNode('body')->getAttribute('data');
+            $node->getNode('body')->setAttribute('data', $namespace.$message);
+        }
+
+        return $node;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doLeaveNode(\Twig_Node $node, \Twig_Environment $env)
+    {
+        if ($node instanceof TransNamespaceNode) {
+            return false;
+        }
+
+        if ($node instanceof \Twig_Node_Block || $node instanceof \Twig_Node_Module) {
+            $this->scope = $this->scope->leave();
+        }
+
+        return $node;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        return -10;
+    }
+}

--- a/src/Symfony/Bridge/Twig/Tests/NodeVisitor/TranslationNamespaceNodeVisitorTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/NodeVisitor/TranslationNamespaceNodeVisitorTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\Tests\NodeVisitor;
+
+use Symfony\Bridge\Twig\NodeVisitor\TranslationNamespaceNodeVisitor;
+use Symfony\Bridge\Twig\NodeVisitor\TranslationNodeVisitor;
+
+class TranslationNamespaceNodeVisitorTest extends \PHPUnit_Framework_TestCase
+{
+    private static $namespace = 'foo';
+    private static $message = '.message';
+
+    /** @dataProvider getNamespaceAssignmentTestData */
+    public function testNamespaceAssignment(\Twig_Node $node)
+    {
+        $env = new \Twig_Environment($this->getMock('Twig_LoaderInterface'), array('cache' => false, 'autoescape' => false, 'optimizations' => 0));
+        $visitor = new TranslationNamespaceNodeVisitor();
+
+        // visit trans_namespace tag
+        $namespace = TwigNodeProvider::getTransNamespaceTag(self::$namespace);
+        $visitor->enterNode($namespace, $env);
+        $visitor->leaveNode($namespace, $env);
+
+        // visit tested node
+        $enteredNode = $visitor->enterNode($node, $env);
+        $leavedNode = $visitor->leaveNode($node, $env);
+        $this->assertSame($node, $enteredNode);
+        $this->assertSame($node, $leavedNode);
+
+        // extracting tested node messages
+        $visitor = new TranslationNodeVisitor();
+        $visitor->enable();
+        $visitor->enterNode($node, $env);
+        $visitor->leaveNode($node, $env);
+
+        $this->assertEquals([[self::$namespace.self::$message, null]], $visitor->getMessages());
+    }
+
+    public function getNamespaceAssignmentTestData()
+    {
+        return array(
+            array(TwigNodeProvider::getTransFilter(self::$message)),
+            array(TwigNodeProvider::getTransChoiceFilter(self::$message)),
+            array(TwigNodeProvider::getTransTag(self::$message)),
+            // with named arguments
+            array(TwigNodeProvider::getTransFilter(self::$message, null, array(
+                'arguments' => new \Twig_Node_Expression_Array(array(), 0),
+            ))),
+            array(TwigNodeProvider::getTransChoiceFilter(self::$message), null, array(
+                'arguments' => new \Twig_Node_Expression_Array(array(), 0),
+            )),
+        );
+    }
+}

--- a/src/Symfony/Bridge/Twig/Tests/NodeVisitor/TwigNodeProvider.php
+++ b/src/Symfony/Bridge/Twig/Tests/NodeVisitor/TwigNodeProvider.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Twig\Tests\NodeVisitor;
 
 use Symfony\Bridge\Twig\Node\TransDefaultDomainNode;
+use Symfony\Bridge\Twig\Node\TransNamespaceNode;
 use Symfony\Bridge\Twig\Node\TransNode;
 
 class TwigNodeProvider
@@ -76,6 +77,13 @@ class TwigNodeProvider
     {
         return new TransDefaultDomainNode(
             new \Twig_Node_Expression_Constant($domain, 0)
+        );
+    }
+
+    public static function getTransNamespaceTag($namespace)
+    {
+        return new TransNamespaceNode(
+            new \Twig_Node_Expression_Constant($namespace, 0)
         );
     }
 }

--- a/src/Symfony/Bridge/Twig/TokenParser/TransNamespaceTokenParser.php
+++ b/src/Symfony/Bridge/Twig/TokenParser/TransNamespaceTokenParser.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\TokenParser;
+
+use Symfony\Bridge\Twig\Node\TransNamespaceNode;
+
+/**
+ * Token Parser for the 'trans_namespace' tag.
+ *
+ * @author Abdellatif Ait boudad <a.aitboudad@gmail.com>
+ */
+class TransNamespaceTokenParser extends \Twig_TokenParser
+{
+    /**
+     * Parses a token and returns a node.
+     *
+     * @param \Twig_Token $token A Twig_Token instance
+     *
+     * @return \Twig_Node A Twig_Node instance
+     */
+    public function parse(\Twig_Token $token)
+    {
+        $expr = $this->parser->getExpressionParser()->parseExpression();
+
+        $this->parser->getStream()->expect(\Twig_Token::BLOCK_END_TYPE);
+
+        return new TransNamespaceNode($expr, $token->getLine(), $this->getTag());
+    }
+
+    /**
+     * Gets the tag name associated with this token parser.
+     *
+     * @return string The tag name
+     */
+    public function getTag()
+    {
+        return 'trans_namespace';
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | n/a |

Before:

``` twig
{% block body %}
    {{ 'admin.menu.home'|trans }}
    {{ 'admin.menu.blog'|trans }}
{% endblock %}
```

After:

``` twig
{% trans_namespace "admin.menu" %}
{% block body %}
    {{ '.home'|trans }}
    {{ '.blog'|trans }}
{% endblock %}
```
