### PR TITLE
Fix repeated "has been" in two sentences of UPGRADE-3.0 file

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -234,13 +234,13 @@ UPGRADE FROM 2.x to 3.0
 ### Form
 
  * The `getBlockPrefix()` method was added to the `FormTypeInterface` in replacement of
-   the `getName()` method which has been has been removed.
+   the `getName()` method which has been removed.
 
  * The `configureOptions()` method was added to the `FormTypeInterface` in replacement
    of the `setDefaultOptions()` method which has been removed.
 
  * The `getBlockPrefix()` method was added to the `ResolvedFormTypeInterface` in
-   replacement of the `getName()` method which has been has been removed.
+   replacement of the `getName()` method which has been removed.
 
  * The option `options` of the `CollectionType` has been removed in favor
    of the `entry_options` option.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

In file UPGRADE-3.0 `has been` is repeated in two sentences.
