### PR TITLE
[WebProfiler] Fixed sf-minitoolbar height

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -5,9 +5,12 @@
     background-color: #222;
     border-top-left-radius: 4px;
     bottom: 0;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
     display: none;
-    height: 30px;
-    padding: 6px 6px 0;
+    height: 36px;
+    padding: 6px;
     position: fixed;
     right: 0;
     z-index: 99999;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

![toolbar-sf-2 8](https://cloud.githubusercontent.com/assets/2028198/12245117/d293c178-b874-11e5-981b-0ca335a8c3aa.png)

EDIT: This bug occurs when we use 

``` css
* {
    box-sizing: border-box;
}
```

in the stylesheet (TwitterBootstrap for instance)
