### PR TITLE
Added pipe for multiline string, which makes them much more readable

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -146,6 +146,8 @@ class Inline
                 return $repr;
             case '' == $value:
                 return "''";
+            case strstr($value, "\n"):
+              return "|\n  ". preg_replace( '/\n/',"\n  " , $value );
             case Escaper::requiresDoubleQuoting($value):
                 return Escaper::escapeWithDoubleQuotes($value);
             case Escaper::requiresSingleQuoting($value):


### PR DESCRIPTION
This PR was submitted on the symfony/yaml read-only repository by @mercmobily and moved automatically to the main Symfony repository (closes symfony/yaml#15).

I made this little change because I am converting a LOT of data into Yaml from a database, and I wanted to make sure that the data as as user-friendly as possible.

I asked this on SO: http://stackoverflow.com/questions/34805558/phps-yaml-deciding-how-to-generate-multiline-strings

Then I discovered your wonderful YAML module, which makes much better YAML than PHP's (at least in terms of user readibility) AND it was reallllyyyy easy to hack to add this simple feature (this tells you something about the quality of your code).

Disclaimer: I don't even know PHP. I am a nodeJS boy. But, I think the patch works, and I think it's worthwhile having.

Note: I am not sure how it should deal with `\n` so that it's actually compatible with any Windows etc. If you feel this is a good addition, let me know and I will try and make it more generic...
