### PR TITLE
Add strict image validation

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Image.php
+++ b/src/Symfony/Component/Validator/Constraints/Image.php
@@ -30,6 +30,7 @@ class Image extends File
     const SQUARE_NOT_ALLOWED_ERROR = '5d41425b-facb-47f7-a55a-de9fbe45cb46';
     const LANDSCAPE_NOT_ALLOWED_ERROR = '6f895685-7cf2-4d65-b3da-9029c5581d88';
     const PORTRAIT_NOT_ALLOWED_ERROR = '65608156-77da-4c79-a88c-02ef6d18c782';
+    const CORRUPTED_IMAGE_ERROR = '5d4163f3-648f-4e39-87fd-cc5ea7aad2d1';
 
     // Include the mapping from the base class
 
@@ -49,6 +50,7 @@ class Image extends File
         self::SQUARE_NOT_ALLOWED_ERROR => 'SQUARE_NOT_ALLOWED_ERROR',
         self::LANDSCAPE_NOT_ALLOWED_ERROR => 'LANDSCAPE_NOT_ALLOWED_ERROR',
         self::PORTRAIT_NOT_ALLOWED_ERROR => 'PORTRAIT_NOT_ALLOWED_ERROR',
+        self::CORRUPTED_IMAGE_ERROR => 'CORRUPTED_IMAGE_ERROR',
     );
 
     public $mimeTypes = 'image/*';
@@ -61,6 +63,7 @@ class Image extends File
     public $allowSquare = true;
     public $allowLandscape = true;
     public $allowPortrait = true;
+    public $detectCorrupted = false;
 
     // The constant for a wrong MIME type is taken from the parent class.
     public $mimeTypesMessage = 'This file is not a valid image.';
@@ -74,4 +77,5 @@ class Image extends File
     public $allowSquareMessage = 'The image is square ({{ width }}x{{ height }}px). Square images are not allowed.';
     public $allowLandscapeMessage = 'The image is landscape oriented ({{ width }}x{{ height }}px). Landscape oriented images are not allowed.';
     public $allowPortraitMessage = 'The image is portrait oriented ({{ width }}x{{ height }}px). Portrait oriented images are not allowed.';
+    public $corruptedMessage = 'The image file is corrupted.';
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/test_corrupted.gif
+++ b/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/test_corrupted.gif
@@ -1,0 +1,86 @@
+GIF89ad d ÷  Ro«(DHÏÓÔm/t8f†j’üÿÿ2W[#V–¥nkwLPQ&9C’³É!49†)u)3²êê®³´15%ITEtx8Wc65jCiw
+e§«¦±Ôtœ¼KFCE‡UŠ˜;djè÷ø2FXx·¹–ÆÆˆº¼"'7to‚E2k±,ÑÜîÏLºèêêW‡ˆ8$G¾ËèL…Šg8€fs¯Hx‡e˜¥36G†—)5:GzHY–Ú÷÷7)XU”›ËæëE&V8B©ÈÖ#$Z£©ˆ“º‹ÄÇ¨Ö×%#EoH˜FYažÀÀGceÃ3¡4juv¥«gVu(RW49Ugª²)*x©¹T+ek³¶He™7A7JdI+aB9F7s”0„†–—SJ–¶R¶S0jØèé
+(Ug"*óþüh‚½6VuU[¦W{–W7vFDdDw”¬ÌC K—S³iS¥—˜š(6X»vÆEj‰AQˆ¶ØÛw–µ  VJj¦ËÎN€|"*æìöiVBLaŠ¦Ùìò‘œÄóôôXxz™Ö×14IQz‡K”›(Kb777pµ7s}y‰W"W"*€‡ˆÉöõC0Hh›´RDEi[#"%3#;¼ÇÆV£žE;VœÈÑ¸e¹&$Xj˜™§ª!$v°®,[s‡„“)ah/,gri#^”½»		rš¦PT…«»WWd ô÷úX‘‹.GMEXt„Jž³ÊÞIvm_ersŽ³’‹—()*)Og BA}Š¢¤}ÃÈKM‘VefÉíðXZo7^^m¶¯p‹­¸áâ$?>íñðQgŠ‚µ±=‚ˆ¸=§	Ã`¼0,¡œ££ÐÏÝßßÈáá0*œ®°£Fœû÷üöûúòïô
+$1PR¶½àH0/,1[[ˆJBO($($-.-RMÌÐ+NO_/o:2y!d¿¾Ãðëïóóï¤áá¡¢¢   ÿÿÿ!ÿNETSCAPE2.0   !ù
+ ÿ ,    d d  ¡ û	H° Áƒ*\È°¡Ã‡#JœH±¢Å‹3jÜÈ±£Ç CŠI²¤É“(Sª\É²¥Ë—0cÊœI³¦Í›8sêÜÉ³§ÏŸ@ƒ
+J´¨Ñ£H“*]Ê´©Ó§P£JJµªÕ«X³jÝÊµ«×¯`ÃŠK¶¬Ù³hÓª]Ë¶­Û·pãÊK·®Ý»xóêÝË·¯ß¿€L¸°áÃˆ+^ÌXp@ !ù
+ ÿ ,    d d  ÿ 7H° Áƒ*\È°¡C#JœH±¢Å‹3jÜÈ±£Ç CŠI²¤É“(Sª\É²¥Ë—0cÊœI³¦Í›8sêÜÉ³§ÏŸ@ƒ
+J´¨Ñ£H“*]Ê´©Ó§P£JJµªÕ«X³jÝÊµ«×¯`ÃŠK¶lÆe´š¶©›Yw’$¤ƒPn*YjÛê7 †d€1H„â®;!¿{ÕUžˆŠd¼˜|ÇÖàÂˆseìøE0 ]-ÄFƒ`Ì™·.hœ‹–ëÏzD‹&}oê¬¾:Þ-ÛÕîµo_åæ@ÄkÞ¾“auÚ½T%¼ºr6jÛ~^uµqP¬‡ñ¯!€óáÅi…_?¾€{òæÎCš À…`¥Ø¿oZÑ–$	lgU}5à§ß û%XC|†q]q†— k!PÈÜ`:øà}ù%‡`… †x	òuWÁw~8ÙŠ"NÑ †SIW`Š*²Ys¦ÙƒÉxÖß{6Vf^ŽÂmhã‘”‘Hd‘BÆÆ“G§ŽLVU…_¶<™ˆ"0¸äŽÃýá 	h pùå|X1„_d^ö"Œ]¡—\ÌY%_Tîù›ný)è „jè¡ˆ&ªè¢Œ6êè£F*é¤”Vjé¥˜fªé¦œvêé§ †úÐ¨ !ù
+ ÿ , ! & %  ÿ ÿ	H°`·*\Èa·‡­"J„Ø°¢@ˆã2.ÐÈq¢Eƒ5’I’dÇ%ê*©®BË—&3¢tˆ€¥ ›8qºŒ‰2âH—9¥ªSÝJ™}¶Äi¦)ª§P‰î<ÊpÒ 7¡>Ùúˆ«ª¨7êB
+2ãR¡_»F[Ë¶ë×¦aG’øp%V´Ø¢ÛË·íÛ¸=Ò¬U-_‹+ÆÁö©Abç"´káéZÅ2kÎÜ×íãÈ)ÍV~rs‘Ó¨O3^»õ³¯±•2R•×ôf¸q/öä5‚Ø”IÛ¾[÷jp%Àž¨‹°™ÚÄS/’øï©Ì_žÎ}zuäŒ KÙZ^+íÄÿJ©§Ò½øw5á!(ïHŠ°ðÓÐÖ·7Î¼øÀÕ7Zbûq‡X¦Ä7R¢¡]tÝXƒØ¨Ž Ïía„ï)Hžl÷mè‚É}XÞ€ŠHÝq	º&Sv†¨b$º8—ljauÖµXF	YhÞƒÃñx‰t5è u«ÖY‹½-(X’ÜœÅ•^~ùè vSRéË]–ååÖVŽý(YYõ£Vešy¦Bu¥y×ctºùæB*÷V.q	äLÅ¹K1ý	hhôýd—‡EA2 !ù
+ ÿ ,  / -  ÿ ÿ	H°àÀn[)\h°¡Ã‡Ž›H±¢Eˆ#þ*ƒ c] Cz¼˜cB‘’RJPÉR$Ã’=’bY¡¦Í•8gŽ„YP"Í @ƒ
+½™r'Ï
+Cª»9´)Q$!&U)TÕ«Xí˜Ðä¸™K«bµ@¶lÖ [£ö”Ô,£·pãšÕªöàD_aÝÊÝ+whÚ®kÁŽ5Ã—°a¾uÐºŒ™7®©Ã#K><·&TÀH7JZòdÏŸá:P•ãÒ·ªž¤VÍ:´kÑ¤/šbAÄ£Û8rçþw{õkÊdcÛ] ®vt‹Š(W¾hQ´Þ¿_]¹)© ¦¢)XN¥»wçoˆÿ÷ýú,H†I=Ú®¬½{÷EÀuŽ7\W•‹ÿÿ v'ß|¿M·Ôù"ÈE¼ €
+äF`Á˜ ‹”p+žà`	þÅÞ„ÖwßùI`JƒLtØá‡"Ž(Þ4Öˆ‡&þq^;U@ G˜ÐbB~¢„wda£8æÈUªäE‚è`„2.É¤“>E¹!•Âˆ¤’Zcf“îhÝŠº¨¡˜Y–y¦‰%vbŠêqð¦•pÆ)§hÚ÷W7º`ÇÞƒ|þƒ%™Œþ9š Oâ‰CƒF†¸h’–¹E…ƒ"´ß¤•Æˆi¦K‚`ªwÚUœ z'à¥óý—yª@éè~ªV žvÛÅ§è˜±ÊŠêŽÓF›)ª½¡t$þ™Á°kì±È’Hž7–*Ì³Ð¾DÐTÔÒ'Y¶t2Òíè:îU ÑWg­¥+Hµ[žU9q$í¼ô¶åØ½±ÕÅUýÛ
+'z[ÒTTq¦Wš•‚?i•ðF¯•àOb–±ÆG+ðÇ1Y„¢Ç% !ù
+ ÿ ,  9 8  ÿ ÿ	H° Á›Ê(\Èð Ã‡vcèNVE‹/6ŒÈ"ÅT CŠL@RãÆŽ(?ŠLÂ²¥Ë‘'S:Té˜Í›8_f”éqáÊœ=‚
+Í	3¦Ì‰ÍÀtéP›EyLZÓ©Õ¦O[š”Jµ*Ö¯`±­ˆ4¥O¯aÓ‚KÖ,I´juxFW-ÔF"}{3®Ü¿€ç
+{wgO‹pëVbñÚÂyîÙÐõëâÆ˜33v|/å™•™^ÆCz´fÎ?ô§dß€KËÖ1»6ÝÓX=¤ŒX(lÒ;‚n›¶qÍ*æ-¹{/ËßÀ³HŸNøéëus–ÌZÖsèÓEÿO½|ñâ„™œÜ{Ktòðã›?[»;½Ÿã™ž¦ùòUG_vu¤†Ð?( ›tþò€
+‡]}þ3‘$	ÒÆÆ –,Ã¡ƒBHž„6f_C$9àXáb‡0†(bÅX7¡‰'Z˜_ j àÁL˜pÄ	%¼âŒkx#,Y$™wÀ†°°bÂ5Xi¤ƒH¾Ü’8¦ÖJŠ¶R¥XfùOŒ\Îhã’6yß…	j`C	C^‰ÄžZ¶è_—%†)§ŽdZ‚§ž{öÑg‡2¨ä%ž¸WvZdš|ÂÂ& ¯€©œQjæ	ˆfº)§a@ª*…rî•@”S’ÿÚÇ¬ŠjÊ(/F¨Ä»®ÊjI‘P©¬BÉf®ð­Áë²½úšYœÀr÷êwpä¢§BÈì®Üb­“•!µ¶h	ç*pd—Û6‹\SºéØ]n˜Æ­ÈÊ×n·ï~;'BÝ%1…ÁÍÈn»ÎÊU!wì)H°ÁŽ¾²¯»‚¶ºZÀ*îÄ4N¬DÂðF‹ôjÌ1usËï³þ–5òÜHPòÆn~™êÊÈ-|qkðhr„ÔÕ˜ð¯m¦†3t bÅÛSBGËL‚´	¨q’ªö40'ÝÕõ1• g	¹ÅWÉÇ¥­öm
+·™D„¶Tà×k6·˜\Úµ×sÃK&jþêÂµÖ\%õkô>¦ÓVyÜU‚@Õ*Y„7.ïãg.'°”WnùåIEÍùèá~Z¸0§®úÛ¦ŸŽ:ë­wTzì¦;G !ù
+ ÿ ,  J <  ÿ ÿ	H° Áƒý)\È°!Â‡#J4Ø°¢Å‰3J´È±£Æ;ŠB²ä¦“ Syò—IY0cÊ4©²&Ë’gdæÜÉs&J›oêÌ©%‡Ñ£H{º£	ô¡P¤0ŠF•:•êQŸMWŽŒiHT.^ÃŠ{uéÏ¬ÿ¶r­
+öJÛ·pÉÝÉ´éV¨cãŽqË7î\ºgUvL ¯Þ¾‡÷¾
+8ðG‹"§2
+¬G˜#ÞœXncÁ%¡HRù²—Ó¨5wæ¶ã˜Ž1V$,tiÔÂÚèÞ­zuo×ë†l‰€T•ã·qç¾Ä¼yêÞÐU¿†ýø¤."Æ+©ÃÝôòæaœóÿŽNÞ3õáÅÿ×Þ]ˆïáÁ‹/Ïºõtá7èO/AÝvAlñ^1ñÉgàx™ùf_peì§Õ~JæŸí°Ã+fX xÌ=GŸ_æá8$fÇ€jàq¡†k°x ‡JWÖ’Xb'Öb†{+®ñ-¹á|1rvE­¸d#7¾àø#ª¸ 4TY¥CvcŒÀÍXq2™£ PJIåi¤	$–Yidˆ_¾´Þ“Rl‘"•Vª©&›Dº)£Qfi¥Þ˜dZp'žz&ÊgŸ~ÚwÞ—ƒ`	Ðyhž‰¦¹¨–.È ƒiEJéRb)¢™îé"£äÕóÛ§•ÿH!0’Jê©˜¦ºf›­~gZK%âÆÂŽzk¡—êª*¯½–ÕgKéÁ°Ä[ª©Pfª²›nÙ¬b°[F*ÄÒjm¡†â±-šzþÓí·®¾ú©ƒãÒZ¬­•’™l»í¾; ¼ñò.AÐV«¤“&¬î¶‰º»é¿G\ß‚ÐLR“tê»¯@ý®z‰Äƒ,/ øÅ*aÂ(_x&»š¾ëEÈ0‹î³©<ºÒu„¦¨rÃ.G³Ì,(Æ–š9PÏãýìóŸ‹ˆó‰Zèq–k¦4ÐÃ[œ7>)5SsšôÕ2ÓlsD]{-%Õ¬îE¶ÄæŠÞ?µUÈvÕ*ööfónÆí4Ýu{7à ï}ßˆ…9Yrƒ‹`áˆ™mV7 &>îâ–)ç­‚n3­µ¸ÕYwe™wúíá~£·é@ ÌyÜJ¦.å«kòÕë¯“<yå@ÕNUë¸¬{„ ÛE{a¿¿˜äÊž’B:%{U}7ˆ’8±žWgÔ7}ýÍkIïi—Õüù÷}Wä'eþç¼£Ïu´£»oÿðN¿ü"füý>‰ÿB§¸™0I´Éˆv÷’vÐ‹v	Ì
+˜Á:# !ù
+ ÿ ,  [ ;  ÿ ÿ	H° Áƒú[È°a·2ÿm˜¨°¢Å‹:ÜñaÇMCfIÒ"Ç“BB¦¨RbÉ—/QNT™²¦¬•.mz„ÉÓ¤ÇŸ3iž¹9”hÑ£5ö\:(M¡Õž¹AUêÍ–La‚|êÎ¨×¨`«Š‹TdV’[;zM°`j*·9âÊ%«¥®]`¯&=‹‘ãÚ·€çÚ¥:¸páyõâä«0èßÀI"Ã0<™²å¹Š¥eLÐ¯$¶Ÿÿˆ–\¹‡i ¨ã”¾l¸ìÊÍœ†™ôéÔªs³¾‹93EÆžg×v›‹ñã¸Wï*©fØ1¹ê>œxqäÉu/gîúHém©Kÿ€€Xyë×±gßÎÝ·Vð´Ï×q0?QzøÕ¯g_Õ}IÇ…&_}$ÔwŸ~ûñ×Ýo}9¥V|óé@ 	fà……ùe¨a‚
+ú—‘_ÅGÜQ"‰jT(Ì…¶ˆ`‡Î™ÕˆáAâ!ä¨H&€‡@®è¢‹ÚÁØ•ŒÉ” ôhT” %>èèãBù"íauQZAIÐä“Qž0%T²ÁÆXf©%‡F"9cŒbŠP™¥ÀbæžiðÊ úæ–qÊyÐƒ:`Î8B©çž|þ³æ+—¸9h‘…zg¢‰b “6@aEžòÉ‹¤”VÊâ¥˜n×œ‡›:ÿ"“æ$cÌ.l¸¢k©¬˜Ê‹ŸÅ¨º*‘­ºº K€)
+Íd§"„**¯{žJ›–[¬±¾ÉÚmMŠÖR«“jîJ-,Vxð+¶Ã²Êe—\I´l3âþól¹Óžû+°Ùjû.¼†"b²)Ñ:.£ƒ˜«ïµÅ´ë¯r–µzìœj1+®­ä&¬°©üjè0¡Kë¡—±€Á7ºq)–„Ð±Ç‡¼mb7&	ÊM€êÃ®ººüF›0§ÌºMühäÑs°Žjš$†Aƒ¼­<ÿD‚©Ñ2„4­(v=Eu€u†SËóAÙb‘3rƒŽ±Ä„ô5ÌpšmµÝgÏŒõw…ÿ7y€ØnÙwã­÷Úhía²Éâ(vÌ….¹äý!žøâ~è8ä‘>yÞ /ÖSßŒknÛuNyå{ÿGzãè1è´×NsŒ|)» ñ>3Ñ‡¿Š;pZcÞûìÀv5ëÃ¯{æ‚%/ýí–þ:ôÑO™6Ôkêüõ_eßÚøp	ßzlJ%þúi—oUõgÑx¤,a¹OYï¯Õ<ú¥¯>ûÌû–Nø÷%ÿÑï€ÿËŸN0×0V¤³Éî£À-Î{<”Û‚@ý-0^d›ü$˜	ÎO$!Å8uBZÐK*¼Ü_ˆÂ’Å'¯ñV¼žsCô)KV%ì!ÿj(¯ ±‡?,"L !ù
+ ÿ ,   d <  ÿ ÿ	H° Áƒ*DØ­ŒÀVB6m˜¸°¢Å‹3œÈ±á/C‚ÔH²$Ie$>D±¥È”0ÿM3I³æÊŽîrêÜ9r Ë—*m
+½(&OYg ]zÔçÑŸC£24š4•Õ«X³’“É´kÕŸí(JÊ2k’³hÓæXëµm¨·]cŽ­YÖ,°»xó²ýZõL5Õ†Ët.ÝVõæ]Ü†–ÇkoHÜ¥²=Ë—µ†jØ¢Ç¾j7M:Î?Ó§1§ÆŒÙoRÎ§rµ+º´m ‘â|ØÍºwkÂ@cô·'%èÐµo_Yž7oß½]>¼8bäÉK3¯·]ÞsèÑSÿ¿©òxÚì=T¤_Î}€{æßÁÿ?–¸ýû³ŸOŸ¡¿zåc´Q{3Ì |ò…WO6Ýçàuûù'Œ„üý§Â¨!‚	*(Yøá¤_„za¢@b¨áŠv8l%=8ŽQ(@à@‰þ¥hâ‰ö¨"‹-º˜Ù‚CÉ¸ 6n‘Œ-wì€Ç“xäˆ¢<R9àŠ6'ä‹E… 7U4s€wÔðÆ™hB©ƒ„ÿìèæ›X©å–C:"ô$óˆ™èâƒ6üs¦“O²	'œqf9'HIõ%˜è)C‹Ø`	T@ñ8ˆBèšo†ša¢ï)$‘\ÉEÔCºø€¤“ÿaÅ¬ÿœ`«%ƒ …šUö:*©¦žJNy`‘7Õ£AŒyA¬%@c«	G@k…º~êë¯¤*ê£õ¨·^’7¤°bú,´èÖÊ©§ÅLxíÀ.Ê­ß&ðèD”£TLFBç#èÈZÊ¹Ñ¦KE®Ö
+„(¶q+ìL÷âë@36âû%½2ú+³Íl0Âí¾o¼ÛÎKo«x‘PËÄ¾è{1K)¹š'Ç\-îŠze¶í•l2«Ø˜ˆÊ,Û»¯CK0 ™ÖŒn)¸&Üf›“ì3£''€ïCí2Æ É¼¬À;mÂ´7ç¬3ÃÚÆ÷0«õ½µÑ/?X=c›ëlÁèJÿ²ÚVîlµÛ.qÝˆÉÍká~™Î«4ïÝ·ßìâÜ+#Ë)¯°Hùò¾_Ë•˜y—]ó´ƒX›#æ¬·78á	ž*¸3ÆEG®nÜ‰Þ’ßjÉ €³®#Û=_Í9íÈ# ÛD­Îü§é¶:(»S˜y©›®YòªBôáFãæ^zÇPwºÃS¬^áðÄg¯ýVÜÇè¸ÒÑüi) fªþ§­¯]àWrßû:?0OfŒX’þð°¿:¤Ïzý w˜ù F‡áˆÖj$4ôX=ÝY·.ÃX'?$QýG5‡ÁÎC$Œ‘®âAÿ9G7Æ{¡j ó—ÊðA´ˆõæ3:i3äH"çâ9F¦Ž¹#3Êä;ÒùG·à·Ä"M‹´!âb¨(Áh†2G¼ •ØE&Ñ5E£ZÈ8Â¼Åw¤ã°ÔØÆÎàÇ<rcãBH>B¥€ãqJHe–:º…{¢cci¬GBò’ˆ¤äA<‡ÉN¥(2	¥&7ÉIO‹'¥å(•JSz)’A™$udT”ZºR&¶Ñ*3BËWºR—»Ì`ˆr‰b˜Á4`/qYÌø!3™¼ì¥ƒ¬3Íj>š'ÌŒyMlvÉšàôf"ÁNqŽ’œ6	 !ù
+ ÿ ,   d =  ÿ ÿ	¸iÁƒ*\È°¡Ã‡»m±bÄ‰-jÔXæ_‰1nYÑŸI&O’Lø±¥Ë•%;ŠT˜²¦Í›*7ºÜ9&K™ªÄI´¨PŽ<{ú<´iÑ¤OB„úÒçK§£‚¤ŠQêT®0·bE©U,×³f"XË¶-Ù®1»†”‹¬GYBÈå-£·¯_»wÛ
+üó-Ö²tý
+L +U¨3k“üO²åÇY	.ØÌy0a¦YášEœóåÈµT«ü¯‹j×°a_&ËMWgÏŸ5¸wcÎŽƒ·~=\žñã‘>(_n¯y¨_zÛžŽ›pèÝu1â-:‡÷šÀkÿYŽ|•ùóÒ—½¶{ê·sóÎîn»ýÓâ¿ÇÙý½ÿ ¦çßz˜UAÄð ø^uJ	å[bïyWNpR¨_~å `v €Ì5gàˆ$Â7ƒ…ö K¶X¡‹°%ÉyÖèá€°¥£ãŽ	*Èà\*žx‚À™Ä‘(iä…¯Ç6F9 zöT<šøãŠù’Ž `Ö!æ˜JC“Î8£†~á¦”ª·^3tBPg‰ZÒ'$‚V‚i#€’&™üq&“gªi^›o6zcœrvQg ƒf¹à–‹m6b˜¢BÀ§j„º…„z„
+‡¦™!£ŽÂ©<æÿ`Š¬±Òs§[î‰ ŸfxúÄ¯ ŠªÃ°k*†¦êd‹²Új«ª'&(’Ëµ˜$#¥#æÚÒ®ôªÊ¸¼an°Â‚`ì©¨&‹!³>-‡SÊCË½®Ü+ƒÙÚzežn}»i¸ä–ûç¢›®
+»ûîšÎÊû(zÆ•b1pàÃ"üNëï¥BîT›Ž‚ˆ[ð?'jYà±m«ì“lJ<o´ê!q+Ð\¼1-°®W–l²Á)«ÌòÅ\òò?17<3ÄÛ<qz#ðÇÎ>o4¸J7rFüiÒJ/íòÓQO¥ÕÎâˆt3óI	cÐ"0ÿbå¸qCrÙãðÚi7m»Ý,Ü®¢GwÝ<÷lùÞ`Ýv Ù}øÁˆ«½ƒâ‹Ë,žqoC-Å“ƒcwå—ó­ƒ·Â÷9Ù¨ˆþé8pœøâsÌ±¸ÃË>îº£Ëûì´ëýBæ:hÛ¯ô˜ è¾“¼%
+Ü¡r1§?GãMÊÓúòô;!Ÿ°bBô{³Qíµ~|=ièÝ“þðŠkò’W3öµvtÓZäwú)"öC‡ó§` "øÙ6X:–­!§sZ»EµªY­y	„ýöfêk‚ù{Ðö5=•nƒŸRã 6³Õ•Ð€T8ÿØÀ"^Nzx¡”øÂŸOƒP´àÊZ&Œ*f ‡Éû¡›·µùåíˆƒaôõÀ1N¯‰h4{×©6‹éÓ¢ëäfÄ/"±Œg\â÷(Æ4*Œâ
+”˜RD-^&”X´º·Œý,_I´Öýð‡ÇÆ0j ÃEªN: I†,Ô?Ö9HU,]sâô4p z`pZ”Œå%Ñø)Mn‹“•JÒwvIB9*g®aa0XHFê {ÍØµd¹Lü)Ñ–m$UÑ²§,^Z“f4á"ƒIL'bPÙ[¬°EÎfÆš%Ë¥Ž^tÍCb3›7k^sT	Ã\hlï¡Ó8Í™ÿ-l½r“ê§{PÀÎvúPQðl”<CÉUfîž0Ñ\ÙÏŠ.S[µÓßÂi©Û¤Æ ¼,)ƒhçèEVšì›Ð´#JíÓ¢=¦DA8v¤h" Ü¨dÒ_øƒ{µ TîÚÂ'}¾4[1(È¶„œÆQFŠ"POQ‚%¥ÎT0
+êE‘z=|Æ‡>7ÍieŠœaÆ)ÚKkàªZ‹TÔ_ÕÑf°¿ò£ÖljlØC×¥®5­ZÅ \åê­§èµxÍ+b{Ö½Ø„CóLV‹*ÔŽRä0óá‹fÃê¢›Î†4ÞzÏdQŽ	}5³ µ«g«˜èÐÕ)¬hq¤Ës¦³uUíj!ÛÚÔêi¶5‰o¡SŸÊÄ6¶Ãý-Š’–¡$7)ÇíÇstÛ±Xeº¯EHN@»”¸L×+jAmw‘Zî:·ã]IyÁû•ª¤·»F9‰|Õ[]ê¾7,ì¥¯mï{]ó’Ä¶™á¯€¼_Ø' !ù
+ ÿ ,    d d  ÿ 	H° Áƒ*”U†¡C!!>\HQá¦‹3jÜÈ±£ÇŠ$ŠIò£É“(Sª´q¥Ë—0»…œI³eÍ˜,qêÜÉÓæÍŸ=ƒ
+•™ÓçÐ£E‘*]JÔ(Ó§[EuJu$P¨X¥&­šµëÕ¦`½rK6ì×²[­šEËößÚ´lÏºŠ€î8»pãÖÕÛö.Þ2Yìœ—/áÁ‚oRü±cÃ#KvÌ¸rãÂo3¿´\7çÏCû½LZs`Ñ¨A'VºäÙ±§[‹þSŽµmÖ¯sÇ–Ý¹ŠoÚÀ¹_Í[·ñØD’ÿ^®¼¹sáÐQ%>ùêçÌÓeÇ›ôŸÔ'/ÿ½¾€»öóè‡«WO¹ø÷ñÄÍ§ŸOß»}]÷Û—¬Íþçäå‡V0`}ÜåÞmšfgä5W`3VèÀ„¸]wJÄ ám6x½(`†¦¨"‚Ìýçâ‹Âö ]&Ò†b 8æXËŽ9¢È"€5Âc*26a€ÛÝÈ£Šô¬h ?&è¡güCäDÇÍåtôM¸¤Ž_šÓ¤“n%ˆX:tÆgkVce*Õ¸fÜuz&˜ˆ	&™u¶ˆ&•pj¢Å 9´™&IGÚx¡’{ê)fžô@Ú£(”)%’©$Qè¦„v
+œŸ’#j¨¢Ž¡>
+i2yŠÀêª’NÿZæ¬—VÃi¦¸v‡®¶vÑë?öØzXhÊ‘™ã«®j ì4«¬«ÈŽÉ§¥(äÚæ­‚f«ë®Ü~àí·ò„ûÁ‚¾-j'ŽÈ6ËÆº!´ëC»ÎBëŠuhÌ›	À`mÛöÛm$ ÿóO bp ä2i2øá.PD\ŠÄÁ¼ï¼ŽNá€Æ›Lµšêë©¶"Ãðï*(üO,·AT÷¡Š.ÃÛ q)'°¢ó:OlƒGË	DYàÇ!“¬´ÉLs‹ò=P»¼ÂÔ_Lí—„{¦J³7ç|y€Ý‡	&”à3ÐAÃ:4Çˆ40=$÷Ü@ôÀÅ¿q ìrÕS÷ÿíw‰çâ¹58ñu6?£8âa“ñ»2à€¶¼ó²]G˜g®ÂæœáùÝu?-ð¤ûmú
+XSøªªØ"B³\›mBˆ ¸@Hâ_q6ä5ÿìêkíÅñš#¯<Ÿ×3Àó£ŸîÄôÔKàŽÿ´úººã|8· þø·³¾SÁÀÏ¬«[ÄO‚ôÇ/Ì%ø“øóß¼ó¥“õú¶œ
+­n{ïRßÄ7»l€|Äùa¶õ±Or“«êG¿Wxp ü`ÂÀ¿”Ð„Ñ“†
+ÈBÔÙ)]´`Ÿ½F6f<0‚œ ú÷®bðb:€Ÿÿ>˜…"†P„#<áèþ1µ¶p€æbÝÖÐµy lÇÀ¡yÀ
+òÐ‡?d–ïPÄ! GD"	•0ƒ[ÜâNlŸ¨ºtqO†ÞC„Øl¨Å-î£l6cÇHF2‚hLãéF9HÃ‘*”ãY †mÏY«YiÇö‡\dé¾RàˆL¤"yHFR’Oœ^ë Õ0î½ Äb'm÷Iòñ ”„« 4\1ˆb¢Í”§L¥*W©„VþÃ‘rl4c)Ëd-ëŽxôZ'=ÙËR°Œ[ÄŒ9d¢2•«a#¡)ÍvRÓ	–´¦ðÊ»n³›å	:9ÿ¶~Ú€œðúa2ÑÉÌ9´RbHh;aùD;ªëŽ›DÂñ)>.†M˜CøÄ0ÿé®y”ƒH'ªÐ…Nr€´¼f¼.‚*ÎÜ¤èø²aˆõŒ˜¤tßG—©¿,Ò -©Ic)Å´±45%Ü,È N™Vt‚'°BÎpšÓtxð©I*T†¶pGñÔ ö"Ç5.¦øü¥ËÆ3bð­TæUÉÕ®žtzZX<øºÈÀ ýt Z?©Ö?ÊŽ£dZ\ƒ'
+eŠT­ìªWYh 
+¯³Œ\*êÛ‘ícaá»v®æä)T¡¾³ŽP›öúZ
+ÆÿqŠ#ì/)±ÖÒ"VŒ•\!‡ÛØÇ~°‘v¥&ÍüÀ\±Ž•žïúkÚñ·:ücú~kNCrµ‹Ô*dåÐÚÉ²¥1¤Å-›K¹`ÓÐ ìvÉKëîvø]kÁ¨ÁþžÑƒY0VÚÌ[¼ò®ÔKl1ööÎ–¹– {	P"|ö5~ÅFÚý^ð}Û[ÝÔ Õ;X¼âÅáè÷-Âæ®XU*a4|/Ÿ¼û£5êáÏ¡jÐ \Gd[ôtÀ ÖŸ™(ÀÂ˜ÁE°X³ì88,V÷©è#Ï*èÖ)ËY$²ÕÀÁ¬"™~Ë{^ ©ùä¬/ÿÂ8 ªü
+ã¸qÂ4Û‡ÇüåÙŠ€ƒòÛ æä9OÍMÎdŒÕ«^?´wftçmÃ7Ú¨*ƒËR†Ÿàˆ[BZÉ³[èÆ· ~v0^oœ…'Øì’Þhu§»ûVÆš¶ì8Ýº2:Ô T¸H5¨=4ÕŽf“DàjÙÅú³ …v6Æfé.¯:¶Ëf]ÑýkÈ­[%×°†É‡BgJG3ÜÛlX¢Âµ“u8yŒþæ:Ý•-Þ¶í×íoÃ-iÁòU>Ð«o=k¥÷f=Ž*;Xs2qó¦7Ë)¯fàû7Q¼SñüÝ4OÙŠT¯†5}¡ç¬›ÎÐÿHù³#žr=ONÙ8ÒŒ*8Y™ÌZS"Õ”*©6tûé`w×Të.R{ªQv°ž ÀLõ‰Z¸ÂMt.„rm=øIN3f	œµ¼ÎC[ãŽN…LÃ¼äYOÌd"Y€ªHSúy‡zt‡-PªDïgµ9êå˜kh:j{Ô÷ø(H@Ì¦˜â¿žTö]Ûï¿qÌôžÍH˜Z8l¦xÎ»bœòÒŸ„ù÷I?–—ÓFßÍ/8§ýqÆH/y©^)†úáçŠC>òµ¼uPú /7mæòSðM?¬Â;ÿ.
+JlWgqÚ—žù¨ŸKåq/ùrAòË?—TN_"]ü¨‡ÐˆJÃ}Å=÷å	ÿö×OÿÝÌŸõò7fÚý÷GÿþâwL" Ñ¸¶'"ì—Íw{	è Ø€¥1xø€+Aˆã¡(~A€¨} X‚$X(€%¸‚!(¨‚,Ø‚¸'X1hƒ7È3hüÇƒ9øƒ2ƒ@Xˆƒ‡²€ !ù
+ ÿ ,    d d  ÿ ËH° A*<È°á‚‡#r+7‘¢Å‹3.Ô¸¡£Ç mt²$ÉD VÇR‚Ë•-YrIÓäÉ›6kª„³çKž>yÎÔ™gD£
+/]Ê4¨Ï£D‹"º³éS«NŸ¢”ÊuêÊŒXej«+åÃ*g³VŒ:®«[‰a—¦%k¶¢L´Dðªýš–-U‡	öælW0a½U±"@ûöï†À	a:Ðl²\Ä_3^»³âÆ~ÿ•\¹t…ÎžÓ­;—)h¨H	[†@»vê»«U÷-ÓïëÑ¤gŸ¾ªº8k ¾“'8(;®ótƒi£6^á±Èß\•fµ-Xºdç¼Söÿtœ}ºyîÑŸ«ùãì¢—kGýÝvú÷¹ë__´uù©üáKpû­W`æ'TY¬aYkµ™!~	¦3á…"8\V2\-jâˆ$–há†""×Ø{Àñ&\Š“Åø¢‰4Ú&ã‰Ayßƒ<¦GÙ5N"C–ö#4v[y=ú$’‚XË”1Òs$‘RV™¤wf1ÙdO&"£˜dVIå•gjy%‘\ªÕQ*9à—(¤•Y¦©çžz>	Óot*ˆa‘GòihŸkfÈXQÁVg9a*é™Tjé”ædš=—bšeŒŽåáO|ã˜FâÙ©¥"°êê¦­Âÿêi’þùX 1•Š"
+ƒšéé«ÉÄ*,k¬±$Û©‰µ¾Ùh£±é¤šÚ¢ì±2û¢p+ÊÏ kí¸i†(•­¸
+ú¯l
+¬Æf+CÞ²1È½õ~.¼ãnZî„ÍÊçaº»â¸.ª¿úl°ÅÎKozØÀËÄËPlo¾Çò[i¢´I5'Á8†|°Œª¾îÅSaE!FDÜrÅ_ìm¸ýZK	3ºÇ´;¥ëÏ¿&ÌjÃ(sPÈH?àÁÑ,·üò24ÌlÍnØ\¤†èî8XžJrÉA/ïwÌ[ñÑ‘¶ÚLtà6ÓMC-u²6+;E„^‚üµÐ«Âÿ:¶Ã
+,½6.„Ç`ø9…³KÜsk°…Uãü3y‘6ßÀ^„àCàÂÂç “ñùáˆ¿írãÛ]Û‹šTt{cþÏµbÿ±° ýIè³ôÞ;!€„N:ãÛÖy‘[mÝš¦ï*L·°k ˆÙ¹ã9ð¾ =8†tÿûèj/s·ëŒ{ü£;»7“]Ãû‹;tô¶ß®û<Œ€Æöü÷ÿ=án‹XÔžQ¾Ç™ÏJ(ëˆ© ëšSÀÃ?úU~l˜—î—?ÿyÁ3\Óh0@ªyÁ£Ì³Ä3Ö€^–À1J@Cr@‚œ¶þ¡éMÐ~GøÄ>ÿ°÷Á"~¯p€ƒHH3ÇAÎ7›˜ØÕ(z@Pe%ÐÝ>þˆ ÚPb>£¼âÅÃ	N,w4¢CxŽ$:‚s@ÆPøÄ.§™XÉÏP ÀÅà›ÓÝ˜ñƒ		&ð"yC1Æ/‚1ä	¡Æ5²ÀpIœƒ&•`­FÎ;Ù#Ï‚ í1ÀðqŒ	ìÃ•Š\¤FËHÐIÛ+÷WI#‰ppÄh†˜Ï3ðBZb¤	MìJ¼È"*E‡=V²	ûèâfÈHÎÒ–Ãâ'¦ÉË^úqJt„0£ðÄ(áuúÇÝD) -°AHKå*ñÿýµÒ•Ùô"7eø,áã"OÈAƒ{æôå%Ý8LNVï¼ìÄô“”$ÂžG›æ>û9V¡JÚH,jñŒè9Û¨‡7ÞÂQÈè-¼Aªy:ógæÑô¹J’æïŸ(E),çÁT¦”
+E§Ç9ÑAT¦E¼$…	GzÃºÊAi#Vù8àøìÜ>ùiT“* 'u*T9àRiN •WÅªµÊ2uvõrƒ8ÚQ‰œ5­†„býG	üq®ll\¹‰@|¢SÍF9õšULÁ¯€¬`™Ù¥¤œµ¨*QIjT£>V²KE%ôg€<ÿ`i”Ì+gýÇÆ"˜4ƒpE‹>G- "P@j‰
+Òö(m[a9£ÖVey0€e»Û½Šð·Ÿ,5@A^7pôŽ(Á@n«Êæ:Ð}euYûC1ˆ,¸n!Û9Cê¶»½ý­#à`ò’·Å]R¬ˆÚqæV{<hl8x€M€ÎV·, ìuKPRW·»ý»¤g•Hà˜°è…J3’Qƒk÷Ãÿ,)\çaJ¼rr½Æ†ƒGUî‚X{"~[0Ml`j„Õ¸ÜXqr© S.>4›þ/J÷gãlâx% ë'pYä7ãôïgA†ÒùÖiI$ðxÌ%GI€ÿS-Ç•¿œ‡}d÷¦ñ›ÊÍ"èaÜ28²‘˜Ž¹·gNgÕläu­2"Ö\ßÆN™µ#˜ ŸUjPlÙ
+èðb=í^x·A>³Ó\à˜ž¨²E0êö’Ì‘=ê¦»ÕÀMœƒ`B¡É€ë˜bµÌmÚæV·ÀF³ž´”,„ªlÿ`AR¡¼ënû›÷
+ç BÊÜco„o,ñš£ôÀŒmÌÉºb	°ÍŒy@9¥rí5½0˜ÃânÞ5¶/µ{n.CŒ/mª¥-é] VUc±¨p9aÏÝöæÃÿvÁzÎ¹¸À[RgÐ¶àÿ'¡:‹Œ%†]‡G!Ý^.ošÏOµA¯ÝÇó˜»/ƒá$÷ç¬ÛACÑt«†\ñRãÙœâx¼Ü­02®5d)éªoŸ{ý}Ó7çˆZÈˆØì‡CZÜ,6@M:ý£c³ ü25s<‚
+Àìææêf¹‘û–Æ|N=€Üm%Û:pU>éøj;`½1Z—ËYt7Ñ‘w¬[áï*<üj7®“ýŒäNã¿ÁÇ[_Þ‚\F¿Z)ÆïöÇÊ|[þ@ÍY¡ïQå»#1O»ú¥,—«WÓ~ÈÃÞ„mhƒ¾àËOæ¹Gàî$ñ‰‡žïàÇáÿ¾š¯ÓSì÷¬_š%Ö®t™‰™^PÂ ¾`÷lýãòÅÒ}3kSÿoßRçú†PÃ7;™u–×-ör~I·€`ô|w,u}`Ew×*Gv³vþçM8zÈ7eS6bn&(3lpt«°
+Èõ€ÑÓCùGw«¡d/äoè€þ‚9ñÂÏ—A)˜‚ûBu•òDÀqPØs08ƒ–6hKµ$…8‚<Xz„„t2*X3TÂ+e• g•-SG„º…ý‡ƒTt·0˜ó<Xxrè…_˜"w*¨{)VµÐ}j¨…Zè„oˆ)Ã/shˆÊ‚ÚÇ.q‡¦ÿWA±r†{Ø5…Sh‰dˆƒø†x¨1b£ˆWÃˆx”v×‰;ÈcQŠ=´Š?‡‰2¸ƒ˜4`C~3+ôñ¤ø*WÃh(«XKe$/:„yu'‹AS&„ø.œR‡6ò'îA"¼¸‡QÈo$Œ¬(ˆÔ"‹QbŒÇ%á&-Ò‡åW:4F™ˆÔ²pÌH"ÿB!ðÀ@ã:1WKw!Ø.úh&Ó"!'Êó(óh€—øŠ±¢{P¢Ž“vˆ(=“ôx´ô€ªã'¤R»«á1Z#ó8‘Dcùˆ‘ç±‘†±y‘¸Rw…HŒëèŽ2IJòŽ,Ù’”âÁ<ÐŽ3ù„4I›q“';ÍX0øaDY“*"”ì¡,$$	©Ñø“½á”C™GÑSôä3½¡”Ky™².PÙQT¤‘aÁ5­–Yk q–—A—jY”¸z)–È—rù¢—¯“•R•‚é–Z‘XÙ"©+¹±—`¹ Šù—·Ò3I™T¹$”Ù![iiÉ‘kÙ “I–	žq\Vi“H¦™›Y™;#šm˜‡©”Óš£±š ‰›£i›;#”m¡<¼¹›ÌášÂY›ðhœÑGÇ	œÈ™œ !ù
+ ÿ ,    d d  ÿ 	H° ÁƒþýC€¡Ã…e"Jœè°!Å‡	hÜÈˆ„* =~YA¡É“(7@T¸á¢8‹.c¾”I³fÇ‘$ÓéÜ™2eËš?aJtÑ›Hqæ„À´çI¡gB*UhÑ‹I+,Â4@ –>­ª¤*öªÙ£Y·Vàêµ™ƒ³UÉÆ-K×&Ú´L×²m¡.Ü¨pÿâÝ¹×­ƒÃÆf9÷o`ÁƒõÖâ«7ñãÆ~/[ü÷§3áÂy+Öœ™tÅ»ž?S­GÓ¥awÔ…w5âÐ¯ÝÁÞmõMÕ¶YÐM|£\ÞÈ}«e]9ïðÑÆ“ÇîM{yó®·û*×¸R:ZÍ³ÿÿ=žyöâX¿»>íýlx’‚‚g?/•#ŠÎåì‡?:?{÷#&`Iæa7Üv÷e’_nûý×uï§Ðu
+¸@ú-ˆƒúçÞ‡Õ7ßˆ|Øa*&xbƒ :è¡rÊG¢€µp¸¢,Bøbz0ÆXa‰åÑH=7¢h¤†Ûq†äŽ<2Ùdjd‰Bâˆ¤ŠÝ­´äl:ªçŒ2HåD¹¥I_Zùdš=‚… MF¦9æly"–Yª¹&›i*_S¶%ç z*©¤|r¹g¢¿¹e€
+9è˜yå†Œ"š©•Žþ9¢‚Î¹Ä›j¨ tœ¦ª*”’}z‰tRÿšL¥zj©šZ•p:ê¨MÐŠk®«»k˜¯Š+°Â:ÉBGFk,‚œŠøh²‰d;Å¶$,¬—µ¢*I„˜6¸aH¦6j­«(hË-·Ì6›QDÒ¦ˆ–ÔÞ‹î¹ûz–®Zƒ²ëî»4ïŽÑÚ«¯VãšÊðgï$ÒRûj·4
+GðæÄrðzÃ¶«ñ„\õú°R/œ¬o«-.¬P·ÈÔ¼Ë! s§à¿*b;éœØ)s*û*EÁ±’0ðÒïºá´Ç7ã¬%Ï=ç×®·"Ìª5¥dþx-Ñ+#MgÌd—ý4PG=N›É¢\‹Ä-÷t?a7× ûf‚acÿ€wÓf{r¶-63`¸­ö‰™m‚‹‡ü3÷!u×ýëÍw«ûý7à£]x
+¤o­ac/³ã”¿pˆë°Ã^ùçyç]ò×#rìyË¼î»à¢G!<éL’ƒé"cœ:êO¼^Àó“@}ô×M»íqÜõ¯º+í4èÁo8ñ§ Ïtê²:?ýúì»n}íð{êUÒ@/ß½òßç|øÃ_<æûýt÷8õá€Dàóª—5¼mu,Sívw?ýNxÃc€ÿNÑ‹¶%ï~ñ‚›HÂ2ÐGÃœ[(Á¿QÐ‚Ä É÷¿Šìƒ«Yéöé‘P`pßûÿRˆÂñ…\ƒ!ÿd8¾ö‚0ÓØ¬xµÎ‡?T ·FDÌuñˆÝ!Çà¥D&f°†t ]wØö0‹YÜ"¿˜#VPwÌ*ãÇ×DÒ!adWÅæðˆ,áë¬WG#6ÒŽb¬âõ8Ã>ú‘Ë¡ÍŒ!ÉQ2‘Š¤ÜÝ)+R‚Q£ãïbhF^Òs©œ"C8+çáC  ¤€þáŒlQŽu´Û0ÈàŠRÓ.E é7dè’ÛÀ,‰L¶Ò‰œc3c	¬RÒ¼L¤4yi8ã—vKg˜à…P …ø 9Á!€
+òºT$z€ÿŒ]B‚x{´ä+iY°Áq³	`(g2ÿ¨KlŒây¦+À	lücGÆE8ŠYŒ¢ˆÃÀÇ6Èð}2`—È`e5øÏKb²›“”åîÚ(MNœóÒÜôüÀÎ¸1<„M1jÔ“ˆÅZ*w!M“ºÀ|ð]@]‰ÈNÆT¦žKè(Ø‰Hl`Ã„~8\q›"“¨É ç0,2 •R“˜Å¨¤‰L0„±©SØE>°UV’N O¤ƒUwç.
+"LàéMéàUŸºO¬d5äPÑÈŽÚUn%¥X—šÒ@Ú4yíegÏÆDÀ>‘ œ,oùÍ›`¨Õ{A6¾ÌÊÿþ£ 8€Mq{´&xhðªÅgùùT‘¦ ª¥å#ù»5nª²cÄÀ0ˆ:zÛ('+\1Œš20LèòV€p¾à˜DjS{KdôÀ½ À8Ó(¾]¬t¹½ÐÚ`×Û-p:£—ÿÅ'ª›Ý“@ˆŒÌšxãCŽšÄDå¯[äÕJÀ ÄÍÇÏˆ_SÆRÂ/¨hE-ÚËm@Î"6±(gT«0   '( ^¥-Š“è…–ÖCôuªNô03—ÛÜ–wè!‚yX¹Qš2~¶ñ£'8k„ƒ´:¼ï‘øáÉ •GöXcÛä>™Èaš_Ù¢à|ìÿÈÄca—UWXsˆ™üdâ.4Lã$¼©bYË •°”gD‚Èé¹Ì“5ó)¯U´&ÂòÅ>mèCGt‚\tvÜÖ¸IˆÒ‘>3”å¶Í¾½ í…W©ÒOCWÂ¸q5 é'iH®úv­®Øê”vC*ttju¥}˜U{ñ×¼BY¹Ž¤8`;Y¶Y³½³ª™eÙc5ƒ]2iï‡Ú–¾6¶Ó,_½yË.ÐÞæì\µ«lÛV#Vå³\›[×Ò>™âÊ-ðs|#ÉË¾÷VÜ_ ?¹Ö•²i›+q÷Ô—ó]MfˆbW
+¢¬#q‹#ÝïÿŠâÂQÉ‡…ÜM©–ÃM²|k\Íüí¸^nnÚL+GÎ*N*:%êå¼[â‚¸ÐDþs C(ãùãøÏR+sx«ÈçMgTLî”ã¼iÜYÔ’®žõ ?‰o_¿¹ÚÛ"ö¡ïÌjÐÒ“Ösf”§ë$íøöº‰¢Sö¹»èïÿ±”n(›êçø*U‹ÎNñ—yï}÷;uì>¤çÝðÓJ|Ý7O÷Î~ë9VÑI²rÝìŸO¼×¾ñ)È]W‰jÖ•>pÒËí4ýƒÚ*]|E§×½ìóÕ{WÝ>÷¨þìYÅz«bÈ÷¼òûÄ||;ÿùo'Öð1S*£ñ¥ûÑßþ…qxï}¯œ†jáfâîð|sžmW¿êCó·|þH©ß½lØ–2í€>þãÇ}‹!ü'1÷—È}ãG%W[—í¡Ø/A/M˜Lw¸
+¸ärpÒçÓ ‚!˜tD°|Ü€ˆ‚ØúG‚g2›ƒóR48 !ù
+ ÿ ,    d d  ÿ 7ü8Á‚ƒ\¨° 8‡¿ œ8Ž!Ãˆ%Žk˜°£Ç	»‰G²ŒIŠ'Kª\É²¥Æ”0[e|™¥Í›8cêlÉó¢Å—;-º3gHžiöüµôbQ—P‰9RêS¤B²ÎtºAàÕŸV§6òj×²f¿†mº–›X·XÅ®]ÚŠiM¡v}šuË·¯_²hëV+sî\™^¹~K
+.àÇ‚7Jž|6-S­†#>¬YÙ2ÈÆ gŽì9®i®—÷úåF„ukÈ)Ëzš-ÇÍ‹‹ºöÕº÷"°cÏ&HûaêÚI‡ã=~uµï*Ðý×MÚtñÒ¹…– =]õï„¿jÿ-­\»yÆé¢7/>1uöÌ×ì^¥Ýy…øsŽ]nö›’<çÝpð‘wŸÊ·›€Ÿ5XàfÆ)¥àóýÖÛIm=Háƒì&`}	rxbÆøc 2˜Šål¸Üˆ'²è!}ù9˜À‚7ö·aŒ)â(`3ú¨¡2:çc€¹šˆ&yä“Ò¤J6©ÛŒ"™e\¸äXL†ˆ”[BÐL^~9d˜T2X¦™žåH%‘<öˆe”dš	g•sÂ§d~¨çžr:ù¢u|Vˆç¢?ž	A*‹Š©&jˆþ	h9˜>—i”ƒ>Ê]—j^JUNêbj ŒvÚ(xZP¨6†ÿféd…Æª)£œ~Ú)«­âZ+ª¦i«–Äúšj¯ðª§oÃ+e©¿:,®Èr™l«ËF{«´ðÐÇ[ŸÐf	iÔb[mµŠªê­®ëb.·ìž‹,¹æ¢iG«*kí¾üöë.¬ÓÆ;¯&lðÁ½6ØÚ®Ž6Ìp ‚@Dzÿ*¬íåÖÃÆwœ²
+'ëp3×bŽÉ(—œrÊÖÞyjÀ#,s%žÐüq«€>|òììó@]KÄ-»sÌ3{\s%çÌ*É%ó,õÔ=WmõÐû}§À\£CÒo¼4Óç¹«9T§ŒÚ';¬¼[û;0ØdÛ<öÍ›Æí@Ä(OÿmÌßl7±öÚXO\4Ürkì5ÝuÛÝøâŸnu~^¹àTKœx×ý*ž	ã;n³È†s·àÞ?_Žùê™[@téY¿Ýùìú‚úÝLïýºŸö­:ëÀîúë°Ón|í¶‹n7êšÎ<Ú”ÿ¼ðÄ¯¯õÉß¾üÞÜ_ÏåäÒ‡?|ñØ{JûÍÙã^I÷ìŸý?˜BÁ–ƒ!À,áàsÈÔãC=‰‡ðÐÿfkxOWü¾öCèãØPŸöF×>ImÈØþËm£.p8 (4‰a€!üH‘
+ÀØ!'Ø€m¤09`GÀ‡Xð!lJÃ]ÿ¯79`áà àþ'€ý-aààæÆ7	NPà~Ã0Õ$¾ñìmƒ+ìW/(@‡ž”`Õ7Ä§qzÜE
+ˆBÀ¡0ˆß7r¶)AKp!t¡NtqYøØ]X©Z49LcúîÖÆA™Œ~r´†!&QGú	@Š˜<À!þ±?º`êø£'¡‹fð{\J!HfJHh
+†ÜE]ðÇ‘fì&%+ù=zHmŽóS¢'ÀºògœØméJ.k‹Êj
+…]ör’K#¦û”9
+ØQ…S»Ÿ1ÚV½-2 1u´–#9È¡gŒ!:	ÿÌ±	ófÚT÷F	†¿ur	Æ$ªˆNv6o‹ÆhF‰&â~8œ]îy†Jœ‚ƒ<˜òþ9…õ‰³SÌ6îçŒmŒb`àeÿ!EcMeÒ4g*}1À™†Q£4%Û†‹û‰Ttn éIx
+Ò3„1›jE0”8­€1¬Ú²&ðƒŒï4ß¹À HÈ‰üìg”ºÔe} ¸*øZ½A9†…b­çÜ!„q¬.8*RÙZ8Þ!°dpe›\ªQq•«¡Ð!n Xµ“±‡ëÄ(ÕÔ	m±Ñ$Ÿé¶…±Òú•)¸ß+›ˆ~†Sœ‚Ú,8±2ÏÿÒU´™H*ASšv3­&m­paË,N5à8Åªr—ZÜŽV·»](24ÑQà÷ºm4V=u×þ97·ÐõÈH¾ÆZ¥¹Ñ°ÏÍ›Ùš[×Æ~`Û!/ãÎ‹^í’¶Qns¯–ÞB«ÑK¾I£/=Á[ÜoËxz}–ˆ†êWÈÍ,»÷U¯„&-põè¿ÎðÓ8gàO8ÂÆšÒÅr¥aÏyøÄZC\Åø;¦›o¦°iU`¹8‰Ãõúpxwœ)˜¬xT,1ç²õë¸M¬•°ŠŒ»gMnÖ“‚Lå(éÉY«‘”aUÙ´ò—-6æ./YË¢2š¾œä)¯iøG—JpäØ«ödˆÎ0ÃsÙ„ I9rzÞ³Ž(µ!¤šÉpÆžãóg])ˆÏ²’ˆC†'%Í˜N’î¯¦­l¶C'šRhõæå_õ'ÓÆW®&]+LWªÔqþ¬ÅdäÜ%Õ”&Q^'‡Éœ6Ò¦/-Þò¼Czás¸”]";çEÔ³¶“W|í'ÛüdØ6vÒt\êA¿
+ØÆw°“3S{<š™I¯]„¢r›ûÝÍv6FˆÓmlC{×î&‘Z „¡c'{Ú¸þH¾áMð­ÛÖw®ò¶]]m~_»0	WøÀ–HGúØ‹fö~øƒo°ÆÞHI@  !ùd ÿ ,    d d  ÿ ÿm¸¡ Áƒ*\Hp¡Ã‡#JôG±¢Å‹3jÜÈ±£Ç CŠI²¤É“(Sª\É²¥Ë—0cÊœI³¦Í›8sêÜÉ³§ÏŸ@ƒ
+J´¨Ñ£H“*]Ê´©Ó§P£JJµªÕ«X³jÝÊµ«×¯`ÃŠK¶¬Ù³hÓª]Ë¶­Û·pãÊ+•¤~àsá‚N9¼wa‹ØN|'•é8I@#¼{Inx3Ö?…S€3„ÍÅåL…+.h¼Y1Ek›äû‡o1ÆLtþÉnÐ¯ÜìxâåÌ$3^v†ðî·Ë?Q€ÄéŸi¬-À;ÉéÐøAðv<ÙÓwRÿÀÖÛ&ê.tW„ôt¹LðÃ—‰}×>á…ù|o|ÝõÓÈ?ùÈ‡“1á°“‚yQZ#†<Æ_äÖË?Ôæ\h±èƒÀ‘aè€ìxr»¹ Ø‚çÍ×ZaüóXm	X1µ	@G7™yHÑ{®A&£€.àMü¼¸Ýzÿà8bGVmýÌX9ø¦Ñ„º}Ç$3Öa,ð5f„ú0Ð;lX„¿}Óäšœ@ØFÖ´‡Izæ$Mº  b*ªÙOØÈ&ÛqQJ9$E*ªÏ)VD'Ã6 ƒ45’$ãH•ñôB?»TZQ#“üµjltPeÉQ, h‚AÞ4àŸE±·Ó®ªö”É?üS<³”HT&–é©„a>Œj,LcàOå¤‚²t]î¸ä–kî¹è¦«îºì¶ëî»ðÆ+ï¼ôÖkï½øæ«ï¾üöëï¿æ !ù
+ ÿ , 1 ?   ÿ ÿ	Ü¯ÑÀþþñãÇ Ñ¯„vHa£F	´ƒX±¢?vÊ	4FG@>ñ&1¨È@ c8äH±L|â‹ÅMcšË4J1iR<„ø<:hŠn9=XNæ„þ²úË“BÎS?µnÄª•ëÐ^G0èv`,±ø]ý—Ô'Uvaó&ì¶²£È z7=ÜkÌè?µÚþkD'ž1NÕÆ"›µÆxì2­Œ-§ÇbËatkX-ƒÁ‡·õ­Ë2ÇxWlDa²çÃ™ n[RnÓ öòJ·&ærý^<{Rìœ¬Ê¦Ø …HÄRüv;:»ßäZ¾ý/SCÏvY'ÿ¯:h‚$;ßÞu=sL«@+rßQ€söíc—@G¹à™5L	u‘HùU´@<ÁUÄA ´P» †vèá‡ †(âˆ$RôX‰(røWE !ù
+ ÿ , 1 B   ÿ ÿ	¸i Áxâ-hçÏ ÃþÊ”+Ób&…>ldl`ƒ]Ø‰¬8pAÈnwñk0‘"IƒË]\‘v-5DËXKcZŽs¸!žQ’øvm€ØÍåÃM`ü—	RÇ—O¥Êl„ æÕ¬™dö‹h¬Ì¦#ªeŠ ,Ù45ªMÓåQ°¹ÖdGÔ%Ã_™ºí6)Öl˜»0fN˜2ùËÄnì¦‹(	¶£9·¢cˆü ÔÙ™íb´PINn$2ÛÁ¹Û’6Ö¤û*®»;s–2žj4ÁaÍ‘‚{(™ôéá‘c†lD§Ðr¬§ç¦ŠSç?ÜÎÎSÅÑhõé~±köžñ¡ÙïìM÷‡ò%àžã÷ÕÏ~íÙægáÇß€>¥ÖcˆÝWò7`}át\ƒ&¸ 7b·‚vxVcÒåáˆ	ú÷O@ ;

--- a/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\Constraints\Image;
 use Symfony\Component\Validator\Constraints\ImageValidator;
-use Symfony\Component\Validator\Validation;
 
 /**
  * @requires extension fileinfo
@@ -32,6 +31,7 @@ class ImageValidatorTest extends AbstractConstraintValidatorTest
     protected $imageLandscape;
     protected $imagePortrait;
     protected $image4By3;
+    protected $imageCorrupted;
 
     protected function createValidator()
     {
@@ -46,6 +46,7 @@ class ImageValidatorTest extends AbstractConstraintValidatorTest
         $this->imageLandscape = __DIR__.'/Fixtures/test_landscape.gif';
         $this->imagePortrait = __DIR__.'/Fixtures/test_portrait.gif';
         $this->image4By3 = __DIR__.'/Fixtures/test_4by3.gif';
+        $this->imageCorrupted = __DIR__.'/Fixtures/test_corrupted.gif';
     }
 
     public function testNullIsValid()
@@ -322,6 +323,28 @@ class ImageValidatorTest extends AbstractConstraintValidatorTest
             ->setParameter('{{ width }}', 1)
             ->setParameter('{{ height }}', 2)
             ->setCode(Image::PORTRAIT_NOT_ALLOWED_ERROR)
+            ->assertRaised();
+    }
+
+    public function testCorrupted()
+    {
+        if (!function_exists('imagecreatefromstring')) {
+            $this->markTestSkipped('This test require GD extension');
+        }
+
+        $constraint = new Image(array(
+            'detectCorrupted' => true,
+            'corruptedMessage' => 'myMessage',
+        ));
+
+        $this->validator->validate($this->image, $constraint);
+
+        $this->assertNoViolation();
+
+        $this->validator->validate($this->imageCorrupted, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setCode(Image::CORRUPTED_IMAGE_ERROR)
             ->assertRaised();
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes (current validator does not validates corrupted images) |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | not, but fail looks like not relates to this PR |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

getimagesize returns correct size for corrupted images, so I've added another check
