### PR TITLE
[PhpUnitBridge] Re-enable the garbage collector

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/README.md
+++ b/src/Symfony/Bridge/PhpUnit/README.md
@@ -5,7 +5,6 @@ Provides utilities for PHPUnit, especially user deprecation notices management.
 
 It comes with the following features:
 
- * disable the garbage collector;
  * enforce a consistent `C` locale;
  * auto-register `class_exists` to load Doctrine annotations;
  * print a user deprecation notices summary at the end of the test suite.

--- a/src/Symfony/Bridge/PhpUnit/bootstrap.php
+++ b/src/Symfony/Bridge/PhpUnit/bootstrap.php
@@ -17,12 +17,6 @@ if (!defined('PHPUNIT_COMPOSER_INSTALL') && !class_exists('PHPUnit_TextUI_Comman
     return;
 }
 
-if (PHP_VERSION_ID >= 50400 && gc_enabled()) {
-    // Disabling Zend Garbage Collection to prevent segfaults with PHP5.4+
-    // https://bugs.php.net/bug.php?id=53976
-    gc_disable();
-}
-
 // Enforce a consistent locale
 setlocale(LC_ALL, 'C');
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17268, #15541, #11566 |
| License | MIT |
| Doc PR | - |

The bug is fixed in PHP and disabling the gc causes issues elsewhere.
