### PR TITLE
[Profiler] make it possible to omit the link var

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_item.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_item.html.twig
@@ -1,6 +1,6 @@
 <div class="sf-toolbar-block sf-toolbar-block-{{ name }} sf-toolbar-status-{{ status|default('normal') }} {{ additional_classes|default('') }}">
-    {% if link %}<a href="{{ path('_profiler', { token: token, panel: name }) }}">{% endif %}
+    {% if link is defined and link %}<a href="{{ path('_profiler', { token: token, panel: name }) }}">{% endif %}
         <div class="sf-toolbar-icon">{{ icon|default('') }}</div>
-    {% if link %}</a>{% endif %}
+    {% if link is defined and link %}</a>{% endif %}
         <div class="sf-toolbar-info">{{ text|default('') }}</div>
 </div>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Currently, when you do not want to have a section in the web profiler,
you would have to explicitly pass `false` as value for the `link`
variable. With this change you can omit it when including the toolbar
item template.
