### PR TITLE
[FrameworkBundle] Fix upgrade guides concerning erroneous removal of assets helper

### DIFF
--- a/UPGRADE-2.7.md
+++ b/UPGRADE-2.7.md
@@ -596,11 +596,11 @@ TwigBundle
 FrameworkBundle
 ---------------
 
- * The `templating.helper.assets` was refactored and returns now an object of the type
+ * The `templating.helper.assets` service was refactored and now returns an object of type
    `Symfony\Bundle\FrameworkBundle\Templating\Helper\AssetsHelper` instead of
    `Symfony\Component\Templating\Helper\CoreAssetsHelper`. You can update your class definition
    or use the `assets.packages` service instead. Using the `assets.packages` service is the recommended 
-   way. The `templating.helper.assets` service will be removed in Symfony 3.0.
+   way.
 
    Before:
 

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -388,51 +388,6 @@ UPGRADE FROM 2.x to 3.0
  * The `request` service was removed. You must inject the `request_stack`
    service instead.
 
- * The `templating.helper.assets` was removed in Symfony 3.0. You should
-   use the `assets.package` service instead.
-
-   Before:
-
-   ```php
-   use Symfony\Component\Templating\Helper\CoreAssetsHelper;
-
-   class DemoService
-   {
-       private $assetsHelper;
-
-       public function __construct(CoreAssetsHelper $assetsHelper)
-       {
-           $this->assetsHelper = $assetsHelper;
-       }
-
-       public function testMethod()
-       {
-           return $this->assetsHelper->getUrl('thumbnail.png', null, $this->assetsHelper->getVersion());
-       }
-   }
-   ```
-
-   After:
-
-   ```php
-   use Symfony\Component\Asset\Packages;
-
-   class DemoService
-   {
-       private $assetPackages;
-
-       public function __construct(Packages $assetPackages)
-       {
-           $this->assetPackages = $assetPackages;
-       }
-
-       public function testMethod()
-       {
-           return $this->assetPackages->getUrl('thumbnail.png').$this->assetPackages->getVersion();
-       }
-   }
-   ```
-
  * The `enctype` method of the `form` helper was removed. You should use the
    new method `start` instead.
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

As mentioned in #17041, the upgrade guides for 2.7 and 3.0 erroneously mention that the `templating.helper.assets` service is removed in 3.0.  #17041 cannot fix these issues since it targets 3.0.

This PR should only be merged after #17041 since it depends on it.
