### PR TITLE
[Filesystem] Optimize FilesystemTest

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -47,18 +47,31 @@ class Filesystem
         }
 
         if ($doCopy) {
-            // https://bugs.php.net/bug.php?id=64634
-            $source = fopen($originFile, 'r');
-            // Stream context created to allow files overwrite when using FTP stream wrapper - disabled by default
-            $target = fopen($targetFile, 'w', null, stream_context_create(array('ftp' => array('overwrite' => true))));
-            stream_copy_to_stream($source, $target);
-            fclose($source);
-            fclose($target);
-            unset($source, $target);
+            $this->doCopy($originFile, $targetFile);
+        }
+    }
 
-            if (!is_file($targetFile)) {
-                throw new IOException(sprintf('Failed to copy %s to %s', $originFile, $targetFile));
-            }
+    /**
+     * Makes of copy from the origin file to the target file.
+     *
+     * @param string $originFile The original filename
+     * @param string $targetFile The target filename
+     *
+     * @throws IOException When copy fails
+     */
+    protected function doCopy($originFile, $targetFile)
+    {
+        // https://bugs.php.net/bug.php?id=64634
+        $source = fopen($originFile, 'r');
+        // Stream context created to allow files overwrite when using FTP stream wrapper - disabled by default
+        $target = fopen($targetFile, 'w', null, stream_context_create(array('ftp' => array('overwrite' => true))));
+        stream_copy_to_stream($source, $target);
+        fclose($source);
+        fclose($target);
+        unset($source, $target);
+
+        if (!is_file($targetFile)) {
+            throw new IOException(sprintf('Failed to copy %s to %s', $originFile, $targetFile));
         }
     }
 

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -152,17 +152,20 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('SOURCE FILE', file_get_contents($targetFilePath));
     }
 
-    public function testCopyForOriginUrlsAndExistingLocalFileDefaultsToNotCopy()
+    public function testCopyForOriginUrlsAndExistingLocalFileDefaultsToCopy()
     {
         $sourceFilePath = 'http://symfony.com/images/common/logo/logo_symfony_header.png';
         $targetFilePath = $this->workspace.DIRECTORY_SEPARATOR.'copy_target_file';
 
         file_put_contents($targetFilePath, 'TARGET FILE');
 
-        $this->filesystem->copy($sourceFilePath, $targetFilePath, false);
-
-        $this->assertFileExists($targetFilePath);
-        $this->assertEquals(file_get_contents($sourceFilePath), file_get_contents($targetFilePath));
+        $fileSystem = $this->getMockBuilder('Symfony\Component\Filesystem\Filesystem')
+            ->setMethods(array('doCopy'))
+            ->getMock();
+        $fileSystem->expects($this->once())
+            ->method('doCopy')
+            ->with($this->equalTo($sourceFilePath), $this->equalTo($targetFilePath));
+        $fileSystem->copy($sourceFilePath, $targetFilePath, false);
     }
 
     public function testMkdirCreatesDirectoriesRecursively()

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -159,13 +159,11 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
 
         file_put_contents($targetFilePath, 'TARGET FILE');
 
-        $fileSystem = $this->getMockBuilder('Symfony\Component\Filesystem\Filesystem')
-            ->setMethods(array('doCopy'))
-            ->getMock();
-        $fileSystem->expects($this->once())
-            ->method('doCopy')
-            ->with($this->equalTo($sourceFilePath), $this->equalTo($targetFilePath));
-        $fileSystem->copy($sourceFilePath, $targetFilePath, false);
+        $fileSystem = new Filesystem();
+        $r = new \ReflectionMethod($fileSystem, 'doCopy');
+        $r->setAccessible(true);
+
+        $this->assertTrue($r->invoke($fileSystem, $sourceFilePath, $targetFilePath, false));
     }
 
     public function testMkdirCreatesDirectoriesRecursively()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17366 |
| License | MIT |
| Doc PR |  |

The `FilesystemTest::testCopyForOriginUrlsAndExistingLocalFileDefaultsToNotCopy` test is slow, because it opens a remote file, so there are network delays involved. There is also a possibility to that file will be unreacheable in the future due to network issues or just because of the url will be modified.
I also modified the test function name, so it actually matches the expected result.

This PR solves this issue by mocking the method that would actually do the copy.

There are merge conflicts in higher versions, but the idea is the same: move the function part that actually does the copy to a separate method, so it can be mocked.

These are the before-after results:

**2.3 before**

```
Time: 421 ms, Memory: 4.00Mb

OK (90 tests, 143 assertions)
OK src/Symfony/Component/Filesystem/
```

**2.3 after**

```
Time: 152 ms, Memory: 6.00Mb

OK (90 tests, 142 assertions)
OK src/Symfony/Component/Filesystem/
```

**2.7 before**

```
Time: 415 ms, Memory: 4.00Mb

OK (104 tests, 166 assertions)

Legacy deprecation notices (1)
OK src/Symfony/Component/Filesystem/
```

**2.7 after**

```
Time: 136 ms, Memory: 6.00Mb

OK (104 tests, 165 assertions)

Legacy deprecation notices (1)
OK src/Symfony/Component/Filesystem/
```

**2.8 before**

```
Time: 415 ms, Memory: 4.00Mb

OK, but incomplete, skipped, or risky tests!
Tests: 114, Assertions: 181, Skipped: 1.

Legacy deprecation notices (1)
OK src/Symfony/Component/Filesystem/
```

**2.8 after**

```
Time: 140 ms, Memory: 6.00Mb

OK, but incomplete, skipped, or risky tests!
Tests: 114, Assertions: 180, Skipped: 1.

Legacy deprecation notices (1)
OK src/Symfony/Component/Filesystem/
```

**3.0 before**

```
Time: 414 ms, Memory: 4.00Mb

OK, but incomplete, skipped, or risky tests!
Tests: 112, Assertions: 176, Skipped: 1.
OK src/Symfony/Component/Filesystem/
```

**3.0 after**

```
Time: 146 ms, Memory: 6.00Mb

OK, but incomplete, skipped, or risky tests!
Tests: 112, Assertions: 175, Skipped: 1.
OK src/Symfony/Component/Filesystem/
```
