### PR TITLE
Fix max width for multibyte keys in choice question

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -165,7 +165,7 @@ class QuestionHelper extends Helper
             $messages = (array) $question->getQuestion();
             foreach ($question->getChoices() as $key => $value) {
                 $width = $maxWidth - $this->strlen($key);
-                $messages[] = "  [<info>".$key.str_repeat(" ", $width)."</info>] ".$value;
+                $messages[] = '  [<info>'.$key.str_repeat(' ', $width).'</info>] '.$value;
             }
 
             $output->writeln($messages);

--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -160,11 +160,12 @@ class QuestionHelper extends Helper
         $message = $question->getQuestion();
 
         if ($question instanceof ChoiceQuestion) {
-            $width = max(array_map('strlen', array_keys($question->getChoices())));
+            $maxWidth = max(array_map([$this, 'strlen'], array_keys($question->getChoices())));
 
             $messages = (array) $question->getQuestion();
             foreach ($question->getChoices() as $key => $value) {
-                $messages[] = sprintf("  [<info>%-${width}s</info>] %s", $key, $value);
+                $width = $maxWidth - $this->strlen($key);
+                $messages[] = "  [<info>".$key.str_repeat(" ", $width)."</info>] ".$value;
             }
 
             $output->writeln($messages);

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Console\Tests\Helper;
 
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\FormatterHelper;
@@ -348,6 +349,34 @@ class QuestionHelperTest extends \PHPUnit_Framework_TestCase
         $dialog = new QuestionHelper();
         $question = new Question('Do you have a job?', 'not yet');
         $this->assertEquals('not yet', $dialog->ask($this->createInputInterfaceMock(false), $this->createOutputInterface(), $question));
+    }
+
+    public function testChoiceOutputFormattingQuestionForUtf8Keys()
+    {
+        $question = 'Lorem ipsum?';
+        $possibleChoices = array(
+            'foo' => 'foo',
+            'żółw' => 'bar',
+            'łabądź' => 'baz',
+        );
+        $outputShown = array(
+            $question,
+            "  [<info>foo   </info>] foo",
+            "  [<info>żółw  </info>] bar",
+            "  [<info>łabądź</info>] baz",
+        );
+        $output = $this->getMock('\Symfony\Component\Console\Output\OutputInterface');
+        $output->method('getFormatter')->willReturn(new OutputFormatter());
+
+        $dialog = new QuestionHelper();
+        $dialog->setInputStream($this->getInputStream("\n"));
+        $helperSet = new HelperSet(array(new FormatterHelper()));
+        $dialog->setHelperSet($helperSet);
+
+        $output->expects($this->once())->method('writeln')->with($this->equalTo($outputShown));
+
+        $question = new ChoiceQuestion($question, $possibleChoices, 'foo');
+        $dialog->ask($this->createInputInterfaceMock(), $output, $question);
     }
 
     protected function getInputStream($input)

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -361,9 +361,9 @@ class QuestionHelperTest extends \PHPUnit_Framework_TestCase
         );
         $outputShown = array(
             $question,
-            "  [<info>foo   </info>] foo",
-            "  [<info>żółw  </info>] bar",
-            "  [<info>łabądź</info>] baz",
+            '  [<info>foo   </info>] foo',
+            '  [<info>żółw  </info>] bar',
+            '  [<info>łabądź</info>] baz',
         );
         $output = $this->getMock('\Symfony\Component\Console\Output\OutputInterface');
         $output->method('getFormatter')->willReturn(new OutputFormatter());


### PR DESCRIPTION
Fixes wrong key max width for ChoiceQuestion in multibyte strings

Before:
![before](https://cloud.githubusercontent.com/assets/2435655/12203385/977e88c0-b626-11e5-9425-d497f84a9ab3.png)

After:
![after](https://cloud.githubusercontent.com/assets/2435655/12203390/9d9a0b4e-b626-11e5-8d4e-ba9290820778.png)

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/issues/15368 |
| License | MIT |
| Doc PR | - |
