### PR TITLE
[FrameworkBundle][DX] Add Levenshtein suggesters to AbstractConfigCommand

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
@@ -46,21 +46,44 @@ abstract class AbstractConfigCommand extends ContainerDebugCommand
     protected function findExtension($name)
     {
         $bundles = $this->initializeBundles();
+        $minScore = INF;
+
         foreach ($bundles as $bundle) {
             if ($name === $bundle->getName()) {
                 return $bundle->getContainerExtension();
             }
 
+            $distance = levenshtein($name, $bundle->getName());
+
+            if ($distance < $minScore) {
+                $guess = $bundle->getName();
+                $minScore = $distance;
+            }
+
             $extension = $bundle->getContainerExtension();
-            if ($extension && $name === $extension->getAlias()) {
-                return $extension;
+
+            if ($extension) {
+                if ($name === $extension->getAlias()) {
+                    return $extension;
+                }
+
+                $distance = levenshtein($name, $extension->getAlias());
+
+                if ($distance < $minScore) {
+                    $guess = $extension->getAlias();
+                    $minScore = $distance;
+                }
             }
         }
 
         if ('Bundle' !== substr($name, -6)) {
-            $message = sprintf('No extensions with configuration available for "%s"', $name);
+            $message = sprintf('No extensions with configuration available for "%s".', $name);
         } else {
-            $message = sprintf('No extension with alias "%s" is enabled', $name);
+            $message = sprintf('No extension with alias "%s" is enabled.', $name);
+        }
+
+        if (isset($guess) && $minScore < 3) {
+            $message .= sprintf("\n\nDid you mean \"%s\"?", $guess);
         }
 
         throw new \LogicException($message);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

It could be helpful to output the best guesses for bundle names and container extension aliases when one could not be found by the exact query.

Perhaps, I could regroup the logic so that it only looks through bundle names if the `Bundle` suffix is present, but I guess this might narrow the use case scope here.
