### PR TITLE
[DX] Remove default match from AbstractConfigCommand::findExtension

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
@@ -45,26 +45,25 @@ abstract class AbstractConfigCommand extends ContainerDebugCommand
 
     protected function findExtension($name)
     {
-        $extension = null;
         $bundles = $this->initializeBundles();
         foreach ($bundles as $bundle) {
+            if ($name === $bundle->getName()) {
+                return $bundle->getContainerExtension();
+            }
+
             $extension = $bundle->getContainerExtension();
-
-            if ($extension && ($name === $extension->getAlias() || $name === $bundle->getName())) {
-                break;
+            if ($extension && $name === $extension->getAlias()) {
+                return $extension;
             }
         }
 
-        if (!$extension) {
+        if ('Bundle' !== substr($name, -6)) {
+            $message = sprintf('No extensions with configuration available for "%s"', $name);
+        } else {
             $message = sprintf('No extension with alias "%s" is enabled', $name);
-            if (preg_match('/Bundle$/', $name)) {
-                $message = sprintf('No extensions with configuration available for "%s"', $name);
-            }
-
-            throw new \LogicException($message);
         }
 
-        return $extension;
+        throw new \LogicException($message);
     }
 
     public function validateConfiguration(ExtensionInterface $extension, $configuration)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

Previously, `findExtension` would return the first extension that might not even match the `$name` parameter, which would quite confuse the user:

```
$ app/console config:debug TotallyNonExistentBundle
# Current configuration for "TotallyNonExistentBundle"
knp_paginator:
    default_options:
        sort_field_name: sort
        sort_direction_name: direction
        filter_field_name: filterField
        filter_value_name: filterValue
        page_name: page
        distinct: true
    template:
        pagination: 'KnpPaginatorBundle:Pagination:sliding.html.twig'
        filtration: 'KnpPaginatorBundle:Pagination:filtration.html.twig'
        sortable: 'KnpPaginatorBundle:Pagination:sortable_link.html.twig'
    page_range: 5
```

Same problem goes for the `config:dump` command. When you dumped the config for a bundle you thought you've registered, but, for example, you'd use a name that's not exactly matching, you'd get confusing output for a different bundle's configuration.

The problem was, an `Extension` [was always fetched in the finder method](https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php#L51), and name/alias misses were ignored.
