### PR TITLE
[Serializer] Allow to use proxies in object_to_populate

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -296,7 +296,7 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
         if (
             isset($context['object_to_populate']) &&
             is_object($context['object_to_populate']) &&
-            $class === get_class($context['object_to_populate'])
+            $context['object_to_populate'] instanceof $class
         ) {
             return $context['object_to_populate'];
         }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/ProxyDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/ProxyDummy.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class ProxyDummy extends ToBeProxyfiedDummy
+{
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/ToBeProxyfiedDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/ToBeProxyfiedDummy.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class ToBeProxyfiedDummy
+{
+    private $foo;
+
+    public function setFoo($foo)
+    {
+        $this->foo = $foo;
+    }
+
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
@@ -5,7 +5,9 @@ namespace Symfony\Component\Serializer\Tests\Normalizer;
 use Symfony\Component\Serializer\Mapping\AttributeMetadata;
 use Symfony\Component\Serializer\Mapping\ClassMetadata;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Tests\Fixtures\AbstractNormalizerDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\ProxyDummy;
 
 /**
  * Provides a dummy Normalizer which extends the AbstractNormalizer.
@@ -87,5 +89,17 @@ class AbstractNormalizerTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->normalizer->getAllowedAttributes('c', array('groups' => array('other')), false);
         $this->assertEquals(array($a3, $a4), $result);
+    }
+
+    public function testObjectToPopulateWithProxy()
+    {
+        $proxyDummy = new ProxyDummy();
+
+        $context = array('object_to_populate' => $proxyDummy);
+
+        $normalizer = new ObjectNormalizer();
+        $normalizer->denormalize(array('foo' => 'bar'), 'Symfony\Component\Serializer\Tests\Fixtures\ToBeProxyfiedDummy', null, $context);
+
+        $this->assertSame('bar', $proxyDummy->getFoo());
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15627, dunglas/DunglasApiBundle#381 |
| License | MIT |
| Doc PR | n/a |

Allows to populate a proxy (or any class having the given type).
