### PR TITLE
Release v2.7.9

### DIFF
--- a/CHANGELOG-2.7.md
+++ b/CHANGELOG-2.7.md
@@ -7,6 +7,30 @@ in 2.7 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.7.0...v2.7.1
 
+* 2.7.9 (2016-01-14)
+
+ * security #17359 do not ship with a custom rng implementation (xabbuh, fabpot)
+ * bug #17314 Fix max width for multibyte keys in choice question (mheki)
+ * bug #17326 [Console] Display console application name even when no version set (polc)
+ * bug #17328 [Serializer] Allow to use proxies in object_to_populate (dunglas)
+ * bug #17347  Workaround https://bugs.php.net/63206 (nicolas-grekas)
+ * bug #17140 [Serializer] Remove normalizer cache in Serializer class (jvasseur)
+ * bug #17307 [FrameworkBundle] Fix paths with % in it (like urlencoded) (scaytrase)
+ * bug #17078 [Bridge] [Doctrine] [Validator] Added support \IteratorAggregate for UniqueEntityValidator (Disparity)
+ * bug #17298 [FrameworkBundle] Use proper class to fetch $versionStrategy property (dosten)
+ * bug #17287 [HttpKernel] Forcing string comparison on query parameters sort in UriSigner (Tim van Densen)
+ * bug #17279 [FrameworkBundle] Add case in Kernel directory guess for PHPUnit (tgalopin)
+ * bug #17278 [FrameworkBundle] Add case in Kernel directory guess for PHPUnit (tgalopin)
+ * bug #17275 [PhpUnitBridge] Re-enable the garbage collector (nicolas-grekas)
+ * bug #17276 [Process] Fix potential race condition (nicolas-grekas)
+ * bug #17183 [FrameworkBundle] Set the kernel.name properly after a cache warmup (jakzal)
+ * bug #17159 [Yaml] recognize when a block scalar is left (xabbuh)
+ * bug #17195 bug #14246 [Filesystem] dumpFile() non atomic (Hidde Boomsma)
+ * feature #16747 [Form] Improved performance of ChoiceType and its subtypes (webmozart)
+ * bug #17177 [Process] Fix potential race condition leading to transient tests (nicolas-grekas)
+ * bug #17163 [Form] fix Catchable Fatal Error if choices is not an array (Gladhon, nicolas-grekas)
+ * bug #17119 [Form] improve deprecation message for "empty_value" and "choice_list" options. (hhamon)
+
 * 2.7.8 (2015-12-26)
 
  * bug #16864 [Yaml] fix indented line handling in folded blocks (xabbuh)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -58,12 +58,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '2.7.9-DEV';
+    const VERSION = '2.7.9';
     const VERSION_ID = 20709;
     const MAJOR_VERSION = 2;
     const MINOR_VERSION = 7;
     const RELEASE_VERSION = 9;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '05/2018';
     const END_OF_LIFE = '05/2019';


### PR DESCRIPTION
Changes since last release: https://github.com/symfony/symfony/compare/v2.7.8...c9b1a84

**Changelog**
- security #17359 do not ship with a custom rng implementation (@xabbuh, @fabpot)
- bug #17314 Fix max width for multibyte keys in choice question (@mheki)
- bug #17326 [Console] Display console application name even when no version set (@polc)
- bug #17328 [Serializer] Allow to use proxies in object_to_populate (@dunglas)
- bug #17347  Workaround https://bugs.php.net/63206 (@nicolas-grekas)
- bug #17140 [Serializer] Remove normalizer cache in Serializer class (@jvasseur)
- bug #17307 [FrameworkBundle] Fix paths with % in it (like urlencoded) (@scaytrase)
- bug #17078 [Bridge] [Doctrine] [Validator] Added support \IteratorAggregate for UniqueEntityValidator (@Disparity)
- bug #17298 [FrameworkBundle] Use proper class to fetch $versionStrategy property (@dosten)
- bug #17287 [HttpKernel] Forcing string comparison on query parameters sort in UriSigner (@Tim van Densen)
- bug #17279 [FrameworkBundle] Add case in Kernel directory guess for PHPUnit (@tgalopin)
- bug #17278 [FrameworkBundle] Add case in Kernel directory guess for PHPUnit (@tgalopin)
- bug #17275 [PhpUnitBridge] Re-enable the garbage collector (@nicolas-grekas)
- bug #17276 [Process] Fix potential race condition (@nicolas-grekas)
- bug #17183 [FrameworkBundle] Set the kernel.name properly after a cache warmup (@jakzal)
- bug #17159 [Yaml] recognize when a block scalar is left (@xabbuh)
- Merge branch '2.3' into 2.7
- bug #17195 bug #14246 [Filesystem] dumpFile() non atomic (@Hidde Boomsma)
- feature #16747 [Form] Improved performance of ChoiceType and its subtypes (@webmozart)
- bug #17177 [Process] Fix potential race condition leading to transient tests (@nicolas-grekas)
- bug #17163 [Form] fix Catchable Fatal Error if choices is not an array (@Gladhon, @nicolas-grekas)
- bug #17119 [Form] improve deprecation message for "empty_value" and "choice_list" options. (@hhamon)
