### PR TITLE
[FrameworkBundle] enable assets when templates are enabled

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -43,6 +43,14 @@ class Configuration implements ConfigurationInterface
         $rootNode = $treeBuilder->root('framework');
 
         $rootNode
+            ->beforeNormalization()
+                ->ifTrue(function ($v) { return !isset($v['assets']) && isset($v['templating']); })
+                ->then(function ($v) {
+                    $v['assets'] = array();
+
+                    return $v;
+                })
+            ->end()
             ->children()
                 ->scalarNode('secret')->end()
                 ->scalarNode('http_method_override')


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16570 |
| License | MIT |
| Doc PR |  |

This puts back the default behavior of Symfony 2.8 where the Asset
component features were implicitly configured with sensible default
values when no explicit configuration was present but the templating
section was enabled.
