### PR TITLE
[Console] Add Application::runCommand() to run sub-commands easily

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -22,6 +22,8 @@ use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputAwareInterface;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
@@ -1016,6 +1018,24 @@ class Application
     public function setDefaultCommand($commandName)
     {
         $this->defaultCommand = $commandName;
+    }
+
+    /**
+     * Helper to run a sub-command from a command.
+     *
+     * @param string               $command Command that should be run.
+     * @param OutputInterface|null $output  The output to use. If not provided, the output will be silenced.
+     *
+     * @return int 0 if everything went fine, or an error code
+     */
+    public function runCommand($command, OutputInterface $output = null)
+    {
+        $input = new StringInput($command);
+        $output = $output ?: new NullOutput();
+
+        $command = $this->find($this->getCommandName($input));
+
+        return $command->run($input, $output);
     }
 
     private function stringWidth($string)

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Console\Tests;
 
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Input\ArgvInput;
@@ -28,6 +29,7 @@ use Symfony\Component\Console\Tester\ApplicationTester;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Console\Event\ConsoleExceptionEvent;
 use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+use Symfony\Component\Console\Tests\Output\TestOutput;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class ApplicationTest extends \PHPUnit_Framework_TestCase
@@ -1051,6 +1053,40 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
 
         $inputStream = $application->getHelperSet()->get('question')->getInputStream();
         $this->assertEquals($tester->getInput()->isInteractive(), @posix_isatty($inputStream));
+    }
+
+    public function testRunCommand()
+    {
+        $application = new Application();
+        $application->add(new \FooCommand());
+
+        $output = new TestOutput();
+        $code = $application->runCommand('foo:bar', $output);
+
+        $this->assertEquals("interact called\ncalled\n", $output->output);
+        $this->assertSame(0, $code);
+    }
+
+    public function testRunCommandWithoutOutput()
+    {
+        $application = new Application();
+        $application->add(new \FooCommand());
+
+        $code = $application->runCommand('foo:bar');
+
+        $this->assertSame(0, $code);
+    }
+
+    public function testRunCommandReturnsIntegerExitCode()
+    {
+        $application = new Application();
+        $command = new Command('foo:bar');
+        $command->setCode(function () {
+            return 1;
+        });
+        $application->add($command);
+
+        $this->assertSame(1, $application->runCommand('foo:bar'));
     }
 }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This PR adds a new `Application::runCommand()` method that allows to easily run a sub-command from within a command.

[How to run a sub-command today](http://symfony.com/doc/current/components/console/introduction.html#calling-an-existing-command):

``` php
protected function execute(InputInterface $input, OutputInterface $output)
{
    $command = $this->getApplication()->find('demo:greet');

    $arguments = array(
        'command' => 'demo:greet',
        'name'    => 'Fabien',
        '--yell'  => true,
    );

    $greetInput = new ArrayInput($arguments);
    $returnCode = $command->run($greetInput, $output);

    // ...
}
```

With this change:

``` php
protected function execute(InputInterface $input, OutputInterface $output)
{
    $app = $this->getApplication();
    $returnCode = $app->runCommand('demo:greet Fabien --yell', $output);

    // ...
}
```

I think that could be useful to avoid having to resort to use yet another tool to run grouped commands, for example Phing. Instead of running `bin/console db:drop --force && bin/console db:create && bin/console db:fixtures:load`, we could have a Symfony command that would run all that.

And yes usually you are better off calling services directly instead of sub-commands, but in some applications it's usually not worth it, especially micro-applications. For example I [ran into this in Silly](https://github.com/mnapoli/silly/issues/17):

``` php
$app->command('init', function ($input, $output) use ($app) {
    $app->runCommand('db:drop --force', $output)
    $app->runCommand('db:create', $output)
    $app->runCommand('db:fixtures', $output)
});
```

That looks super simple and easy to maintain.

Feedback welcome on the method and parameter names, I'm not 100% satisfied but it's better than nothing…
