### PR TITLE
[SecurityBundle] Optimize dependency injection tests

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
@@ -187,7 +187,6 @@ abstract class CompleteConfigurationTest extends \PHPUnit_Framework_TestCase
         if (isset(self::$containerCache[$file])) {
             return self::$containerCache[$file];
         }
-
         $container = new ContainerBuilder();
         $security = new SecurityExtension();
         $container->registerExtension($security);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
@@ -19,6 +19,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 abstract class CompleteConfigurationTest extends \PHPUnit_Framework_TestCase
 {
+    private static $containerCache = array();
+
     abstract protected function loadFromFile(ContainerBuilder $container, $file);
 
     public function testRolesHierarchy()
@@ -182,6 +184,10 @@ abstract class CompleteConfigurationTest extends \PHPUnit_Framework_TestCase
 
     protected function getContainer($file)
     {
+        if (isset(self::$containerCache[$file])) {
+            return self::$containerCache[$file];
+        }
+
         $container = new ContainerBuilder();
         $security = new SecurityExtension();
         $container->registerExtension($security);
@@ -194,6 +200,6 @@ abstract class CompleteConfigurationTest extends \PHPUnit_Framework_TestCase
         $container->getCompilerPassConfig()->setRemovingPasses(array());
         $container->compile();
 
-        return $container;
+        return self::$containerCache[$file] = $container;
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17366 |
| License | MIT |
| Doc PR | - |

Tests building the same container multiple times. The same solution can be applied as here: #17399. This time I ran comparison tests only on 2.3. (my laptop is really slow)

**2.3 before**

``` go
Time: 14.79 seconds, Memory: 48.25Mb
OK (77 tests, 227 assertions)
OK src/Symfony/Bundle/SecurityBundle/
```

**2.3 after**

``` go
Time: 9.78 seconds, Memory: 48.75Mb
OK (77 tests, 227 assertions)
OK src/Symfony/Bundle/SecurityBundle/
```
