### PR TITLE
Remove useless duplicated tests

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -17,11 +17,6 @@ use Symfony\Component\HttpFoundation\Request;
 
 class RequestTest extends \PHPUnit_Framework_TestCase
 {
-    public function testConstructor()
-    {
-        $this->testInitialize();
-    }
-
     public function testInitialize()
     {
         $request = new Request();


### PR DESCRIPTION
Although there isn't much speed difference, it makes no sense to run the same test twice.

| Q | A |
| --- | --- |
| License | MIT |
| Fixed tickets | - |
