### PR TITLE
Removed a duplicated test in CardSchemeValidatorTest

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Constraints/CardSchemeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CardSchemeValidatorTest.php
@@ -92,7 +92,6 @@ class CardSchemeValidatorTest extends AbstractConstraintValidatorTest
             array('MAESTRO', '5020507657408074712'),
             array('MAESTRO', '5612559223580173965'),
             array('MAESTRO', '6759744069209'),
-            array('MAESTRO', '6759744069209'),
             array('MAESTRO', '6594371785970435599'),
             array('MASTERCARD', '5555555555554444'),
             array('MASTERCARD', '5105105105105100'),


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

I was looking into making `CardSchemeValidatorTest` faster. I couldn't make it, but I found a duplicated test.
