### PR TITLE
[Finder] Improve the phpdoc of SplFileInfo methods

### DIFF
--- a/src/Symfony/Component/Finder/SplFileInfo.php
+++ b/src/Symfony/Component/Finder/SplFileInfo.php
@@ -38,6 +38,8 @@ class SplFileInfo extends \SplFileInfo
     /**
      * Returns the relative path.
      *
+     * This path does not contain the file name.
+     *
      * @return string the relative path
      */
     public function getRelativePath()
@@ -47,6 +49,8 @@ class SplFileInfo extends \SplFileInfo
 
     /**
      * Returns the relative path name.
+     *
+     * This path contains the file name.
      *
      * @return string the relative path name
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

I **always** get confused when I need to use the finder (getFilename, getPath, getPathname, getRelativePath, getRelativePathname, …). This is only addressing the last two methods but hopefully it will help.
