### PR TITLE
[2.7][FrameworkBundle] Add case in Kernel directory guess for PHPUnit

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -79,8 +79,12 @@ abstract class KernelTestCase extends \PHPUnit_Framework_TestCase
             if (preg_match('/^-[^ \-]*c$/', $testArg) || $testArg === '--configuration') {
                 $dir = realpath($reversedArgs[$argIndex - 1]);
                 break;
-            } elseif (strpos($testArg, '--configuration=') === 0) {
+            } elseif (0 === strpos($testArg, '--configuration=')) {
                 $argPath = substr($testArg, strlen('--configuration='));
+                $dir = realpath($argPath);
+                break;
+            } elseif (0 === strpos($testArg, '-c')) {
+                $argPath = substr($testArg, strlen('-c'));
                 $dir = realpath($argPath);
                 break;
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The current automatic guess of the Kernel directory in the context of PHPUnit does work properly using the following commands:
- `phpunit -c app`
- `phpunit --configuration app`
- `phpunit --configuration=app`

But it fails with the synthax `phpunit -capp`, even if PHPUnit supports it. This PR fixes this.

See https://github.com/symfony/symfony/pull/17272.
