### PR TITLE
[Console] HHVM read input stream bug

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -437,8 +437,8 @@ class QuestionHelper extends Helper
      */
     private function readFromInput($stream)
     {
-        if (STDIN === $stream && function_exists('readline') && !defined('HHVM_VERSION')) {
-            $ret = readline();
+        if (STDIN === $stream && function_exists('readline')) {
+            $ret = readline('');
         } else {
             $ret = fgets($stream, 4096);
         }

--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -437,7 +437,7 @@ class QuestionHelper extends Helper
      */
     private function readFromInput($stream)
     {
-        if (STDIN === $stream && function_exists('readline')) {
+        if (STDIN === $stream && function_exists('readline') && !defined('HHVM_VERSION')) {
             $ret = readline();
         } else {
             $ret = fgets($stream, 4096);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [yes] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| License | MIT |

HHVM readline() function requires a parameter  see:

https://github.com/facebook/hhvm/blob/master/hphp/runtime/ext/readline/ext_readline.php

But the php readline does not require one.

```
In   Symfony\Component\Console\Helper\QuestionHelper
 …
 readFromInput($stream)
 …
```

we use readline() without a parameter.

HHVM Version:

```
HipHop VM 3.10.1 (rel)
Compiler: tags/HHVM-3.10.1-0-g689b4969a141620ee5a282ce0dbf72278c84d44b
Repo schema: 6c99ee1f98340f6f3ef397a332583f0e843a627d
```

Docker Container: 

```
docker run --rm -it -v `pwd`:`pwd` -w `pwd` brunoric/hhvm:deb hhvm test.php ls 
```

Test.php

```
<?php
use Symfony\Component\Console\Application;
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Input\InputArgument;
use Symfony\Component\Console\Input\InputOption;
use Symfony\Component\Console\Output\OutputInterface;
use Symfony\Component\Console\Question\Question;

use Symfony\Component\Console\Helper\QuestionHelper;

require_once  "vendor/autoload.php";

$console = new Application();

$console
    ->register('ls')
    ->setDescription('Try input')
    ->setCode(function (InputInterface $input, OutputInterface $output) {

        $question = new Question('Your email address: ');
        $question->setValidator(
            function ($answer) {
                return $answer;
            }
        );
        $question->setMaxAttempts(5);
            $helper = new QuestionHelper();
          $email = $helper->ask($input, $output, $question);

        $output->writeln(sprintf('Email Adress: <info>%s</info>', $email));
    })
;
$console->run();
```

composer.json

```
{
    "require": {
        "symfony/console": "^3.0"
    }
}
```

Result:
No input is possible and you got a warning 

```
Your email address: 
Warning: readline() expects exactly 1 parameter, 0 given in /clitest/vendor/symfony/console/Helper/QuestionHelper.php on line 436
Email Adress:
```

Fix:
Add a empty string parameter to  readline() or use fgets() for hhvm.
