### PR TITLE
[HttpFoundation] Make some Request methods static

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1301,7 +1301,7 @@ class Request
      *
      * @return string The associated mime type (null if not found)
      */
-    public function getMimeType($format)
+    public static function getMimeType($format)
     {
         if (null === static::$formats) {
             static::initializeFormats();
@@ -1333,7 +1333,7 @@ class Request
      *
      * @return string|null The format (null if not found)
      */
-    public function getFormat($mimeType)
+    public static function getFormat($mimeType)
     {
         if (false !== $pos = strpos($mimeType, ';')) {
             $mimeType = substr($mimeType, 0, $pos);
@@ -1356,7 +1356,7 @@ class Request
      * @param string       $format    The format
      * @param string|array $mimeTypes The associated mime types (the preferred one must be the first as it will be used as the content type)
      */
-    public function setFormat($format, $mimeTypes)
+    public static function setFormat($format, $mimeTypes)
     {
         if (null === static::$formats) {
             static::initializeFormats();

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -303,20 +303,18 @@ class RequestTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetFormatFromMimeType($format, $mimeTypes)
     {
-        $request = new Request();
         foreach ($mimeTypes as $mime) {
-            $this->assertEquals($format, $request->getFormat($mime));
+            $this->assertEquals($format, Request::getFormat($mime));
         }
-        $request->setFormat($format, $mimeTypes);
+        Request::setFormat($format, $mimeTypes);
         foreach ($mimeTypes as $mime) {
-            $this->assertEquals($format, $request->getFormat($mime));
+            $this->assertEquals($format, Request::getFormat($mime));
         }
     }
 
     public function testGetFormatFromMimeTypeWithParameters()
     {
-        $request = new Request();
-        $this->assertEquals('json', $request->getFormat('application/json; charset=utf-8'));
+        $this->assertEquals('json', Request::getFormat('application/json; charset=utf-8'));
     }
 
     /**
@@ -325,8 +323,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function testGetMimeTypeFromFormat($format, $mimeTypes)
     {
         if (null !== $format) {
-            $request = new Request();
-            $this->assertEquals($mimeTypes[0], $request->getMimeType($format));
+            $this->assertEquals($mimeTypes[0], Request::getMimeType($format));
         }
     }
 
@@ -342,8 +339,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
     public function testGetMimeTypesFromInexistentFormat()
     {
-        $request = new Request();
-        $this->assertNull($request->getMimeType('foo'));
+        $this->assertNull(Request::getMimeType('foo'));
         $this->assertEquals(array(), Request::getMimeTypes('foo'));
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/pull/17318#discussion-diff-49376474 |
| License | MIT |
| Doc PR |  |

This PR makes `Request::getMimeType()`,  `Request::getFormat()` and `Request::setFormat()` static.

I'll check if this methods are in the docs and if yes, I'll create a pull request for the docs.
