### PR TITLE
[Cache] Optimize ArrayAdapter by using a generator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,7 @@
         "symfony/yaml": "self.version"
     },
     "require-dev": {
-        "cache/integration-tests": "^0.6",
+        "cache/integration-tests": "^0.7",
         "doctrine/cache": "~1.6",
         "doctrine/data-fixtures": "1.0.*",
         "doctrine/dbal": "~2.4",

--- a/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
@@ -58,16 +58,11 @@ class ArrayAdapter implements CacheItemPoolInterface
      */
     public function getItems(array $keys = array())
     {
-        $f = $this->createCacheItem;
-        $items = array();
-        $now = time();
-
         foreach ($keys as $key) {
-            $isHit = isset($this->expiries[$this->validateKey($key)]) && ($this->expiries[$key] >= $now || !$this->deleteItem($key));
-            $items[$key] = $f($key, $isHit ? $this->values[$key] : null, $isHit);
+            $this->validateKey($key);
         }
 
-        return $items;
+        return $this->createGenerator($keys);
     }
 
     /**
@@ -176,5 +171,16 @@ class ArrayAdapter implements CacheItemPoolInterface
         }
 
         return $key;
+    }
+
+    private function createGenerator(array $keys)
+    {
+        $f = $this->createCacheItem;
+
+        foreach ($keys as $key) {
+            $isHit = isset($this->expiries[$key]) && ($this->expiries[$key] >= time() || !$this->deleteItem($key));
+
+            yield $key => $f($key, $isHit ? $this->values[$key] : null, $isHit);
+        }
     }
 }

--- a/src/Symfony/Component/Cache/composer.json
+++ b/src/Symfony/Component/Cache/composer.json
@@ -23,7 +23,7 @@
         "psr/cache": "~1.0"
     },
     "require-dev": {
-        "cache/integration-tests": "^0.6",
+        "cache/integration-tests": "^0.7",
         "doctrine/cache": "~1.6"
     },
     "autoload": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes/no [Depends on](https://github.com/php-cache/integration-tests/pull/34) |
| License | MIT |

Added to generators to where possible to optimize code and save memory especially on `ArrayAdapter`.

Code works and test pass with fixed [cache/integration-tests](https://github.com/php-cache/integration-tests/pull/34) (Currently does not support `\Traversable`)
- [x] Wait for accept PR on [cache/integration-tests](https://github.com/php-cache/integration-tests/pull/34)
