### PR TITLE
[Serializer] Remove useless is_object condition

### DIFF
--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -185,10 +185,6 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
      */
     private function getNormalizer($data, $format)
     {
-        if ($isObject = is_object($data)) {
-            $class = get_class($data);
-        }
-
         foreach ($this->normalizers as $normalizer) {
             if ($normalizer instanceof NormalizerInterface && $normalizer->supportsNormalization($data, $format)) {
                 return $normalizer;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

[This condition](https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/Serializer/Serializer.php#L185) is useless, because `$class` is not used in `getNormalizer()`.
