### PR TITLE
[Console] Show code when an exception is thrown

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -588,7 +588,10 @@ class Application
         $output->writeln('', OutputInterface::VERBOSITY_QUIET);
 
         do {
-            $title = sprintf('  [%s]  ', get_class($e));
+            $title = $output->isVerbose() && ($code = $e->getCode()) > 0
+                ? sprintf('  [%s - code %s]  ', get_class($e), $code)
+                : sprintf('  [%s]  ', get_class($e))
+            ;
 
             $len = $this->stringWidth($title);
 

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -588,10 +588,11 @@ class Application
         $output->writeln('', OutputInterface::VERBOSITY_QUIET);
 
         do {
-            $title = $output->isVerbose() && ($code = $e->getCode()) > 0
-                ? sprintf('  [%s - code %s]  ', get_class($e), $code)
-                : sprintf('  [%s]  ', get_class($e))
-            ;
+            $title = sprintf(
+                '  [%s%s]  ',
+                get_class($e),
+                $output->isVerbose() && ($code = $e->getCode()) !== 0 ? ' ('.$code.')' : ''
+            );
 
             $len = $this->stringWidth($title);
 

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -591,7 +591,7 @@ class Application
             $title = sprintf(
                 '  [%s%s]  ',
                 get_class($e),
-                $output->isVerbose() && ($code = $e->getCode()) !== 0 ? ' ('.$code.')' : ''
+                $output->isVerbose() && 0 !== ($code = $e->getCode()) ? ' ('.$code.')' : ''
             );
 
             $len = $this->stringWidth($title);

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -520,6 +520,11 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $tester->run(array('command' => 'foo3:bar'), array('decorated' => false));
         $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception3.txt', $tester->getDisplay(true), '->renderException() renders a pretty exceptions with previous exceptions');
 
+        $tester->run(array('command' => 'foo3:bar'), array('decorated' => false, 'verbosity' => Output::VERBOSITY_VERBOSE));
+        $this->assertRegExp('/\[Exception\]\s*First exception/', $tester->getDisplay(), '->renderException() renders a pretty exception without code exception when code exception is default and verbosity is verbose');
+        $this->assertRegExp('/\[Exception\]\s*Second exception/', $tester->getDisplay(), '->renderException() renders a pretty exception without code exception when code exception is 0 and verbosity is verbose');
+        $this->assertRegExp('/\[Exception \(404\)\]\s*Third exception/', $tester->getDisplay(), '->renderException() renders a pretty exception with code exception when code exception is 404 and verbosity is verbose');
+
         $tester->run(array('command' => 'foo3:bar'), array('decorated' => true));
         $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception3decorated.txt', $tester->getDisplay(true), '->renderException() renders a pretty exceptions with previous exceptions');
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/Foo3Command.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Foo3Command.php
@@ -23,7 +23,7 @@ class Foo3Command extends Command
                 throw new \Exception('Second exception <comment>comment</comment>', 0, $e);
             }
         } catch (\Exception $e) {
-            throw new \Exception('Third exception <fg=blue;bg=red>comment</>', 0, $e);
+            throw new \Exception('Third exception <fg=blue;bg=red>comment</>', 404, $e);
         }
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Hi !

When an exception is thrown, sf console doesn't show the code exception, while this code is very useful during developpement (for example, [guzzle put http status code in his code exception](https://github.com/guzzle/guzzle/blob/6.1.1/src/Exception/RequestException.php#L30-L33)).

I propose you that we show the code exception only when the code exception > 0 and with `-v` verbosity. It means :
- `throw new Exception('Not found', 0)` with normal verbosity --> no change
- `throw new Exception('Not found', 0)` with `-v` verbosity --> no change
- `throw new Exception('Not found', 404)` with normal verbosity --> no change
- **but** `throw new Exception('Not found', 404)` with `-v` verbosity --> showing : 

![image](https://cloud.githubusercontent.com/assets/4578773/12530638/052991f2-c1e5-11e5-92f1-b7b3f60cc4ba.png)
