### PR TITLE
[FrameworkBundle] Throw for missing container extensions

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
@@ -48,6 +48,10 @@ abstract class AbstractConfigCommand extends ContainerDebugCommand
         $bundles = $this->initializeBundles();
         foreach ($bundles as $bundle) {
             if ($name === $bundle->getName()) {
+                if (!$bundle->getContainerExtension()) {
+                    throw new \LogicException(sprintf('Bundle "%s" does not have a container extension.', $name));
+                }
+
                 return $bundle->getContainerExtension();
             }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

This covers the case when an existing bundle does not have an extension, and its config is dumped. Before, calling `app/console config:dump` on such bundle lead to FatalErrorException with `Call to a member function getAlias() on null`, now we process such cases and throw an exception with some explanatory text.
