### PR TITLE
[FrameworkBundle] Use proper class to fetch $versionStrategy property

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/AssetExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/AssetExtension.php
@@ -98,19 +98,16 @@ class AssetExtension extends \Twig_Extension
     {
         if ($version) {
             $package = $this->packages->getPackage($packageName);
-            $class = new \ReflectionClass($package);
 
-            while ('Symfony\Component\Asset\Package' !== $class->getName()) {
-                $class = $class->getParentClass();
-            }
-
-            $v = $class->getProperty('versionStrategy');
+            $v = new \ReflectionProperty('Symfony\Component\Asset\Package', 'versionStrategy');
             $v->setAccessible(true);
+
             $currentVersionStrategy = $v->getValue($package);
 
             if (property_exists($currentVersionStrategy, 'format')) {
                 $f = new \ReflectionProperty($currentVersionStrategy, 'format');
                 $f->setAccessible(true);
+
                 $format = $f->getValue($currentVersionStrategy);
 
                 $v->setValue($package, new StaticVersionStrategy($version, $format));

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/AssetsHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/AssetsHelper.php
@@ -95,13 +95,14 @@ class AssetsHelper extends Helper
         if ($version) {
             $package = $this->packages->getPackage($packageName);
 
-            $v = new \ReflectionProperty($package, 'versionStrategy');
+            $v = new \ReflectionProperty('Symfony\Component\Asset\Package', 'versionStrategy');
             $v->setAccessible(true);
 
             $currentVersionStrategy = $v->getValue($package);
 
             $f = new \ReflectionProperty($currentVersionStrategy, 'format');
             $f->setAccessible(true);
+
             $format = $f->getValue($currentVersionStrategy);
 
             $v->setValue($package, new StaticVersionStrategy($version, $format));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/AssetsHelperTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/AssetsHelperTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Templating\Helper;
 use Symfony\Bundle\FrameworkBundle\Templating\Helper\AssetsHelper;
 use Symfony\Component\Asset\Package;
 use Symfony\Component\Asset\Packages;
+use Symfony\Component\Asset\PathPackage;
 use Symfony\Component\Asset\VersionStrategy\StaticVersionStrategy;
 
 class AssetsHelperTest extends \PHPUnit_Framework_TestCase
@@ -23,11 +24,14 @@ class AssetsHelperTest extends \PHPUnit_Framework_TestCase
      */
     public function testLegacyGetUrl()
     {
-        $package = new Package(new StaticVersionStrategy('22', '%s?version=%s'));
-        $packages = new Packages($package);
+        $versionStrategy = new StaticVersionStrategy('22', '%s?version=%s');
+        $package = new Package($versionStrategy);
+        $imagePackage = new PathPackage('images', $versionStrategy);
+        $packages = new Packages($package, array('images' => $imagePackage));
         $helper = new AssetsHelper($packages);
 
         $this->assertEquals('me.png?version=42', $helper->getUrl('me.png', null, '42'));
+        $this->assertEquals('/images/me.png?version=42', $helper->getUrl('me.png', 'images', '42'));
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17259 |
| License | MIT |

This is a replacement of #17260
