### PR TITLE
[DependencyInjection] Deprecate unsupported attributes/elements for alias

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -132,6 +132,8 @@ class XmlFileLoader extends FileLoader
     private function parseDefinition(\DOMElement $service, $file)
     {
         if ($alias = $service->getAttribute('alias')) {
+            $this->validateAlias($service, $file);
+
             $public = true;
             if ($publicAttr = $service->getAttribute('public')) {
                 $public = XmlUtils::phpize($publicAttr);
@@ -488,6 +490,27 @@ EOF
         }
 
         return $valid;
+    }
+
+    /**
+     * Validates an alias.
+     *
+     * @param \DOMElement $alias
+     * @param string      $file
+     */
+    private function validateAlias(\DOMElement $alias, $file)
+    {
+        foreach ($alias->attributes as $name => $node) {
+            if (!in_array($name, array('alias', 'id', 'public'))) {
+                @trigger_error(sprintf('Using the attribute "%s" is deprecated for alias definition "%s" in "%s". Allowed attributes are "alias", "id" and "public". The XmlFileLoader will raise an exception in Symfony 4.0, instead of silently ignoring unsupported attributes.', $name, $alias->getAttribute('id'), $file), E_USER_DEPRECATED);
+            }
+        }
+
+        foreach ($alias->childNodes as $child) {
+            if ($child instanceof \DOMElement && $child->namespaceURI === self::NS) {
+                @trigger_error(sprintf('Using the element "%s" is deprecated for alias definition "%s" in "%s". The XmlFileLoader will raise an exception in Symfony 4.0, instead of silently ignoring unsupported elements.', $child->localName, $alias->getAttribute('id'), $file), E_USER_DEPRECATED);
+            }
+        }
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -177,6 +177,12 @@ class YamlFileLoader extends FileLoader
             $public = !array_key_exists('public', $service) || (bool) $service['public'];
             $this->container->setAlias($id, new Alias($service['alias'], $public));
 
+            foreach ($service as $key => $value) {
+                if (!in_array($key, array('alias', 'public'))) {
+                    @trigger_error(sprintf('The configuration key "%s" is unsupported for alias definition "%s" in "%s". Allowed configuration keys are "alias" and "public". The YamlFileLoader will raise an exception in Symfony 4.0, instead of silently ignoring unsupported attributes.', $key, $id, $file), E_USER_DEPRECATED);
+                }
+            }
+
             return;
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/legacy_invalid_alias_definition.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/legacy_invalid_alias_definition.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="foo" class="Foo" />
+
+    <service id="bar" alias="foo" class="Foo">
+        <tag name="foo.bar" />
+        <factory service="foobar" method="getBar" />
+    </service>
+  </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/legacy_invalid_alias_definition.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/legacy_invalid_alias_definition.yml
@@ -1,0 +1,5 @@
+services:
+    foo:
+        alias: bar
+        factory: foo
+        parent: quz

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -505,7 +505,7 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $loader->load('legacy_invalid_alias_definition.xml');
 
         $this->assertTrue($container->has('bar'));
-        
+
         $this->assertCount(3, $deprecations);
         $this->assertContains('Using the attribute "class" is deprecated for alias definition "bar"', $deprecations[0]);
         $this->assertContains('Using the element "tag" is deprecated for alias definition "bar"', $deprecations[1]);

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -486,4 +486,31 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($container->getDefinition('bar')->isAutowired());
     }
+
+    /**
+     * @group legacy
+     */
+    public function testAliasDefinitionContainsUnsupportedElements()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+
+        $deprecations = array();
+        set_error_handler(function ($type, $msg) use (&$deprecations) {
+            if (E_USER_DEPRECATED === $type) {
+                $deprecations[] = $msg;
+            }
+        });
+
+        $loader->load('legacy_invalid_alias_definition.xml');
+
+        $this->assertTrue($container->has('bar'));
+        
+        $this->assertCount(3, $deprecations);
+        $this->assertContains('Using the attribute "class" is deprecated for alias definition "bar"', $deprecations[0]);
+        $this->assertContains('Using the element "tag" is deprecated for alias definition "bar"', $deprecations[1]);
+        $this->assertContains('Using the element "factory" is deprecated for alias definition "bar"', $deprecations[2]);
+
+        restore_error_handler();
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -322,7 +322,7 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $loader->load('legacy_invalid_alias_definition.yml');
 
         $this->assertTrue($container->has('foo'));
-        
+
         $this->assertCount(2, $deprecations);
         $this->assertContains('The configuration key "factory" is unsupported for alias definition "foo"', $deprecations[0]);
         $this->assertContains('The configuration key "parent" is unsupported for alias definition "foo"', $deprecations[1]);

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -303,4 +303,30 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
         $loader->load('legacy_invalid_definition.yml');
     }
+
+    /**
+     * @group legacy
+     */
+    public function testAliasDefinitionContainsUnsupportedKeywords()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+
+        $deprecations = array();
+        set_error_handler(function ($type, $msg) use (&$deprecations) {
+            if (E_USER_DEPRECATED === $type) {
+                $deprecations[] = $msg;
+            }
+        });
+
+        $loader->load('legacy_invalid_alias_definition.yml');
+
+        $this->assertTrue($container->has('foo'));
+        
+        $this->assertCount(2, $deprecations);
+        $this->assertContains('The configuration key "factory" is unsupported for alias definition "foo"', $deprecations[0]);
+        $this->assertContains('The configuration key "parent" is unsupported for alias definition "foo"', $deprecations[1]);
+
+        restore_error_handler();
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #17256 |
| License | MIT |

Following https://github.com/symfony/symfony/pull/17133, this PR deprecates using unsupported keywords on alias definition.

For example the following examples will trigger deprecations:

``` xml
<?xml version="1.0" encoding="utf-8"?>
<container>
  <services>
    <service id="bar" alias="foo" class="Foo">
        <tag name="foo.bar" />
    </service>
  </services>
</container>
```

``` yml
services:
    bar:
        alias: foo
        parent: quz
```
