### PR TITLE
[VarDumper] Add flags to allow fine tuning dumps representation

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,8 @@
         <ini name="intl.default_locale" value="en" />
         <ini name="intl.error_level" value="0" />
         <ini name="memory_limit" value="-1" />
+        <env name="DUMP_LIGHT_ARRAY" value="" />
+        <env name="DUMP_STRING_LENGTH" value="" />
     </php>
 
     <testsuites>

--- a/src/Symfony/Component/VarDumper/Dumper/AbstractDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/AbstractDumper.php
@@ -21,6 +21,9 @@ use Symfony\Component\VarDumper\Cloner\DumperInterface;
  */
 abstract class AbstractDumper implements DataDumperInterface, DumperInterface
 {
+    const DUMP_LIGHT_ARRAY = 1;
+    const DUMP_STRING_LENGTH = 2;
+
     public static $defaultOutput = 'php://output';
 
     protected $line = '';
@@ -28,15 +31,18 @@ abstract class AbstractDumper implements DataDumperInterface, DumperInterface
     protected $outputStream;
     protected $decimalPoint; // This is locale dependent
     protected $indentPad = '  ';
+    protected $flags;
 
     private $charset;
 
     /**
      * @param callable|resource|string|null $output  A line dumper callable, an opened stream or an output path, defaults to static::$defaultOutput.
      * @param string                        $charset The default character encoding to use for non-UTF8 strings.
+     * @param int                           $flags   A bit field of static::DUMP_* constants to fine tune dumps representation.
      */
-    public function __construct($output = null, $charset = null)
+    public function __construct($output = null, $charset = null, $flags = 0)
     {
+        $this->flags = (int) $flags;
         $this->setCharset($charset ?: ini_get('php.output_encoding') ?: ini_get('default_charset') ?: 'UTF-8');
         $this->decimalPoint = (string) 0.5;
         $this->decimalPoint = $this->decimalPoint[1];

--- a/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
@@ -54,9 +54,9 @@ class CliDumper extends AbstractDumper
     /**
      * {@inheritdoc}
      */
-    public function __construct($output = null, $charset = null)
+    public function __construct($output = null, $charset = null, $flags = 0)
     {
-        parent::__construct($output, $charset);
+        parent::__construct($output, $charset, $flags);
 
         if ('\\' === DIRECTORY_SEPARATOR && false !== @getenv('ANSICON')) {
             // Use only the base 16 xterm colors when using ANSICON
@@ -180,6 +180,9 @@ class CliDumper extends AbstractDumper
             $m = count($str) - 1;
             $i = $lineCut = 0;
 
+            if (self::DUMP_STRING_LENGTH & $this->flags) {
+                $this->line .= '('.$attr['length'].') ';
+            }
             if ($bin) {
                 $this->line .= 'b';
             }
@@ -249,7 +252,7 @@ class CliDumper extends AbstractDumper
         } elseif (Cursor::HASH_RESOURCE === $type) {
             $prefix = $this->style('note', $class.' resource').($hasChild ? ' {' : ' ');
         } else {
-            $prefix = $class ? $this->style('note', 'array:'.$class).' [' : '[';
+            $prefix = $class && !(self::DUMP_LIGHT_ARRAY & $this->flags) ? $this->style('note', 'array:'.$class).' [' : '[';
         }
 
         if ($cursor->softRefCount || 0 < $cursor->softRefHandle) {
@@ -314,6 +317,9 @@ class CliDumper extends AbstractDumper
             switch ($cursor->hashType) {
                 default:
                 case Cursor::HASH_INDEXED:
+                    if (self::DUMP_LIGHT_ARRAY & $this->flags) {
+                        break;
+                    }
                     $style = 'index';
                 case Cursor::HASH_ASSOC:
                     if (is_int($key)) {

--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -48,9 +48,9 @@ class HtmlDumper extends CliDumper
     /**
      * {@inheritdoc}
      */
-    public function __construct($output = null, $charset = null)
+    public function __construct($output = null, $charset = null, $flags = 0)
     {
-        AbstractDumper::__construct($output, $charset);
+        AbstractDumper::__construct($output, $charset, $flags);
         $this->dumpId = 'sf-dump-'.mt_rand();
     }
 

--- a/src/Symfony/Component/VarDumper/Test/VarDumperTestTrait.php
+++ b/src/Symfony/Component/VarDumper/Test/VarDumperTestTrait.php
@@ -31,10 +31,13 @@ trait VarDumperTestTrait
 
     protected function getDump($data)
     {
+        $flags = getenv('DUMP_LIGHT_ARRAY') ? CliDumper::DUMP_LIGHT_ARRAY : 0;
+        $flags |= getenv('DUMP_STRING_LENGTH') ? CliDumper::DUMP_STRING_LENGTH : 0;
+
         $h = fopen('php://memory', 'r+b');
         $cloner = new VarCloner();
         $cloner->setMaxItems(-1);
-        $dumper = new CliDumper($h);
+        $dumper = new CliDumper($h, null, $flags);
         $dumper->setColors(false);
         $dumper->dump($cloner->cloneVar($data)->withRefHandles(false));
         $data = stream_get_contents($h, -1, 0);

--- a/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
@@ -160,6 +160,38 @@ EOTXT
         );
     }
 
+    public function testFlags()
+    {
+        putenv('DUMP_LIGHT_ARRAY=1');
+        putenv('DUMP_STRING_LENGTH=1');
+
+        $var = array(
+            range(1,3),
+            array('foo', 2 => 'bar'),
+        );
+
+        $this->assertDumpEquals(
+            <<<EOTXT
+[
+  [
+    1
+    2
+    3
+  ]
+  [
+    0 => (3) "foo"
+    2 => (3) "bar"
+  ]
+]
+EOTXT
+            ,
+            $var
+        );
+
+        putenv('DUMP_LIGHT_ARRAY=');
+        putenv('DUMP_STRING_LENGTH=');
+    }
+
     public function testThrowingCaster()
     {
         $out = fopen('php://memory', 'r+b');

--- a/src/Symfony/Component/VarDumper/phpunit.xml.dist
+++ b/src/Symfony/Component/VarDumper/phpunit.xml.dist
@@ -8,6 +8,8 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
+        <env name="DUMP_LIGHT_ARRAY" value="" />
+        <env name="DUMP_STRING_LENGTH" value="" />
     </php>
 
     <testsuites>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15856 |
| License | MIT |
| Doc PR | - |

The `DUMP_STRING_LENGTH` behavior has been requested in #15856,
the `DUMP_LIGHT_ARRAY` behavior is what should have been done for the VarDumperTestTrait. Anticipated usage is opt-in, by adding `<env name="DUMP_LIGHT_ARRAY" value="1" />` in `phpunit.xml.dist`.
Any more flags proposal anyone? Better names maybe?
