### PR TITLE
PdoSessionHandler - Set mysql binlog_format=row to prevent mysql error

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -432,6 +432,9 @@ class PdoSessionHandler implements \SessionHandlerInterface
      * Also MySQLs default isolation, REPEATABLE READ, causes deadlock for different sessions
      * due to http://www.mysqlperformanceblog.com/2013/12/12/one-more-innodb-gap-lock-to-avoid/ .
      * So we change it to READ COMMITTED.
+     * 
+     * MySQLs default binlog_fomat is STATEMENT, and it's not good for single row operations.
+     * Also you would have a General error: 1665 in some MySQL versions
      */
     private function beginTransaction()
     {
@@ -441,6 +444,7 @@ class PdoSessionHandler implements \SessionHandlerInterface
             } else {
                 if ('mysql' === $this->driver) {
                     $this->pdo->exec('SET TRANSACTION ISOLATION LEVEL READ COMMITTED');
+                    $this->pdo->exec('SET binlog_format=row');
                 }
                 $this->pdo->beginTransaction();
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #13592 |
| License | MIT |
| Doc PR | - |

binlog_format=STATEMENT it not good for single row operations.
Also, it fixes MySQL general error: 1665 in some MySQL versions
