### PR TITLE
[Console] Fix: Allow to inject QuestionHelper into SymfonyStyle

### DIFF
--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Helper\SymfonyQuestionHelper;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
@@ -335,6 +336,11 @@ class SymfonyStyle extends OutputStyle
         }
 
         return $answer;
+    }
+
+    public function setQuestionHelper(QuestionHelper $questionHelper)
+    {
+        $this->questionHelper = $questionHelper;
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | **yes** |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This PR
- [x] asserts that a `Helper\QuestionHelper` can be injected into `Style\SymfonyStyle`
- [x] provides a  mutator for the `Helper\QuestionHelper` otherwise internally created by  `Style\SymfonyStyle`

:information_desk_person: If using `Style\SymfonyStyle` and asking a question in a command, it's impossible to use the instructions laid out [here](http://symfony.com/doc/current/components/console/helpers/questionhelper.html#testing-a-command-that-expects-input) to provide an input stream. By allowing to inject an instance of `Helper\QuestionHelper`into `Style\SymfonyStyle`, testing becomes possible again.
