### PR TITLE
RFC Added stdout to console handler 

### DIFF
--- a/src/Symfony/Bridge/Monolog/Handler/ConsoleHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/ConsoleHandler.php
@@ -45,6 +45,8 @@ class ConsoleHandler extends AbstractProcessingHandler implements EventSubscribe
      */
     private $output;
 
+    private $stdoutput;
+
     /**
      * @var array
      */
@@ -122,7 +124,8 @@ class ConsoleHandler extends AbstractProcessingHandler implements EventSubscribe
     {
         $output = $event->getOutput();
         if ($output instanceof ConsoleOutputInterface) {
-            $output = $output->getErrorOutput();
+            $this->stdoutput = $output->getStdOutput();
+            $output          = $output->getErrorOutput();
         }
 
         $this->setOutput($output);
@@ -154,7 +157,13 @@ class ConsoleHandler extends AbstractProcessingHandler implements EventSubscribe
      */
     protected function write(array $record)
     {
-        $this->output->write((string) $record['formatted']);
+        if (Logger::ERROR > $record['level']) {
+            $this->stdoutput->write((string)$record['formatted']);
+
+            return;
+        }
+
+        $this->output->write((string)$record['formatted']);
     }
 
     /**

--- a/src/Symfony/Component/Console/Output/ConsoleOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleOutput.php
@@ -32,6 +32,8 @@ class ConsoleOutput extends StreamOutput implements ConsoleOutputInterface
      * @var StreamOutput
      */
     private $stderr;
+    private $stdout;
+
 
     /**
      * Constructor.
@@ -43,6 +45,7 @@ class ConsoleOutput extends StreamOutput implements ConsoleOutputInterface
     public function __construct($verbosity = self::VERBOSITY_NORMAL, $decorated = null, OutputFormatterInterface $formatter = null)
     {
         parent::__construct($this->openOutputStream(), $verbosity, $decorated, $formatter);
+        $this->stdout= new StreamOutput($this->openOutputStream(), $verbosity, $decorated, $formatter);
 
         $actualDecorated = $this->isDecorated();
         $this->stderr = new StreamOutput($this->openErrorStream(), $verbosity, $decorated, $this->getFormatter());
@@ -152,5 +155,13 @@ class ConsoleOutput extends StreamOutput implements ConsoleOutputInterface
         $errorStream = $this->hasStderrSupport() ? 'php://stderr' : 'php://output';
 
         return fopen($errorStream, 'w');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStdOutput()
+    {
+        return $this->stdout;
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Please DON'T review this PR, it's just an PoC! 

Is there any reason why the `ConsoleHandler` is redirecting all output to stderr?

In this code `ConsoleHandler` writes on the error output if the level is equal or greater than `ERROR`, otherwise it writes into standard output.

If the community like this change I'll rework naming, interfaces etc.
