### PR TITLE
fix merge 2.3 into 2.7 for SecureRandom dependency

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -26,7 +26,7 @@
         "symfony/http-kernel": "~2.7",
         "symfony/filesystem": "~2.3",
         "symfony/routing": "~2.6,>2.6.4",
-        "symfony/security-core": "~2.6",
+        "symfony/security-core": "~2.6.13|~2.7.9|~2.8",
         "symfony/security-csrf": "~2.6",
         "symfony/stopwatch": "~2.3",
         "symfony/templating": "~2.1",

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.9",
-        "symfony/security": "~2.7.9|~2.8",
+        "symfony/security": "~2.7",
         "symfony/security-acl": "~2.7",
         "symfony/http-kernel": "~2.2"
     },


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/commit/8d7b19fbbecd5b12c60ca84f7d5c9c12c78b9487 |
| License | MIT |
| Doc PR | - |

As the SecureRandom service moved from SecurityBundle to FrameworkBundle, the dependency needs to be moved as well.
