### PR TITLE
Fix toolbar display when nvd3 is loaded on page

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -20,6 +20,7 @@
 .sf-minitoolbar img {
     max-height: 24px;
     max-width: 24px;
+    display: inline;
 }
 
 .sf-toolbarreset * {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | not applicable |

Minor CSS fix for the toolbar, as nvd3 sets `svg { display: block }` so you end up with something like:

![image](https://cloud.githubusercontent.com/assets/183678/12079564/974aa694-b235-11e5-897e-ecb31ba20f26.png)
