### PR TITLE
[WebProfilerBundle] Fixed "passed by reference" in templates

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/events.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/events.html.twig
@@ -58,7 +58,7 @@
             </tr>
         </thead>
 
-        {% set previous_event = (listeners|first).event %}
+        {% set previous_event = (listeners.first()).event %}
         {% for listener in listeners %}
             {% if loop.first or listener.event != previous_event %}
                 {% if not loop.first %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
@@ -131,7 +131,7 @@
 
 {% macro render_table(logs, show_level = false, is_deprecation = false) %}
     {% import _self as helper %}
-    {% set channel_is_defined = (logs|first).channel is defined %}
+    {% set channel_is_defined = (logs.first()).channel is defined %}
 
     <table class="logs">
         <thead>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

When used with PHP7, PHP throws a Twig compile error, regarding strict standards: "Compile Error: Only variables can be passed by reference".

I used `.first()` method instead of `|first` filter to select the first element in collection and Twig's cache is properly compiled.

It is worth mentioning that I'm using this bundle through https://github.com/silexphp/Silex-WebProfiler on a Windows platform.
