### PR TITLE
[Form] fixed false value being converted to an empty string in ChoiceArrayList

### DIFF
--- a/src/Symfony/Component/Form/ChoiceList/ArrayChoiceList.php
+++ b/src/Symfony/Component/Form/ChoiceList/ArrayChoiceList.php
@@ -233,7 +233,7 @@ class ArrayChoiceList implements ChoiceListInterface
                 }
 
                 continue;
-            } elseif (!is_scalar($choice)) {
+            } elseif (!is_scalar($choice) || false === $choice) {
                 return false;
             } elseif (isset($cache[(string) $choice])) {
                 return false;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17292 |
| License | MIT |
| Doc PR |  |

When `false` value is used as a choice value, it is converted to an empty string,
which conflicts with the empty value, if the choice is optional. If the choice
is not optional, then there may be problems with html validation, since required
choice does not allow empty value to be submitted.

This patch disables value casting to string, if the choices contain `false` value.
