### PR TITLE
[Debug] Fix handleError pass \Throwable to handleException

### DIFF
--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -350,8 +350,14 @@ class ErrorHandler
      *
      * @internal
      */
-    public function handleError($type, $message, $file, $line, array $context, array $backtrace = null)
+    public function handleError($type, $message = null, $file = null, $line = null, array $context = null, array $backtrace = null)
     {
+        if ($type instanceof \Throwable) {
+            $this->handleException($type);
+
+            return true;
+        }
+
         $level = error_reporting() | E_RECOVERABLE_ERROR | E_USER_ERROR;
         $log = $this->loggedErrors & $type;
         $throw = $this->thrownErrors & $type & $level;


### PR DESCRIPTION
## Discussion

[Debug] Fix handleError pass \Throwable to handleException

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17410 |
| License | MIT |

For some strange reason i could not discover yet the error_handler is called for catchable fatal errors in PHP 7 with arguments it normally should call the exception_handler.

I have worked around this by declaring the other arguments of handleError as optional an test $type for beeing an instance of Throwable and pass the object to the correct method.

I dont know i you need a example for this case. I have tried to create a small example but i was not able to create a example yet.
## Commits

f303286 [Debug] Fix handleError pass \Throwable to handleException
