### PR TITLE
Fix markdown typo

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -19,7 +19,7 @@ UPGRADE FROM 2.x to 3.0
  * The `DebugUniversalClassLoader` class has been removed in favor of
    `DebugClassLoader`. The difference is that the constructor now takes a
    loader to wrap.
-   ```
+
 
 ### Config
 


### PR DESCRIPTION
There was too much backticks before Config paragraph

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | symfony/symfony-docs |
