### PR TITLE
[Serializer] Unset object_to_populate after using it

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -279,7 +279,7 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
      * Instantiates an object using constructor parameters when needed.
      *
      * This method also allows to denormalize data into an existing object if
-     * it is present in the context with the object_to_populate key.
+     * it is present in the context with the object_to_populate key then remove this key.
      *
      * @param array            $data
      * @param string           $class
@@ -298,7 +298,10 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
             is_object($context['object_to_populate']) &&
             $class === get_class($context['object_to_populate'])
         ) {
-            return $context['object_to_populate'];
+            $object = $context['object_to_populate'];
+            unset($context['object_to_populate']);
+
+            return $object;
         }
 
         $constructor = $reflectionClass->getConstructor();

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -279,7 +279,9 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
      * Instantiates an object using constructor parameters when needed.
      *
      * This method also allows to denormalize data into an existing object if
-     * it is present in the context with the object_to_populate key then remove this key.
+     * it is present in the context with the object_to_populate. This object
+     * is removed from the context before being returned to avoid side effects
+     * when recursively normalizing an object graph.
      *
      * @param array            $data
      * @param string           $class


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

The `object_to_populate` key must be unset after using it to avoid problems when normalizing sub objects. Needed for #17193.
