### PR TITLE
synchronize 2.7 and 3.0 upgrade files

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -19,6 +19,12 @@ UPGRADE FROM 2.x to 3.0
  * The `DebugUniversalClassLoader` class has been removed in favor of
    `DebugClassLoader`. The difference is that the constructor now takes a
    loader to wrap.
+   ```
+
+### Config
+
+ * The `__toString()` method of the `\Symfony\Component\Config\ConfigCache` class
+   was removed in favor of the new `getPath()` method.
 
 ### Console
 
@@ -99,12 +105,37 @@ UPGRADE FROM 2.x to 3.0
    removed: `ContainerBuilder::synchronize()`, `Definition::isSynchronized()`,
    and `Definition::setSynchronized()`.
 
+### DoctrineBridge
+
+ * The `property` option of `DoctrineType` was removed in favor of the `choice_label` option.
+
+ * The `loader` option of `DoctrineType` was removed. You now have to override the `getLoader()`
+   method in your custom type.
+
+ * The `Symfony\Bridge\Doctrine\Form\ChoiceList\EntityChoiceList` was removed in favor
+   of `Symfony\Bridge\Doctrine\Form\ChoiceList\DoctrineChoiceLoader`.
+
+ * Passing a query builder closure to `ORMQueryBuilderLoader` is not supported anymore.
+   You should pass resolved query builders only.
+
+   Consequently, the arguments `$manager` and `$class` of `ORMQueryBuilderLoader`
+   have been removed as well.
+
+   Note that the `query_builder` option of `DoctrineType` *does* support
+   closures, but the closure is now resolved in the type instead of in the
+   loader.
+
 ### EventDispatcher
 
  * The interface `Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcherInterface`
    extends `Symfony\Component\EventDispatcher\EventDispatcherInterface`.
 
 ### Form
+
+ *  The `ChoiceToBooleanArrayTransformer`, `ChoicesToBooleanArrayTransformer`,
+    `FixRadioInputListener`, and `FixCheckboxInputListener` classes were removed.
+
+ * The `choice_list` option of `ChoiceType` was removed.
 
  * The option "precision" was renamed to "scale".
 
@@ -271,11 +302,11 @@ UPGRADE FROM 2.x to 3.0
    `NumberToLocalizedStringTransformer` were renamed to `ROUND_HALF_EVEN`,
    `ROUND_HALF_UP` and `ROUND_HALF_DOWN`.
 
- * The methods `ChoiceListInterface::getIndicesForChoices()` and
-   `ChoiceListInterface::getIndicesForValues()` were removed. No direct
-   replacement exists, although in most cases
-   `ChoiceListInterface::getChoicesForValues()` and
-   `ChoiceListInterface::getValuesForChoices()` should be sufficient.
+ * The `Symfony\Component\Form\Extension\Core\ChoiceList\ChoiceListInterface` was
+   removed in favor of `Symfony\Component\Form\ChoiceList\ChoiceListInterface`.
+
+ * `Symfony\Component\Form\Extension\Core\View\ChoiceView` was removed in favor of
+   `Symfony\Component\Form\ChoiceList\View\ChoiceView`.
 
  * The interface `Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface`
    and all of its implementations were removed. Use the new interface
@@ -544,7 +575,7 @@ UPGRADE FROM 2.x to 3.0
 
  * Some route settings have been renamed:
 
-     * The `pattern` setting for a route has been deprecated in favor of `path`
+     * The `pattern` setting has been removed in favor of `path`
      * The `_scheme` and `_method` requirements have been moved to the `schemes` and `methods` settings
 
    Before:
@@ -597,9 +628,22 @@ UPGRADE FROM 2.x to 3.0
    the performance gains were minimal and it's hard to replicate the behaviour
    of PHP implementation.
 
+ * The `getMatcherDumperInstance()` and `getGeneratorDumperInstance()` methods in the
+   `Symfony\Component\Routing\Router` have been changed from `public` to `protected`.
+
 ### Security
 
  * The `Resources/` directory was moved to `Core/Resources/`
+
+### Serializer
+
+ * The `setCamelizedAttributes()` method of the
+   `Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer` and
+   `Symfony\Component\Serializer\Normalizer\PropertyNormalizer` classes
+   was removed.
+
+ * The `Symfony\Component\Serializer\Exception\Exception` interface was removed
+   in favor of the new `Symfony\Component\Serializer\Exception\ExceptionInterface`.
 
 ### Translator
 
@@ -665,10 +709,17 @@ UPGRADE FROM 2.x to 3.0
 
 ### TwigBundle
 
+ * The `Symfony\Bundle\TwigBundle\TwigDefaultEscapingStrategy` was removed
+   in favor of `Twig_FileExtensionEscapingStrategy`.
+
  * The `twig:debug` command has been deprecated since Symfony 2.7 and will be
    removed in Symfony 3.0. Use the `debug:twig` command instead.
 
 ### Validator
+
+ * The PHP7-incompatible constraints (`Null`, `True`, `False`) and their related
+   validators (`NullValidator`, `TrueValidator`, `FalseValidator`) have been
+   removed in favor of their `Is`-prefixed equivalent.
 
  * The class `Symfony\Component\Validator\Mapping\Cache\ApcCache` has been removed in favor
    of `Symfony\Component\Validator\Mapping\Cache\DoctrineCache`.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16667 |
| License | MIT |
| Doc PR |  |

This is a first step into solving #16667 by checking also the entries from the `UPGRADE-2.7.md` file.
