### PR TITLE
[Validator] Remove calls to non-existing method

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -55,21 +54,12 @@ abstract class AbstractComparisonValidator extends ConstraintValidator
         }
 
         if (!$this->compareValues($value, $comparedValue)) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value, self::OBJECT_TO_STRING | self::PRETTY_DATE))
-                    ->setParameter('{{ compared_value }}', $this->formatValue($comparedValue, self::OBJECT_TO_STRING | self::PRETTY_DATE))
-                    ->setParameter('{{ compared_value_type }}', $this->formatTypeOf($comparedValue))
-                    ->setCode($this->getErrorCode())
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value, self::OBJECT_TO_STRING | self::PRETTY_DATE))
-                    ->setParameter('{{ compared_value }}', $this->formatValue($comparedValue, self::OBJECT_TO_STRING | self::PRETTY_DATE))
-                    ->setParameter('{{ compared_value_type }}', $this->formatTypeOf($comparedValue))
-                    ->setCode($this->getErrorCode())
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value, self::OBJECT_TO_STRING | self::PRETTY_DATE))
+                ->setParameter('{{ compared_value }}', $this->formatValue($comparedValue, self::OBJECT_TO_STRING | self::PRETTY_DATE))
+                ->setParameter('{{ compared_value_type }}', $this->formatTypeOf($comparedValue))
+                ->setCode($this->getErrorCode())
+                ->addViolation();
         }
     }
 

--- a/src/Symfony/Component/Validator/Constraints/BlankValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/BlankValidator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -31,17 +30,10 @@ class BlankValidator extends ConstraintValidator
         }
 
         if ('' !== $value && null !== $value) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Blank::NOT_BLANK_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Blank::NOT_BLANK_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Blank::NOT_BLANK_ERROR)
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/CardSchemeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CardSchemeValidator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -100,17 +99,10 @@ class CardSchemeValidator extends ConstraintValidator
         }
 
         if (!is_numeric($value)) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(CardScheme::NOT_NUMERIC_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(CardScheme::NOT_NUMERIC_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(CardScheme::NOT_NUMERIC_ERROR)
+                ->addViolation();
 
             return;
         }
@@ -126,16 +118,9 @@ class CardSchemeValidator extends ConstraintValidator
             }
         }
 
-        if ($this->context instanceof ExecutionContextInterface) {
-            $this->context->buildViolation($constraint->message)
-                ->setParameter('{{ value }}', $this->formatValue($value))
-                ->setCode(CardScheme::INVALID_FORMAT_ERROR)
-                ->addViolation();
-        } else {
-            $this->buildViolation($constraint->message)
-                ->setParameter('{{ value }}', $this->formatValue($value))
-                ->setCode(CardScheme::INVALID_FORMAT_ERROR)
-                ->addViolation();
-        }
+        $this->context->buildViolation($constraint->message)
+            ->setParameter('{{ value }}', $this->formatValue($value))
+            ->setCode(CardScheme::INVALID_FORMAT_ERROR)
+            ->addViolation();
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
@@ -61,19 +60,11 @@ class ChoiceValidator extends ConstraintValidator
         if ($constraint->multiple) {
             foreach ($value as $_value) {
                 if (!in_array($_value, $choices, $constraint->strict)) {
-                    if ($this->context instanceof ExecutionContextInterface) {
-                        $this->context->buildViolation($constraint->multipleMessage)
-                            ->setParameter('{{ value }}', $this->formatValue($_value))
-                            ->setCode(Choice::NO_SUCH_CHOICE_ERROR)
-                            ->setInvalidValue($_value)
-                            ->addViolation();
-                    } else {
-                        $this->buildViolation($constraint->multipleMessage)
-                            ->setParameter('{{ value }}', $this->formatValue($_value))
-                            ->setCode(Choice::NO_SUCH_CHOICE_ERROR)
-                            ->setInvalidValue($_value)
-                            ->addViolation();
-                    }
+                    $this->context->buildViolation($constraint->multipleMessage)
+                        ->setParameter('{{ value }}', $this->formatValue($_value))
+                        ->setCode(Choice::NO_SUCH_CHOICE_ERROR)
+                        ->setInvalidValue($_value)
+                        ->addViolation();
 
                     return;
                 }
@@ -82,52 +73,29 @@ class ChoiceValidator extends ConstraintValidator
             $count = count($value);
 
             if ($constraint->min !== null && $count < $constraint->min) {
-                if ($this->context instanceof ExecutionContextInterface) {
-                    $this->context->buildViolation($constraint->minMessage)
-                        ->setParameter('{{ limit }}', $constraint->min)
-                        ->setPlural((int) $constraint->min)
-                        ->setCode(Choice::TOO_FEW_ERROR)
-                        ->addViolation();
-                } else {
-                    $this->buildViolation($constraint->minMessage)
-                        ->setParameter('{{ limit }}', $constraint->min)
-                        ->setPlural((int) $constraint->min)
-                        ->setCode(Choice::TOO_FEW_ERROR)
-                        ->addViolation();
-                }
+                $this->context->buildViolation($constraint->minMessage)
+                    ->setParameter('{{ limit }}', $constraint->min)
+                    ->setPlural((int) $constraint->min)
+                    ->setCode(Choice::TOO_FEW_ERROR)
+                    ->addViolation();
 
                 return;
             }
 
             if ($constraint->max !== null && $count > $constraint->max) {
-                if ($this->context instanceof ExecutionContextInterface) {
-                    $this->context->buildViolation($constraint->maxMessage)
-                        ->setParameter('{{ limit }}', $constraint->max)
-                        ->setPlural((int) $constraint->max)
-                        ->setCode(Choice::TOO_MANY_ERROR)
-                        ->addViolation();
-                } else {
-                    $this->buildViolation($constraint->maxMessage)
-                        ->setParameter('{{ limit }}', $constraint->max)
-                        ->setPlural((int) $constraint->max)
-                        ->setCode(Choice::TOO_MANY_ERROR)
-                        ->addViolation();
-                }
+                $this->context->buildViolation($constraint->maxMessage)
+                    ->setParameter('{{ limit }}', $constraint->max)
+                    ->setPlural((int) $constraint->max)
+                    ->setCode(Choice::TOO_MANY_ERROR)
+                    ->addViolation();
 
                 return;
             }
         } elseif (!in_array($value, $choices, $constraint->strict)) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Choice::NO_SUCH_CHOICE_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Choice::NO_SUCH_CHOICE_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Choice::NO_SUCH_CHOICE_ERROR)
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/CountValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CountValidator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -37,45 +36,25 @@ class CountValidator extends ConstraintValidator
         $count = count($value);
 
         if (null !== $constraint->max && $count > $constraint->max) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->min == $constraint->max ? $constraint->exactMessage : $constraint->maxMessage)
-                    ->setParameter('{{ count }}', $count)
-                    ->setParameter('{{ limit }}', $constraint->max)
-                    ->setInvalidValue($value)
-                    ->setPlural((int) $constraint->max)
-                    ->setCode(Count::TOO_MANY_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->min == $constraint->max ? $constraint->exactMessage : $constraint->maxMessage)
-                    ->setParameter('{{ count }}', $count)
-                    ->setParameter('{{ limit }}', $constraint->max)
-                    ->setInvalidValue($value)
-                    ->setPlural((int) $constraint->max)
-                    ->setCode(Count::TOO_MANY_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->min == $constraint->max ? $constraint->exactMessage : $constraint->maxMessage)
+                ->setParameter('{{ count }}', $count)
+                ->setParameter('{{ limit }}', $constraint->max)
+                ->setInvalidValue($value)
+                ->setPlural((int) $constraint->max)
+                ->setCode(Count::TOO_MANY_ERROR)
+                ->addViolation();
 
             return;
         }
 
         if (null !== $constraint->min && $count < $constraint->min) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->min == $constraint->max ? $constraint->exactMessage : $constraint->minMessage)
-                    ->setParameter('{{ count }}', $count)
-                    ->setParameter('{{ limit }}', $constraint->min)
-                    ->setInvalidValue($value)
-                    ->setPlural((int) $constraint->min)
-                    ->setCode(Count::TOO_FEW_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->min == $constraint->max ? $constraint->exactMessage : $constraint->minMessage)
-                    ->setParameter('{{ count }}', $count)
-                    ->setParameter('{{ limit }}', $constraint->min)
-                    ->setInvalidValue($value)
-                    ->setPlural((int) $constraint->min)
-                    ->setCode(Count::TOO_FEW_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->min == $constraint->max ? $constraint->exactMessage : $constraint->minMessage)
+                ->setParameter('{{ count }}', $count)
+                ->setParameter('{{ limit }}', $constraint->min)
+                ->setInvalidValue($value)
+                ->setPlural((int) $constraint->min)
+                ->setCode(Count::TOO_FEW_ERROR)
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/CountryValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CountryValidator.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\Intl\Intl;
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -45,17 +44,10 @@ class CountryValidator extends ConstraintValidator
         $countries = Intl::getRegionBundle()->getCountryNames();
 
         if (!isset($countries[$value])) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Country::NO_SUCH_COUNTRY_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Country::NO_SUCH_COUNTRY_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Country::NO_SUCH_COUNTRY_ERROR)
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/CurrencyValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CurrencyValidator.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\Intl\Intl;
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -46,17 +45,10 @@ class CurrencyValidator extends ConstraintValidator
         $currencies = Intl::getCurrencyBundle()->getCurrencyNames();
 
         if (!isset($currencies[$value])) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Currency::NO_SUCH_CURRENCY_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Currency::NO_SUCH_CURRENCY_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Currency::NO_SUCH_CURRENCY_ERROR)
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
@@ -42,47 +41,26 @@ class DateTimeValidator extends DateValidator
         $value = (string) $value;
 
         if (!preg_match(static::PATTERN, $value, $matches)) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(DateTime::INVALID_FORMAT_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(DateTime::INVALID_FORMAT_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(DateTime::INVALID_FORMAT_ERROR)
+                ->addViolation();
 
             return;
         }
 
         if (!DateValidator::checkDate($matches[1], $matches[2], $matches[3])) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(DateTime::INVALID_DATE_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(DateTime::INVALID_DATE_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(DateTime::INVALID_DATE_ERROR)
+                ->addViolation();
         }
 
         if (!TimeValidator::checkTime($matches[4], $matches[5], $matches[6])) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(DateTime::INVALID_TIME_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(DateTime::INVALID_TIME_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(DateTime::INVALID_TIME_ERROR)
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/DateValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateValidator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -59,33 +58,19 @@ class DateValidator extends ConstraintValidator
         $value = (string) $value;
 
         if (!preg_match(static::PATTERN, $value, $matches)) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Date::INVALID_FORMAT_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Date::INVALID_FORMAT_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Date::INVALID_FORMAT_ERROR)
+                ->addViolation();
 
             return;
         }
 
         if (!self::checkDate($matches[1], $matches[2], $matches[3])) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Date::INVALID_DATE_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Date::INVALID_DATE_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Date::INVALID_DATE_ERROR)
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\RuntimeException;
@@ -63,32 +62,18 @@ class EmailValidator extends ConstraintValidator
             $strictValidator = new \Egulias\EmailValidator\EmailValidator();
 
             if (!$strictValidator->isValid($value, false, true)) {
-                if ($this->context instanceof ExecutionContextInterface) {
-                    $this->context->buildViolation($constraint->message)
-                        ->setParameter('{{ value }}', $this->formatValue($value))
-                        ->setCode(Email::INVALID_FORMAT_ERROR)
-                        ->addViolation();
-                } else {
-                    $this->buildViolation($constraint->message)
-                        ->setParameter('{{ value }}', $this->formatValue($value))
-                        ->setCode(Email::INVALID_FORMAT_ERROR)
-                        ->addViolation();
-                }
-
-                return;
-            }
-        } elseif (!preg_match('/^.+\@\S+\.\S+$/', $value)) {
-            if ($this->context instanceof ExecutionContextInterface) {
                 $this->context->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
                     ->setCode(Email::INVALID_FORMAT_ERROR)
                     ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Email::INVALID_FORMAT_ERROR)
-                    ->addViolation();
+
+                return;
             }
+        } elseif (!preg_match('/^.+\@\S+\.\S+$/', $value)) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Email::INVALID_FORMAT_ERROR)
+                ->addViolation();
 
             return;
         }
@@ -98,34 +83,20 @@ class EmailValidator extends ConstraintValidator
         // Check for host DNS resource records
         if ($constraint->checkMX) {
             if (!$this->checkMX($host)) {
-                if ($this->context instanceof ExecutionContextInterface) {
-                    $this->context->buildViolation($constraint->message)
-                        ->setParameter('{{ value }}', $this->formatValue($value))
-                        ->setCode(Email::MX_CHECK_FAILED_ERROR)
-                        ->addViolation();
-                } else {
-                    $this->buildViolation($constraint->message)
-                        ->setParameter('{{ value }}', $this->formatValue($value))
-                        ->setCode(Email::MX_CHECK_FAILED_ERROR)
-                        ->addViolation();
-                }
+                $this->context->buildViolation($constraint->message)
+                    ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(Email::MX_CHECK_FAILED_ERROR)
+                    ->addViolation();
             }
 
             return;
         }
 
         if ($constraint->checkHost && !$this->checkHost($host)) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Email::HOST_CHECK_FAILED_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Email::HOST_CHECK_FAILED_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Email::HOST_CHECK_FAILED_ERROR)
+                ->addViolation();
         }
     }
 

--- a/src/Symfony/Component/Validator/Constraints/ExpressionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionValidator.php
@@ -77,17 +77,10 @@ class ExpressionValidator extends ConstraintValidator
         }
 
         if (!$this->getExpressionLanguage()->evaluate($constraint->expression, $variables)) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Expression::EXPRESSION_FAILED_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Expression::EXPRESSION_FAILED_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Expression::EXPRESSION_FAILED_ERROR)
+                ->addViolation();
         }
     }
 

--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\HttpFoundation\File\File as FileObject;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -62,103 +61,53 @@ class FileValidator extends ConstraintValidator
                     }
 
                     list($sizeAsString, $limitAsString, $suffix) = $this->factorizeSizes(0, $limitInBytes, $binaryFormat);
-                    if ($this->context instanceof ExecutionContextInterface) {
-                        $this->context->buildViolation($constraint->uploadIniSizeErrorMessage)
-                            ->setParameter('{{ limit }}', $limitAsString)
-                            ->setParameter('{{ suffix }}', $suffix)
-                            ->setCode(UPLOAD_ERR_INI_SIZE)
-                            ->addViolation();
-                    } else {
-                        $this->buildViolation($constraint->uploadIniSizeErrorMessage)
-                            ->setParameter('{{ limit }}', $limitAsString)
-                            ->setParameter('{{ suffix }}', $suffix)
-                            ->setCode(UPLOAD_ERR_INI_SIZE)
-                            ->addViolation();
-                    }
+                    $this->context->buildViolation($constraint->uploadIniSizeErrorMessage)
+                        ->setParameter('{{ limit }}', $limitAsString)
+                        ->setParameter('{{ suffix }}', $suffix)
+                        ->setCode(UPLOAD_ERR_INI_SIZE)
+                        ->addViolation();
 
                     return;
                 case UPLOAD_ERR_FORM_SIZE:
-                    if ($this->context instanceof ExecutionContextInterface) {
-                        $this->context->buildViolation($constraint->uploadFormSizeErrorMessage)
-                            ->setCode(UPLOAD_ERR_FORM_SIZE)
-                            ->addViolation();
-                    } else {
-                        $this->buildViolation($constraint->uploadFormSizeErrorMessage)
-                            ->setCode(UPLOAD_ERR_FORM_SIZE)
-                            ->addViolation();
-                    }
+                    $this->context->buildViolation($constraint->uploadFormSizeErrorMessage)
+                        ->setCode(UPLOAD_ERR_FORM_SIZE)
+                        ->addViolation();
 
                     return;
                 case UPLOAD_ERR_PARTIAL:
-                    if ($this->context instanceof ExecutionContextInterface) {
-                        $this->context->buildViolation($constraint->uploadPartialErrorMessage)
-                            ->setCode(UPLOAD_ERR_PARTIAL)
-                            ->addViolation();
-                    } else {
-                        $this->buildViolation($constraint->uploadPartialErrorMessage)
-                            ->setCode(UPLOAD_ERR_PARTIAL)
-                            ->addViolation();
-                    }
+                    $this->context->buildViolation($constraint->uploadPartialErrorMessage)
+                        ->setCode(UPLOAD_ERR_PARTIAL)
+                        ->addViolation();
 
                     return;
                 case UPLOAD_ERR_NO_FILE:
-                    if ($this->context instanceof ExecutionContextInterface) {
-                        $this->context->buildViolation($constraint->uploadNoFileErrorMessage)
-                            ->setCode(UPLOAD_ERR_NO_FILE)
-                            ->addViolation();
-                    } else {
-                        $this->buildViolation($constraint->uploadNoFileErrorMessage)
-                            ->setCode(UPLOAD_ERR_NO_FILE)
-                            ->addViolation();
-                    }
+                    $this->context->buildViolation($constraint->uploadNoFileErrorMessage)
+                        ->setCode(UPLOAD_ERR_NO_FILE)
+                        ->addViolation();
 
                     return;
                 case UPLOAD_ERR_NO_TMP_DIR:
-                    if ($this->context instanceof ExecutionContextInterface) {
-                        $this->context->buildViolation($constraint->uploadNoTmpDirErrorMessage)
-                            ->setCode(UPLOAD_ERR_NO_TMP_DIR)
-                            ->addViolation();
-                    } else {
-                        $this->buildViolation($constraint->uploadNoTmpDirErrorMessage)
-                            ->setCode(UPLOAD_ERR_NO_TMP_DIR)
-                            ->addViolation();
-                    }
+                    $this->context->buildViolation($constraint->uploadNoTmpDirErrorMessage)
+                        ->setCode(UPLOAD_ERR_NO_TMP_DIR)
+                        ->addViolation();
 
                     return;
                 case UPLOAD_ERR_CANT_WRITE:
-                    if ($this->context instanceof ExecutionContextInterface) {
-                        $this->context->buildViolation($constraint->uploadCantWriteErrorMessage)
-                            ->setCode(UPLOAD_ERR_CANT_WRITE)
-                            ->addViolation();
-                    } else {
-                        $this->buildViolation($constraint->uploadCantWriteErrorMessage)
-                            ->setCode(UPLOAD_ERR_CANT_WRITE)
-                            ->addViolation();
-                    }
+                    $this->context->buildViolation($constraint->uploadCantWriteErrorMessage)
+                        ->setCode(UPLOAD_ERR_CANT_WRITE)
+                        ->addViolation();
 
                     return;
                 case UPLOAD_ERR_EXTENSION:
-                    if ($this->context instanceof ExecutionContextInterface) {
-                        $this->context->buildViolation($constraint->uploadExtensionErrorMessage)
-                            ->setCode(UPLOAD_ERR_EXTENSION)
-                            ->addViolation();
-                    } else {
-                        $this->buildViolation($constraint->uploadExtensionErrorMessage)
-                            ->setCode(UPLOAD_ERR_EXTENSION)
-                            ->addViolation();
-                    }
+                    $this->context->buildViolation($constraint->uploadExtensionErrorMessage)
+                        ->setCode(UPLOAD_ERR_EXTENSION)
+                        ->addViolation();
 
                     return;
                 default:
-                    if ($this->context instanceof ExecutionContextInterface) {
-                        $this->context->buildViolation($constraint->uploadErrorMessage)
-                            ->setCode($value->getError())
-                            ->addViolation();
-                    } else {
-                        $this->buildViolation($constraint->uploadErrorMessage)
-                            ->setCode($value->getError())
-                            ->addViolation();
-                    }
+                    $this->context->buildViolation($constraint->uploadErrorMessage)
+                        ->setCode($value->getError())
+                        ->addViolation();
 
                     return;
             }
@@ -171,33 +120,19 @@ class FileValidator extends ConstraintValidator
         $path = $value instanceof FileObject ? $value->getPathname() : (string) $value;
 
         if (!is_file($path)) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->notFoundMessage)
-                    ->setParameter('{{ file }}', $this->formatValue($path))
-                    ->setCode(File::NOT_FOUND_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->notFoundMessage)
-                    ->setParameter('{{ file }}', $this->formatValue($path))
-                    ->setCode(File::NOT_FOUND_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->notFoundMessage)
+                ->setParameter('{{ file }}', $this->formatValue($path))
+                ->setCode(File::NOT_FOUND_ERROR)
+                ->addViolation();
 
             return;
         }
 
         if (!is_readable($path)) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->notReadableMessage)
-                    ->setParameter('{{ file }}', $this->formatValue($path))
-                    ->setCode(File::NOT_READABLE_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->notReadableMessage)
-                    ->setParameter('{{ file }}', $this->formatValue($path))
-                    ->setCode(File::NOT_READABLE_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->notReadableMessage)
+                ->setParameter('{{ file }}', $this->formatValue($path))
+                ->setCode(File::NOT_READABLE_ERROR)
+                ->addViolation();
 
             return;
         }
@@ -205,17 +140,10 @@ class FileValidator extends ConstraintValidator
         $sizeInBytes = filesize($path);
 
         if (0 === $sizeInBytes) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->disallowEmptyMessage)
-                    ->setParameter('{{ file }}', $this->formatValue($path))
-                    ->setCode(File::EMPTY_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->disallowEmptyMessage)
-                    ->setParameter('{{ file }}', $this->formatValue($path))
-                    ->setCode(File::EMPTY_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->disallowEmptyMessage)
+                ->setParameter('{{ file }}', $this->formatValue($path))
+                ->setCode(File::EMPTY_ERROR)
+                ->addViolation();
 
             return;
         }
@@ -225,23 +153,13 @@ class FileValidator extends ConstraintValidator
 
             if ($sizeInBytes > $limitInBytes) {
                 list($sizeAsString, $limitAsString, $suffix) = $this->factorizeSizes($sizeInBytes, $limitInBytes, $constraint->binaryFormat);
-                if ($this->context instanceof ExecutionContextInterface) {
-                    $this->context->buildViolation($constraint->maxSizeMessage)
-                        ->setParameter('{{ file }}', $this->formatValue($path))
-                        ->setParameter('{{ size }}', $sizeAsString)
-                        ->setParameter('{{ limit }}', $limitAsString)
-                        ->setParameter('{{ suffix }}', $suffix)
-                        ->setCode(File::TOO_LARGE_ERROR)
-                        ->addViolation();
-                } else {
-                    $this->buildViolation($constraint->maxSizeMessage)
-                        ->setParameter('{{ file }}', $this->formatValue($path))
-                        ->setParameter('{{ size }}', $sizeAsString)
-                        ->setParameter('{{ limit }}', $limitAsString)
-                        ->setParameter('{{ suffix }}', $suffix)
-                        ->setCode(File::TOO_LARGE_ERROR)
-                        ->addViolation();
-                }
+                $this->context->buildViolation($constraint->maxSizeMessage)
+                    ->setParameter('{{ file }}', $this->formatValue($path))
+                    ->setParameter('{{ size }}', $sizeAsString)
+                    ->setParameter('{{ limit }}', $limitAsString)
+                    ->setParameter('{{ suffix }}', $suffix)
+                    ->setCode(File::TOO_LARGE_ERROR)
+                    ->addViolation();
 
                 return;
             }
@@ -267,21 +185,12 @@ class FileValidator extends ConstraintValidator
                 }
             }
 
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->mimeTypesMessage)
-                    ->setParameter('{{ file }}', $this->formatValue($path))
-                    ->setParameter('{{ type }}', $this->formatValue($mime))
-                    ->setParameter('{{ types }}', $this->formatValues($mimeTypes))
-                    ->setCode(File::INVALID_MIME_TYPE_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->mimeTypesMessage)
-                    ->setParameter('{{ file }}', $this->formatValue($path))
-                    ->setParameter('{{ type }}', $this->formatValue($mime))
-                    ->setParameter('{{ types }}', $this->formatValues($mimeTypes))
-                    ->setCode(File::INVALID_MIME_TYPE_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->mimeTypesMessage)
+                ->setParameter('{{ file }}', $this->formatValue($path))
+                ->setParameter('{{ type }}', $this->formatValue($mime))
+                ->setParameter('{{ types }}', $this->formatValues($mimeTypes))
+                ->setCode(File::INVALID_MIME_TYPE_ERROR)
+                ->addViolation();
         }
     }
 

--- a/src/Symfony/Component/Validator/Constraints/IbanValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IbanValidator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -161,17 +160,10 @@ class IbanValidator extends ConstraintValidator
 
         // The IBAN must contain only digits and characters...
         if (!ctype_alnum($canonicalized)) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Iban::INVALID_CHARACTERS_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Iban::INVALID_CHARACTERS_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Iban::INVALID_CHARACTERS_ERROR)
+                ->addViolation();
 
             return;
         }
@@ -180,34 +172,20 @@ class IbanValidator extends ConstraintValidator
         $countryCode = substr($canonicalized, 0, 2);
 
         if (!ctype_alpha($countryCode)) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Iban::INVALID_COUNTRY_CODE_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Iban::INVALID_COUNTRY_CODE_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Iban::INVALID_COUNTRY_CODE_ERROR)
+                ->addViolation();
 
             return;
         }
 
         // ...have a format available
         if (!array_key_exists($countryCode, self::$formats)) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Iban::NOT_SUPPORTED_COUNTRY_CODE_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Iban::NOT_SUPPORTED_COUNTRY_CODE_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Iban::NOT_SUPPORTED_COUNTRY_CODE_ERROR)
+                ->addViolation();
 
             return;
         }
@@ -215,17 +193,10 @@ class IbanValidator extends ConstraintValidator
         // ...and have a valid format
         if (!preg_match('/^'.self::$formats[$countryCode].'$/', $canonicalized)
         ) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Iban::INVALID_FORMAT_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Iban::INVALID_FORMAT_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Iban::INVALID_FORMAT_ERROR)
+                ->addViolation();
 
             return;
         }
@@ -246,17 +217,10 @@ class IbanValidator extends ConstraintValidator
         // We cannot use PHP's modulo operator, so we calculate the
         // modulo step-wisely instead
         if (1 !== self::bigModulo97($checkSum)) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Iban::CHECKSUM_FAILED_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Iban::CHECKSUM_FAILED_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Iban::CHECKSUM_FAILED_ERROR)
+                ->addViolation();
         }
     }
 

--- a/src/Symfony/Component/Validator/Constraints/ImageValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ImageValidator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -54,15 +53,9 @@ class ImageValidator extends FileValidator
         $size = @getimagesize($value);
 
         if (empty($size) || ($size[0] === 0) || ($size[1] === 0)) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->sizeNotDetectedMessage)
-                    ->setCode(Image::SIZE_NOT_DETECTED_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->sizeNotDetectedMessage)
-                    ->setCode(Image::SIZE_NOT_DETECTED_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->sizeNotDetectedMessage)
+                ->setCode(Image::SIZE_NOT_DETECTED_ERROR)
+                ->addViolation();
 
             return;
         }
@@ -76,19 +69,11 @@ class ImageValidator extends FileValidator
             }
 
             if ($width < $constraint->minWidth) {
-                if ($this->context instanceof ExecutionContextInterface) {
-                    $this->context->buildViolation($constraint->minWidthMessage)
-                        ->setParameter('{{ width }}', $width)
-                        ->setParameter('{{ min_width }}', $constraint->minWidth)
-                        ->setCode(Image::TOO_NARROW_ERROR)
-                        ->addViolation();
-                } else {
-                    $this->buildViolation($constraint->minWidthMessage)
-                        ->setParameter('{{ width }}', $width)
-                        ->setParameter('{{ min_width }}', $constraint->minWidth)
-                        ->setCode(Image::TOO_NARROW_ERROR)
-                        ->addViolation();
-                }
+                $this->context->buildViolation($constraint->minWidthMessage)
+                    ->setParameter('{{ width }}', $width)
+                    ->setParameter('{{ min_width }}', $constraint->minWidth)
+                    ->setCode(Image::TOO_NARROW_ERROR)
+                    ->addViolation();
 
                 return;
             }
@@ -100,19 +85,11 @@ class ImageValidator extends FileValidator
             }
 
             if ($width > $constraint->maxWidth) {
-                if ($this->context instanceof ExecutionContextInterface) {
-                    $this->context->buildViolation($constraint->maxWidthMessage)
-                        ->setParameter('{{ width }}', $width)
-                        ->setParameter('{{ max_width }}', $constraint->maxWidth)
-                        ->setCode(Image::TOO_WIDE_ERROR)
-                        ->addViolation();
-                } else {
-                    $this->buildViolation($constraint->maxWidthMessage)
-                        ->setParameter('{{ width }}', $width)
-                        ->setParameter('{{ max_width }}', $constraint->maxWidth)
-                        ->setCode(Image::TOO_WIDE_ERROR)
-                        ->addViolation();
-                }
+                $this->context->buildViolation($constraint->maxWidthMessage)
+                    ->setParameter('{{ width }}', $width)
+                    ->setParameter('{{ max_width }}', $constraint->maxWidth)
+                    ->setCode(Image::TOO_WIDE_ERROR)
+                    ->addViolation();
 
                 return;
             }
@@ -124,19 +101,11 @@ class ImageValidator extends FileValidator
             }
 
             if ($height < $constraint->minHeight) {
-                if ($this->context instanceof ExecutionContextInterface) {
-                    $this->context->buildViolation($constraint->minHeightMessage)
-                        ->setParameter('{{ height }}', $height)
-                        ->setParameter('{{ min_height }}', $constraint->minHeight)
-                        ->setCode(Image::TOO_LOW_ERROR)
-                        ->addViolation();
-                } else {
-                    $this->buildViolation($constraint->minHeightMessage)
-                        ->setParameter('{{ height }}', $height)
-                        ->setParameter('{{ min_height }}', $constraint->minHeight)
-                        ->setCode(Image::TOO_LOW_ERROR)
-                        ->addViolation();
-                }
+                $this->context->buildViolation($constraint->minHeightMessage)
+                    ->setParameter('{{ height }}', $height)
+                    ->setParameter('{{ min_height }}', $constraint->minHeight)
+                    ->setCode(Image::TOO_LOW_ERROR)
+                    ->addViolation();
 
                 return;
             }
@@ -148,19 +117,11 @@ class ImageValidator extends FileValidator
             }
 
             if ($height > $constraint->maxHeight) {
-                if ($this->context instanceof ExecutionContextInterface) {
-                    $this->context->buildViolation($constraint->maxHeightMessage)
-                        ->setParameter('{{ height }}', $height)
-                        ->setParameter('{{ max_height }}', $constraint->maxHeight)
-                        ->setCode(Image::TOO_HIGH_ERROR)
-                        ->addViolation();
-                } else {
-                    $this->buildViolation($constraint->maxHeightMessage)
-                        ->setParameter('{{ height }}', $height)
-                        ->setParameter('{{ max_height }}', $constraint->maxHeight)
-                        ->setCode(Image::TOO_HIGH_ERROR)
-                        ->addViolation();
-                }
+                $this->context->buildViolation($constraint->maxHeightMessage)
+                    ->setParameter('{{ height }}', $height)
+                    ->setParameter('{{ max_height }}', $constraint->maxHeight)
+                    ->setCode(Image::TOO_HIGH_ERROR)
+                    ->addViolation();
             }
         }
 
@@ -172,19 +133,11 @@ class ImageValidator extends FileValidator
             }
 
             if ($ratio < $constraint->minRatio) {
-                if ($this->context instanceof ExecutionContextInterface) {
-                    $this->context->buildViolation($constraint->minRatioMessage)
-                        ->setParameter('{{ ratio }}', $ratio)
-                        ->setParameter('{{ min_ratio }}', $constraint->minRatio)
-                        ->setCode(Image::RATIO_TOO_SMALL_ERROR)
-                        ->addViolation();
-                } else {
-                    $this->buildViolation($constraint->minRatioMessage)
-                        ->setParameter('{{ ratio }}', $ratio)
-                        ->setParameter('{{ min_ratio }}', $constraint->minRatio)
-                        ->setCode(Image::RATIO_TOO_SMALL_ERROR)
-                        ->addViolation();
-                }
+                $this->context->buildViolation($constraint->minRatioMessage)
+                    ->setParameter('{{ ratio }}', $ratio)
+                    ->setParameter('{{ min_ratio }}', $constraint->minRatio)
+                    ->setCode(Image::RATIO_TOO_SMALL_ERROR)
+                    ->addViolation();
             }
         }
 
@@ -194,68 +147,36 @@ class ImageValidator extends FileValidator
             }
 
             if ($ratio > $constraint->maxRatio) {
-                if ($this->context instanceof ExecutionContextInterface) {
-                    $this->context->buildViolation($constraint->maxRatioMessage)
-                        ->setParameter('{{ ratio }}', $ratio)
-                        ->setParameter('{{ max_ratio }}', $constraint->maxRatio)
-                        ->setCode(Image::RATIO_TOO_BIG_ERROR)
-                        ->addViolation();
-                } else {
-                    $this->buildViolation($constraint->maxRatioMessage)
-                        ->setParameter('{{ ratio }}', $ratio)
-                        ->setParameter('{{ max_ratio }}', $constraint->maxRatio)
-                        ->setCode(Image::RATIO_TOO_BIG_ERROR)
-                        ->addViolation();
-                }
+                $this->context->buildViolation($constraint->maxRatioMessage)
+                    ->setParameter('{{ ratio }}', $ratio)
+                    ->setParameter('{{ max_ratio }}', $constraint->maxRatio)
+                    ->setCode(Image::RATIO_TOO_BIG_ERROR)
+                    ->addViolation();
             }
         }
 
         if (!$constraint->allowSquare && $width == $height) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->allowSquareMessage)
-                    ->setParameter('{{ width }}', $width)
-                    ->setParameter('{{ height }}', $height)
-                    ->setCode(Image::SQUARE_NOT_ALLOWED_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->allowSquareMessage)
-                    ->setParameter('{{ width }}', $width)
-                    ->setParameter('{{ height }}', $height)
-                    ->setCode(Image::SQUARE_NOT_ALLOWED_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->allowSquareMessage)
+                ->setParameter('{{ width }}', $width)
+                ->setParameter('{{ height }}', $height)
+                ->setCode(Image::SQUARE_NOT_ALLOWED_ERROR)
+                ->addViolation();
         }
 
         if (!$constraint->allowLandscape && $width > $height) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->allowLandscapeMessage)
-                    ->setParameter('{{ width }}', $width)
-                    ->setParameter('{{ height }}', $height)
-                    ->setCode(Image::LANDSCAPE_NOT_ALLOWED_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->allowLandscapeMessage)
-                    ->setParameter('{{ width }}', $width)
-                    ->setParameter('{{ height }}', $height)
-                    ->setCode(Image::LANDSCAPE_NOT_ALLOWED_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->allowLandscapeMessage)
+                ->setParameter('{{ width }}', $width)
+                ->setParameter('{{ height }}', $height)
+                ->setCode(Image::LANDSCAPE_NOT_ALLOWED_ERROR)
+                ->addViolation();
         }
 
         if (!$constraint->allowPortrait && $width < $height) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->allowPortraitMessage)
-                    ->setParameter('{{ width }}', $width)
-                    ->setParameter('{{ height }}', $height)
-                    ->setCode(Image::PORTRAIT_NOT_ALLOWED_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->allowPortraitMessage)
-                    ->setParameter('{{ width }}', $width)
-                    ->setParameter('{{ height }}', $height)
-                    ->setCode(Image::PORTRAIT_NOT_ALLOWED_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->allowPortraitMessage)
+                ->setParameter('{{ width }}', $width)
+                ->setParameter('{{ height }}', $height)
+                ->setCode(Image::PORTRAIT_NOT_ALLOWED_ERROR)
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/IpValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IpValidator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -94,17 +93,10 @@ class IpValidator extends ConstraintValidator
         }
 
         if (!filter_var($value, FILTER_VALIDATE_IP, $flag)) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Ip::INVALID_IP_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Ip::INVALID_IP_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Ip::INVALID_IP_ERROR)
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/IsFalseValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IsFalseValidator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -34,16 +33,9 @@ class IsFalseValidator extends ConstraintValidator
             return;
         }
 
-        if ($this->context instanceof ExecutionContextInterface) {
-            $this->context->buildViolation($constraint->message)
-                ->setParameter('{{ value }}', $this->formatValue($value))
-                ->setCode(IsFalse::NOT_FALSE_ERROR)
-                ->addViolation();
-        } else {
-            $this->buildViolation($constraint->message)
-                ->setParameter('{{ value }}', $this->formatValue($value))
-                ->setCode(IsFalse::NOT_FALSE_ERROR)
-                ->addViolation();
-        }
+        $this->context->buildViolation($constraint->message)
+            ->setParameter('{{ value }}', $this->formatValue($value))
+            ->setCode(IsFalse::NOT_FALSE_ERROR)
+            ->addViolation();
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/IsNullValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IsNullValidator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -31,17 +30,10 @@ class IsNullValidator extends ConstraintValidator
         }
 
         if (null !== $value) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(IsNull::NOT_NULL_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(IsNull::NOT_NULL_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(IsNull::NOT_NULL_ERROR)
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/IsTrueValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IsTrueValidator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -35,17 +34,10 @@ class IsTrueValidator extends ConstraintValidator
         }
 
         if (true !== $value && 1 !== $value && '1' !== $value) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(IsTrue::NOT_TRUE_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(IsTrue::NOT_TRUE_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(IsTrue::NOT_TRUE_ERROR)
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/IsbnValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IsbnValidator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -50,17 +49,10 @@ class IsbnValidator extends ConstraintValidator
         // Explicitly validate against ISBN-10
         if ('isbn10' === $constraint->type) {
             if (true !== ($code = $this->validateIsbn10($canonical))) {
-                if ($this->context instanceof ExecutionContextInterface) {
-                    $this->context->buildViolation($this->getMessage($constraint, $constraint->type))
-                        ->setParameter('{{ value }}', $this->formatValue($value))
-                        ->setCode($code)
-                        ->addViolation();
-                } else {
-                    $this->buildViolation($this->getMessage($constraint, $constraint->type))
-                        ->setParameter('{{ value }}', $this->formatValue($value))
-                        ->setCode($code)
-                        ->addViolation();
-                }
+                $this->context->buildViolation($this->getMessage($constraint, $constraint->type))
+                    ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode($code)
+                    ->addViolation();
             }
 
             return;
@@ -69,17 +61,10 @@ class IsbnValidator extends ConstraintValidator
         // Explicitly validate against ISBN-13
         if ('isbn13' === $constraint->type) {
             if (true !== ($code = $this->validateIsbn13($canonical))) {
-                if ($this->context instanceof ExecutionContextInterface) {
-                    $this->context->buildViolation($this->getMessage($constraint, $constraint->type))
-                        ->setParameter('{{ value }}', $this->formatValue($value))
-                        ->setCode($code)
-                        ->addViolation();
-                } else {
-                    $this->buildViolation($this->getMessage($constraint, $constraint->type))
-                        ->setParameter('{{ value }}', $this->formatValue($value))
-                        ->setCode($code)
-                        ->addViolation();
-                }
+                $this->context->buildViolation($this->getMessage($constraint, $constraint->type))
+                    ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode($code)
+                    ->addViolation();
             }
 
             return;
@@ -102,17 +87,10 @@ class IsbnValidator extends ConstraintValidator
         }
 
         if (true !== $code) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($this->getMessage($constraint))
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode($code)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($this->getMessage($constraint))
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode($code)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($this->getMessage($constraint))
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode($code)
+                ->addViolation();
         }
     }
 

--- a/src/Symfony/Component/Validator/Constraints/IssnValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IssnValidator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -52,17 +51,10 @@ class IssnValidator extends ConstraintValidator
             // remove hyphen
             $canonical = substr($canonical, 0, 4).substr($canonical, 5);
         } elseif ($constraint->requireHyphen) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Issn::MISSING_HYPHEN_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Issn::MISSING_HYPHEN_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Issn::MISSING_HYPHEN_ERROR)
+                ->addViolation();
 
             return;
         }
@@ -70,33 +62,19 @@ class IssnValidator extends ConstraintValidator
         $length = strlen($canonical);
 
         if ($length < 8) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Issn::TOO_SHORT_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Issn::TOO_SHORT_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Issn::TOO_SHORT_ERROR)
+                ->addViolation();
 
             return;
         }
 
         if ($length > 8) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Issn::TOO_LONG_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Issn::TOO_LONG_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Issn::TOO_LONG_ERROR)
+                ->addViolation();
 
             return;
         }
@@ -104,17 +82,10 @@ class IssnValidator extends ConstraintValidator
         // 1234567X
         // ^^^^^^^ digits only
         if (!ctype_digit(substr($canonical, 0, 7))) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Issn::INVALID_CHARACTERS_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Issn::INVALID_CHARACTERS_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Issn::INVALID_CHARACTERS_ERROR)
+                ->addViolation();
 
             return;
         }
@@ -122,17 +93,10 @@ class IssnValidator extends ConstraintValidator
         // 1234567X
         //        ^ digit, x or X
         if (!ctype_digit($canonical{7}) && 'x' !== $canonical{7} && 'X' !== $canonical{7}) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Issn::INVALID_CHARACTERS_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Issn::INVALID_CHARACTERS_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Issn::INVALID_CHARACTERS_ERROR)
+                ->addViolation();
 
             return;
         }
@@ -140,17 +104,10 @@ class IssnValidator extends ConstraintValidator
         // 1234567X
         //        ^ case-sensitive?
         if ($constraint->caseSensitive && 'x' === $canonical{7}) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Issn::INVALID_CASE_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Issn::INVALID_CASE_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Issn::INVALID_CASE_ERROR)
+                ->addViolation();
 
             return;
         }
@@ -167,17 +124,10 @@ class IssnValidator extends ConstraintValidator
         }
 
         if (0 !== $checkSum % 11) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Issn::CHECKSUM_FAILED_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Issn::CHECKSUM_FAILED_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Issn::CHECKSUM_FAILED_ERROR)
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/LanguageValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LanguageValidator.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\Intl\Intl;
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -45,17 +44,10 @@ class LanguageValidator extends ConstraintValidator
         $languages = Intl::getLanguageBundle()->getLanguageNames();
 
         if (!isset($languages[$value])) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Language::NO_SUCH_LANGUAGE_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Language::NO_SUCH_LANGUAGE_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Language::NO_SUCH_LANGUAGE_ERROR)
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/LengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LengthValidator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -48,65 +47,36 @@ class LengthValidator extends ConstraintValidator
         $invalidCharset = false === $length;
 
         if ($invalidCharset) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->charsetMessage)
-                    ->setParameter('{{ value }}', $this->formatValue($stringValue))
-                    ->setParameter('{{ charset }}', $constraint->charset)
-                    ->setInvalidValue($value)
-                    ->setCode(Length::INVALID_CHARACTERS_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->charsetMessage)
-                    ->setParameter('{{ value }}', $this->formatValue($stringValue))
-                    ->setParameter('{{ charset }}', $constraint->charset)
-                    ->setInvalidValue($value)
-                    ->setCode(Length::INVALID_CHARACTERS_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->charsetMessage)
+                ->setParameter('{{ value }}', $this->formatValue($stringValue))
+                ->setParameter('{{ charset }}', $constraint->charset)
+                ->setInvalidValue($value)
+                ->setCode(Length::INVALID_CHARACTERS_ERROR)
+                ->addViolation();
 
             return;
         }
 
         if (null !== $constraint->max && $length > $constraint->max) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->min == $constraint->max ? $constraint->exactMessage : $constraint->maxMessage)
-                    ->setParameter('{{ value }}', $this->formatValue($stringValue))
-                    ->setParameter('{{ limit }}', $constraint->max)
-                    ->setInvalidValue($value)
-                    ->setPlural((int) $constraint->max)
-                    ->setCode(Length::TOO_LONG_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->min == $constraint->max ? $constraint->exactMessage : $constraint->maxMessage)
-                    ->setParameter('{{ value }}', $this->formatValue($stringValue))
-                    ->setParameter('{{ limit }}', $constraint->max)
-                    ->setInvalidValue($value)
-                    ->setPlural((int) $constraint->max)
-                    ->setCode(Length::TOO_LONG_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->min == $constraint->max ? $constraint->exactMessage : $constraint->maxMessage)
+                ->setParameter('{{ value }}', $this->formatValue($stringValue))
+                ->setParameter('{{ limit }}', $constraint->max)
+                ->setInvalidValue($value)
+                ->setPlural((int) $constraint->max)
+                ->setCode(Length::TOO_LONG_ERROR)
+                ->addViolation();
 
             return;
         }
 
         if (null !== $constraint->min && $length < $constraint->min) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->min == $constraint->max ? $constraint->exactMessage : $constraint->minMessage)
-                    ->setParameter('{{ value }}', $this->formatValue($stringValue))
-                    ->setParameter('{{ limit }}', $constraint->min)
-                    ->setInvalidValue($value)
-                    ->setPlural((int) $constraint->min)
-                    ->setCode(Length::TOO_SHORT_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->min == $constraint->max ? $constraint->exactMessage : $constraint->minMessage)
-                    ->setParameter('{{ value }}', $this->formatValue($stringValue))
-                    ->setParameter('{{ limit }}', $constraint->min)
-                    ->setInvalidValue($value)
-                    ->setPlural((int) $constraint->min)
-                    ->setCode(Length::TOO_SHORT_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->min == $constraint->max ? $constraint->exactMessage : $constraint->minMessage)
+                ->setParameter('{{ value }}', $this->formatValue($stringValue))
+                ->setParameter('{{ limit }}', $constraint->min)
+                ->setInvalidValue($value)
+                ->setPlural((int) $constraint->min)
+                ->setCode(Length::TOO_SHORT_ERROR)
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/LocaleValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LocaleValidator.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\Intl\Intl;
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -45,17 +44,10 @@ class LocaleValidator extends ConstraintValidator
         $locales = Intl::getLocaleBundle()->getLocaleNames();
 
         if (!isset($locales[$value])) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Locale::NO_SUCH_LOCALE_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Locale::NO_SUCH_LOCALE_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Locale::NO_SUCH_LOCALE_ERROR)
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/LuhnValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LuhnValidator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -57,17 +56,10 @@ class LuhnValidator extends ConstraintValidator
         $value = (string) $value;
 
         if (!ctype_digit($value)) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Luhn::INVALID_CHARACTERS_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Luhn::INVALID_CHARACTERS_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Luhn::INVALID_CHARACTERS_ERROR)
+                ->addViolation();
 
             return;
         }
@@ -95,17 +87,10 @@ class LuhnValidator extends ConstraintValidator
         }
 
         if (0 === $checkSum || 0 !== $checkSum % 10) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Luhn::CHECKSUM_FAILED_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Luhn::CHECKSUM_FAILED_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Luhn::CHECKSUM_FAILED_ERROR)
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -31,17 +30,10 @@ class NotBlankValidator extends ConstraintValidator
         }
 
         if (false === $value || (empty($value) && '0' != $value)) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(NotBlank::IS_BLANK_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(NotBlank::IS_BLANK_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(NotBlank::IS_BLANK_ERROR)
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/NotNullValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotNullValidator.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
@@ -31,17 +30,10 @@ class NotNullValidator extends ConstraintValidator
         }
 
         if (null === $value) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(NotNull::IS_NULL_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(NotNull::IS_NULL_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(NotNull::IS_NULL_ERROR)
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/RangeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/RangeValidator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -35,17 +34,10 @@ class RangeValidator extends ConstraintValidator
         }
 
         if (!is_numeric($value) && !$value instanceof \DateTime && !$value instanceof \DateTimeInterface) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->invalidMessage)
-                    ->setParameter('{{ value }}', $this->formatValue($value, self::PRETTY_DATE))
-                    ->setCode(Range::INVALID_CHARACTERS_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->invalidMessage)
-                    ->setParameter('{{ value }}', $this->formatValue($value, self::PRETTY_DATE))
-                    ->setCode(Range::INVALID_CHARACTERS_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->invalidMessage)
+                ->setParameter('{{ value }}', $this->formatValue($value, self::PRETTY_DATE))
+                ->setCode(Range::INVALID_CHARACTERS_ERROR)
+                ->addViolation();
 
             return;
         }
@@ -68,37 +60,21 @@ class RangeValidator extends ConstraintValidator
         }
 
         if (null !== $constraint->max && $value > $max) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->maxMessage)
-                    ->setParameter('{{ value }}', $this->formatValue($value, self::PRETTY_DATE))
-                    ->setParameter('{{ limit }}', $this->formatValue($max, self::PRETTY_DATE))
-                    ->setCode(Range::TOO_HIGH_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->maxMessage)
-                    ->setParameter('{{ value }}', $this->formatValue($value, self::PRETTY_DATE))
-                    ->setParameter('{{ limit }}', $this->formatValue($max, self::PRETTY_DATE))
-                    ->setCode(Range::TOO_HIGH_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->maxMessage)
+                ->setParameter('{{ value }}', $this->formatValue($value, self::PRETTY_DATE))
+                ->setParameter('{{ limit }}', $this->formatValue($max, self::PRETTY_DATE))
+                ->setCode(Range::TOO_HIGH_ERROR)
+                ->addViolation();
 
             return;
         }
 
         if (null !== $constraint->min && $value < $min) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->minMessage)
-                    ->setParameter('{{ value }}', $this->formatValue($value, self::PRETTY_DATE))
-                    ->setParameter('{{ limit }}', $this->formatValue($min, self::PRETTY_DATE))
-                    ->setCode(Range::TOO_LOW_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->minMessage)
-                    ->setParameter('{{ value }}', $this->formatValue($value, self::PRETTY_DATE))
-                    ->setParameter('{{ limit }}', $this->formatValue($min, self::PRETTY_DATE))
-                    ->setCode(Range::TOO_LOW_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->minMessage)
+                ->setParameter('{{ value }}', $this->formatValue($value, self::PRETTY_DATE))
+                ->setParameter('{{ limit }}', $this->formatValue($min, self::PRETTY_DATE))
+                ->setCode(Range::TOO_LOW_ERROR)
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/RegexValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/RegexValidator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -44,17 +43,10 @@ class RegexValidator extends ConstraintValidator
         $value = (string) $value;
 
         if ($constraint->match xor preg_match($constraint->pattern, $value)) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Regex::REGEX_FAILED_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Regex::REGEX_FAILED_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Regex::REGEX_FAILED_ERROR)
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/TimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TimeValidator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -59,33 +58,19 @@ class TimeValidator extends ConstraintValidator
         $value = (string) $value;
 
         if (!preg_match(static::PATTERN, $value, $matches)) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Time::INVALID_FORMAT_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Time::INVALID_FORMAT_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Time::INVALID_FORMAT_ERROR)
+                ->addViolation();
 
             return;
         }
 
         if (!self::checkTime($matches[1], $matches[2], $matches[3])) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Time::INVALID_TIME_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Time::INVALID_TIME_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Time::INVALID_TIME_ERROR)
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/TypeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TypeValidator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -47,18 +46,10 @@ class TypeValidator extends ConstraintValidator
             return;
         }
 
-        if ($this->context instanceof ExecutionContextInterface) {
-            $this->context->buildViolation($constraint->message)
-                ->setParameter('{{ value }}', $this->formatValue($value))
-                ->setParameter('{{ type }}', $constraint->type)
-                ->setCode(Type::INVALID_TYPE_ERROR)
-                ->addViolation();
-        } else {
-            $this->buildViolation($constraint->message)
-                ->setParameter('{{ value }}', $this->formatValue($value))
-                ->setParameter('{{ type }}', $constraint->type)
-                ->setCode(Type::INVALID_TYPE_ERROR)
-                ->addViolation();
-        }
+        $this->context->buildViolation($constraint->message)
+            ->setParameter('{{ value }}', $this->formatValue($value))
+            ->setParameter('{{ type }}', $constraint->type)
+            ->setCode(Type::INVALID_TYPE_ERROR)
+            ->addViolation();
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/UrlValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UrlValidator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -62,17 +61,10 @@ class UrlValidator extends ConstraintValidator
         $pattern = sprintf(static::PATTERN, implode('|', $constraint->protocols));
 
         if (!preg_match($pattern, $value)) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Url::INVALID_URL_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Url::INVALID_URL_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Url::INVALID_URL_ERROR)
+                ->addViolation();
 
             return;
         }
@@ -81,17 +73,10 @@ class UrlValidator extends ConstraintValidator
             $host = parse_url($value, PHP_URL_HOST);
 
             if (!checkdnsrr($host, 'ANY')) {
-                if ($this->context instanceof ExecutionContextInterface) {
-                    $this->context->buildViolation($constraint->dnsMessage)
-                        ->setParameter('{{ value }}', $this->formatValue($host))
-                        ->setCode(Url::INVALID_URL_ERROR)
-                        ->addViolation();
-                } else {
-                    $this->buildViolation($constraint->dnsMessage)
-                        ->setParameter('{{ value }}', $this->formatValue($host))
-                        ->setCode(Url::INVALID_URL_ERROR)
-                        ->addViolation();
-                }
+                $this->context->buildViolation($constraint->dnsMessage)
+                    ->setParameter('{{ value }}', $this->formatValue($host))
+                    ->setCode(Url::INVALID_URL_ERROR)
+                    ->addViolation();
             }
         }
     }

--- a/src/Symfony/Component/Validator/Constraints/UuidValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UuidValidator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -99,17 +98,10 @@ class UuidValidator extends ConstraintValidator
         for ($i = 0; $i < $l; ++$i) {
             // Check length
             if (!isset($trimmed{$i})) {
-                if ($this->context instanceof ExecutionContextInterface) {
-                    $this->context->buildViolation($constraint->message)
-                        ->setParameter('{{ value }}', $this->formatValue($value))
-                        ->setCode(Uuid::TOO_SHORT_ERROR)
-                        ->addViolation();
-                } else {
-                    $this->buildViolation($constraint->message)
-                        ->setParameter('{{ value }}', $this->formatValue($value))
-                        ->setCode(Uuid::TOO_SHORT_ERROR)
-                        ->addViolation();
-                }
+                $this->context->buildViolation($constraint->message)
+                    ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(Uuid::TOO_SHORT_ERROR)
+                    ->addViolation();
 
                 return;
             }
@@ -119,17 +111,10 @@ class UuidValidator extends ConstraintValidator
             //     ^    ^    ^    ^    ^    ^    ^
             if ('-' === $trimmed{$i}) {
                 if ($i !== $h) {
-                    if ($this->context instanceof ExecutionContextInterface) {
-                        $this->context->buildViolation($constraint->message)
-                            ->setParameter('{{ value }}', $this->formatValue($value))
-                            ->setCode(Uuid::INVALID_HYPHEN_PLACEMENT_ERROR)
-                            ->addViolation();
-                    } else {
-                        $this->buildViolation($constraint->message)
-                            ->setParameter('{{ value }}', $this->formatValue($value))
-                            ->setCode(Uuid::INVALID_HYPHEN_PLACEMENT_ERROR)
-                            ->addViolation();
-                    }
+                    $this->context->buildViolation($constraint->message)
+                        ->setParameter('{{ value }}', $this->formatValue($value))
+                        ->setCode(Uuid::INVALID_HYPHEN_PLACEMENT_ERROR)
+                        ->addViolation();
 
                     return;
                 }
@@ -147,17 +132,10 @@ class UuidValidator extends ConstraintValidator
 
             // Check characters
             if (!ctype_xdigit($trimmed{$i})) {
-                if ($this->context instanceof ExecutionContextInterface) {
-                    $this->context->buildViolation($constraint->message)
-                        ->setParameter('{{ value }}', $this->formatValue($value))
-                        ->setCode(Uuid::INVALID_CHARACTERS_ERROR)
-                        ->addViolation();
-                } else {
-                    $this->buildViolation($constraint->message)
-                        ->setParameter('{{ value }}', $this->formatValue($value))
-                        ->setCode(Uuid::INVALID_CHARACTERS_ERROR)
-                        ->addViolation();
-                }
+                $this->context->buildViolation($constraint->message)
+                    ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(Uuid::INVALID_CHARACTERS_ERROR)
+                    ->addViolation();
 
                 return;
             }
@@ -165,17 +143,10 @@ class UuidValidator extends ConstraintValidator
 
         // Check length again
         if (isset($trimmed{$i})) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Uuid::TOO_LONG_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Uuid::TOO_LONG_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Uuid::TOO_LONG_ERROR)
+                ->addViolation();
         }
     }
 
@@ -194,17 +165,10 @@ class UuidValidator extends ConstraintValidator
         for ($i = 0; $i < self::STRICT_LENGTH; ++$i) {
             // Check length
             if (!isset($value{$i})) {
-                if ($this->context instanceof ExecutionContextInterface) {
-                    $this->context->buildViolation($constraint->message)
-                        ->setParameter('{{ value }}', $this->formatValue($value))
-                        ->setCode(Uuid::TOO_SHORT_ERROR)
-                        ->addViolation();
-                } else {
-                    $this->buildViolation($constraint->message)
-                        ->setParameter('{{ value }}', $this->formatValue($value))
-                        ->setCode(Uuid::TOO_SHORT_ERROR)
-                        ->addViolation();
-                }
+                $this->context->buildViolation($constraint->message)
+                    ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(Uuid::TOO_SHORT_ERROR)
+                    ->addViolation();
 
                 return;
             }
@@ -214,23 +178,13 @@ class UuidValidator extends ConstraintValidator
             //         ^    ^    ^    ^
             if ('-' === $value{$i}) {
                 if ($i !== $h) {
-                    if ($this->context instanceof ExecutionContextInterface) {
-                        $this->context->buildViolation($constraint->message)
-                             ->setParameter(
-                                 '{{ value }}',
-                                 $this->formatValue($value)
-                             )
-                             ->setCode(Uuid::INVALID_HYPHEN_PLACEMENT_ERROR)
-                             ->addViolation();
-                    } else {
-                        $this->buildViolation($constraint->message)
-                              ->setParameter(
-                                  '{{ value }}',
-                                  $this->formatValue($value)
-                              )
-                              ->setCode(Uuid::INVALID_HYPHEN_PLACEMENT_ERROR)
-                              ->addViolation();
-                    }
+                    $this->context->buildViolation($constraint->message)
+                        ->setParameter(
+                            '{{ value }}',
+                            $this->formatValue($value)
+                        )
+                        ->setCode(Uuid::INVALID_HYPHEN_PLACEMENT_ERROR)
+                        ->addViolation();
 
                     return;
                 }
@@ -246,34 +200,20 @@ class UuidValidator extends ConstraintValidator
 
             // Check characters
             if (!ctype_xdigit($value{$i})) {
-                if ($this->context instanceof ExecutionContextInterface) {
-                    $this->context->buildViolation($constraint->message)
-                        ->setParameter('{{ value }}', $this->formatValue($value))
-                        ->setCode(Uuid::INVALID_CHARACTERS_ERROR)
-                        ->addViolation();
-                } else {
-                    $this->buildViolation($constraint->message)
-                        ->setParameter('{{ value }}', $this->formatValue($value))
-                        ->setCode(Uuid::INVALID_CHARACTERS_ERROR)
-                        ->addViolation();
-                }
+                $this->context->buildViolation($constraint->message)
+                    ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(Uuid::INVALID_CHARACTERS_ERROR)
+                    ->addViolation();
 
                 return;
             }
 
             // Missing hyphen
             if ($i === $h) {
-                if ($this->context instanceof ExecutionContextInterface) {
-                    $this->context->buildViolation($constraint->message)
-                        ->setParameter('{{ value }}', $this->formatValue($value))
-                        ->setCode(Uuid::INVALID_HYPHEN_PLACEMENT_ERROR)
-                        ->addViolation();
-                } else {
-                    $this->buildViolation($constraint->message)
-                        ->setParameter('{{ value }}', $this->formatValue($value))
-                        ->setCode(Uuid::INVALID_HYPHEN_PLACEMENT_ERROR)
-                        ->addViolation();
-                }
+                $this->context->buildViolation($constraint->message)
+                    ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(Uuid::INVALID_HYPHEN_PLACEMENT_ERROR)
+                    ->addViolation();
 
                 return;
             }
@@ -281,32 +221,18 @@ class UuidValidator extends ConstraintValidator
 
         // Check length again
         if (isset($value{$i})) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Uuid::TOO_LONG_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Uuid::TOO_LONG_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Uuid::TOO_LONG_ERROR)
+                ->addViolation();
         }
 
         // Check version
         if (!in_array($value{self::STRICT_VERSION_POSITION}, $constraint->versions)) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Uuid::INVALID_VERSION_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Uuid::INVALID_VERSION_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Uuid::INVALID_VERSION_ERROR)
+                ->addViolation();
         }
 
         // Check variant - first two bits must equal "10"
@@ -314,17 +240,10 @@ class UuidValidator extends ConstraintValidator
         // & 0b1100 (12)
         // = 0b1000 (8)
         if ((hexdec($value{self::STRICT_VARIANT_POSITION}) & 12) !== 8) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Uuid::INVALID_VARIANT_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($constraint->message)
-                    ->setParameter('{{ value }}', $this->formatValue($value))
-                    ->setCode(Uuid::INVALID_VARIANT_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Uuid::INVALID_VARIANT_ERROR)
+                ->addViolation();
         }
     }
 }

--- a/src/Symfony/Component/Validator/Context/ExecutionContextInterface.php
+++ b/src/Symfony/Component/Validator/Context/ExecutionContextInterface.php
@@ -16,6 +16,7 @@ use Symfony\Component\Validator\Mapping;
 use Symfony\Component\Validator\Mapping\MetadataInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
 
 /**
  * The context of a validation run.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This PR removes some useless code after #16024.

**1.** [ConstraintValidator::buildViolation()](https://github.com/symfony/symfony/blob/2.8/src/Symfony/Component/Validator/ConstraintValidator.php#L64) marked as deprecated in [2.8](https://github.com/symfony/symfony/blob/2.8/src/Symfony/Component/Validator/ConstraintValidator.php#L64), and has been removed in [3.0](https://github.com/symfony/symfony/blob/3.0/src/Symfony/Component/Validator/ConstraintValidator.php#L51).

But all the `Symfony/Component/Validator/Constraints/*`validators still making calls to this parent method.

**2.** Correct me if I'm wrong, but this condition:

``` php
$this->context instanceof ExecutionContextInterface
```

in the `Symfony/Component/Validator/Constraints/*` validators is useless since 3.0, because the `$context` can only be `ExecutionContextInterface`. I guess the porpuse of this condition was, that in 2.8 there was a [legacy interface](https://github.com/symfony/symfony/blob/2.8/src/Symfony/Component/Validator/Context/ExecutionContextInterface.php#L63) too.

And AFAIK, the `$context` is [always initialized](https://github.com/symfony/symfony/blob/3.0/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php#L842) before validation, so no need to check that `$context` is whether null or not.

**3.** The return value of [ExecutionContextInterface::getViolations()](https://github.com/symfony/symfony/blob/3.0/src/Symfony/Component/Validator/Context/ExecutionContextInterface.php#L239), is in a different namespace, so it should be used.
