### PR TITLE
[Form] fixed DateTimeType tests using "date_widget"="choice".

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -29,6 +29,7 @@ class DateTimeTypeTest extends TestCase
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'date_widget' => 'choice',
+            'years' => array(2010),
             'time_widget' => 'choice',
             'input' => 'datetime',
         ));
@@ -57,6 +58,7 @@ class DateTimeTypeTest extends TestCase
             'view_timezone' => 'UTC',
             'input' => 'string',
             'date_widget' => 'choice',
+            'years' => array(2010),
             'time_widget' => 'choice',
         ));
 
@@ -82,6 +84,7 @@ class DateTimeTypeTest extends TestCase
             'view_timezone' => 'UTC',
             'input' => 'timestamp',
             'date_widget' => 'choice',
+            'years' => array(2010),
             'time_widget' => 'choice',
         ));
 
@@ -108,12 +111,13 @@ class DateTimeTypeTest extends TestCase
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'date_widget' => 'choice',
+            'years' => array(2010),
             'time_widget' => 'choice',
             'input' => 'datetime',
             'with_minutes' => false,
         ));
 
-        $form->setData(new \DateTime('2010-06-02 03:04:05 UTC'));
+        $form->setData(new \DateTime());
 
         $input = array(
             'date' => array(
@@ -137,12 +141,13 @@ class DateTimeTypeTest extends TestCase
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'date_widget' => 'choice',
+            'years' => array(2010),
             'time_widget' => 'choice',
             'input' => 'datetime',
             'with_seconds' => true,
         ));
 
-        $form->setData(new \DateTime('2010-06-02 03:04:05 UTC'));
+        $form->setData(new \DateTime());
 
         $input = array(
             'date' => array(
@@ -168,6 +173,7 @@ class DateTimeTypeTest extends TestCase
             'model_timezone' => 'America/New_York',
             'view_timezone' => 'Pacific/Tahiti',
             'date_widget' => 'choice',
+            'years' => array(2010),
             'time_widget' => 'choice',
             'input' => 'string',
             'with_seconds' => true,

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -187,6 +187,7 @@ class DateTypeTest extends TestCase
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'choice',
+            'years' => array(2010),
         ));
 
         $text = array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | no |
| License | MIT |
| Doc PR | no |

As said in the [documentation](http://symfony.com/doc/current/reference/forms/types/datetime.html#years), the default years available in the `DateType` go from five year before to five year after the current year. So now that it's 2016 all around, the tests which use the `"date_widget"="choice"` without defining a `"years"` option and tries to submit a date in 2010 are failing because 2010 is not in the default choice list.

This PR fixes the issue by setting the `"years"` option to `"2010"` for each test that need it. It also remove unnecessary (and confusing) dummy data from some tests which were suffering the same issue but silently.

Edit : The PHP 5.6 build on travis seems to fetch and run some old version of the tests. So it still fail on this build but not on the others anymore.
