### PR TITLE
[FrameworkBundle] Add case in Kernel directory guess for PHPUnit

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -83,6 +83,10 @@ abstract class KernelTestCase extends \PHPUnit_Framework_TestCase
                 $argPath = substr($testArg, strlen('--configuration='));
                 $dir = realpath($argPath);
                 break;
+            } elseif (strpos($testArg, '-c') === 0) {
+                $argPath = substr($testArg, strlen('-c'));
+                $dir = realpath($argPath);
+                break;
             }
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The current automatic guess of the Kernel directory in the context of PHPUnit does work properly using the following commands:
- `phpunit -c app`
- `phpunit --configuration app`
- `phpunit --configuration=app`

But it fails with the synthax `phpunit -capp`, even if PHPUnit supports it. This PR fixes this.
