### PR TITLE
Allow absolute URLs to be displayed in the debug toolbar

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -223,7 +223,7 @@
                         path = url.substr({{ (request.schemeAndHttpHost ~ request.basePath)|length }});
                     }
 
-                    if (path.substr(0, 1) === '/' && !path.match(new RegExp({{ excluded_ajax_paths|json_encode|raw }}))) {
+                    if (!path.match(new RegExp({{ excluded_ajax_paths|json_encode|raw }}))) {
                         var stackElement = {
                             loading: true,
                             error: false,


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12221 |
| License | MIT |
| Doc PR | - |

If you agree with the original issue, this should do the trick. If you don't agree, please explain the reasons and close #12221. Thanks!
