### PR TITLE
[Form] Filter non-uuids when selecting entities by guid ID

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
@@ -100,7 +100,7 @@ class ORMQueryBuilderLoader implements EntityLoaderInterface
             // Filter out non-uuid values (e.g. "", 1, "asdf"). If we don't, some
             // databases such as PostgreSQL fail.
             $values = array_values(array_filter($values, function ($v) {
-                return (bool)preg_match('/^\{?[a-fA-F0-9]{8}-?[a-fA-F0-9]{4}-?[a-fA-F0-9]{4}-?[a-fA-F0-9]{4}-?[a-fA-F0-9]{12}\}?$/', $v);
+                return (bool) preg_match('/^\{?[a-fA-F0-9]{8}-?[a-fA-F0-9]{4}-?[a-fA-F0-9]{4}-?[a-fA-F0-9]{4}-?[a-fA-F0-9]{12}\}?$/', $v);
             }));
         } else {
             $parameterType = Connection::PARAM_STR_ARRAY;

--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
@@ -94,7 +94,7 @@ class ORMQueryBuilderLoader implements EntityLoaderInterface
             $values = array_values(array_filter($values, function ($v) {
                 return (string) $v === (string) (int) $v;
             }));
-        } elseif (in_array($identifierFieldType, array('guid'))) {
+        } elseif ('guid' === $identifierFieldType) {
             $parameterType = Connection::PARAM_STR_ARRAY;
 
             // Filter out non-uuid values (e.g. "", 1, "asdf"). If we don't, some

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/SingleGuidIdEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/SingleGuidIdEntity.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+
+/** @Entity */
+class SingleGuidIdEntity
+{
+    /** @Id @Column(type="guid") */
+    protected $id;
+
+    /** @Column(type="string", nullable=true) */
+    public $name;
+
+    public function __construct($id, $name)
+    {
+        $this->id = $id;
+        $this->name = $name;
+    }
+
+    public function __toString()
+    {
+        return (string) $this->name;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/ORMQueryBuilderLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/ORMQueryBuilderLoaderTest.php
@@ -115,7 +115,7 @@ class ORMQueryBuilderLoaderTest extends \PHPUnit_Framework_TestCase
 
         $query->expects($this->once())
             ->method('setParameter')
-            ->with('ORMQueryBuilderLoader_getEntitiesByIds_id', array("f0b928bd-e471-4870-9f99-430a005e3897", "e586ff90-222e-4a86-ac82-82627e84adfb"), Connection::PARAM_STR_ARRAY)
+            ->with('ORMQueryBuilderLoader_getEntitiesByIds_id', array('f0b928bd-e471-4870-9f99-430a005e3897', 'e586ff90-222e-4a86-ac82-82627e84adfb'), Connection::PARAM_STR_ARRAY)
             ->willReturn($query);
 
         $qb = $this->getMockBuilder('Doctrine\ORM\QueryBuilder')

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/ORMQueryBuilderLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/ORMQueryBuilderLoaderTest.php
@@ -105,6 +105,35 @@ class ORMQueryBuilderLoaderTest extends \PHPUnit_Framework_TestCase
         $loader->getEntitiesByIds('id', array(1, '', 2, 3, 'foo'));
     }
 
+    public function testFilterNonGuidValues()
+    {
+        $em = DoctrineTestHelper::createTestEntityManager();
+
+        $query = $this->getMockBuilder('QueryMock')
+            ->setMethods(array('setParameter', 'getResult', 'getSql', '_doExecute'))
+            ->getMock();
+
+        $query->expects($this->once())
+            ->method('setParameter')
+            ->with('ORMQueryBuilderLoader_getEntitiesByIds_id', array("f0b928bd-e471-4870-9f99-430a005e3897", "e586ff90-222e-4a86-ac82-82627e84adfb"), Connection::PARAM_STR_ARRAY)
+            ->willReturn($query);
+
+        $qb = $this->getMockBuilder('Doctrine\ORM\QueryBuilder')
+            ->setConstructorArgs(array($em))
+            ->setMethods(array('getQuery'))
+            ->getMock();
+
+        $qb->expects($this->once())
+            ->method('getQuery')
+            ->willReturn($query);
+
+        $qb->select('e')
+            ->from('Symfony\Bridge\Doctrine\Tests\Fixtures\SingleGuidIdEntity', 'e');
+
+        $loader = new ORMQueryBuilderLoader($qb);
+        $loader->getEntitiesByIds('id', array(1, '', 'f0b928bd-e471-4870-9f99-430a005e3897', 'g0b928bd-e471-4870-9f99-430a005e3897', 'e586ff90-222e-4a86-ac82-82627e84adfb', 'foo'));
+    }
+
     public function testEmbeddedIdentifierName()
     {
         if (Version::compare('2.5.0') > 0) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | 17488 |
| License | MIT |
| Doc PR | - |

This fix prevents the ORMQueryBuilderLoader from passing non-uuid values through to the query builder for a uuid id entity, as they will cause exceptions on some platforms, e.g. Postgres
