### PR TITLE
[HttpFoundation] Add missing apostrophe in setSaveHandler phpdoc

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -332,7 +332,7 @@ class NativeSessionStorage implements SessionStorageInterface
      * session.save_handler and session.save_path e.g.
      *
      *     ini_set('session.save_handler', 'files');
-     *     ini_set('session.save_path', /tmp');
+     *     ini_set('session.save_path', '/tmp');
      *
      * or pass in a NativeSessionHandler instance which configures session.save_handler in the
      * constructor, for a template see NativeFileSessionHandler or use handlers in


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets |  |
| License | MIT |

I fixed php code in comment to one of functions as it couldn't be used with simple copy and paste.
