### PR TITLE
[HttpKernel] Make Bundle::getContainerExtensionClass public

### DIFF
--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -212,7 +212,7 @@ abstract class Bundle implements BundleInterface
      *
      * @return string
      */
-    protected function getContainerExtensionClass()
+    public function getContainerExtensionClass()
     {
         $basename = preg_replace('/Bundle$/', '', $this->getName());
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none, will do |

This adds more flexibility for bundle extension class names and also makes working with container extensions less error-prone. I think allowing end users to specify exact extension class names would make things more transparent, as now I as an end user can change the extension class name, but this would just break my bundle.

Imagine I got distracted in a middle of a bundle rename refactoring. I've renamed the bundle class, updated my AppKernel, moved stuff to a different namespace — quite a lot of things to do already — and yet I forget to rename the extension class. Since that moment, `Bundle::getContainerExtension()` would just always return `false` for no apparent reason (as it would look to me).

Having this merged, we'll be able to also handle the cases when we cannot accept `null` for an `ExtensionInterface` gracefully: if there's no extension returned, we'd be able to throw an exception describing the exact extension classname we expected to exist.

Also, we'll be able to allow end users to explicitly specify their bundles' extension classes, which would make things a bit more transparent (and this needs a doc PR [here](http://symfony.com/doc/current/cookbook/bundles/extension.html#creating-an-extension-class)).
