### PR TITLE
add PSR-6 cache adapter for validator

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/Cache/PsrCache.php
+++ b/src/Symfony/Component/Validator/Mapping/Cache/PsrCache.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Mapping\Cache;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+
+/**
+ * Adapts a PSR-6 cache to a CacheInterface.
+ *
+ * @author David Maicher <mail@dmaicher.de>
+ */
+class PsrCache implements CacheInterface
+{
+    /**
+     * @var CacheItemPoolInterface
+     */
+    private $cache;
+
+    /**
+     * @param CacheItemPoolInterface $cache
+     */
+    public function __construct(CacheItemPoolInterface $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * @param string $class
+     *
+     * @return string
+     */
+    private function getCacheKey($class)
+    {
+        //backslash is a reserved character and not allowed in PSR-6 cache keys
+        return str_replace('\\', '_', $class);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($class)
+    {
+        return $this->cache->hasItem($this->getCacheKey($class));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function read($class)
+    {
+        $item = $this->cache->getItem($this->getCacheKey($class));
+
+        return $item->isHit() ? $item->get() : false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function write(ClassMetadata $metadata)
+    {
+        $item = $this->cache->getItem($this->getCacheKey($metadata->getClassName()));
+        $item->set($metadata);
+        $this->cache->save($item);
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Mapping/Cache/AbstractCacheTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Cache/AbstractCacheTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Mapping\Cache;
+
+use Symfony\Component\Validator\Mapping\Cache\CacheInterface;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+
+abstract class AbstractCacheTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var CacheInterface
+     */
+    private $cache;
+
+    public function setUp()
+    {
+        $this->cache = $this->getCache();
+    }
+
+    /**
+     * @param string $className
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject|ClassMetadata
+     */
+    private function getMetaDataMock($className = 'Some\Nice\Class')
+    {
+        $meta = $this->getMockBuilder('Symfony\\Component\\Validator\\Mapping\\ClassMetadata')
+            ->disableOriginalConstructor()
+            ->setMethods(['getClassName'])
+            ->getMock();
+
+        $meta->expects($this->atLeastOnce())
+            ->method('getClassName')
+            ->will($this->returnValue($className));
+
+        return $meta;
+    }
+
+    /**
+     * @return CacheInterface
+     */
+    protected abstract function getCache();
+
+    public function testWrite()
+    {
+        $meta = $this->getMetaDataMock();
+
+        $this->cache->write($meta);
+
+        $this->assertInstanceOf(
+            'Symfony\\Component\\Validator\\Mapping\\ClassMetadata',
+            $this->cache->read($meta->getClassName()),
+            'write() stores metadata'
+        );
+    }
+
+    public function testHas()
+    {
+        $meta = $this->getMetaDataMock();
+
+        $this->assertFalse($this->cache->has($meta->getClassName()), 'has() returns false when there is no entry');
+
+        $this->cache->write($meta);
+        $this->assertTrue($this->cache->has($meta->getClassName()), 'has() returns true when the is an entry');
+    }
+
+    public function testRead()
+    {
+        $meta = $this->getMetaDataMock();
+
+        $this->assertFalse($this->cache->read($meta->getClassName()), 'read() returns false when there is no entry');
+
+        $this->cache->write($meta);
+
+        $this->assertInstanceOf(
+            'Symfony\\Component\\Validator\\Mapping\\ClassMetadata',
+            $this->cache->read($meta->getClassName()),
+            'read() returns metadata'
+        );
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Mapping/Cache/PsrCacheTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Cache/PsrCacheTest.php
@@ -11,16 +11,16 @@
 
 namespace Symfony\Component\Validator\Tests\Mapping\Cache;
 
-use Doctrine\Common\Cache\ArrayCache;
-use Symfony\Component\Validator\Mapping\Cache\DoctrineCache;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Validator\Mapping\Cache\PsrCache;
 
-class DoctrineCacheTest extends AbstractCacheTest
+class PsrCacheTest extends AbstractCacheTest
 {
     /**
      * {@inheritdoc}
      */
     protected function getCache()
     {
-        return new DoctrineCache(new ArrayCache());
+        return new PsrCache(new ArrayAdapter());
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Following the recently merged PSR-6 Cache from @nicolas-grekas I thought it might be a good starting point to add an adapter for the Validator meta data caching.
