### PR TITLE
[FrameworkBundle] Optimize framework extension tests

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -309,9 +309,9 @@ abstract class FrameworkExtensionTest extends TestCase
 
     protected function createContainerFromFile($file, $data = array())
     {
-        $cacheKey = md5(serialize($data));
+        $cacheKey = md5($file.serialize($data));
 
-        if (!isset(self::$containerCache[$file][$cacheKey])) {
+        if (!isset(self::$containerCache[$cacheKey])) {
             $container = $this->createContainer($data);
 
             $container->registerExtension(new FrameworkExtension());
@@ -321,9 +321,9 @@ abstract class FrameworkExtensionTest extends TestCase
             $container->getCompilerPassConfig()->setRemovingPasses(array());
             $container->compile();
 
-            self::$containerCache[$file][$cacheKey] = $container;
+            self::$containerCache[$cacheKey] = $container;
         }
 
-        return self::$containerCache[$file][$cacheKey];
+        return self::$containerCache[$cacheKey];
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -309,9 +309,9 @@ abstract class FrameworkExtensionTest extends TestCase
 
     protected function createContainerFromFile($file, $data = array())
     {
-        $dataHash = md5(serialize($data));
+        $cacheKey = md5(serialize($data));
 
-        if (!isset(self::$containerCache[$file][$dataHash])) {
+        if (!isset(self::$containerCache[$file][$cacheKey])) {
             $container = $this->createContainer($data);
 
             $container->registerExtension(new FrameworkExtension());
@@ -321,9 +321,9 @@ abstract class FrameworkExtensionTest extends TestCase
             $container->getCompilerPassConfig()->setRemovingPasses(array());
             $container->compile();
 
-            self::$containerCache[$file][$dataHash] = $container;
+            self::$containerCache[$file][$cacheKey] = $container;
         }
 
-        return self::$containerCache[$file][$dataHash];
+        return self::$containerCache[$file][$cacheKey];
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -310,20 +310,17 @@ abstract class FrameworkExtensionTest extends TestCase
     protected function createContainerFromFile($file, $data = array())
     {
         $cacheKey = md5($file.serialize($data));
-
-        if (!isset(self::$containerCache[$cacheKey])) {
-            $container = $this->createContainer($data);
-
-            $container->registerExtension(new FrameworkExtension());
-            $this->loadFromFile($container, $file);
-
-            $container->getCompilerPassConfig()->setOptimizationPasses(array());
-            $container->getCompilerPassConfig()->setRemovingPasses(array());
-            $container->compile();
-
-            self::$containerCache[$cacheKey] = $container;
+        if (isset(self::$containerCache[$cacheKey])) {
+            return self::$containerCache[$cacheKey];
         }
+        $container = $this->createContainer($data);
+        $container->registerExtension(new FrameworkExtension());
+        $this->loadFromFile($container, $file);
 
-        return self::$containerCache[$cacheKey];
+        $container->getCompilerPassConfig()->setOptimizationPasses(array());
+        $container->getCompilerPassConfig()->setRemovingPasses(array());
+        $container->compile();
+
+        return self::$containerCache[$cacheKey] = $container;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -312,7 +312,6 @@ abstract class FrameworkExtensionTest extends TestCase
         $dataHash = md5(serialize($data));
 
         if (!isset(self::$containerCache[$file][$dataHash])) {
-
             $container = $this->createContainer($data);
 
             $container->registerExtension(new FrameworkExtension());


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17366 |
| License | MIT |
| Doc PR | - |

`XmlFrameworkExtensionTest`, `YamlFrameworkExtensionTest` and `PhpFrameworkExtensionTest` are slow tests. The reason is that the [parent test](https://github.com/symfony/symfony/blob/2.3/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php#L308) creates the container in every test case. With different parameters, but the same is created several times. (actually with 'full' parameter it is created 12 times in 2.3) If we cache the different containers during test, we avoid to creating the same container multiple times.

As I experienced it can be merged without a conflict into 2.3 and 2.7, but 2.8 and 3.0 conflicts.

I have these result on my local setup. Not that big optimalization, but a few second can matter too imo. :)

**2.3 before**

``` go
Time: 8.79 seconds, Memory: 55.75Mb
OK (449 tests, 586 assertions)
OK src/Symfony/Bundle/FrameworkBundle
```

**2.3 after**

``` go
Time: 5.85 seconds, Memory: 58.25Mb
OK (449 tests, 586 assertions)
OK src/Symfony/Bundle/FrameworkBundle
```

---

**2.7 before**

``` go
Time: 17.17 seconds, Memory: 81.50Mb
OK, but incomplete, skipped, or risky tests!
Tests: 753, Assertions: 1098, Skipped: 3.
Legacy deprecation notices (45)
OK src/Symfony/Bundle/FrameworkBundle
```

**2.7 after**

``` go
Time: 12.65 seconds, Memory: 88.00Mb
OK, but incomplete, skipped, or risky tests!
Tests: 753, Assertions: 1098, Skipped: 3.
Legacy deprecation notices (41)
OK src/Symfony/Bundle/FrameworkBundle
```

---

**2.8 before**

``` go
Time: 18.94 seconds, Memory: 88.00Mb
OK, but incomplete, skipped, or risky tests!
Tests: 787, Assertions: 1159, Skipped: 3.
Legacy deprecation notices (89)
OK src/Symfony/Bundle/FrameworkBundle
```

**2.8 after**

``` go
Time: 12.69 seconds, Memory: 94.50Mb
OK, but incomplete, skipped, or risky tests!
Tests: 787, Assertions: 1159, Skipped: 3.
Legacy deprecation notices (85)
OK src/Symfony/Bundle/FrameworkBundle
```

---

**3.0 before**

``` go
Time: 16.48 seconds, Memory: 73.75Mb
OK (741 tests, 1043 assertions)
OK src/Symfony/Bundle/FrameworkBundle
```

**3.0 after**

``` go
Time: 11.49 seconds, Memory: 76.75Mb
OK (741 tests, 1043 assertions)
OK src/Symfony/Bundle/FrameworkBundle
```
