### PR TITLE
[DependencyInjection] Remove useless array declaration

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckReferenceValidityPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckReferenceValidityPass.php
@@ -38,8 +38,6 @@ class CheckReferenceValidityPass implements CompilerPassInterface
     {
         $this->container = $container;
 
-        $ancestors = array();
-
         foreach ($container->getDefinitions() as $id => $definition) {
             if ($definition->isSynthetic() || $definition->isAbstract()) {
                 continue;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

In [2.8](https://github.com/symfony/symfony/blob/2.8/src/Symfony/Component/DependencyInjection/Compiler/CheckReferenceValidityPass.php#L54) `$ancestors` was populated with `$scopes`. 4a3e2f4 removed this, except the array declaration.
