### PR TITLE
[Asset] ChooseBaseUrl should return an offset

### DIFF
--- a/src/Symfony/Component/Asset/UrlPackage.php
+++ b/src/Symfony/Component/Asset/UrlPackage.php
@@ -112,11 +112,11 @@ class UrlPackage extends Package
      *
      * @param string $path
      *
-     * @return string The base URL for the given path
+     * @return int The base URL offset for the given path
      */
     protected function chooseBaseUrl($path)
     {
-        return fmod(hexdec(substr(hash('sha256', $path), 0, 10)), count($this->baseUrls));
+        return (int) fmod(hexdec(substr(hash('sha256', $path), 0, 10)), count($this->baseUrls));
     }
 
     private function getSslUrls($urls)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Enforce chooseBaseUrl to return an integer offset to the baseUrls member.
