### PR TITLE
Remove remaining calls to non-existing method

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -12,7 +12,6 @@
 namespace Symfony\Bridge\Doctrine\Validator\Constraints;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
@@ -139,16 +138,9 @@ class UniqueEntityValidator extends ConstraintValidator
         $errorPath = null !== $constraint->errorPath ? $constraint->errorPath : $fields[0];
         $invalidValue = isset($criteria[$errorPath]) ? $criteria[$errorPath] : $criteria[$fields[0]];
 
-        if ($this->context instanceof ExecutionContextInterface) {
-            $this->context->buildViolation($constraint->message)
-                ->atPath($errorPath)
-                ->setInvalidValue($invalidValue)
-                ->addViolation();
-        } else {
-            $this->buildViolation($constraint->message)
-                ->atPath($errorPath)
-                ->setInvalidValue($invalidValue)
-                ->addViolation();
-        }
+        $this->context->buildViolation($constraint->message)
+            ->atPath($errorPath)
+            ->setInvalidValue($invalidValue)
+            ->addViolation();
     }
 }

--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -114,39 +114,22 @@ class FormValidator extends ConstraintValidator
                     ? (string) $form->getViewData()
                     : gettype($form->getViewData());
 
-                if ($this->context instanceof ExecutionContextInterface) {
-                    $this->context->buildViolation($config->getOption('invalid_message'))
-                        ->setParameters(array_replace(array('{{ value }}' => $clientDataAsString), $config->getOption('invalid_message_parameters')))
-                        ->setInvalidValue($form->getViewData())
-                        ->setCode(Form::NOT_SYNCHRONIZED_ERROR)
-                        ->setCause($form->getTransformationFailure())
-                        ->addViolation();
-                } else {
-                    $this->buildViolation($config->getOption('invalid_message'))
-                        ->setParameters(array_replace(array('{{ value }}' => $clientDataAsString), $config->getOption('invalid_message_parameters')))
-                        ->setInvalidValue($form->getViewData())
-                        ->setCode(Form::NOT_SYNCHRONIZED_ERROR)
-                        ->setCause($form->getTransformationFailure())
-                        ->addViolation();
-                }
+                $this->context->buildViolation($config->getOption('invalid_message'))
+                    ->setParameters(array_replace(array('{{ value }}' => $clientDataAsString), $config->getOption('invalid_message_parameters')))
+                    ->setInvalidValue($form->getViewData())
+                    ->setCode(Form::NOT_SYNCHRONIZED_ERROR)
+                    ->setCause($form->getTransformationFailure())
+                    ->addViolation();
             }
         }
 
         // Mark the form with an error if it contains extra fields
         if (!$config->getOption('allow_extra_fields') && count($form->getExtraData()) > 0) {
-            if ($this->context instanceof ExecutionContextInterface) {
-                $this->context->buildViolation($config->getOption('extra_fields_message'))
-                    ->setParameter('{{ extra_fields }}', implode('", "', array_keys($form->getExtraData())))
-                    ->setInvalidValue($form->getExtraData())
-                    ->setCode(Form::NO_SUCH_FIELD_ERROR)
-                    ->addViolation();
-            } else {
-                $this->buildViolation($config->getOption('extra_fields_message'))
-                    ->setParameter('{{ extra_fields }}', implode('", "', array_keys($form->getExtraData())))
-                    ->setInvalidValue($form->getExtraData())
-                    ->setCode(Form::NO_SUCH_FIELD_ERROR)
-                    ->addViolation();
-            }
+            $this->context->buildViolation($config->getOption('extra_fields_message'))
+                ->setParameter('{{ extra_fields }}', implode('", "', array_keys($form->getExtraData())))
+                ->setInvalidValue($form->getExtraData())
+                ->setCode(Form::NO_SUCH_FIELD_ERROR)
+                ->addViolation();
         }
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This removes the `$this->buildViolation` calls (which is a dead method) from validators in 3.0, as #17357 did. I just found 3 more. I hope it's not a problem, that it's not in 2 separate PR (Doctrine Bridge, Form). But I can split them if I have to. :)
