### PR TITLE
[HttpFoundation] [Cookie] Cookie DateTimeInterface fix

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -29,13 +29,13 @@ class Cookie
     /**
      * Constructor.
      *
-     * @param string               $name     The name of the cookie
-     * @param string               $value    The value of the cookie
-     * @param int|string|\DateTime $expire   The time the cookie expires
-     * @param string               $path     The path on the server in which the cookie will be available on
-     * @param string               $domain   The domain that the cookie is available to
-     * @param bool                 $secure   Whether the cookie should only be transmitted over a secure HTTPS connection from the client
-     * @param bool                 $httpOnly Whether the cookie will be made accessible only through the HTTP protocol
+     * @param string                        $name     The name of the cookie
+     * @param string                        $value    The value of the cookie
+     * @param int|string|\DateTimeInterface $expire   The time the cookie expires
+     * @param string                        $path     The path on the server in which the cookie will be available on
+     * @param string                        $domain   The domain that the cookie is available to
+     * @param bool                          $secure   Whether the cookie should only be transmitted over a secure HTTPS connection from the client
+     * @param bool                          $httpOnly Whether the cookie will be made accessible only through the HTTP protocol
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -51,7 +51,7 @@ class Cookie
         }
 
         // convert expiration time to a Unix timestamp
-        if ($expire instanceof \DateTime) {
+        if ($expire instanceof \DateTimeInterface) {
             $expire = $expire->format('U');
         } elseif (!is_numeric($expire)) {
             $expire = strtotime($expire);

--- a/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
@@ -85,6 +85,14 @@ class CookieTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expire->format('U'), $cookie->getExpiresTime(), '->getExpiresTime() returns the expire date');
     }
 
+    public function testConstructorWithDateTimeImmutable()
+    {
+        $expire = new \DateTimeImmutable();
+        $cookie = new Cookie('foo', 'bar', $expire);
+
+        $this->assertEquals($expire->format('U'), $cookie->getExpiresTime(), '->getExpiresTime() returns the expire date');
+    }
+
     public function testGetExpiresTimeWithStringValue()
     {
         $value = '+1 day';


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

I came across an issue with expiration times on cookies. They were not working with DateTimeImmutable but only the DateTime implementation itself. I refactored this to work with the DateTimeInterface.
