### PR TITLE
[2.7] [FrameworkBundle] [DX] Sort bundles in config commands

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
@@ -30,7 +30,13 @@ abstract class AbstractConfigCommand extends ContainerDebugCommand
     {
         $headers = array('Bundle name', 'Extension alias');
         $rows = array();
-        foreach ($this->getContainer()->get('kernel')->getBundles() as $bundle) {
+
+        $bundles = $this->getContainer()->get('kernel')->getBundles();
+        usort($bundles, function($bundleA, $bundleB) {
+            return strcmp($bundleA->getName(), $bundleB->getName());
+        });
+
+        foreach ($bundles as $bundle) {
             $extension = $bundle->getContainerExtension();
             $rows[] = array($bundle->getName(), $extension ? $extension->getAlias() : '');
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

Reopened against `2.7` instead of #17490 

This makes the behaviour of config commands a bit more user-friendly. Scanning through an ordered list should be a lot easier for the user, especially if she knows what's the exact bundle they're looking for. The sort is applied to the bundle name, as the extension alias might not always be present.

Before:
![before](https://cloud.githubusercontent.com/assets/345754/12498061/8e0ff30a-c0c1-11e5-9c96-561065eedc79.png)
After:
![after](https://cloud.githubusercontent.com/assets/345754/12498064/93019bde-c0c1-11e5-8bbc-c85a74b3f5e8.png)
