### PR TITLE
Add gc_mem_caches() call for PHP7 after HttpKernel::stripComments()

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -653,6 +653,10 @@ abstract class Kernel implements KernelInterface, TerminableInterface
         $content = $dumper->dump(array('class' => $class, 'base_class' => $baseClass, 'file' => (string) $cache));
         if (!$this->debug) {
             $content = static::stripComments($content);
+            // reclaim memory for php7, as memory manager will not release after token_get_all()
+            if (function_exists('gc_mem_caches')) {
+                gc_mem_caches();
+            }
         }
 
         $cache->write($content, $container->getResources());


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | sort of |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16868 |
| License | MIT |

New PHP7 memory manager will not release small buckets to OS automatically in cases exposed by `token_get_all()`. This function call addition specifically for PHP7 will reclaim this memory to keep the footprint down of long processe

See above ticket and suggested actions by PHP internals team for long-running tasks (https://bugs.php.net/bug.php?id=70098) - I think `cache:clear/warmup` on a heavy app justifies this.
