### PR TITLE
[Form] Make tests compatible with master

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -1495,7 +1495,6 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
                     '1' => '1',
                     '2' => '2',
                 ),
-                'choices_as_values' => true,
             )
         );
         $builder->add('subChoice', 'Symfony\Component\Form\Tests\Fixtures\ChoiceSubType');

--- a/src/Symfony/Component/Form/Tests/Fixtures/ChoiceSubType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/ChoiceSubType.php
@@ -24,7 +24,7 @@ class ChoiceSubType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array('expanded' => true, 'choices_as_values' => true));
+        $resolver->setDefaults(array('expanded' => true));
         $resolver->setNormalizer('choices', function () {
             return array(
                 'attr1' => 'Attribute 1',


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

I wrote tests in this PR: #17406 which was compatible only with 2.7. @xabbuh fixed it in 2.8 and 3.0 here: #17463. And this PR fixes deprecated notices in master.

Kind of an unfortunate situation...
