### PR TITLE
[WebProfilerBundle] Add main template in twig toolbar

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/twig.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/twig.html.twig
@@ -10,6 +10,10 @@
 
     {% set text %}
         <div class="sf-toolbar-info-piece">
+            <b>Main Template</b>
+            <span>{{ collector.templates|keys|first }}</span>
+        </div>
+        <div class="sf-toolbar-info-piece">
             <b>Render Time</b>
             <span>{{ time }} ms</span>
         </div>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Before :
<img width="149" alt="web profiler twig toolbar before" src="https://cloud.githubusercontent.com/assets/758625/12141721/483f4df4-b472-11e5-92b2-41affe91591e.png">

After:
<img width="241" alt="web profiler twig toolbar after" src="https://cloud.githubusercontent.com/assets/758625/12141722/48413718-b472-11e5-860b-c69e42460fe6.png">
