### PR TITLE
CS: keep phpdocs throws and return annotations in same order

### DIFF
--- a/src/Symfony/Bridge/Twig/NodeVisitor/Scope.php
+++ b/src/Symfony/Bridge/Twig/NodeVisitor/Scope.php
@@ -69,9 +69,9 @@ class Scope
      * @param string $key
      * @param mixed  $value
      *
-     * @throws \LogicException
-     *
      * @return Scope Current scope
+     *
+     * @throws \LogicException
      */
     public function set($key, $value)
     {

--- a/src/Symfony/Component/CssSelector/Parser/Parser.php
+++ b/src/Symfony/Component/CssSelector/Parser/Parser.php
@@ -56,9 +56,9 @@ class Parser implements ParserInterface
      *
      * @param Token[] $tokens
      *
-     * @throws SyntaxErrorException
-     *
      * @return array
+     *
+     * @throws SyntaxErrorException
      */
     public static function parseSeries(array $tokens)
     {
@@ -131,9 +131,9 @@ class Parser implements ParserInterface
      *
      * @param TokenStream $stream
      *
-     * @throws SyntaxErrorException
-     *
      * @return Node\SelectorNode
+     *
+     * @throws SyntaxErrorException
      */
     private function parserSelectorNode(TokenStream $stream)
     {
@@ -171,9 +171,9 @@ class Parser implements ParserInterface
      * @param TokenStream $stream
      * @param bool        $insideNegation
      *
-     * @throws SyntaxErrorException
-     *
      * @return array
+     *
+     * @throws SyntaxErrorException
      */
     private function parseSimpleSelector(TokenStream $stream, $insideNegation = false)
     {
@@ -328,9 +328,9 @@ class Parser implements ParserInterface
      * @param Node\NodeInterface $selector
      * @param TokenStream        $stream
      *
-     * @throws SyntaxErrorException
-     *
      * @return Node\AttributeNode
+     *
+     * @throws SyntaxErrorException
      */
     private function parseAttributeNode(Node\NodeInterface $selector, TokenStream $stream)
     {

--- a/src/Symfony/Component/CssSelector/Parser/TokenStream.php
+++ b/src/Symfony/Component/CssSelector/Parser/TokenStream.php
@@ -83,9 +83,9 @@ class TokenStream
     /**
      * Returns next token.
      *
-     * @throws InternalErrorException If there is no more token
-     *
      * @return Token
+     *
+     * @throws InternalErrorException If there is no more token
      */
     public function getNext()
     {
@@ -131,9 +131,9 @@ class TokenStream
     /**
      * Returns nex identifier token.
      *
-     * @throws SyntaxErrorException If next token is not an identifier
-     *
      * @return string The identifier token value
+     *
+     * @throws SyntaxErrorException If next token is not an identifier
      */
     public function getNextIdentifier()
     {
@@ -149,9 +149,9 @@ class TokenStream
     /**
      * Returns nex identifier or star delimiter token.
      *
-     * @throws SyntaxErrorException If next token is not an identifier or a star delimiter
-     *
      * @return null|string The identifier token value or null if star found
+     *
+     * @throws SyntaxErrorException If next token is not an identifier or a star delimiter
      */
     public function getNextIdentifierOrStar()
     {

--- a/src/Symfony/Component/CssSelector/XPath/Translator.php
+++ b/src/Symfony/Component/CssSelector/XPath/Translator.php
@@ -266,9 +266,9 @@ class Translator implements TranslatorInterface
      * @param string    $attribute
      * @param string    $value
      *
-     * @throws ExpressionErrorException
-     *
      * @return XPathExpr
+     *
+     * @throws ExpressionErrorException
      */
     public function addAttributeMatching(XPathExpr $xpath, $operator, $attribute, $value)
     {

--- a/src/Symfony/Component/EventDispatcher/GenericEvent.php
+++ b/src/Symfony/Component/EventDispatcher/GenericEvent.php
@@ -61,9 +61,9 @@ class GenericEvent extends Event implements \ArrayAccess, \IteratorAggregate
      *
      * @param string $key Key.
      *
-     * @throws \InvalidArgumentException If key is not found.
-     *
      * @return mixed Contents of array key.
+     *
+     * @throws \InvalidArgumentException If key is not found.
      */
     public function getArgument($key)
     {
@@ -130,9 +130,9 @@ class GenericEvent extends Event implements \ArrayAccess, \IteratorAggregate
      *
      * @param string $key Array key.
      *
-     * @throws \InvalidArgumentException If key does not exist in $this->args.
-     *
      * @return mixed
+     *
+     * @throws \InvalidArgumentException If key does not exist in $this->args.
      */
     public function offsetGet($key)
     {

--- a/src/Symfony/Component/Finder/Expression/Expression.php
+++ b/src/Symfony/Component/Finder/Expression/Expression.php
@@ -123,9 +123,9 @@ class Expression implements ValueInterface
     }
 
     /**
-     * @throws \LogicException
-     *
      * @return Glob
+     *
+     * @throws \LogicException
      */
     public function getGlob()
     {

--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -128,9 +128,9 @@ class Finder implements \IteratorAggregate, \Countable
      *
      * @param string $name
      *
-     * @throws \InvalidArgumentException
-     *
      * @return Finder The current Finder instance
+     *
+     * @throws \InvalidArgumentException
      */
     public function setAdapter($name)
     {

--- a/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
@@ -181,9 +181,9 @@ class ResponseHeaderBag extends HeaderBag
      *
      * @param string $format
      *
-     * @throws \InvalidArgumentException When the $format is invalid
-     *
      * @return array
+     *
+     * @throws \InvalidArgumentException When the $format is invalid
      */
     public function getCookies($format = self::COOKIES_FLAT)
     {

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/SessionStorageInterface.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/SessionStorageInterface.php
@@ -24,9 +24,9 @@ interface SessionStorageInterface
     /**
      * Starts the session.
      *
-     * @throws \RuntimeException If something goes wrong starting the session.
-     *
      * @return bool True if started.
+     *
+     * @throws \RuntimeException If something goes wrong starting the session.
      */
     public function start();
 

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -388,9 +388,9 @@ class Process
      * In comparison with the getOutput method which always return the whole
      * output, this one returns the new output since the last call.
      *
-     * @throws LogicException In case the process is not started
-     *
      * @return string The process output since the last call
+     *
+     * @throws LogicException In case the process is not started
      */
     public function getIncrementalOutput()
     {
@@ -433,9 +433,9 @@ class Process
      * whole error output, this one returns the new error output since the last
      * call.
      *
-     * @throws LogicException In case the process is not started
-     *
      * @return string The process error output since the last call
+     *
+     * @throws LogicException In case the process is not started
      */
     public function getIncrementalErrorOutput()
     {

--- a/src/Symfony/Component/Security/Acl/Dbal/MutableAclProvider.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/MutableAclProvider.php
@@ -529,9 +529,9 @@ QUERY;
      *
      * @param SecurityIdentityInterface $sid
      *
-     * @throws \InvalidArgumentException
-     *
      * @return string
+     *
+     * @throws \InvalidArgumentException
      */
     protected function getInsertSecurityIdentitySql(SecurityIdentityInterface $sid)
     {
@@ -601,9 +601,9 @@ QUERY;
      *
      * @param SecurityIdentityInterface $sid
      *
-     * @throws \InvalidArgumentException
-     *
      * @return string
+     *
+     * @throws \InvalidArgumentException
      */
     protected function getSelectSecurityIdentityIdSql(SecurityIdentityInterface $sid)
     {
@@ -631,9 +631,9 @@ QUERY;
      * @param int   $pk
      * @param array $changes
      *
-     * @throws \InvalidArgumentException
-     *
      * @return string
+     *
+     * @throws \InvalidArgumentException
      */
     protected function getUpdateObjectIdentitySql($pk, array $changes)
     {
@@ -655,9 +655,9 @@ QUERY;
      * @param int   $pk
      * @param array $sets
      *
-     * @throws \InvalidArgumentException
-     *
      * @return string
+     *
+     * @throws \InvalidArgumentException
      */
     protected function getUpdateAccessControlEntrySql($pk, array $sets)
     {

--- a/src/Symfony/Component/Security/Acl/Domain/ObjectIdentity.php
+++ b/src/Symfony/Component/Security/Acl/Domain/ObjectIdentity.php
@@ -52,9 +52,9 @@ final class ObjectIdentity implements ObjectIdentityInterface
      *
      * @param object $domainObject
      *
-     * @throws InvalidDomainObjectException
-     *
      * @return ObjectIdentity
+     *
+     * @throws InvalidDomainObjectException
      */
     public static function fromDomainObject($domainObject)
     {

--- a/src/Symfony/Component/Security/Acl/Model/AclInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/AclInterface.php
@@ -97,9 +97,9 @@ interface AclInterface extends \Serializable
      * @param array $securityIdentities
      * @param bool  $administrativeMode
      *
-     * @throws NoAceFoundException when no ACE was applicable for this request
-     *
      * @return bool
+     *
+     * @throws NoAceFoundException when no ACE was applicable for this request
      */
     public function isGranted(array $masks, array $securityIdentities, $administrativeMode = false);
 

--- a/src/Symfony/Component/Security/Acl/Model/MutableAclProviderInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/MutableAclProviderInterface.php
@@ -25,10 +25,10 @@ interface MutableAclProviderInterface extends AclProviderInterface
      *
      * @param ObjectIdentityInterface $oid
      *
+     * @return MutableAclInterface
+     *
      * @throws AclAlreadyExistsException when there already is an ACL for the given
      *                                   object identity
-     *
-     * @return MutableAclInterface
      */
     public function createAcl(ObjectIdentityInterface $oid);
 

--- a/src/Symfony/Component/Security/Acl/Permission/MaskBuilder.php
+++ b/src/Symfony/Component/Security/Acl/Permission/MaskBuilder.php
@@ -180,10 +180,10 @@ class MaskBuilder
      *
      * @param int $mask
      *
+     * @return string
+     *
      * @throws \InvalidArgumentException
      * @throws \RuntimeException
-     *
-     * @return string
      */
     public static function getCode($mask)
     {

--- a/src/Symfony/Component/Stopwatch/StopwatchEvent.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchEvent.php
@@ -89,10 +89,9 @@ class StopwatchEvent
     /**
      * Stops the last started event period.
      *
-     * @throws \LogicException When start wasn't called before stopping
-     *
      * @return StopwatchEvent The event
      *
+     * @throws \LogicException When start wasn't called before stopping
      * @throws \LogicException When stop() is called without a matching call to start()
      */
     public function stop()

--- a/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
@@ -78,10 +78,9 @@ class XliffFileLoader implements LoaderInterface
      *
      * @param string $file
      *
-     * @throws \RuntimeException
-     *
      * @return \SimpleXMLElement
      *
+     * @throws \RuntimeException
      * @throws InvalidResourceException
      */
     private function parseFile($file)

--- a/src/Symfony/Component/Translation/TranslatorInterface.php
+++ b/src/Symfony/Component/Translation/TranslatorInterface.php
@@ -26,9 +26,9 @@ interface TranslatorInterface
      * @param string $domain     The domain for the message
      * @param string $locale     The locale
      *
-     * @throws \InvalidArgumentException If the locale contains invalid characters
-     *
      * @return string The translated string
+     *
+     * @throws \InvalidArgumentException If the locale contains invalid characters
      */
     public function trans($id, array $parameters = array(), $domain = null, $locale = null);
 
@@ -41,9 +41,9 @@ interface TranslatorInterface
      * @param string $domain     The domain for the message
      * @param string $locale     The locale
      *
-     * @throws \InvalidArgumentException If the locale contains invalid characters
-     *
      * @return string The translated string
+     *
+     * @throws \InvalidArgumentException If the locale contains invalid characters
      */
     public function transChoice($id, $number, array $parameters = array(), $domain = null, $locale = null);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | ? |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

The reverse order (even if encouraged by PSR-5 proposal) is violated in 224 files.
