### PR TITLE
[Bridge] [Doctrine] Normalize params only when used. [2.3]

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Logger/DbalLogger.php
+++ b/src/Symfony/Bridge/Doctrine/Logger/DbalLogger.php
@@ -49,12 +49,8 @@ class DbalLogger implements SQLLogger
             $this->stopwatch->start('doctrine', 'doctrine');
         }
 
-        if (is_array($params)) {
-            $params = $this->normalizeParams($params);
-        }
-
         if (null !== $this->logger) {
-            $this->log($sql, null === $params ? array() : $params);
+            $this->log($sql, null === $params ? array() : $this->normalizeParams($params));
         }
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

If no logger is set the params are not used so those don't have to be normalized.
