### PR TITLE
[Console][2.3] ApplicationTester - test stdout and stderr

### DIFF
--- a/src/Symfony/Component/Console/Output/ConsoleOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleOutput.php
@@ -14,15 +14,16 @@ namespace Symfony\Component\Console\Output;
 use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 
 /**
- * ConsoleOutput is the default class for all CLI output. It uses STDOUT.
+ * ConsoleOutput is the default class for all CLI output. It uses STDOUT and STDERR.
  *
- * This class is a convenient wrapper around `StreamOutput`.
+ * This class is a convenient wrapper around `StreamOutput` for both STDOUT and STDERR.
  *
  *     $output = new ConsoleOutput();
  *
  * This is equivalent to:
  *
  *     $output = new StreamOutput(fopen('php://stdout', 'w'));
+ *     $stdErr = new StreamOutput(fopen('php://stderr', 'w'));
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
@@ -139,9 +140,11 @@ class ConsoleOutput extends StreamOutput implements ConsoleOutputInterface
      */
     private function openOutputStream()
     {
-        $outputStream = $this->hasStdoutSupport() ? 'php://stdout' : 'php://output';
+        if (!$this->hasStdoutSupport()) {
+            return fopen('php://output', 'w');
+        }
 
-        return @fopen($outputStream, 'w') ?: fopen('php://output', 'w');
+        return @fopen('php://stdout', 'w') ?: fopen('php://output', 'w');
     }
 
     /**
@@ -149,8 +152,6 @@ class ConsoleOutput extends StreamOutput implements ConsoleOutputInterface
      */
     private function openErrorStream()
     {
-        $errorStream = $this->hasStderrSupport() ? 'php://stderr' : 'php://output';
-
-        return fopen($errorStream, 'w');
+        return fopen($this->hasStderrSupport() ? 'php://stderr' : 'php://output', 'w');
     }
 }

--- a/src/Symfony/Component/Console/Tester/ApplicationTester.php
+++ b/src/Symfony/Component/Console/Tester/ApplicationTester.php
@@ -37,7 +37,7 @@ class ApplicationTester
      * @var OutputInterface
      */
     private $output;
-    private $captureOutputStreamsIndependent = false;
+    private $captureStreamsIndependently = false;
 
     public function __construct(Application $application)
     {
@@ -66,8 +66,8 @@ class ApplicationTester
             $this->input->setInteractive($options['interactive']);
         }
 
-        $this->captureOutputStreamsIndependent = array_key_exists('capture_stderr_separately', $options) && $options['capture_stderr_separately'];
-        if (!$this->captureOutputStreamsIndependent) {
+        $this->captureStreamsIndependently = array_key_exists('capture_stderr_separately', $options) && $options['capture_stderr_separately'];
+        if (!$this->captureStreamsIndependently) {
             $this->output = new StreamOutput(fopen('php://memory', 'w', false));
             if (isset($options['decorated'])) {
                 $this->output->setDecorated($options['decorated']);
@@ -129,8 +129,8 @@ class ApplicationTester
      */
     public function getErrorOutput($normalize = false)
     {
-        if (!$this->captureOutputStreamsIndependent) {
-            throw new \LogicException('Error output not available when tester run without "capture_stderr_separately" option set.');
+        if (!$this->captureStreamsIndependently) {
+            throw new \LogicException('The error output is not available when the tester is run without "capture_stderr_separately" option set.');
         }
 
         rewind($this->output->getErrorOutput()->getStream());

--- a/src/Symfony/Component/Console/Tester/ApplicationTester.php
+++ b/src/Symfony/Component/Console/Tester/ApplicationTester.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Console\Tester;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 
@@ -31,13 +32,13 @@ class ApplicationTester
 {
     private $application;
     private $input;
-    private $output;
 
     /**
-     * Constructor.
-     *
-     * @param Application $application An Application instance to test.
+     * @var OutputInterface
      */
+    private $output;
+    private $captureOutputStreamsIndependent = false;
+
     public function __construct(Application $application)
     {
         $this->application = $application;
@@ -48,9 +49,10 @@ class ApplicationTester
      *
      * Available options:
      *
-     *  * interactive: Sets the input interactive flag
-     *  * decorated:   Sets the output decorated flag
-     *  * verbosity:   Sets the output verbosity flag
+     *  * interactive:               Sets the input interactive flag
+     *  * decorated:                 Sets the output decorated flag
+     *  * verbosity:                 Sets the output verbosity flag
+     *  * capture_stderr_separately: Make output of stdOut and stdErr separately available
      *
      * @param array $input   An array of arguments and options
      * @param array $options An array of options
@@ -64,12 +66,35 @@ class ApplicationTester
             $this->input->setInteractive($options['interactive']);
         }
 
-        $this->output = new StreamOutput(fopen('php://memory', 'w', false));
-        if (isset($options['decorated'])) {
-            $this->output->setDecorated($options['decorated']);
-        }
-        if (isset($options['verbosity'])) {
-            $this->output->setVerbosity($options['verbosity']);
+        $this->captureOutputStreamsIndependent = array_key_exists('capture_stderr_separately', $options) && $options['capture_stderr_separately'];
+        if (!$this->captureOutputStreamsIndependent) {
+            $this->output = new StreamOutput(fopen('php://memory', 'w', false));
+            if (isset($options['decorated'])) {
+                $this->output->setDecorated($options['decorated']);
+            }
+            if (isset($options['verbosity'])) {
+                $this->output->setVerbosity($options['verbosity']);
+            }
+        } else {
+            $this->output = new ConsoleOutput(
+                isset($options['verbosity']) ? $options['verbosity'] : ConsoleOutput::VERBOSITY_NORMAL,
+                isset($options['decorated']) ? $options['decorated'] : null
+            );
+
+            $errorOutput = new StreamOutput(fopen('php://memory', 'w', false));
+            $errorOutput->setFormatter($this->output->getFormatter());
+            $errorOutput->setVerbosity($this->output->getVerbosity());
+            $errorOutput->setDecorated($this->output->isDecorated());
+
+            $reflectedOutput = new \ReflectionObject($this->output);
+            $strErrProperty = $reflectedOutput->getProperty('stderr');
+            $strErrProperty->setAccessible(true);
+            $strErrProperty->setValue($this->output, $errorOutput);
+
+            $reflectedParent = $reflectedOutput->getParentClass();
+            $streamProperty = $reflectedParent->getProperty('stream');
+            $streamProperty->setAccessible(true);
+            $streamProperty->setValue($this->output, fopen('php://memory', 'w', false));
         }
 
         return $this->application->run($this->input, $this->output);
@@ -87,6 +112,30 @@ class ApplicationTester
         rewind($this->output->getStream());
 
         $display = stream_get_contents($this->output->getStream());
+
+        if ($normalize) {
+            $display = str_replace(PHP_EOL, "\n", $display);
+        }
+
+        return $display;
+    }
+
+    /**
+     * Gets the output written to STDERR by the application.
+     *
+     * @param bool $normalize Whether to normalize end of lines to \n or not
+     *
+     * @return string
+     */
+    public function getErrorOutput($normalize = false)
+    {
+        if (!$this->captureOutputStreamsIndependent) {
+            throw new \LogicException('Error output not available when tester run without "capture_stderr_separately" option set.');
+        }
+
+        rewind($this->output->getErrorOutput()->getStream());
+
+        $display = stream_get_contents($this->output->getErrorOutput()->getStream());
 
         if ($normalize) {
             $display = str_replace(PHP_EOL, "\n", $display);

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -411,8 +411,9 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $tester = new ApplicationTester($application);
 
         $application->setCatchExceptions(true);
-        $tester->run(array('command' => 'foo'), array('decorated' => false));
-        $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception1.txt', $tester->getDisplay(true), '->setCatchExceptions() sets the catch exception flag');
+        $tester->run(array('command' => 'foo'), array('decorated' => false, 'capture_stderr_separately' => true));
+        $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception1.txt', $tester->getErrorOutput(true), '->setCatchExceptions() sets the catch exception flag');
+        $this->assertSame('', $tester->getDisplay(true));
 
         $application->setCatchExceptions(false);
         try {
@@ -461,22 +462,22 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(120));
         $tester = new ApplicationTester($application);
 
-        $tester->run(array('command' => 'foo'), array('decorated' => false));
-        $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception1.txt', $tester->getDisplay(true), '->renderException() renders a pretty exception');
+        $tester->run(array('command' => 'foo'), array('decorated' => false, 'capture_stderr_separately' => true));
+        $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception1.txt', $tester->getErrorOutput(true), '->renderException() renders a pretty exception');
 
-        $tester->run(array('command' => 'foo'), array('decorated' => false, 'verbosity' => Output::VERBOSITY_VERBOSE));
-        $this->assertContains('Exception trace', $tester->getDisplay(), '->renderException() renders a pretty exception with a stack trace when verbosity is verbose');
+        $tester->run(array('command' => 'foo'), array('decorated' => false, 'verbosity' => Output::VERBOSITY_VERBOSE, 'capture_stderr_separately' => true));
+        $this->assertContains('Exception trace', $tester->getErrorOutput(), '->renderException() renders a pretty exception with a stack trace when verbosity is verbose');
 
-        $tester->run(array('command' => 'list', '--foo' => true), array('decorated' => false));
-        $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception2.txt', $tester->getDisplay(true), '->renderException() renders the command synopsis when an exception occurs in the context of a command');
+        $tester->run(array('command' => 'list', '--foo' => true), array('decorated' => false, 'capture_stderr_separately' => true));
+        $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception2.txt', $tester->getErrorOutput(true), '->renderException() renders the command synopsis when an exception occurs in the context of a command');
 
         $application->add(new \Foo3Command());
         $tester = new ApplicationTester($application);
-        $tester->run(array('command' => 'foo3:bar'), array('decorated' => false));
-        $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception3.txt', $tester->getDisplay(true), '->renderException() renders a pretty exceptions with previous exceptions');
+        $tester->run(array('command' => 'foo3:bar'), array('decorated' => false, 'capture_stderr_separately' => true));
+        $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception3.txt', $tester->getErrorOutput(true), '->renderException() renders a pretty exceptions with previous exceptions');
 
-        $tester->run(array('command' => 'foo3:bar'), array('decorated' => true));
-        $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception3decorated.txt', $tester->getDisplay(true), '->renderException() renders a pretty exceptions with previous exceptions');
+        $tester->run(array('command' => 'foo3:bar'), array('decorated' => true, 'capture_stderr_separately' => true));
+        $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception3decorated.txt', $tester->getErrorOutput(true), '->renderException() renders a pretty exceptions with previous exceptions');
 
         $application = $this->getMock('Symfony\Component\Console\Application', array('getTerminalWidth'));
         $application->setAutoExit(false);
@@ -485,8 +486,8 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(32));
         $tester = new ApplicationTester($application);
 
-        $tester->run(array('command' => 'foo'), array('decorated' => false));
-        $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception4.txt', $tester->getDisplay(true), '->renderException() wraps messages when they are bigger than the terminal');
+        $tester->run(array('command' => 'foo'), array('decorated' => false,  'capture_stderr_separately' => true));
+        $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception4.txt', $tester->getErrorOutput(true), '->renderException() wraps messages when they are bigger than the terminal');
     }
 
     /**
@@ -504,11 +505,11 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         });
         $tester = new ApplicationTester($application);
 
-        $tester->run(array('command' => 'foo'), array('decorated' => false));
-        $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception_doublewidth1.txt', $tester->getDisplay(true), '->renderException() renders a pretty exceptions with previous exceptions');
+        $tester->run(array('command' => 'foo'), array('decorated' => false, 'capture_stderr_separately' => true));
+        $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception_doublewidth1.txt', $tester->getErrorOutput(true), '->renderException() renders a pretty exceptions with previous exceptions');
 
-        $tester->run(array('command' => 'foo'), array('decorated' => true));
-        $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception_doublewidth1decorated.txt', $tester->getDisplay(true), '->renderException() renders a pretty exceptions with previous exceptions');
+        $tester->run(array('command' => 'foo'), array('decorated' => true, 'capture_stderr_separately' => true));
+        $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception_doublewidth1decorated.txt', $tester->getErrorOutput(true), '->renderException() renders a pretty exceptions with previous exceptions');
 
         $application = $this->getMock('Symfony\Component\Console\Application', array('getTerminalWidth'));
         $application->setAutoExit(false);
@@ -519,8 +520,8 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
             throw new \Exception('コマンドの実行中にエラーが発生しました。');
         });
         $tester = new ApplicationTester($application);
-        $tester->run(array('command' => 'foo'), array('decorated' => false));
-        $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception_doublewidth2.txt', $tester->getDisplay(true), '->renderException() wraps messages when they are bigger than the terminal');
+        $tester->run(array('command' => 'foo'), array('decorated' => false, 'capture_stderr_separately' => true));
+        $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception_doublewidth2.txt', $tester->getErrorOutput(true), '->renderException() wraps messages when they are bigger than the terminal');
     }
 
     public function testRun()
@@ -622,8 +623,8 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $application = $this->getMock('Symfony\Component\Console\Application', array('doRun'));
         $application->setAutoExit(false);
         $application->expects($this->once())
-             ->method('doRun')
-             ->will($this->throwException($exception));
+            ->method('doRun')
+            ->will($this->throwException($exception));
 
         $exitCode = $application->run(new ArrayInput(array()), new NullOutput());
 
@@ -637,8 +638,8 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $application = $this->getMock('Symfony\Component\Console\Application', array('doRun'));
         $application->setAutoExit(false);
         $application->expects($this->once())
-             ->method('doRun')
-             ->will($this->throwException($exception));
+            ->method('doRun')
+            ->will($this->throwException($exception));
 
         $exitCode = $application->run(new ArrayInput(array()), new NullOutput());
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

Currently it is not possible to test application output of both `stdout` _and_ `stderr` using the `ApplicationTester`. This makes it hard to check if an application writes to the correct output.
