### PR TITLE
[Process] don't populate internal buffer if user closure is supplied

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1211,14 +1211,14 @@ class Process
     {
         $out = self::OUT;
         $callback = function ($type, $data) use ($callback, $out) {
-            if ($out == $type) {
-                $this->addOutput($data);
-            } else {
-                $this->addErrorOutput($data);
-            }
-
             if (null !== $callback) {
                 call_user_func($callback, $type, $data);
+            } else {
+                if ($out == $type) {
+                    $this->addOutput($data);
+                } else {
+                    $this->addErrorOutput($data);
+                }
             }
         };
 

--- a/src/Symfony/Component/Process/README.md
+++ b/src/Symfony/Component/Process/README.md
@@ -19,7 +19,7 @@ if (!$process->isSuccessful()) {
 print $process->getOutput();
 ```
 
-You can think that this is easy to achieve with plain PHP but it's not especially
+You may think that this is easy to achieve with plain PHP but it's not especially
 if you want to take care of the subtle differences between the different platforms.
 
 You can simplify the code by using `mustRun()` instead of `run()`, which will
@@ -35,9 +35,9 @@ $process->mustRun();
 print $process->getOutput();
 ```
 
-And if you want to be able to get some feedback in real-time, just pass an
+If you want to be able to get some feedback in real-time, just pass an
 anonymous function to the ``run()`` method and you will get the output buffer
-as it becomes available:
+as it becomes available instead:
 
 ```php
 use Symfony\Component\Process\Process;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17390 |
| License | MIT |
| Doc PR | N/A |

Requesting a pull to main repo instead of readonly mirror. 
