### PR TITLE
[Console] Allow clients to check if a console input object has an option set.

### DIFF
--- a/src/Symfony/Component/Console/Input/Input.php
+++ b/src/Symfony/Component/Console/Input/Input.php
@@ -223,6 +223,18 @@ abstract class Input implements InputInterface
     }
 
     /**
+     * Returns true if the option value was set by name.
+     *
+     * @param string $name The option name
+     *
+     * @return bool true if the option is set (not a default value)
+     */
+    public function hasOptionSet($name)
+    {
+        return isset($this->options[$name]);
+    }
+
+    /**
      * Escapes a token through escapeshellarg if it contains unsafe chars.
      *
      * @param string $token

--- a/src/Symfony/Component/Console/Input/InputInterface.php
+++ b/src/Symfony/Component/Console/Input/InputInterface.php
@@ -139,6 +139,15 @@ interface InputInterface
     public function hasOption($name);
 
     /**
+     * Returns true if the option value was set by name.
+     *
+     * @param string $name The option name
+     *
+     * @return bool true if the option is set (not a default value)
+     */
+    public function hasOptionSet($name);
+
+    /**
      * Is this input means interactive?
      *
      * @return bool


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

Related to https://github.com/symfony/symfony/issues/8486.

Please note that based on the contribution guide, I am not allowed to add a new method to the `InputInterface` interface.

Thus, this PR is more of a discussion if this little change has its place or not.
