### PR TITLE
Fixed form types in profiler

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
@@ -437,7 +437,7 @@
                 <div class="toggle-icon empty"></div>
             {% endif %}
 
-            {{ name|default('(no name)') }} {% if data.type_class is defined and data.type is defined %}[<abbr title="{{ data.type_class }}">{{ data.type }}</abbr>]{% endif %}
+            {{ name|default('(no name)') }} {% if data.type_class is defined %}[<abbr title="{{ data.type_class }}">{{ data.type_class|split('\\')|last }}</abbr>]{% endif %}
 
             {% if data.errors is defined and data.errors|length > 0 %}
                 <div class="badge-error">{{ data.errors|length }}</div>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17453 |
| License | MIT |
| Doc PR | - |

This only affects to Symfony 3.0 and higher.

| Before | After |
| --- | --- |
| ![form_types_before](https://cloud.githubusercontent.com/assets/73419/12448020/aa59c134-bf73-11e5-8ce4-205a97c50339.png) | ![form_types_after](https://cloud.githubusercontent.com/assets/73419/12448024/acad1a6c-bf73-11e5-98cc-2d9ba11d1e29.png) |
