### PR TITLE
Improved the error message when a template is not found

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
+++ b/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
@@ -89,7 +89,10 @@ class FilesystemLoader extends \Twig_Loader_Filesystem
         }
 
         if (false === $file || null === $file) {
-            throw new \Twig_Error_Loader(sprintf('Unable to find template "%s".', $logicalName), -1, null, $previous);
+            list($namespace, $name) = $this->parseName($logicalName);
+            $paths = $this->getPaths($namespace);
+            array_walk($paths, function (&$path) use ($name) { $path .= '/' . $name; });
+            throw new \Twig_Error_Loader(sprintf('Unable to find template "%s" (tried: %s).', $name, implode(', ', $paths)), -1, null, $previous);
         }
 
         return $this->cache[$logicalName] = $file;

--- a/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
+++ b/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
@@ -91,7 +91,7 @@ class FilesystemLoader extends \Twig_Loader_Filesystem
         if (false === $file || null === $file) {
             try {
                 list($namespace, $name) = $this->parseName($logicalName);
-                $paths = sprintf(' (looked into: %s)', implode(', ', $this->getPaths($namespace)));;
+                $paths = sprintf(' (looked into: %s)', implode(', ', $this->getPaths($namespace)));
             } catch (\Twig_Error_Loader $e) {
                 $paths = '';
             }

--- a/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
+++ b/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
@@ -78,6 +78,7 @@ class FilesystemLoader extends \Twig_Loader_Filesystem
             $file = parent::findTemplate($logicalName);
         } catch (\Twig_Error_Loader $e) {
             $previous = $e;
+            $errorMessage = $e->getMessage();
 
             // for BC
             try {
@@ -89,14 +90,7 @@ class FilesystemLoader extends \Twig_Loader_Filesystem
         }
 
         if (false === $file || null === $file) {
-            try {
-                list($namespace, $name) = $this->parseName($logicalName);
-                $paths = sprintf(' (looked into: %s)', implode(', ', $this->getPaths($namespace)));
-            } catch (\Twig_Error_Loader $e) {
-                $paths = '';
-            }
-
-            throw new \Twig_Error_Loader(sprintf('Unable to find template "%s"%s.', $name, $paths, -1, null, $previous));
+            throw new \Twig_Error_Loader($errorMessage, -1, null, $previous);
         }
 
         return $this->cache[$logicalName] = $file;

--- a/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
+++ b/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
@@ -91,7 +91,7 @@ class FilesystemLoader extends \Twig_Loader_Filesystem
         if (false === $file || null === $file) {
             list($namespace, $name) = $this->parseName($logicalName);
             $paths = $this->getPaths($namespace);
-            array_walk($paths, function (&$path) use ($name) { $path .= '/' . $name; });
+            array_walk($paths, function (&$path) use ($name) { $path .= '/'.$name; });
             throw new \Twig_Error_Loader(sprintf('Unable to find template "%s" (tried: %s).', $name, implode(', ', $paths)), -1, null, $previous);
         }
 

--- a/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
+++ b/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
@@ -89,10 +89,14 @@ class FilesystemLoader extends \Twig_Loader_Filesystem
         }
 
         if (false === $file || null === $file) {
-            list($namespace, $name) = $this->parseName($logicalName);
-            $paths = $this->getPaths($namespace);
-            array_walk($paths, function (&$path) use ($name) { $path .= '/'.$name; });
-            throw new \Twig_Error_Loader(sprintf('Unable to find template "%s" (tried: %s).', $name, implode(', ', $paths)), -1, null, $previous);
+            try {
+                list($namespace, $name) = $this->parseName($logicalName);
+                $paths = sprintf(' (looked into: %s)', implode(', ', $this->getPaths($namespace)));;
+            } catch (\Twig_Error_Loader $e) {
+                $paths = '';
+            }
+
+            throw new \Twig_Error_Loader(sprintf('Unable to find template "%s"%s.', $name, $paths, -1, null, $previous));
         }
 
         return $this->cache[$logicalName] = $file;

--- a/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
+++ b/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
@@ -77,20 +77,18 @@ class FilesystemLoader extends \Twig_Loader_Filesystem
         try {
             $file = parent::findTemplate($logicalName);
         } catch (\Twig_Error_Loader $e) {
-            $previous = $e;
-            $errorMessage = $e->getMessage();
+            $twigLoaderException = $e;
 
             // for BC
             try {
                 $template = $this->parser->parse($template);
                 $file = $this->locator->locate($template);
             } catch (\Exception $e) {
-                $previous = $e;
             }
         }
 
         if (false === $file || null === $file) {
-            throw new \Twig_Error_Loader($errorMessage, -1, null, $previous);
+            throw $twigLoaderException;
         }
 
         return $this->cache[$logicalName] = $file;

--- a/src/Symfony/Bundle/TwigBundle/Tests/Loader/FilesystemLoaderTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Loader/FilesystemLoaderTest.php
@@ -98,4 +98,21 @@ class FilesystemLoaderTest extends TestCase
         $loader = new FilesystemLoader($locator, $parser);
         $loader->getCacheKey('name.format.engine');
     }
+
+    /**
+     * @expectedException \Twig_Error_Loader
+     * @expectedExceptionMessageRegExp /Unable to find template "name\.format\.engine" \(looked into: .*\/Tests\/Loader\/\.\.\/DependencyInjection\/Fixtures\/Resources\/views\)/
+     */
+    public function testTwigErrorIfTemplateDoesNotExist()
+    {
+        $parser = $this->getMock('Symfony\Component\Templating\TemplateNameParserInterface');
+        $locator = $this->getMock('Symfony\Component\Config\FileLocatorInterface');
+
+        $loader = new FilesystemLoader($locator, $parser);
+        $loader->addPath(__DIR__.'/../DependencyInjection/Fixtures/Resources/views');
+
+        $method = new \ReflectionMethod('Symfony\Bundle\TwigBundle\Loader\FilesystemLoader', 'findTemplate');
+        $method->setAccessible(true);
+        $method->invoke($loader, 'name.format.engine');
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | #14806 |
| License | MIT |
| Doc PR | - |
### Before

![template_error_before](https://cloud.githubusercontent.com/assets/73419/12414237/7db29212-be94-11e5-85b4-c6444aa853f8.png)
### After

![template_error_after](https://cloud.githubusercontent.com/assets/73419/12414242/80ed1eca-be94-11e5-992e-a0596a1e95ca.png)

This seems to work in the browser ... but I can't make tests pass. Could anybody please help me? Thanks!
