### PR TITLE
[Form] ChoiceType: Fix a notice when 'choices' normalizer is replaced

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -291,7 +291,8 @@ class ChoiceType extends AbstractType
                 // forms)
                 $labels = $choiceLabels->labels;
 
-                // Reset labels to prevent previous invocation
+                // The $choiceLabels object is shared with the 'choices' closure.
+                // Since that normalizer can be replaced, labels have to be cleared here.
                 $choiceLabels->labels = array();
 
                 return function ($choice, $key) use ($labels) {

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -291,6 +291,9 @@ class ChoiceType extends AbstractType
                 // forms)
                 $labels = $choiceLabels->labels;
 
+                // Reset labels to prevent previous invocation
+                $choiceLabels->labels = array();
+
                 return function ($choice, $key) use ($labels) {
                     return $labels[$key];
                 };

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -1902,8 +1902,8 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $builder->add('choice', 'choice', array(
                 'choices' => array(
                     '1' => '1',
-                    '2' => '2'
-                )
+                    '2' => '2',
+                ),
             )
         );
         $builder->add('subChoice', new ChoiceSubType());
@@ -1912,7 +1912,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
                     '1' => '1',
                     '2' => '2',
                     '3' => '3',
-                )
+                ),
             )
         );
         $form = $builder->getForm();

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -1907,21 +1907,11 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
             )
         );
         $builder->add('subChoice', new ChoiceSubType());
-        $builder->add('choiceTwo', 'choice', array(
-                'choices' => array(
-                    '1' => '1',
-                    '2' => '2',
-                    '3' => '3',
-                ),
-            )
-        );
         $form = $builder->getForm();
 
-        $this->assertInstanceOf('\Closure', $form->get('choice')->getConfig()->getOption('choice_label'));
-        // Since a custom 'choices' normalizer is set in ChoiceSubType, the $choicesNormalizer closure
-        // in ChoiceType::configureOptions() is not resolved and the $choiceLabels->labels will be an empty array.
-        // In this case the $choiceLabel closure in ChoiceType::configureOptions() will return null.
+        // The default 'choices' normalizer would fill the $choiceLabels, but it has been replaced
+        // in the custom choice type, so $choiceLabels->labels remains empty array.
+        // In this case the 'choice_label' closure returns null.
         $this->assertNull($form->get('subChoice')->getConfig()->getOption('choice_label'));
-        $this->assertInstanceOf('\Closure', $form->get('choiceTwo')->getConfig()->getOption('choice_label'));
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -1911,7 +1911,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
         // The default 'choices' normalizer would fill the $choiceLabels, but it has been replaced
         // in the custom choice type, so $choiceLabels->labels remains empty array.
-        // In this case the 'choice_label' closure returns null.
+        // In this case the 'choice_label' closure returns null and not the closure from the first choice type.
         $this->assertNull($form->get('subChoice')->getConfig()->getOption('choice_label'));
     }
 }

--- a/src/Symfony/Component/Form/Tests/Fixtures/ChoiceSubType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/ChoiceSubType.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Form\Tests\Fixtures;
 
 use Symfony\Component\Form\AbstractType;

--- a/src/Symfony/Component/Form/Tests/Fixtures/ChoiceSubType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/ChoiceSubType.php
@@ -1,0 +1,41 @@
+<?php
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @author Paráda József <joczy.parada@gmail.com>
+ */ 
+class ChoiceSubType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array('expanded' => true));
+        $resolver->setNormalizer('choices', function () {
+            return array(
+                'attr1' => 'Attribute 1',
+                'attr2' => 'Attribute 2',
+            );
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'sub_choice';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent()
+    {
+        return 'choice';
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/ChoiceSubType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/ChoiceSubType.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Symfony\Component\Form\Tests\Fixtures;
 
 use Symfony\Component\Form\AbstractType;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17270 |
| License | MIT |
| Doc PR | - |

As @gseidel [mentioned](https://github.com/symfony/symfony/issues/17270#issuecomment-169115049), the notice only occurs, when a custom choice field added after a choice field **and** the custom type is expanded, **and** the `'choices'` normalizer is replaced. The problem is that when `'choices'` option is replaced, the [default choiceNormalizer](https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php#L262) is not invoked. This normalizer would [clear](https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php#L264) the labels from previous invocation, but it's been replaced in the custom choice type. As a result [$choiceLabel](https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php#L279) normalizer will get the wrong labels because it shares the same scope with [$choiceNormalizer](https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php#L262). Resetting the label values after copy solves this problem. 
