### PR TITLE
[Form] ArrayChoiceList can now deal with a null in choices

### DIFF
--- a/src/Symfony/Component/Form/ChoiceList/ArrayChoiceList.php
+++ b/src/Symfony/Component/Form/ChoiceList/ArrayChoiceList.php
@@ -141,7 +141,7 @@ class ArrayChoiceList implements ChoiceListInterface
         $choices = array();
 
         foreach ($values as $i => $givenValue) {
-            if (isset($this->choices[$givenValue])) {
+            if (array_key_exists($givenValue, $this->choices)) {
                 $choices[$i] = $this->choices[$givenValue];
             }
         }

--- a/src/Symfony/Component/Form/Tests/ChoiceList/ArrayChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/ArrayChoiceListTest.php
@@ -130,4 +130,11 @@ class ArrayChoiceListTest extends AbstractChoiceListTest
         $this->assertSame(array(2 => 'value2'), $choiceList->getValuesForChoices(array(2 => $obj2)));
         $this->assertSame(array(2 => 'value2'), $choiceList->getValuesForChoices(array(2 => (object) array('value' => 'value2'))));
     }
+
+    public function testGetChoicesForValuesWithContainingNull()
+    {
+        $choiceList = new ArrayChoiceList(array('Null' => null));
+
+        $this->assertSame(array(0 => null), $choiceList->getChoicesForValues(array('0')));
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Documentation says, since 2.7, choice value is treated as corresponding item value (if `choices_as_values` option is true). Null as well.

``` php
$builder->add('attending', 'choice', array(
    'choices' => array(
        'yes' => true,
        'no' => false,
        'maybe' => null,
    ),
    'choices_as_values' => true,
));
```

But actually null doesn't work as expected since `ArrayChoiceList::getChoicesForValues()` uses `isset` to check whether given value exists in its choices.

It should use `array_key_exists` instead to do so here.
