### PR TITLE
[Cache] Added RedisAdapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,9 @@ cache:
         - .phpunit
         - php-$MIN_PHP
 
-services: mongodb
+services:
+    - mongodb
+    - redis-server
 
 before_install:
     - if [[ ! $deps && ! $TRAVIS_PHP_VERSION = ${MIN_PHP%.*} && $TRAVIS_PHP_VERSION != hhvm && $TRAVIS_PULL_REQUEST != false ]]; then deps=skip; fi;

--- a/src/Symfony/Component/Cache/Adapter/RedisAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/RedisAdapter.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Adapter;
+
+/**
+ * @author Aurimas Niekis <aurimas@niekis.lt>
+ */
+class RedisAdapter extends AbstractAdapter
+{
+    /**
+     * @var \Redis
+     */
+    private $redis;
+
+    /**
+     * @param \Redis $redisConnection
+     * @param string $namespace
+     * @param int    $defaultLifetime
+     */
+    public function __construct(\Redis $redisConnection, $namespace = '', $defaultLifetime = 0)
+    {
+        $this->redis = $redisConnection;
+
+        parent::__construct($namespace, $defaultLifetime);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doFetch(array $ids)
+    {
+        $values = $this->redis->mget($ids);
+
+        $index = 0;
+        $result = [];
+
+        foreach ($ids as $id) {
+            $value = $values[$index++];
+
+            if (false === $value) {
+                continue;
+            }
+
+            $result[$id] = unserialize($value);
+        }
+
+        return $result;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doHave($id)
+    {
+        return $this->redis->exists($id);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doClear()
+    {
+        return $this->redis->flushDB();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doDelete(array $ids)
+    {
+        $this->redis->del($ids);
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doSave(array $values, $lifetime)
+    {
+        $failed = [];
+        foreach ($values as $key => $value) {
+            $value = serialize($value);
+
+            if ($lifetime < 1) {
+                $response = $this->redis->set($key, $value);
+            } else {
+                $response = $this->redis->setex($key, $lifetime, $value);
+            }
+
+            if (false === $response) {
+                $failed[] = $key;
+            }
+        }
+
+        return count($failed) > 0 ? $failed : true;
+    }
+}

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Adapter;
+
+use Cache\IntegrationTests\CachePoolTest;
+use Symfony\Component\Cache\Adapter\RedisAdapter;
+
+class RedisAdapterTest extends CachePoolTest
+{
+    /**
+     * @var \Redis
+     */
+    private static $redis;
+
+    public function createCachePool()
+    {
+        return new RedisAdapter($this->getRedis(), __CLASS__);
+    }
+
+    private function getRedis()
+    {
+        if (self::$redis) {
+            return self::$redis;
+        }
+
+        self::$redis = new \Redis();
+        self::$redis->connect('127.0.0.1');
+        self::$redis->select(1993);
+
+        return self::$redis;
+    }
+
+    public static function tearDownAfterClass()
+    {
+        self::$redis->flushDB();
+        self::$redis->close();
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

I have added RedisAdapter. I haven't hardcoded that it would use _phpredis_ extension version client because there is many other clients which provide same API so to support them I left open. For test purpose I wrote a _FakeRedis_ client implementation which acts like real just stores everything in array.

If we choose to use extension version I will remove FakeRedis and add variable requirement for `\Redis` type. But we will need redis instance on tests... Or somehow find way to mock it (We will need extend all cache/integration-test tests because of mocking)
