### PR TITLE
[2.3] [CS] MethodSeparationFixer - findings.

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Node/TransNodeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/TransNodeTest.php
@@ -36,6 +36,7 @@ class TransNodeTest extends \PHPUnit_Framework_TestCase
              trim($compiler->compile($node)->getSource())
         );
     }
+
     protected function getVariableGetterWithoutStrictCheck($name)
     {
         if (PHP_VERSION_ID >= 50400) {

--- a/src/Symfony/Component/Console/Tests/Descriptor/AbstractDescriptorTest.php
+++ b/src/Symfony/Component/Console/Tests/Descriptor/AbstractDescriptorTest.php
@@ -82,6 +82,7 @@ abstract class AbstractDescriptorTest extends \PHPUnit_Framework_TestCase
     }
 
     abstract protected function getDescriptor();
+
     abstract protected function getFormat();
 
     private function getDescriptionTestData(array $objects)

--- a/src/Symfony/Component/CssSelector/Tests/Node/AbstractNodeTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/Node/AbstractNodeTest.php
@@ -28,5 +28,6 @@ abstract class AbstractNodeTest extends \PHPUnit_Framework_TestCase
     }
 
     abstract public function getToStringConversionTestData();
+
     abstract public function getSpecificityValueTestData();
 }

--- a/src/Symfony/Component/CssSelector/Tests/Parser/Handler/AbstractHandlerTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/Parser/Handler/AbstractHandlerTest.php
@@ -43,7 +43,9 @@ abstract class AbstractHandlerTest extends \PHPUnit_Framework_TestCase
     }
 
     abstract public function getHandleValueTestData();
+
     abstract public function getDontHandleValueTestData();
+
     abstract protected function generateHandler();
 
     protected function assertStreamEmpty(TokenStream $stream)

--- a/src/Symfony/Component/Form/Tests/Extension/HttpFoundation/HttpFoundationRequestHandlerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/HttpFoundation/HttpFoundationRequestHandlerTest.php
@@ -28,6 +28,7 @@ class HttpFoundationRequestHandlerTest extends AbstractRequestHandlerTest
     {
         $this->requestHandler->handleRequest($this->getMockForm('name', 'GET'));
     }
+
     /**
      * @expectedException \Symfony\Component\Form\Exception\UnexpectedTypeException
      */

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -977,6 +977,7 @@ class Response
     }
 
     // http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
+
     /**
      * Is response invalid?
      *

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/RoutableFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/RoutableFragmentRendererTest.php
@@ -65,6 +65,7 @@ class Renderer extends RoutableFragmentRenderer
     public function render($uri, Request $request, array $options = array())
     {
     }
+
     public function getName()
     {
     }

--- a/src/Symfony/Component/Security/Tests/Core/Encoder/EncoderFactoryTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Encoder/EncoderFactoryTest.php
@@ -85,15 +85,19 @@ class SomeUser implements UserInterface
     public function getRoles()
     {
     }
+
     public function getPassword()
     {
     }
+
     public function getSalt()
     {
     }
+
     public function getUsername()
     {
     }
+
     public function eraseCredentials()
     {
     }

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/AnnotationLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/AnnotationLoaderTest.php
@@ -87,6 +87,7 @@ class AnnotationLoaderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected_parent, $parent_metadata);
     }
+
     /**
      * Test MetaData merge with parent annotation.
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

Th goal of this PR is _not_ to have it merged, but to see if the `MethodSeparationFixer` (https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/1426) is suitable for SF level/configuration in the PHP-CS-Fixer (and thereby might later become part of `fabbot.io`).  
