### PR TITLE
[Validator] Remove pre 3.0 ApcCache leftovers

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -436,12 +436,7 @@ class Configuration implements ConfigurationInterface
                     ->info('validation configuration')
                     ->canBeEnabled()
                     ->children()
-                        ->scalarNode('cache')
-                            ->beforeNormalization()
-                                // Can be removed in 3.0, once ApcCache support is dropped
-                                ->ifString()->then(function ($v) { return 'apc' === $v ? 'validator.mapping.cache.apc' : $v; })
-                            ->end()
-                        ->end()
+                        ->scalarNode('cache')->end()
                         ->booleanNode('enable_annotations')->defaultFalse()->end()
                         ->arrayNode('static_method')
                             ->defaultValue(array('loadValidatorMetadata'))

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
@@ -28,10 +28,6 @@
 
         <service id="validator.mapping.class_metadata_factory" alias="validator" public="false" />
 
-        <service id="validator.mapping.cache.apc" class="Symfony\Component\Validator\Mapping\Cache\ApcCache" public="false">
-            <argument>%validator.mapping.cache.prefix%</argument>
-        </service>
-
         <service id="validator.validator_factory" class="Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory" public="false">
             <argument type="service" id="service_container" />
             <argument type="collection" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
@@ -56,7 +56,7 @@ $container->loadFromExtension('framework', array(
     ),
     'validation' => array(
         'enabled' => true,
-        'cache' => 'apc',
+        'cache' => 'validator.mapping.cache.doctrine.apc',
     ),
     'annotations' => array(
         'cache' => 'file',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
@@ -38,7 +38,7 @@
         <framework:translator enabled="true" fallback="fr" logging="true">
             <framework:path>%kernel.root_dir%/Fixtures/translations</framework:path>
         </framework:translator>
-        <framework:validation enabled="true" cache="apc" />
+        <framework:validation enabled="true" cache="validator.mapping.cache.doctrine.apc" />
         <framework:annotations cache="file" debug="true" file-cache-dir="%kernel.cache_dir%/annotations" />
         <framework:serializer enabled="true" enable-annotations="true" cache="serializer.mapping.cache.apc" name-converter="serializer.name_converter.camel_case_to_snake_case" />
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
@@ -44,7 +44,7 @@ framework:
         paths: ['%kernel.root_dir%/Fixtures/translations']
     validation:
         enabled: true
-        cache:   apc
+        cache:   validator.mapping.cache.doctrine.apc
     annotations:
         cache:   file
         debug:   true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -298,7 +298,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertSame('addMethodMapping', $calls[4][0]);
         $this->assertSame(array('loadValidatorMetadata'), $calls[4][1]);
         $this->assertSame('setMetadataCache', $calls[5][0]);
-        $this->assertEquals(array(new Reference('validator.mapping.cache.apc')), $calls[5][1]);
+        $this->assertEquals(array(new Reference('validator.mapping.cache.doctrine.apc')), $calls[5][1]);
     }
 
     public function testValidationService()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Remove some leftover references to `Symfony\Component\Validator\Mapping\Cache\ApcCache`.
This class was removed in commit https://github.com/symfony/symfony/commit/2a6b629e39a3069f67af94e991c7a1b672c7b983.
