### PR TITLE
Release v2.3.37

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -7,6 +7,21 @@ in 2.3 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.3.0...v2.3.1
 
+* 2.3.37 (2016-01-14)
+
+ * security #17359 do not ship with a custom rng implementation (xabbuh, fabpot)
+ * bug #17326 [Console] Display console application name even when no version set (polc)
+ * bug #17140 [Serializer] Remove normalizer cache in Serializer class (jvasseur)
+ * bug #17307 [FrameworkBundle] Fix paths with % in it (like urlencoded) (scaytrase)
+ * bug #17078 [Bridge] [Doctrine] [Validator] Added support \IteratorAggregate for UniqueEntityValidator (Disparity)
+ * bug #17287 [HttpKernel] Forcing string comparison on query parameters sort in UriSigner (Tim van Densen)
+ * bug #17278 [FrameworkBundle] Add case in Kernel directory guess for PHPUnit (tgalopin)
+ * bug #17276 [Process] Fix potential race condition (nicolas-grekas)
+ * bug #17183 [FrameworkBundle] Set the kernel.name properly after a cache warmup (jakzal)
+ * bug #17159 [Yaml] recognize when a block scalar is left (xabbuh)
+ * bug #17195 bug #14246 [Filesystem] dumpFile() non atomic (Hidde Boomsma)
+ * bug #17177 [Process] Fix potential race condition leading to transient tests (nicolas-grekas)
+
 * 2.3.36 (2015-12-26)
 
  * bug #16864 [Yaml] fix indented line handling in folded blocks (xabbuh)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -75,45 +75,45 @@ Symfony is the result of the work of many people who made the code better
  - Arnaud Le Blanc (arnaud-lb)
  - Tim Nagel (merk)
  - Brice BERNARD (brikou)
+ - Graham Campbell (graham)
  - Jérôme Tamarelle (gromnan)
  - marc.weistroff
- - lenar
- - Graham Campbell (graham)
- - Włodzimierz Gajda (gajdaw)
  - Michal Piotrowski (eventhorizon)
+ - lenar
+ - Włodzimierz Gajda (gajdaw)
  - Florian Voutzinos (florianv)
  - Peter Rehm (rpet)
  - Colin Frei
+ - Dariusz Ruminski
  - Adrien Brault (adrienbrault)
  - excelwebzone
  - Jacob Dreesen (jdreesen)
- - Dariusz Ruminski
  - Peter Kokot (maastermedia)
  - Fabien Pennequin (fabienpennequin)
  - Pierre du Plessis (pierredup)
  - Alexander Schwenn (xelaris)
  - Gordon Franke (gimler)
+ - Iltar van der Berg (kjarli)
  - Robert Schönthal (digitalkaoz)
  - Jérémy DERUSSÉ (jderusse)
  - Joshua Thijssen
  - Stefano Sala (stefano.sala)
  - David Buchmann (dbu)
  - Issei Murasawa (issei_m)
- - Iltar van der Berg (kjarli)
  - Juti Noppornpitak (shiroyuki)
  - Eric GELOEN (gelo)
  - Sebastian Hörl (blogsh)
  - Daniel Gomes (danielcsgomes)
  - Hidenori Goto (hidenorigoto)
+ - Vladimir Reznichenko (kalessil)
  - Guilherme Blanco (guilhermeblanco)
  - Pablo Godel (pgodel)
- - Vladimir Reznichenko (kalessil)
+ - Tigran Azatyan (tigranazatyan)
  - Jérémie Augustin (jaugustin)
  - Sebastiaan Stok (sstok)
  - Rafael Dohms (rdohms)
  - Arnaud Kleinpeter (nanocom)
  - Alexander M. Turek (derrabus)
- - Tigran Azatyan (tigranazatyan)
  - Richard Shank (iampersistent)
  - Charles Sarrazin (csarrazi)
  - Clemens Tolboom
@@ -149,6 +149,7 @@ Symfony is the result of the work of many people who made the code better
  - sun (sun)
  - Larry Garfield (crell)
  - Martin Schuhfuß (usefulthink)
+ - Jáchym Toušek
  - Matthieu Bontemps (mbontemps)
  - Pierre Minnieur (pminnieur)
  - fivestar
@@ -166,7 +167,6 @@ Symfony is the result of the work of many people who made the code better
  - Rui Marinho (ruimarinho)
  - Julien Brochet (mewt)
  - Sergey Linnik (linniksa)
- - Jáchym Toušek
  - Marcel Beerta (mazen)
  - Vincent AUBERT (vincent)
  - julien pauli (jpauli)
@@ -177,6 +177,7 @@ Symfony is the result of the work of many people who made the code better
  - Elnur Abdurrakhimov (elnur)
  - Manuel Reinhard (sprain)
  - Danny Berger (dpb587)
+ - Diego Saint Esteben (dosten)
  - Roman Marintšenko (inori)
  - Xavier Montaña Carreras (xmontana)
  - Chris Wilkinson (thewilkybarkid)
@@ -207,7 +208,6 @@ Symfony is the result of the work of many people who made the code better
  - Ruben Gonzalez (rubenrua)
  - Marcos Sánchez
  - Kim Hemsø Rasmussen (kimhemsoe)
- - Diego Saint Esteben (dosten)
  - Tom Van Looy (tvlooy)
  - Wouter Van Hecke
  - Peter Kruithof (pkruithof)
@@ -237,6 +237,7 @@ Symfony is the result of the work of many people who made the code better
  - Jan Decavele (jandc)
  - Gustavo Piltcher
  - Stepan Tanasiychuk (stfalcon)
+ - Titouan Galopin (tgalopin)
  - Tiago Ribeiro (fixe)
  - Bob den Otter (bopp)
  - Adrian Rudnik (kreischweide)
@@ -321,6 +322,7 @@ Symfony is the result of the work of many people who made the code better
  - Jan Schumann
  - Niklas Fiekas
  - Mark Challoner (markchalloner)
+ - Gregor Harlan (gharlan)
  - Markus Bachmann (baachi)
  - lancergr
  - Olivier Dolbeau (odolbeau)
@@ -337,6 +339,7 @@ Symfony is the result of the work of many people who made the code better
  - cedric lombardot (cedriclombardot)
  - Jonas Flodén (flojon)
  - Christian Schmidt
+ - Jakub Kucharovic (jkucharovic)
  - Marcin Sikoń (marphi)
  - Dominik Zogg (dominik.zogg)
  - Mathieu Lemoine
@@ -396,7 +399,6 @@ Symfony is the result of the work of many people who made the code better
  - MatTheCat
  - John Bafford (jbafford)
  - Denis Gorbachev (starfall)
- - Titouan Galopin (tgalopin)
  - Steven Surowiec
  - Kevin Saliou (kbsali)
  - Ryan
@@ -440,7 +442,6 @@ Symfony is the result of the work of many people who made the code better
  - Wang Jingyu
  - Åsmund Garfors
  - Maxime Douailin
- - Gregor Harlan
  - Michael Hirschler (mvhirsch)
  - Javier López (loalf)
  - Reinier Kip
@@ -457,7 +458,6 @@ Symfony is the result of the work of many people who made the code better
  - Tristan Maindron (tmaindron)
  - Ke WANG (yktd26)
  - Strate
- - Jakub Kucharovic
  - Miquel Rodríguez Telep (mrtorrent)
  - Sergey Kolodyazhnyy (skolodyazhnyy)
  - umpirski
@@ -507,6 +507,7 @@ Symfony is the result of the work of many people who made the code better
  - Joshua Nye
  - Dave Marshall (davedevelopment)
  - avorobiev
+ - Gladhon
  - Venu
  - Lars Vierbergen
  - Dennis Hotson
@@ -572,6 +573,7 @@ Symfony is the result of the work of many people who made the code better
  - Aleksey Podskrebyshev
  - Steffen Roßkamp
  - David Marín Carreño (davefx)
+ - Hidde Boomsma (hboomsma)
  - Jörn Lang (j.lang)
  - mwsaz
  - Benoît Bourgeois
@@ -615,6 +617,7 @@ Symfony is the result of the work of many people who made the code better
  - Benoît Merlet (trompette)
  - Koen Kuipers
  - datibbaw
+ - Sébastien Santoro
  - Raul Fraile (raulfraile)
  - sensio
  - Patrick Kaufmann
@@ -686,6 +689,7 @@ Symfony is the result of the work of many people who made the code better
  - Max Beutel
  - Michal Trojanowski
  - Catalin Dan
+ - Mihai Stancu
  - nacho
  - Piotr Antosik (antek88)
  - Artem Lopata
@@ -698,6 +702,7 @@ Symfony is the result of the work of many people who made the code better
  - Max Grigorian (maxakawizard)
  - benatespina (benatespina)
  - Denis Kop
+ - EdgarPE
  - jfcixmedia
  - Martijn Evers
  - Benjamin Paap (benjaminpaap)
@@ -980,6 +985,7 @@ Symfony is the result of the work of many people who made the code better
  - Michal Gebauer
  - Gleb Sidora
  - David Stone
+ - Adrien Lucas (adrienlucas)
  - Pablo Maria Martelletti (pmartelletti)
  - Yassine Guedidi (yguedidi)
  - Luis Muñoz
@@ -1056,6 +1062,7 @@ Symfony is the result of the work of many people who made the code better
  - devel
  - Trevor Suarez
  - gedrox
+ - Mathieu MARCHOIS
  - dropfen
  - Andrey Chernykh
  - Edvinas Klovas
@@ -1179,7 +1186,6 @@ Symfony is the result of the work of many people who made the code better
  - srsbiz
  - Taylan Kasap
  - Nicolas A. Bérard-Nault
- - Gladhon
  - Saem Ghani
  - Stefan Oderbolz
  - Curtis
@@ -1233,6 +1239,7 @@ Symfony is the result of the work of many people who made the code better
  - Eric J. Duran
  - cmfcmf
  - Drew Butler
+ - pawel-lewtak
  - Steve Müller
  - Andras Ratz
  - andreabreu98
@@ -1260,7 +1267,6 @@ Symfony is the result of the work of many people who made the code better
  - Pierre-Louis LAUNAY
  - djama
  - Eduardo Conceição
- - Sébastien Santoro
  - Jon Cave
  - Sébastien HOUZE
  - Abdulkadir N. A.

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -58,12 +58,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '2.3.37-DEV';
+    const VERSION = '2.3.37';
     const VERSION_ID = 20337;
     const MAJOR_VERSION = 2;
     const MINOR_VERSION = 3;
     const RELEASE_VERSION = 37;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     /**
      * Constructor.


### PR DESCRIPTION
Changes since last release: https://github.com/symfony/symfony/compare/v2.3.36...2f98f15

**Changelog**
- security #17359 do not ship with a custom rng implementation (@xabbuh, @fabpot)
- bug #17326 [Console] Display console application name even when no version set (@polc)
- bug #17140 [Serializer] Remove normalizer cache in Serializer class (@jvasseur)
- bug #17307 [FrameworkBundle] Fix paths with % in it (like urlencoded) (@scaytrase)
- bug #17078 [Bridge] [Doctrine] [Validator] Added support \IteratorAggregate for UniqueEntityValidator (@Disparity)
- bug #17287 [HttpKernel] Forcing string comparison on query parameters sort in UriSigner (@Tim van Densen)
- bug #17278 [FrameworkBundle] Add case in Kernel directory guess for PHPUnit (@tgalopin)
- bug #17276 [Process] Fix potential race condition (@nicolas-grekas)
- bug #17183 [FrameworkBundle] Set the kernel.name properly after a cache warmup (@jakzal)
- bug #17159 [Yaml] recognize when a block scalar is left (@xabbuh)
- bug #17195 bug #14246 [Filesystem] dumpFile() non atomic (@Hidde Boomsma)
- bug #17177 [Process] Fix potential race condition leading to transient tests (@nicolas-grekas)
