### PR TITLE
[Asset] ChooseBaseUrl should return an offset

### DIFF
--- a/src/Symfony/Component/Asset/UrlPackage.php
+++ b/src/Symfony/Component/Asset/UrlPackage.php
@@ -108,15 +108,15 @@ class UrlPackage extends Package
      * Determines which base URL to use for the given path.
      *
      * Override this method to change the default distribution strategy.
-     * This method should always return the same base URL for a given path.
+     * This method should always return the same base URL index for a given path.
      *
      * @param string $path
      *
-     * @return string The base URL for the given path
+     * @return int The base URL index for the given path
      */
     protected function chooseBaseUrl($path)
     {
-        return fmod(hexdec(substr(hash('sha256', $path), 0, 10)), count($this->baseUrls));
+        return (int) fmod(hexdec(substr(hash('sha256', $path), 0, 10)), count($this->baseUrls));
     }
 
     private function getSslUrls($urls)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Enforce chooseBaseUrl to return an integer offset to the baseUrls member.
