### PR TITLE
[AssetsHelper] use proper class to fetch asset version strategy property

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/AssetsHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/AssetsHelper.php
@@ -94,8 +94,13 @@ class AssetsHelper extends Helper
     {
         if ($version) {
             $package = $this->packages->getPackage($packageName);
+            $class = new \ReflectionClass($package);
 
-            $v = new \ReflectionProperty($package, 'versionStrategy');
+            while ('Symfony\Component\Asset\Package' !== $class->getName()) {
+                $class = $class->getParentClass();
+            }
+
+            $v = $class->getProperty('versionStrategy');
             $v->setAccessible(true);
 
             $currentVersionStrategy = $v->getValue($package);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [yes] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | no] |
| Tests pass? | [yes] |
| Fixed tickets | [https://github.com/symfony/symfony/issues/17259] |
| License | MIT |
| Doc PR |  |
