### PR TITLE
Updated copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Bridge/Doctrine/LICENSE
+++ b/src/Symfony/Bridge/Doctrine/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Bridge/Monolog/LICENSE
+++ b/src/Symfony/Bridge/Monolog/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Bridge/PhpUnit/LICENSE
+++ b/src/Symfony/Bridge/PhpUnit/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2015 Fabien Potencier
+Copyright (c) 2014-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Bridge/ProxyManager/LICENSE
+++ b/src/Symfony/Bridge/ProxyManager/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Bridge/Twig/LICENSE
+++ b/src/Symfony/Bridge/Twig/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Bundle/DebugBundle/Resources/meta/LICENSE
+++ b/src/Symfony/Bundle/DebugBundle/Resources/meta/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2015 Fabien Potencier
+Copyright (c) 2014-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/meta/LICENSE
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/meta/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Bundle/SecurityBundle/Resources/meta/LICENSE
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/meta/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Bundle/TwigBundle/Resources/meta/LICENSE
+++ b/src/Symfony/Bundle/TwigBundle/Resources/meta/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/meta/LICENSE
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/meta/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/Asset/LICENSE
+++ b/src/Symfony/Component/Asset/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/BrowserKit/LICENSE
+++ b/src/Symfony/Component/BrowserKit/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/ClassLoader/LICENSE
+++ b/src/Symfony/Component/ClassLoader/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/Config/LICENSE
+++ b/src/Symfony/Component/Config/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/Console/LICENSE
+++ b/src/Symfony/Component/Console/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/CssSelector/LICENSE
+++ b/src/Symfony/Component/CssSelector/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/Debug/LICENSE
+++ b/src/Symfony/Component/Debug/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/DependencyInjection/LICENSE
+++ b/src/Symfony/Component/DependencyInjection/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/DomCrawler/LICENSE
+++ b/src/Symfony/Component/DomCrawler/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/EventDispatcher/LICENSE
+++ b/src/Symfony/Component/EventDispatcher/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/ExpressionLanguage/LICENSE
+++ b/src/Symfony/Component/ExpressionLanguage/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/Filesystem/LICENSE
+++ b/src/Symfony/Component/Filesystem/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/Finder/LICENSE
+++ b/src/Symfony/Component/Finder/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/Form/LICENSE
+++ b/src/Symfony/Component/Form/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/HttpFoundation/LICENSE
+++ b/src/Symfony/Component/HttpFoundation/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/HttpKernel/LICENSE
+++ b/src/Symfony/Component/HttpKernel/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/Intl/LICENSE
+++ b/src/Symfony/Component/Intl/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/Ldap/LICENSE
+++ b/src/Symfony/Component/Ldap/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/OptionsResolver/LICENSE
+++ b/src/Symfony/Component/OptionsResolver/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/Process/LICENSE
+++ b/src/Symfony/Component/Process/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/PropertyAccess/LICENSE
+++ b/src/Symfony/Component/PropertyAccess/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/PropertyInfo/LICENSE
+++ b/src/Symfony/Component/PropertyInfo/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015 Fabien Potencier
+Copyright (c) 2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/Routing/LICENSE
+++ b/src/Symfony/Component/Routing/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/Security/Core/LICENSE
+++ b/src/Symfony/Component/Security/Core/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/Security/Csrf/LICENSE
+++ b/src/Symfony/Component/Security/Csrf/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/Security/Guard/LICENSE
+++ b/src/Symfony/Component/Security/Guard/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/Security/Http/LICENSE
+++ b/src/Symfony/Component/Security/Http/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/Security/LICENSE
+++ b/src/Symfony/Component/Security/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/Serializer/LICENSE
+++ b/src/Symfony/Component/Serializer/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/Stopwatch/LICENSE
+++ b/src/Symfony/Component/Stopwatch/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/Templating/LICENSE
+++ b/src/Symfony/Component/Templating/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/Translation/LICENSE
+++ b/src/Symfony/Component/Translation/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/Validator/LICENSE
+++ b/src/Symfony/Component/Validator/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/VarDumper/LICENSE
+++ b/src/Symfony/Component/VarDumper/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2015 Fabien Potencier
+Copyright (c) 2014-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Symfony/Component/Yaml/LICENSE
+++ b/src/Symfony/Component/Yaml/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2015 Fabien Potencier
+Copyright (c) 2004-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Happy new year to you all! I updated the copyright years in all license
files.

PS. #17239 (and the many others) only cover the main LICENSE file, but this one is more thorough. I might have missed some, but I couldn't find any other occurrences of '2015'
