### PR TITLE
Use a simpler composer constraint for symfony/polyfill-apcu

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3",
         "doctrine/common": "~2.4",
         "paragonie/random_compat": "~1.0",
-        "symfony/polyfill-apcu": "~1.0,>=1.0.2",
+        "symfony/polyfill-apcu": "~1.0",
         "twig/twig": "~1.23|~2.0",
         "psr/log": "~1.0"
     },


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |

[`symfony/polyfill-apcu`](https://github.com/symfony/polyfill-apcu) hasn't been released yet so we do not need this complex constraint.

ping @nicolas-grekas 
