### PR TITLE
[Security][Encoder] hash_equals throws an error if $password1 is null

### DIFF
--- a/src/Symfony/Component/Security/Core/Encoder/BasePasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/BasePasswordEncoder.php
@@ -81,6 +81,10 @@ abstract class BasePasswordEncoder implements PasswordEncoderInterface
      */
     protected function comparePasswords($password1, $password2)
     {
+        if ($password1 === null || $password2 === null) {
+            return false;
+        }
+
         return hash_equals($password1, $password2);
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Its possible to pass null as $password1. the hash_equals function throws an error: 

hash_equals(): Expected known_string to be a string, null given.
