### PR TITLE
Use is_subclass_of instead of Reflection when possible

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/CustomNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/CustomNormalizer.php
@@ -59,8 +59,6 @@ class CustomNormalizer extends SerializerAwareNormalizer implements NormalizerIn
      */
     public function supportsDenormalization($data, $type, $format = null)
     {
-        $class = new \ReflectionClass($type);
-
-        return $class->isSubclassOf('Symfony\Component\Serializer\Normalizer\DenormalizableInterface');
+        return is_subclass_of($type, 'Symfony\Component\Serializer\Normalizer\DenormalizableInterface');
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |

For performance reason, I replaced a reflection instantiation by `is_subclass_of` 
