### PR TITLE
[AstGenerator] [WIP] New Component, add normalizer generator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,8 @@
         "egulias/email-validator": "~1.2,>=1.2.8|~2.0",
         "symfony/polyfill-apcu": "~1.1",
         "symfony/security-acl": "~2.8|~3.0",
-        "phpdocumentor/reflection-docblock": "^3.0"
+        "phpdocumentor/reflection-docblock": "^3.0",
+        "nikic/PHP-Parser": "~2.0"
     },
     "conflict": {
         "phpdocumentor/reflection-docblock": "<3.0",

--- a/src/Symfony/Component/AstGenerator/.gitignore
+++ b/src/Symfony/Component/AstGenerator/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Symfony/Component/AstGenerator/AstGeneratorChain.php
+++ b/src/Symfony/Component/AstGenerator/AstGeneratorChain.php
@@ -21,7 +21,7 @@ class AstGeneratorChain implements AstGeneratorInterface
     /** @var AstGeneratorInterface[] A list of generators */
     protected $generators;
 
-    /** @var boolean Whether the generation must return as soon as possible or use all generators, default to false */
+    /** @var bool Whether the generation must return as soon as possible or use all generators, default to false */
     protected $returnOnFirst;
 
     public function __construct(array $generators = [], $returnOnFirst = false)

--- a/src/Symfony/Component/AstGenerator/AstGeneratorChain.php
+++ b/src/Symfony/Component/AstGenerator/AstGeneratorChain.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AstGenerator;
+
+/**
+ * Generator delegating the generation to a chain of generators.
+ *
+ * @author Joel Wurtz <joel.wurtz@gmail.com>
+ */
+class AstGeneratorChain implements AstGeneratorInterface
+{
+    /** @var AstGeneratorInterface[] A list of generators */
+    protected $generators;
+
+    /** @var boolean Whether the generation must return as soon as possible or use all generators, default to false */
+    protected $returnOnFirst;
+
+    public function __construct(array $generators = [], $returnOnFirst = false)
+    {
+        $this->generators = $generators;
+        $this->returnOnFirst = $returnOnFirst;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generate($object, array $context = [])
+    {
+        $nodes = [];
+
+        foreach ($this->generators as $generator) {
+            if ($generator instanceof AstGeneratorInterface && $generator->supportsGeneration($object)) {
+                $nodes = array_merge($nodes, $generator->generate($object, $context));
+
+                if ($this->returnOnFirst) {
+                    return $nodes;
+                }
+            }
+        }
+
+        return $nodes;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsGeneration($object)
+    {
+        foreach ($this->generators as $generator) {
+            if ($generator instanceof AstGeneratorInterface && $generator->supportsGeneration($object)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Symfony/Component/AstGenerator/AstGeneratorChain.php
+++ b/src/Symfony/Component/AstGenerator/AstGeneratorChain.php
@@ -24,7 +24,7 @@ class AstGeneratorChain implements AstGeneratorInterface
     /** @var bool Whether the generation must return as soon as possible or use all generators, default to false */
     protected $returnOnFirst;
 
-    public function __construct(array $generators = [], $returnOnFirst = false)
+    public function __construct(array $generators = array(), $returnOnFirst = false)
     {
         $this->generators = $generators;
         $this->returnOnFirst = $returnOnFirst;
@@ -33,9 +33,9 @@ class AstGeneratorChain implements AstGeneratorInterface
     /**
      * {@inheritdoc}
      */
-    public function generate($object, array $context = [])
+    public function generate($object, array $context = array())
     {
-        $nodes = [];
+        $nodes = array();
 
         foreach ($this->generators as $generator) {
             if ($generator instanceof AstGeneratorInterface && $generator->supportsGeneration($object)) {

--- a/src/Symfony/Component/AstGenerator/AstGeneratorInterface.php
+++ b/src/Symfony/Component/AstGenerator/AstGeneratorInterface.php
@@ -12,14 +12,14 @@
 namespace Symfony\Component\AstGenerator;
 
 /**
- * An AstGeneratorInterface is a contract to transform an object into an AST
+ * An AstGeneratorInterface is a contract to transform an object into an AST.
  *
  * @author Joel Wurtz <joel.wurtz@gmail.com>
  */
 interface AstGeneratorInterface
 {
     /**
-     * Generate an object into an AST given a specific context
+     * Generate an object into an AST given a specific context.
      *
      * @param mixed $object  Object to generate AST from
      * @param array $context Context for the generator
@@ -29,11 +29,11 @@ interface AstGeneratorInterface
     public function generate($object, array $context = []);
 
     /**
-     * Check whether the given object is supported for generation by this generator
+     * Check whether the given object is supported for generation by this generator.
      *
      * @param mixed $object Object to generate AST from
      *
-     * @return boolean
+     * @return bool
      */
     public function supportsGeneration($object);
 }

--- a/src/Symfony/Component/AstGenerator/AstGeneratorInterface.php
+++ b/src/Symfony/Component/AstGenerator/AstGeneratorInterface.php
@@ -18,7 +18,22 @@ namespace Symfony\Component\AstGenerator;
  */
 interface AstGeneratorInterface
 {
-    public function generate();
+    /**
+     * Generate an object into an AST given a specific context
+     *
+     * @param mixed $object  Object to generate AST from
+     * @param array $context Context for the generator
+     *
+     * @return \PhpParser\Node[] An array of statements (AST Node)
+     */
+    public function generate($object, array $context = []);
 
-    public function supportsGeneration();
+    /**
+     * Check whether the given object is supported for generation by this generator
+     *
+     * @param mixed $object Object to generate AST from
+     *
+     * @return boolean
+     */
+    public function supportsGeneration($object);
 }

--- a/src/Symfony/Component/AstGenerator/AstGeneratorInterface.php
+++ b/src/Symfony/Component/AstGenerator/AstGeneratorInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AstGenerator;
+
+/**
+ * An AstGeneratorInterface is a contract to transform an object into an AST
+ *
+ * @author Joel Wurtz <joel.wurtz@gmail.com>
+ */
+interface AstGeneratorInterface
+{
+    public function generate();
+
+    public function supportsGeneration();
+}

--- a/src/Symfony/Component/AstGenerator/AstGeneratorInterface.php
+++ b/src/Symfony/Component/AstGenerator/AstGeneratorInterface.php
@@ -26,7 +26,7 @@ interface AstGeneratorInterface
      *
      * @return \PhpParser\Node[] An array of statements (AST Node)
      */
-    public function generate($object, array $context = []);
+    public function generate($object, array $context = array());
 
     /**
      * Check whether the given object is supported for generation by this generator.

--- a/src/Symfony/Component/AstGenerator/Exception/MissingContextException.php
+++ b/src/Symfony/Component/AstGenerator/Exception/MissingContextException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\AstGenerator\Exception;
+
+class MissingContextException extends \RuntimeException
+{
+}

--- a/src/Symfony/Component/AstGenerator/Hydrate/ArrayHydrateGenerator.php
+++ b/src/Symfony/Component/AstGenerator/Hydrate/ArrayHydrateGenerator.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AstGenerator\Hydrate;
+
+use PhpParser\Node\Name;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Scalar;
+
+/**
+ * Create AST Statement to normalize a Class into a stdClassObject
+ *
+ * @author Joel Wurtz <joel.wurtz@gmail.com>
+ */
+class ArrayHydrateGenerator extends HydrateFromObjectGenerator
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAssignStatement($dataVariable)
+    {
+        return new Expr\Assign($dataVariable, new Expr\Array_());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getSubAssignVariableStatement($dataVariable, $property)
+    {
+        return new Expr\ArrayDimFetch($dataVariable, new Scalar\String_($property));
+    }
+}

--- a/src/Symfony/Component/AstGenerator/Hydrate/ArrayHydrateGenerator.php
+++ b/src/Symfony/Component/AstGenerator/Hydrate/ArrayHydrateGenerator.php
@@ -11,12 +11,11 @@
 
 namespace Symfony\Component\AstGenerator\Hydrate;
 
-use PhpParser\Node\Name;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Scalar;
 
 /**
- * Create AST Statement to normalize a Class into a stdClassObject
+ * Create AST Statement to normalize a Class into a stdClassObject.
  *
  * @author Joel Wurtz <joel.wurtz@gmail.com>
  */

--- a/src/Symfony/Component/AstGenerator/Hydrate/HydrateFromObjectGenerator.php
+++ b/src/Symfony/Component/AstGenerator/Hydrate/HydrateFromObjectGenerator.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AstGenerator\Hydrate;
+
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Expr;
+use Symfony\Component\AstGenerator\AstGeneratorInterface;
+use Symfony\Component\AstGenerator\Exception\MissingContextException;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
+
+abstract class HydrateFromObjectGenerator implements AstGeneratorInterface
+{
+    /** @var PropertyInfoExtractorInterface Extract list of properties from a class */
+    protected $propertyInfoExtractor;
+
+    /** @var AstGeneratorInterface Generator for normalization of types */
+    protected $typeHydrateAstGenerator;
+
+    public function __construct(PropertyInfoExtractorInterface $propertyInfoExtractor, AstGeneratorInterface $typeHydrateAstGenerator)
+    {
+        $this->propertyInfoExtractor = $propertyInfoExtractor;
+        $this->typeHydrateAstGenerator = $typeHydrateAstGenerator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generate($object, array $context = [])
+    {
+        if (!isset($context['input'])) {
+            throw new MissingContextException('Input variable not defined in context');
+        }
+
+        $dataVariable = new Expr\Variable('data');
+        $statements = [$this->getAssignStatement($dataVariable)];
+
+        foreach ($this->propertyInfoExtractor->getProperties($object, $context) as $property) {
+            // Only normalize readable property
+            if (!$this->propertyInfoExtractor->isReadable($object, $property, $context)) {
+                continue;
+            }
+
+            // @TODO Have property info extractor extract the way of reading a property (public or method with method name)
+            $input = new Expr\MethodCall($context['input'], 'get'.ucfirst($property));
+            $output = $this->getSubAssignVariableStatement($dataVariable, $property);
+            $types = $this->propertyInfoExtractor->getTypes($object, $property, $context);
+
+            // If no type can be extracted, directly assign output to input
+            if (null === $types || count($types) == 0) {
+                $statements[] = new Expr\Assign($output, $input);
+
+                continue;
+            }
+
+            // If there is multiple types, we need to know which one we must normalize
+            $conditionNeeded = (boolean)(count($types) > 1);
+            $noAssignment = true;
+
+            foreach ($types as $type) {
+                if (!$this->typeHydrateAstGenerator->supportsGeneration($type)) {
+                    continue;
+                }
+
+                $noAssignment = false;
+                $statements = array_merge($statements, $this->typeHydrateAstGenerator->generate($type, array_merge($context, [
+                    'input' => $input,
+                    'output' => $output,
+                    'condition' => $conditionNeeded
+                ])));
+            }
+
+            // If nothing has been assigned, we directly put input into output
+            if ($noAssignment) {
+                $statements[] = new Expr\Assign($output, $input);
+            }
+        }
+
+        $statements[] = new Stmt\Return_($dataVariable);
+
+        return $statements;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsGeneration($object)
+    {
+        return (is_string($object) && class_exists($object));
+    }
+
+    /**
+     * Create the assign statement
+     *
+     * @param Expr\Variable $dataVariable Variable to use
+     *
+     * @return Expr\Assign An assignment for the variable
+     */
+    abstract protected function getAssignStatement($dataVariable);
+
+
+    /**
+     * Create the sub assign variable statement
+     *
+     * @param Expr\Variable $dataVariable Variable to use
+     * @param string        $property     Property name for object or array dimension
+     *
+     * @return Expr\ArrayDimFetch|Expr\PropertyFetch
+     */
+    abstract protected function getSubAssignVariableStatement($dataVariable, $property);
+}

--- a/src/Symfony/Component/AstGenerator/Hydrate/HydrateFromObjectGenerator.php
+++ b/src/Symfony/Component/AstGenerator/Hydrate/HydrateFromObjectGenerator.php
@@ -12,11 +12,9 @@
 namespace Symfony\Component\AstGenerator\Hydrate;
 
 use PhpParser\Node\Name;
-use PhpParser\Node\Stmt;
 use PhpParser\Node\Expr;
 use Symfony\Component\AstGenerator\AstGeneratorInterface;
 use Symfony\Component\AstGenerator\Exception\MissingContextException;
-use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
 
 abstract class HydrateFromObjectGenerator implements AstGeneratorInterface
@@ -67,7 +65,7 @@ abstract class HydrateFromObjectGenerator implements AstGeneratorInterface
             }
 
             // If there is multiple types, we need to know which one we must normalize
-            $conditionNeeded = (boolean)(count($types) > 1);
+            $conditionNeeded = (boolean) (count($types) > 1);
             $noAssignment = true;
 
             foreach ($types as $type) {
@@ -79,7 +77,7 @@ abstract class HydrateFromObjectGenerator implements AstGeneratorInterface
                 $statements = array_merge($statements, $this->typeHydrateAstGenerator->generate($type, array_merge($context, [
                     'input' => $input,
                     'output' => $output,
-                    'condition' => $conditionNeeded
+                    'condition' => $conditionNeeded,
                 ])));
             }
 
@@ -97,11 +95,11 @@ abstract class HydrateFromObjectGenerator implements AstGeneratorInterface
      */
     public function supportsGeneration($object)
     {
-        return (is_string($object) && class_exists($object));
+        return is_string($object) && class_exists($object);
     }
 
     /**
-     * Create the assign statement
+     * Create the assign statement.
      *
      * @param Expr\Variable $dataVariable Variable to use
      *
@@ -109,9 +107,8 @@ abstract class HydrateFromObjectGenerator implements AstGeneratorInterface
      */
     abstract protected function getAssignStatement($dataVariable);
 
-
     /**
-     * Create the sub assign variable statement
+     * Create the sub assign variable statement.
      *
      * @param Expr\Variable $dataVariable Variable to use
      * @param string        $property     Property name for object or array dimension

--- a/src/Symfony/Component/AstGenerator/Hydrate/HydrateFromObjectGenerator.php
+++ b/src/Symfony/Component/AstGenerator/Hydrate/HydrateFromObjectGenerator.php
@@ -39,7 +39,7 @@ abstract class HydrateFromObjectGenerator implements AstGeneratorInterface
     /**
      * {@inheritdoc}
      */
-    public function generate($object, array $context = [])
+    public function generate($object, array $context = array())
     {
         if (!isset($context['input']) || !($context['input'] instanceof Expr\Variable)) {
             throw new MissingContextException('Input variable not defined or not a Expr\Variable in generation context');
@@ -49,7 +49,7 @@ abstract class HydrateFromObjectGenerator implements AstGeneratorInterface
             throw new MissingContextException('Output variable not defined or not a Expr\Variable in generation context');
         }
 
-        $statements = [$this->getAssignStatement($context['output'])];
+        $statements = array($this->getAssignStatement($context['output']));
 
         foreach ($this->propertyInfoExtractor->getProperties($object, $context) as $property) {
             // Only normalize readable property

--- a/src/Symfony/Component/AstGenerator/Hydrate/ObjectHydrateFromArrayGenerator.php
+++ b/src/Symfony/Component/AstGenerator/Hydrate/ObjectHydrateFromArrayGenerator.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AstGenerator\Hydrate;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Scalar;
+
+class ObjectHydrateFromArrayGenerator extends ObjectHydrateGenerator
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function createInputExpr(Expr\Variable $inputVariable, $property)
+    {
+        return new Expr\ArrayDimFetch($inputVariable, new Scalar\String_($property));
+    }
+}

--- a/src/Symfony/Component/AstGenerator/Hydrate/ObjectHydrateFromStdClassGenerator.php
+++ b/src/Symfony/Component/AstGenerator/Hydrate/ObjectHydrateFromStdClassGenerator.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AstGenerator\Hydrate;
+
+use PhpParser\Node\Expr;
+
+class ObjectHydrateFromStdClassGenerator extends ObjectHydrateGenerator
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function createInputExpr(Expr\Variable $inputVariable, $property)
+    {
+        return new Expr\PropertyFetch($inputVariable, sprintf("{'%s'}", $property));
+    }
+}

--- a/src/Symfony/Component/AstGenerator/Hydrate/ObjectHydrateGenerator.php
+++ b/src/Symfony/Component/AstGenerator/Hydrate/ObjectHydrateGenerator.php
@@ -41,7 +41,7 @@ abstract class ObjectHydrateGenerator implements AstGeneratorInterface
     /**
      * {@inheritdoc}
      */
-    public function generate($object, array $context = [])
+    public function generate($object, array $context = array())
     {
         if (!isset($context['input']) || !($context['input'] instanceof Expr\Variable)) {
             throw new MissingContextException('Input variable not defined or not a Expr\Variable in generation context');
@@ -52,9 +52,9 @@ abstract class ObjectHydrateGenerator implements AstGeneratorInterface
         }
 
         $uniqueVariableScope = isset($context['unique_variable_scope']) ? $context['unique_variable_scope'] : new UniqueVariableScope();
-        $statements = [
+        $statements = array(
             new Expr\Assign($context['output'], new Expr\New_(new Name("\\".$object))),
-        ];
+        );
 
         foreach ($this->propertyInfoExtractor->getProperties($object, $context) as $property) {
             // Only hydrate writable property

--- a/src/Symfony/Component/AstGenerator/Hydrate/StdClassHydrateGenerator.php
+++ b/src/Symfony/Component/AstGenerator/Hydrate/StdClassHydrateGenerator.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AstGenerator\Hydrate;
+
+use PhpParser\Node\Name;
+use PhpParser\Node\Expr;
+
+/**
+ * Create AST Statement to normalize a Class into a stdClassObject
+ *
+ * @author Joel Wurtz <joel.wurtz@gmail.com>
+ */
+class StdClassHydrateGenerator extends HydrateFromObjectGenerator
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAssignStatement($dataVariable)
+    {
+        return new Expr\Assign($dataVariable, new Expr\New_(new Name("\\stdClass")));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getSubAssignVariableStatement($dataVariable, $property)
+    {
+        return new Expr\PropertyFetch($dataVariable, sprintf("{'%s'}", $property));
+    }
+}

--- a/src/Symfony/Component/AstGenerator/Hydrate/StdClassHydrateGenerator.php
+++ b/src/Symfony/Component/AstGenerator/Hydrate/StdClassHydrateGenerator.php
@@ -15,7 +15,7 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Expr;
 
 /**
- * Create AST Statement to normalize a Class into a stdClassObject
+ * Create AST Statement to normalize a Class into a stdClassObject.
  *
  * @author Joel Wurtz <joel.wurtz@gmail.com>
  */
@@ -26,7 +26,7 @@ class StdClassHydrateGenerator extends HydrateFromObjectGenerator
      */
     protected function getAssignStatement($dataVariable)
     {
-        return new Expr\Assign($dataVariable, new Expr\New_(new Name("\\stdClass")));
+        return new Expr\Assign($dataVariable, new Expr\New_(new Name('\\stdClass')));
     }
 
     /**

--- a/src/Symfony/Component/AstGenerator/Hydrate/Type/CollectionTypeGenerator.php
+++ b/src/Symfony/Component/AstGenerator/Hydrate/Type/CollectionTypeGenerator.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AstGenerator\Hydrate\Type;
+
+use PhpParser\Node\Expr;
+use Symfony\Component\AstGenerator\AstGeneratorInterface;
+use Symfony\Component\AstGenerator\Exception\MissingContextException;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * Abstract class to generate collection hydration
+ *
+ * @author Joel Wurtz <joel.wurtz@gmail.com>
+ */
+class CollectionTypeGenerator implements AstGeneratorInterface
+{
+    const COLLECTION_WITH_STDCLASS = 0;
+    const COLLECTION_WITH_ARRAY = 1;
+
+    /**
+     * CollectionTypeGenerator constructor.
+     *
+     * @param AstGeneratorInterface $subValueTypeGenerator Generator for the value of the collection
+     * @param int|null              $fromCollectionType    From collection type to generate, array or stdClass, use null
+     * to have a dynamic choice depending on the type of the collection key (where int will be array and string stdClass)
+     * @param int|null              $toCollectionType      To collection type to generate, array or stdClass, use null
+     * to have a dynamic choice depending on the type of the collection key (where int will be array and string stdClass)
+     */
+    public function __construct(AstGeneratorInterface $subValueTypeGenerator, $fromCollectionType = null, $toCollectionType = null)
+    {
+
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param Type $object A type extracted with PropertyInfo component
+     */
+    public function generate($object, array $context = [])
+    {
+        if (!isset($context['input']) || !($context['input'] instanceof Expr)) {
+            throw new MissingContextException('Input variable not defined or not an Expr in generation context');
+        }
+
+        if (!isset($context['output']) || !($context['output'] instanceof Expr)) {
+            throw new MissingContextException('Output variable not defined or not an Expr in generation context');
+        }
+
+        $statements = [
+            new Expr\Assign($context['output'], $this->createCollectionAssignStatement()),
+        ];
+
+        $loopValueVar = new Expr\Variable($context->getUniqueVariableName('value'));
+        $loopKeyVar = $this->createLoopKeyStatement($context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsGeneration($object)
+    {
+        return $object instanceof Type && $object->isCollection();
+    }
+
+    /**
+     * Create the collection assign statement
+     *
+     * @return Expr
+     */
+    protected function createCollectionAssignStatement()
+    {
+
+    }
+}

--- a/src/Symfony/Component/AstGenerator/Hydrate/Type/CollectionTypeGenerator.php
+++ b/src/Symfony/Component/AstGenerator/Hydrate/Type/CollectionTypeGenerator.php
@@ -12,8 +12,11 @@
 namespace Symfony\Component\AstGenerator\Hydrate\Type;
 
 use PhpParser\Node\Expr;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt;
 use Symfony\Component\AstGenerator\AstGeneratorInterface;
 use Symfony\Component\AstGenerator\Exception\MissingContextException;
+use Symfony\Component\AstGenerator\UniqueVariableScope;
 use Symfony\Component\PropertyInfo\Type;
 
 /**
@@ -23,21 +26,44 @@ use Symfony\Component\PropertyInfo\Type;
  */
 class CollectionTypeGenerator implements AstGeneratorInterface
 {
-    const COLLECTION_WITH_STDCLASS = 0;
+    const COLLECTION_WITH_OBJECT = 0;
     const COLLECTION_WITH_ARRAY = 1;
+
+    const OBJECT_ASSIGNMENT_ARRAY = 0;
+    const OBJECT_ASSIGNMENT_PROPERTY = 1;
+
+    /** @var AstGeneratorInterface Generator for the value of the collection */
+    private $subValueTypeGenerator;
+
+    /** @var int|null Output collection type to generate */
+    private $outputCollectionType;
+
+    /** @var string Class of object to use for the collection of the output */
+    private $outputObjectClass;
+
+    /** @var int Assignment type for the output */
+    private $outputObjectAssignment;
 
     /**
      * CollectionTypeGenerator constructor.
      *
      * @param AstGeneratorInterface $subValueTypeGenerator Generator for the value of the collection
-     * @param int|null              $fromCollectionType    From collection type to generate, array or stdClass, use null
+     * @param int|null              $outputCollectionType   Output collection type to generate, array or stdClass, use null
      * to have a dynamic choice depending on the type of the collection key (where int will be array and string stdClass)
-     * @param int|null              $toCollectionType      To collection type to generate, array or stdClass, use null
-     * to have a dynamic choice depending on the type of the collection key (where int will be array and string stdClass)
+     * @param string                $outputObjectClass      Class of object to use for the collection of the output
+     * @param int                   $outputObjectAssignment Assignment type for the output
      */
-    public function __construct(AstGeneratorInterface $subValueTypeGenerator, $fromCollectionType = null, $toCollectionType = null)
+    public function __construct(
+        AstGeneratorInterface $subValueTypeGenerator,
+        $outputCollectionType = null,
+        $outputObjectClass = '\\stdClass',
+        $outputObjectAssignment = self::OBJECT_ASSIGNMENT_PROPERTY
+    )
     {
-
+        $this->subValueTypeGenerator = $subValueTypeGenerator;
+        $this->outputCollectionType = $outputCollectionType;
+        $this->outputObjectClass = $outputObjectClass;
+        $this->outputObjectAssignment = $outputObjectAssignment;
     }
 
     /**
@@ -55,12 +81,34 @@ class CollectionTypeGenerator implements AstGeneratorInterface
             throw new MissingContextException('Output variable not defined or not an Expr in generation context');
         }
 
+        $uniqueVariableScope = isset($context['unique_variable_scope']) ? $context['unique_variable_scope'] : new UniqueVariableScope();
         $statements = [
-            new Expr\Assign($context['output'], $this->createCollectionAssignStatement()),
+            new Expr\Assign($context['output'], $this->createCollectionAssignStatement($object)),
         ];
 
-        $loopValueVar = new Expr\Variable($context->getUniqueVariableName('value'));
-        $loopKeyVar = $this->createLoopKeyStatement($context);
+        // Create item input
+        $loopValueVar = new Expr\Variable($uniqueVariableScope->getUniqueName('value'));
+
+        // Create item output
+        $loopKeyVar = new Expr\Variable($uniqueVariableScope->getUniqueName('key'));
+        $output = $this->createCollectionItemExpr($object, $loopKeyVar, $context['output']);
+
+        // Loop statements
+        $loopStatements = [new Expr\Assign($output, $loopValueVar)];
+
+        if (null !== $object->getCollectionValueType() && $this->subValueTypeGenerator->supportsGeneration($object->getCollectionValueType())) {
+            $loopStatements = $this->subValueTypeGenerator->generate($object->getCollectionValueType(), array_merge($context, [
+                'input' => $loopValueVar,
+                'output' => $output
+            ]));
+        }
+
+        $statements[] = new Stmt\Foreach_($context['input'], $loopValueVar, [
+            'keyVar' => $loopKeyVar,
+            'stmts'  => $loopStatements
+        ]);
+
+        return $statements;
     }
 
     /**
@@ -76,8 +124,56 @@ class CollectionTypeGenerator implements AstGeneratorInterface
      *
      * @return Expr
      */
-    protected function createCollectionAssignStatement()
+    protected function createCollectionAssignStatement(Type $type)
     {
+        $outputCollectionType = $this->getOutputCollectionType($type);
 
+        if ($outputCollectionType === self::COLLECTION_WITH_ARRAY) {
+            return new Expr\Array_();
+        }
+
+        return new Expr\New_(new Name($this->outputObjectClass));
+    }
+
+    /**
+     * Create the expression for the output assignment of an item in the array
+     *
+     * @param Type          $type       Type of property
+     * @param Expr\Variable $loopKeyVar Variable for the key in the loop
+     * @param Expr          $output     Output to use for the collection
+     *
+     * @return Expr\ArrayDimFetch|Expr\PropertyFetch
+     */
+    protected function createCollectionItemExpr(Type $type, Expr\Variable $loopKeyVar, Expr $output)
+    {
+        $outputCollectionType = $this->getOutputCollectionType($type);
+
+        if ($outputCollectionType === self::COLLECTION_WITH_ARRAY || $this->outputObjectAssignment == self::OBJECT_ASSIGNMENT_ARRAY) {
+            return new Expr\ArrayDimFetch($output, $loopKeyVar);
+        }
+
+        return new Expr\PropertyFetch($output, $loopKeyVar);
+    }
+
+    /**
+     * Get output collection type, set in constructor or guessed from type of the collection key
+     *
+     * @param Type $type
+     *
+     * @return int|null
+     */
+    private function getOutputCollectionType(Type $type)
+    {
+        $outputCollectionType = $this->outputCollectionType;
+
+        if ($outputCollectionType === null) {
+            $outputCollectionType = self::COLLECTION_WITH_ARRAY;
+
+            if ($type->getCollectionKeyType() !== null && $type->getCollectionKeyType()->getBuiltinType() !== Type::BUILTIN_TYPE_INT) {
+                $outputCollectionType = self::COLLECTION_WITH_OBJECT;
+            }
+        }
+
+        return $outputCollectionType;
     }
 }

--- a/src/Symfony/Component/AstGenerator/Hydrate/Type/CollectionTypeGenerator.php
+++ b/src/Symfony/Component/AstGenerator/Hydrate/Type/CollectionTypeGenerator.php
@@ -71,7 +71,7 @@ class CollectionTypeGenerator implements AstGeneratorInterface
      *
      * @param Type $object A type extracted with PropertyInfo component
      */
-    public function generate($object, array $context = [])
+    public function generate($object, array $context = array())
     {
         if (!isset($context['input']) || !($context['input'] instanceof Expr)) {
             throw new MissingContextException('Input variable not defined or not an Expr in generation context');
@@ -82,9 +82,9 @@ class CollectionTypeGenerator implements AstGeneratorInterface
         }
 
         $uniqueVariableScope = isset($context['unique_variable_scope']) ? $context['unique_variable_scope'] : new UniqueVariableScope();
-        $statements = [
+        $statements = array(
             new Expr\Assign($context['output'], $this->createCollectionAssignStatement($object)),
-        ];
+        );
 
         // Create item input
         $loopValueVar = new Expr\Variable($uniqueVariableScope->getUniqueName('value'));
@@ -94,19 +94,19 @@ class CollectionTypeGenerator implements AstGeneratorInterface
         $output = $this->createCollectionItemExpr($object, $loopKeyVar, $context['output']);
 
         // Loop statements
-        $loopStatements = [new Expr\Assign($output, $loopValueVar)];
+        $loopStatements = array(new Expr\Assign($output, $loopValueVar));
 
         if (null !== $object->getCollectionValueType() && $this->subValueTypeGenerator->supportsGeneration($object->getCollectionValueType())) {
-            $loopStatements = $this->subValueTypeGenerator->generate($object->getCollectionValueType(), array_merge($context, [
+            $loopStatements = $this->subValueTypeGenerator->generate($object->getCollectionValueType(), array_merge($context, array(
                 'input' => $loopValueVar,
                 'output' => $output
-            ]));
+            )));
         }
 
-        $statements[] = new Stmt\Foreach_($context['input'], $loopValueVar, [
+        $statements[] = new Stmt\Foreach_($context['input'], $loopValueVar, array(
             'keyVar' => $loopKeyVar,
             'stmts'  => $loopStatements
-        ]);
+        ));
 
         return $statements;
     }

--- a/src/Symfony/Component/AstGenerator/Hydrate/Type/DenormalizableObjectTypeGenerator.php
+++ b/src/Symfony/Component/AstGenerator/Hydrate/Type/DenormalizableObjectTypeGenerator.php
@@ -32,7 +32,7 @@ class DenormalizableObjectTypeGenerator implements AstGeneratorInterface
      *
      * @param Type $object A type extracted with PropertyInfo component
      */
-    public function generate($object, array $context = [])
+    public function generate($object, array $context = array())
     {
         if (!isset($context['input']) || !($context['input'] instanceof Expr)) {
             throw new MissingContextException('Input variable not defined or not an Expr in generation context');
@@ -68,7 +68,7 @@ class DenormalizableObjectTypeGenerator implements AstGeneratorInterface
         ];
 
         if (isset($context['condition']) && $context['condition']) {
-            return [new Stmt\If_(
+            return array(new Stmt\If_(
                 new Expr\BinaryOp\LogicalAnd(
                     new Expr\MethodCall(
                         $context['denormalizer'],
@@ -76,10 +76,10 @@ class DenormalizableObjectTypeGenerator implements AstGeneratorInterface
                         $normalizationArgs
                     )
                 ),
-                [
+                array(
                     'stmts' => $assign
-                ]
-            )];
+                )
+            ));
         }
 
         return $assign;

--- a/src/Symfony/Component/AstGenerator/Hydrate/Type/NormalizableObjectTypeGenerator.php
+++ b/src/Symfony/Component/AstGenerator/Hydrate/Type/NormalizableObjectTypeGenerator.php
@@ -31,7 +31,7 @@ class NormalizableObjectTypeGenerator implements AstGeneratorInterface
      *
      * @param Type $object A type extracted with PropertyInfo component
      */
-    public function generate($object, array $context = [])
+    public function generate($object, array $context = array())
     {
         if (!isset($context['input']) || !($context['input'] instanceof Expr)) {
             throw new MissingContextException('Input variable not defined or not an Expr in generation context');
@@ -55,16 +55,16 @@ class NormalizableObjectTypeGenerator implements AstGeneratorInterface
             $normalizationArgs[] = new Arg($context['context']);
         }
 
-        $assign = [
+        $assign = array(
             new Expr\Assign($context['output'], new Expr\MethodCall(
                 $context['normalizer'],
                 'normalize',
                 $normalizationArgs
             ))
-        ];
+        );
 
         if (isset($context['condition']) && $context['condition']) {
-            return [new Stmt\If_(
+            return array(new Stmt\If_(
                 new Expr\BinaryOp\LogicalAnd(
                     new Expr\Instanceof_(new Expr\Variable('data'), new Name($object->getClassName())),
                     new Expr\MethodCall(
@@ -73,10 +73,10 @@ class NormalizableObjectTypeGenerator implements AstGeneratorInterface
                         $normalizationArgs
                     )
                 ),
-                [
+                array(
                     'stmts' => $assign
-                ]
-            )];
+                )
+            ));
         }
 
         return $assign;

--- a/src/Symfony/Component/AstGenerator/Hydrate/Type/NormalizableObjectTypeGenerator.php
+++ b/src/Symfony/Component/AstGenerator/Hydrate/Type/NormalizableObjectTypeGenerator.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AstGenerator\Hydrate\Type;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Name;
+use Symfony\Component\AstGenerator\AstGeneratorInterface;
+use Symfony\Component\AstGenerator\Exception\MissingContextException;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * Generate hydration of normalizable object type.
+ *
+ * @author Guilhem N. <egetick@gmail.com>
+ */
+class NormalizableObjectTypeGenerator implements AstGeneratorInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @param Type $object A type extracted with PropertyInfo component
+     */
+    public function generate($object, array $context = [])
+    {
+        if (!isset($context['input']) || !($context['input'] instanceof Expr)) {
+            throw new MissingContextException('Input variable not defined or not an Expr in generation context');
+        }
+
+        if (!isset($context['output']) || !($context['output'] instanceof Expr)) {
+            throw new MissingContextException('Output variable not defined or not an Expr in generation context');
+        }
+
+        if (!isset($context['normalizer']) || !($context['normalizer'] instanceof Expr)) {
+            throw new MissingContextException('Denormalizer variable not defined or not an Expr in generation context');
+        }
+
+        $assign = [
+            new Expr\Assign($context['output'], $context['input'])
+        ];
+
+        if (isset($context['condition']) && $context['condition']) {
+            return [new Stmt\If_(
+                new Expr\BinaryOp\LogicalAnd(
+                    new Expr\FuncCall(
+                        'is_object',
+                        array(
+                            new Arg($context['input']),
+                        )
+                    ),
+                    new Expr\MethodCall(
+                        $context['normalizer'],
+                        'supportsNormalization'
+                        call_user_func(function() use ($context) {
+                            $args = array(new Arg($context['input']));
+                            if (isset($context['format'])) {
+                                $args[] = new Arg($context['input']);
+                            } else {
+                                $args[] = new Arg(new Expr\ConstFetch(new Name('null')));
+                            }
+                            if (isset($context['context'])) {
+                                $args[] = new Arg($context['context']);
+                            }
+
+                            return $args;
+                        })
+                    )
+                ),
+                [
+                    'stmts' => $assign
+                ]
+            )];
+        }
+
+        return $assign;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsGeneration($object)
+    {
+        return $object instanceof Type && Type::BUILTIN_TYPE_OBJECT === $object->getBuiltinType();
+    }
+}

--- a/src/Symfony/Component/AstGenerator/Hydrate/Type/TypeGenerator.php
+++ b/src/Symfony/Component/AstGenerator/Hydrate/Type/TypeGenerator.php
@@ -11,6 +11,78 @@
 
 namespace Symfony\Component\AstGenerator\Hydrate\Type;
 
-class TypeGenerator
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Name;
+use Symfony\Component\AstGenerator\AstGeneratorInterface;
+use Symfony\Component\AstGenerator\Exception\MissingContextException;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * Generate hydration of simple type.
+ *
+ * @author Joel Wurtz <joel.wurtz@gmail.com>
+ */
+class TypeGenerator implements AstGeneratorInterface
 {
+    protected $supportedTypes = [
+        Type::BUILTIN_TYPE_BOOL,
+        Type::BUILTIN_TYPE_FLOAT,
+        Type::BUILTIN_TYPE_INT,
+        Type::BUILTIN_TYPE_NULL,
+        Type::BUILTIN_TYPE_STRING,
+    ];
+
+    protected $conditionMapping = [
+        Type::BUILTIN_TYPE_BOOL => 'is_bool',
+        Type::BUILTIN_TYPE_FLOAT => 'is_float',
+        Type::BUILTIN_TYPE_INT => 'is_int',
+        Type::BUILTIN_TYPE_NULL => 'is_null',
+        Type::BUILTIN_TYPE_STRING => 'is_string',
+    ];
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param Type $object A type extracted with PropertyInfo component
+     */
+    public function generate($object, array $context = [])
+    {
+        if (!isset($context['input']) || !($context['input'] instanceof Expr)) {
+            throw new MissingContextException('Input variable not defined or not an Expr in generation context');
+        }
+
+        if (!isset($context['output']) || !($context['output'] instanceof Expr)) {
+            throw new MissingContextException('Output variable not defined or not an Expr in generation context');
+        }
+
+        $assign = [
+            new Expr\Assign($context['output'], $context['input'])
+        ];
+
+        if (isset($context['condition']) && $context['condition']) {
+            return [new Stmt\If_(
+                new Expr\FuncCall(
+                    new Name($this->conditionMapping[$object->getBuiltinType()]),
+                    [
+                        new Arg($context['input'])
+                    ]
+                ),
+                [
+                    'stmts' => $assign
+                ]
+            )];
+        }
+
+        return $assign;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsGeneration($object)
+    {
+        return $object instanceof Type && in_array($object->getBuiltinType(), $this->supportedTypes);
+    }
 }

--- a/src/Symfony/Component/AstGenerator/Hydrate/Type/TypeGenerator.php
+++ b/src/Symfony/Component/AstGenerator/Hydrate/Type/TypeGenerator.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AstGenerator\Hydrate\Type;
+
+class TypeGenerator
+{
+}

--- a/src/Symfony/Component/AstGenerator/Hydrate/Type/TypeGenerator.php
+++ b/src/Symfony/Component/AstGenerator/Hydrate/Type/TypeGenerator.php
@@ -26,28 +26,28 @@ use Symfony\Component\PropertyInfo\Type;
  */
 class TypeGenerator implements AstGeneratorInterface
 {
-    protected $supportedTypes = [
+    protected $supportedTypes = array(
         Type::BUILTIN_TYPE_BOOL,
         Type::BUILTIN_TYPE_FLOAT,
         Type::BUILTIN_TYPE_INT,
         Type::BUILTIN_TYPE_NULL,
         Type::BUILTIN_TYPE_STRING,
-    ];
+    );
 
-    protected $conditionMapping = [
+    protected $conditionMapping = array(
         Type::BUILTIN_TYPE_BOOL => 'is_bool',
         Type::BUILTIN_TYPE_FLOAT => 'is_float',
         Type::BUILTIN_TYPE_INT => 'is_int',
         Type::BUILTIN_TYPE_NULL => 'is_null',
         Type::BUILTIN_TYPE_STRING => 'is_string',
-    ];
+    );
 
     /**
      * {@inheritdoc}
      *
      * @param Type $object A type extracted with PropertyInfo component
      */
-    public function generate($object, array $context = [])
+    public function generate($object, array $context = array())
     {
         if (!isset($context['input']) || !($context['input'] instanceof Expr)) {
             throw new MissingContextException('Input variable not defined or not an Expr in generation context');
@@ -57,22 +57,22 @@ class TypeGenerator implements AstGeneratorInterface
             throw new MissingContextException('Output variable not defined or not an Expr in generation context');
         }
 
-        $assign = [
+        $assign = array(
             new Expr\Assign($context['output'], $context['input'])
-        ];
+        );
 
         if (isset($context['condition']) && $context['condition']) {
-            return [new Stmt\If_(
+            return array(new Stmt\If_(
                 new Expr\FuncCall(
                     new Name($this->conditionMapping[$object->getBuiltinType()]),
-                    [
+                    array(
                         new Arg($context['input'])
-                    ]
+                    )
                 ),
-                [
+                array(
                     'stmts' => $assign
-                ]
-            )];
+                )
+            ));
         }
 
         return $assign;

--- a/src/Symfony/Component/AstGenerator/LICENSE
+++ b/src/Symfony/Component/AstGenerator/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2016 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/AstGenerator/Normalizer/NormalizerGenerator.php
+++ b/src/Symfony/Component/AstGenerator/Normalizer/NormalizerGenerator.php
@@ -11,14 +11,177 @@
 
 namespace Symfony\Component\AstGenerator\Normalizer;
 
+use PhpParser\Node\Name;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Scalar;
 use Symfony\Component\AstGenerator\AstGeneratorInterface;
 
 /**
- * Generate a Normalizer given a
+ * Generate a Normalizer given a Class
  *
  * @author Joel Wurtz <joel.wurtz@gmail.com>
  */
 class NormalizerGenerator implements AstGeneratorInterface
 {
+    /** @var AstGeneratorInterface Generator which generate the statements for normalization of a given class */
+    protected $normalizeStatementsGenerator;
 
+    /** @var AstGeneratorInterface Generator which generate the statements for denormalization of a given class */
+    protected $denormalizeStatementsGenerator;
+
+    /**
+     * NormalizerGenerator constructor.
+     *
+     * @param AstGeneratorInterface $normalizeStatementsGenerator   Generator which generate the statements for normalization of a given class
+     * @param AstGeneratorInterface $denormalizeStatementsGenerator Generator which generate the statements for denormalization of a given class
+     */
+    public function __construct(AstGeneratorInterface $normalizeStatementsGenerator, AstGeneratorInterface $denormalizeStatementsGenerator)
+    {
+        $this->normalizeStatementsGenerator = $normalizeStatementsGenerator;
+        $this->denormalizeStatementsGenerator = $denormalizeStatementsGenerator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generate($object, array $context = [])
+    {
+        if (!isset($context['name'])) {
+            $reflectionClass = new \ReflectionClass($object);
+            $context['name'] = $reflectionClass->getShortName().'Normalizer';
+        }
+
+        return [new Stmt\Class_(
+            new Name($context['name']),
+            [
+                'stmts' => [
+                    $this->createSupportsNormalizationMethod($object),
+                    $this->createSupportsDenormalizationMethod($object),
+                    $this->createNormalizeMethod($object, $context),
+                    $this->createDenormalizeMethod($object, $context),
+                ],
+                'implements' => [
+                    new Name('\Symfony\Component\Serializer\Normalizer\DenormalizerInterface'),
+                    new Name('\Symfony\Component\Serializer\Normalizer\NormalizerInterface')
+                ],
+                'extends' => new Name('\Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer')
+            ]
+        )];
+    }
+
+    /**
+     * Create method to check if normalization is supported
+     *
+     * @param string $class Fully Qualified name of the model class
+     *
+     * @return Stmt\ClassMethod
+     */
+    protected function createSupportsNormalizationMethod($class)
+    {
+        if (strpos($class, '\\') !== 0) {
+            $class = '\\'.$class;
+        }
+
+        return new Stmt\ClassMethod('supportsNormalization', [
+            'type' => Stmt\Class_::MODIFIER_PUBLIC,
+            'params' => [
+                new Param('data'),
+                new Param('format', new Expr\ConstFetch(new Name("null"))),
+            ],
+            'stmts' => [
+                new Stmt\If_(
+                    new Expr\Instanceof_(new Expr\Variable('data'), new Name($class)),
+                    [
+                        'stmts' => [
+                            new Stmt\Return_(new Expr\ConstFetch(new Name("true")))
+                        ]
+                    ]
+                ),
+                new Stmt\Return_(new Expr\ConstFetch(new Name("false")))
+            ]
+        ]);
+    }
+
+    /**
+     * Create method to check if denormalization is supported
+     *
+     * @param string $class Fully Qualified name of the model class
+     *
+     * @return Stmt\ClassMethod
+     */
+    protected function createSupportsDenormalizationMethod($class)
+    {
+        return new Stmt\ClassMethod('supportsDenormalization', [
+            'type' => Stmt\Class_::MODIFIER_PUBLIC,
+            'params' => [
+                new Param('data'),
+                new Param('type'),
+                new Param('format', new Expr\ConstFetch(new Name("null"))),
+            ],
+            'stmts' => [
+                new Stmt\If_(
+                    new Expr\BinaryOp\NotIdentical(new Expr\Variable('type'), new Scalar\String_($class)),
+                    [
+                        'stmts' => [
+                            new Stmt\Return_(new Expr\ConstFetch(new Name("false")))
+                        ]
+                    ]
+                ),
+                new Stmt\Return_(new Expr\ConstFetch(new Name("true")))
+            ]
+        ]);
+    }
+
+    /**
+     * Create the normalization method
+     *
+     * @param string $class   Class to create normalization from
+     * @param array  $context Context of generation
+     *
+     * @return Stmt\ClassMethod
+     */
+    protected function createNormalizeMethod($class, array $context = [])
+    {
+        return new Stmt\ClassMethod('normalize', [
+            'type' => Stmt\Class_::MODIFIER_PUBLIC,
+            'params' => [
+                new Param('object'),
+                new Param('format', new Expr\ConstFetch(new Name("null"))),
+                new Param('context', new Expr\Array_(), 'array'),
+            ],
+            'stmts' => $this->normalizeStatementsGenerator->generate($class, $context)
+        ]);
+    }
+
+    /**
+     * Create the denormalization method
+     *
+     * @param string $class   Class to create denormalization from
+     * @param array  $context Context of generation
+     *
+     * @return Stmt\ClassMethod
+     */
+    protected function createDenormalizeMethod($class, array $context = [])
+    {
+        return new Stmt\ClassMethod('denormalize', [
+            'type' => Stmt\Class_::MODIFIER_PUBLIC,
+            'params' => [
+                new Param('data'),
+                new Param('class'),
+                new Param('format', new Expr\ConstFetch(new Name("null"))),
+                new Param('context', new Expr\Array_(), 'array'),
+            ],
+            'stmts' => $this->denormalizeStatementsGenerator->generate($class, $context)
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsGeneration($object)
+    {
+        return (is_string($object) && class_exists($object));
+    }
 }

--- a/src/Symfony/Component/AstGenerator/Normalizer/NormalizerGenerator.php
+++ b/src/Symfony/Component/AstGenerator/Normalizer/NormalizerGenerator.php
@@ -149,6 +149,9 @@ class NormalizerGenerator implements AstGeneratorInterface
      */
     protected function createNormalizeMethod($class, array $context = [])
     {
+        $input = new Expr\Variable('object');
+        $output = new Expr\Variable('data');
+
         return new Stmt\ClassMethod('normalize', [
             'type' => Stmt\Class_::MODIFIER_PUBLIC,
             'params' => [
@@ -156,9 +159,12 @@ class NormalizerGenerator implements AstGeneratorInterface
                 new Param('format', new Expr\ConstFetch(new Name('null'))),
                 new Param('context', new Expr\Array_(), 'array'),
             ],
-            'stmts' => $this->normalizeStatementsGenerator->generate($class, array_merge($context, [
-                'input' => new Expr\Variable('object'),
-            ])),
+            'stmts' => array_merge($this->normalizeStatementsGenerator->generate($class, array_merge($context, [
+                'input' => $input,
+                'output' => $output
+            ])), [
+                new Stmt\Return_($output)
+            ])
         ]);
     }
 
@@ -173,7 +179,7 @@ class NormalizerGenerator implements AstGeneratorInterface
     protected function createDenormalizeMethod($class, array $context = [])
     {
         $input = new Expr\Variable('data');
-        $output = new Expr\Variable('output');
+        $output = new Expr\Variable('object');
 
         return new Stmt\ClassMethod('denormalize', [
             'type' => Stmt\Class_::MODIFIER_PUBLIC,

--- a/src/Symfony/Component/AstGenerator/Normalizer/NormalizerGenerator.php
+++ b/src/Symfony/Component/AstGenerator/Normalizer/NormalizerGenerator.php
@@ -172,6 +172,9 @@ class NormalizerGenerator implements AstGeneratorInterface
      */
     protected function createDenormalizeMethod($class, array $context = [])
     {
+        $input = new Expr\Variable('data');
+        $output = new Expr\Variable('output');
+
         return new Stmt\ClassMethod('denormalize', [
             'type' => Stmt\Class_::MODIFIER_PUBLIC,
             'params' => [
@@ -180,9 +183,12 @@ class NormalizerGenerator implements AstGeneratorInterface
                 new Param('format', new Expr\ConstFetch(new Name("null"))),
                 new Param('context', new Expr\Array_(), 'array'),
             ],
-            'stmts' => $this->denormalizeStatementsGenerator->generate($class, array_merge($context, [
-                'input' => new Expr\Variable('data')
-            ]))
+            'stmts' => array_merge($this->denormalizeStatementsGenerator->generate($class, array_merge($context, [
+                'input' => $input,
+                'output' => $output
+            ])), [
+                new Stmt\Return_($output)
+            ])
         ]);
     }
 

--- a/src/Symfony/Component/AstGenerator/Normalizer/NormalizerGenerator.php
+++ b/src/Symfony/Component/AstGenerator/Normalizer/NormalizerGenerator.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AstGenerator\Normalizer;
+
+use Symfony\Component\AstGenerator\AstGeneratorInterface;
+
+/**
+ * Generate a Normalizer given a
+ *
+ * @author Joel Wurtz <joel.wurtz@gmail.com>
+ */
+class NormalizerGenerator implements AstGeneratorInterface
+{
+
+}

--- a/src/Symfony/Component/AstGenerator/Normalizer/NormalizerGenerator.php
+++ b/src/Symfony/Component/AstGenerator/Normalizer/NormalizerGenerator.php
@@ -20,7 +20,7 @@ use Symfony\Component\AstGenerator\AstGeneratorInterface;
 use Symfony\Component\AstGenerator\UniqueVariableScope;
 
 /**
- * Generate a Normalizer given a Class
+ * Generate a Normalizer given a Class.
  *
  * @author Joel Wurtz <joel.wurtz@gmail.com>
  */
@@ -61,23 +61,23 @@ class NormalizerGenerator implements AstGeneratorInterface
                     $this->createSupportsNormalizationMethod($object),
                     $this->createSupportsDenormalizationMethod($object),
                     $this->createNormalizeMethod($object, array_merge($context, [
-                        'unique_variable_scope' => new UniqueVariableScope()
+                        'unique_variable_scope' => new UniqueVariableScope(),
                     ])),
                     $this->createDenormalizeMethod($object, array_merge($context, [
-                        'unique_variable_scope' => new UniqueVariableScope()
+                        'unique_variable_scope' => new UniqueVariableScope(),
                     ])),
                 ],
                 'implements' => [
                     new Name('\Symfony\Component\Serializer\Normalizer\DenormalizerInterface'),
-                    new Name('\Symfony\Component\Serializer\Normalizer\NormalizerInterface')
+                    new Name('\Symfony\Component\Serializer\Normalizer\NormalizerInterface'),
                 ],
-                'extends' => new Name('\Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer')
+                'extends' => new Name('\Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer'),
             ]
         )];
     }
 
     /**
-     * Create method to check if normalization is supported
+     * Create method to check if normalization is supported.
      *
      * @param string $class Fully Qualified name of the model class
      *
@@ -93,24 +93,24 @@ class NormalizerGenerator implements AstGeneratorInterface
             'type' => Stmt\Class_::MODIFIER_PUBLIC,
             'params' => [
                 new Param('data'),
-                new Param('format', new Expr\ConstFetch(new Name("null"))),
+                new Param('format', new Expr\ConstFetch(new Name('null'))),
             ],
             'stmts' => [
                 new Stmt\If_(
                     new Expr\Instanceof_(new Expr\Variable('data'), new Name($class)),
                     [
                         'stmts' => [
-                            new Stmt\Return_(new Expr\ConstFetch(new Name("true")))
-                        ]
+                            new Stmt\Return_(new Expr\ConstFetch(new Name('true'))),
+                        ],
                     ]
                 ),
-                new Stmt\Return_(new Expr\ConstFetch(new Name("false")))
-            ]
+                new Stmt\Return_(new Expr\ConstFetch(new Name('false'))),
+            ],
         ]);
     }
 
     /**
-     * Create method to check if denormalization is supported
+     * Create method to check if denormalization is supported.
      *
      * @param string $class Fully Qualified name of the model class
      *
@@ -123,24 +123,24 @@ class NormalizerGenerator implements AstGeneratorInterface
             'params' => [
                 new Param('data'),
                 new Param('type'),
-                new Param('format', new Expr\ConstFetch(new Name("null"))),
+                new Param('format', new Expr\ConstFetch(new Name('null'))),
             ],
             'stmts' => [
                 new Stmt\If_(
                     new Expr\BinaryOp\NotIdentical(new Expr\Variable('type'), new Scalar\String_($class)),
                     [
                         'stmts' => [
-                            new Stmt\Return_(new Expr\ConstFetch(new Name("false")))
-                        ]
+                            new Stmt\Return_(new Expr\ConstFetch(new Name('false'))),
+                        ],
                     ]
                 ),
-                new Stmt\Return_(new Expr\ConstFetch(new Name("true")))
-            ]
+                new Stmt\Return_(new Expr\ConstFetch(new Name('true'))),
+            ],
         ]);
     }
 
     /**
-     * Create the normalization method
+     * Create the normalization method.
      *
      * @param string $class   Class to create normalization from
      * @param array  $context Context of generation
@@ -153,17 +153,17 @@ class NormalizerGenerator implements AstGeneratorInterface
             'type' => Stmt\Class_::MODIFIER_PUBLIC,
             'params' => [
                 new Param('object'),
-                new Param('format', new Expr\ConstFetch(new Name("null"))),
+                new Param('format', new Expr\ConstFetch(new Name('null'))),
                 new Param('context', new Expr\Array_(), 'array'),
             ],
             'stmts' => $this->normalizeStatementsGenerator->generate($class, array_merge($context, [
-                'input' => new Expr\Variable('object')
-            ]))
+                'input' => new Expr\Variable('object'),
+            ])),
         ]);
     }
 
     /**
-     * Create the denormalization method
+     * Create the denormalization method.
      *
      * @param string $class   Class to create denormalization from
      * @param array  $context Context of generation
@@ -180,15 +180,15 @@ class NormalizerGenerator implements AstGeneratorInterface
             'params' => [
                 new Param('data'),
                 new Param('class'),
-                new Param('format', new Expr\ConstFetch(new Name("null"))),
+                new Param('format', new Expr\ConstFetch(new Name('null'))),
                 new Param('context', new Expr\Array_(), 'array'),
             ],
             'stmts' => array_merge($this->denormalizeStatementsGenerator->generate($class, array_merge($context, [
                 'input' => $input,
-                'output' => $output
+                'output' => $output,
             ])), [
-                new Stmt\Return_($output)
-            ])
+                new Stmt\Return_($output),
+            ]),
         ]);
     }
 
@@ -197,6 +197,6 @@ class NormalizerGenerator implements AstGeneratorInterface
      */
     public function supportsGeneration($object)
     {
-        return (is_string($object) && class_exists($object));
+        return is_string($object) && class_exists($object);
     }
 }

--- a/src/Symfony/Component/AstGenerator/Normalizer/NormalizerGenerator.php
+++ b/src/Symfony/Component/AstGenerator/Normalizer/NormalizerGenerator.php
@@ -17,6 +17,7 @@ use PhpParser\Node\Stmt;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Scalar;
 use Symfony\Component\AstGenerator\AstGeneratorInterface;
+use Symfony\Component\AstGenerator\UniqueVariableScope;
 
 /**
  * Generate a Normalizer given a Class
@@ -59,8 +60,12 @@ class NormalizerGenerator implements AstGeneratorInterface
                 'stmts' => [
                     $this->createSupportsNormalizationMethod($object),
                     $this->createSupportsDenormalizationMethod($object),
-                    $this->createNormalizeMethod($object, $context),
-                    $this->createDenormalizeMethod($object, $context),
+                    $this->createNormalizeMethod($object, array_merge($context, [
+                        'unique_variable_scope' => new UniqueVariableScope()
+                    ])),
+                    $this->createDenormalizeMethod($object, array_merge($context, [
+                        'unique_variable_scope' => new UniqueVariableScope()
+                    ])),
                 ],
                 'implements' => [
                     new Name('\Symfony\Component\Serializer\Normalizer\DenormalizerInterface'),
@@ -151,7 +156,9 @@ class NormalizerGenerator implements AstGeneratorInterface
                 new Param('format', new Expr\ConstFetch(new Name("null"))),
                 new Param('context', new Expr\Array_(), 'array'),
             ],
-            'stmts' => $this->normalizeStatementsGenerator->generate($class, $context)
+            'stmts' => $this->normalizeStatementsGenerator->generate($class, array_merge($context, [
+                'input' => new Expr\Variable('object')
+            ]))
         ]);
     }
 
@@ -173,7 +180,9 @@ class NormalizerGenerator implements AstGeneratorInterface
                 new Param('format', new Expr\ConstFetch(new Name("null"))),
                 new Param('context', new Expr\Array_(), 'array'),
             ],
-            'stmts' => $this->denormalizeStatementsGenerator->generate($class, $context)
+            'stmts' => $this->denormalizeStatementsGenerator->generate($class, array_merge($context, [
+                'input' => new Expr\Variable('data')
+            ]))
         ]);
     }
 

--- a/src/Symfony/Component/AstGenerator/Normalizer/NormalizerGenerator.php
+++ b/src/Symfony/Component/AstGenerator/Normalizer/NormalizerGenerator.php
@@ -70,8 +70,9 @@ class NormalizerGenerator implements AstGeneratorInterface
                 'implements' => [
                     new Name('\Symfony\Component\Serializer\Normalizer\DenormalizerInterface'),
                     new Name('\Symfony\Component\Serializer\Normalizer\NormalizerInterface'),
+                    new Name('\Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface'),
                 ],
-                'extends' => new Name('\Symfony\Component\Serializer\Normalizer\SerializerAwareNormalizer'),
+                'uses' => new Name('\Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait'),
             ]
         )];
     }
@@ -161,7 +162,11 @@ class NormalizerGenerator implements AstGeneratorInterface
             ],
             'stmts' => array_merge($this->normalizeStatementsGenerator->generate($class, array_merge($context, [
                 'input' => $input,
-                'output' => $output
+                'output' => $output,
+                'normalizer' => new Expr\MethodCall(
+                    new Expr\Variable('$this'),
+                    'getNormalizer'
+                )
             ])), [
                 new Stmt\Return_($output)
             ])

--- a/src/Symfony/Component/AstGenerator/Normalizer/NormalizerGenerator.php
+++ b/src/Symfony/Component/AstGenerator/Normalizer/NormalizerGenerator.php
@@ -48,41 +48,41 @@ class NormalizerGenerator implements AstGeneratorInterface
     /**
      * {@inheritdoc}
      */
-    public function generate($object, array $context = [])
+    public function generate($object, array $context = array())
     {
         if (!isset($context['name'])) {
             $reflectionClass = new \ReflectionClass($object);
             $context['name'] = $reflectionClass->getShortName().'Normalizer';
         }
 
-        return [new Stmt\Class_(
+        return array(new Stmt\Class_(
             new Name($context['name']),
-            [
-                'stmts' => [
+            array(
+                'stmts' => array(
                     new Stmt\Use_(array(
                         new Name('\Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait'),
                         new Name('\Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait'),
                     )),
                     $this->createSupportsNormalizationMethod($object),
                     $this->createSupportsDenormalizationMethod($object),
-                    $this->createNormalizeMethod($object, array_merge($context, [
+                    $this->createNormalizeMethod($object, array_merge($context, array(
                         'unique_variable_scope' => new UniqueVariableScope(),
-                    ])),
-                    $this->createDenormalizeMethod($object, array_merge($context, [
+                    ))),
+                    $this->createDenormalizeMethod($object, array_merge($context, array(
                         'unique_variable_scope' => new UniqueVariableScope(),
-                    ])),
-                ],
-                'implements' => [
+                    ))),
+                ),
+                'implements' => array(
                     new Name('\Symfony\Component\Serializer\Normalizer\DenormalizerInterface'),
                     new Name('\Symfony\Component\Serializer\Normalizer\NormalizerInterface'),
                     new Name('\Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface'),
                     new Name('\Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface'),
-                ],
-            ],
-            [
-                'comments' => [new Comment("/**\n * This class is generated.\n * Please do not update it manually.\n */")],
-            ]
-        )];
+                ),
+            ),
+            array(
+                'comments' => array(new Comment("/**\n * This class is generated.\n * Please do not update it manually.\n */")),
+            )
+        ));
     }
 
     /**
@@ -98,24 +98,24 @@ class NormalizerGenerator implements AstGeneratorInterface
             $class = '\\'.$class;
         }
 
-        return new Stmt\ClassMethod('supportsNormalization', [
+        return new Stmt\ClassMethod('supportsNormalization', array(
             'type' => Stmt\Class_::MODIFIER_PUBLIC,
-            'params' => [
+            'params' => array(
                 new Param('data'),
                 new Param('format', new Expr\ConstFetch(new Name('null'))),
-            ],
-            'stmts' => [
+            ),
+            'stmts' => array(
                 new Stmt\If_(
                     new Expr\Instanceof_(new Expr\Variable('data'), new Name($class)),
-                    [
-                        'stmts' => [
+                    array(
+                        'stmts' => array(
                             new Stmt\Return_(new Expr\ConstFetch(new Name('true'))),
-                        ],
-                    ]
+                        ),
+                    )
                 ),
                 new Stmt\Return_(new Expr\ConstFetch(new Name('false'))),
-            ],
-        ]);
+            ),
+        ));
     }
 
     /**
@@ -127,25 +127,25 @@ class NormalizerGenerator implements AstGeneratorInterface
      */
     protected function createSupportsDenormalizationMethod($class)
     {
-        return new Stmt\ClassMethod('supportsDenormalization', [
+        return new Stmt\ClassMethod('supportsDenormalization', array(
             'type' => Stmt\Class_::MODIFIER_PUBLIC,
-            'params' => [
+            'params' => array(
                 new Param('data'),
                 new Param('type'),
                 new Param('format', new Expr\ConstFetch(new Name('null'))),
-            ],
-            'stmts' => [
+            ),
+            'stmts' => array(
                 new Stmt\If_(
                     new Expr\BinaryOp\NotIdentical(new Expr\Variable('type'), new Scalar\String_($class)),
-                    [
-                        'stmts' => [
+                    array(
+                        'stmts' => array(
                             new Stmt\Return_(new Expr\ConstFetch(new Name('false'))),
-                        ],
-                    ]
+                        ),
+                    )
                 ),
                 new Stmt\Return_(new Expr\ConstFetch(new Name('true'))),
-            ],
-        ]);
+            ),
+        ));
     }
 
     /**
@@ -156,19 +156,19 @@ class NormalizerGenerator implements AstGeneratorInterface
      *
      * @return Stmt\ClassMethod
      */
-    protected function createNormalizeMethod($class, array $context = [])
+    protected function createNormalizeMethod($class, array $context = array())
     {
         $input = new Expr\Variable('object');
         $output = new Expr\Variable('data');
 
-        return new Stmt\ClassMethod('normalize', [
+        return new Stmt\ClassMethod('normalize', array(
             'type' => Stmt\Class_::MODIFIER_PUBLIC,
-            'params' => [
+            'params' => array(
                 new Param('object'),
                 new Param('format', new Expr\ConstFetch(new Name('null'))),
                 new Param('context', new Expr\Array_(), 'array'),
-            ],
-            'stmts' => array_merge($this->normalizeStatementsGenerator->generate($class, array_merge($context, [
+            ),
+            'stmts' => array_merge($this->normalizeStatementsGenerator->generate($class, array_merge($context, array(
                 'input' => $input,
                 'output' => $output,
                 'normalizer' => new Expr\PropertyFetch(
@@ -177,10 +177,10 @@ class NormalizerGenerator implements AstGeneratorInterface
                 ),
                 'format' => new Expr\Variable(new Name('format')),
                 'context' => new Expr\Variable(new Name('context')),
-            ])), [
-                new Stmt\Return_($output)
-            ])
-        ]);
+            ))), array(
+                new Stmt\Return_($output),
+            ))
+        ));
     }
 
     /**
@@ -191,20 +191,20 @@ class NormalizerGenerator implements AstGeneratorInterface
      *
      * @return Stmt\ClassMethod
      */
-    protected function createDenormalizeMethod($class, array $context = [])
+    protected function createDenormalizeMethod($class, array $context = array())
     {
         $input = new Expr\Variable('data');
         $output = new Expr\Variable('object');
 
-        return new Stmt\ClassMethod('denormalize', [
+        return new Stmt\ClassMethod('denormalize', array(
             'type' => Stmt\Class_::MODIFIER_PUBLIC,
-            'params' => [
+            'params' => array(
                 new Param('data'),
                 new Param('class'),
                 new Param('format', new Expr\ConstFetch(new Name('null'))),
                 new Param('context', new Expr\Array_(), 'array'),
-            ],
-            'stmts' => array_merge($this->denormalizeStatementsGenerator->generate($class, array_merge($context, [
+            ),
+            'stmts' => array_merge($this->denormalizeStatementsGenerator->generate($class, array_merge($context, array(
                 'input' => $input,
                 'output' => $output,
                 'denormalizer' => new Expr\PropertyFetch(
@@ -213,10 +213,10 @@ class NormalizerGenerator implements AstGeneratorInterface
                 ),
                 'format' => new Expr\Variable(new Name('format')),
                 'context' => new Expr\Variable(new Name('context')),
-            ])), [
+            ))), array(
                 new Stmt\Return_($output),
-            ]),
-        ]);
+            )),
+        ));
     }
 
     /**

--- a/src/Symfony/Component/AstGenerator/Normalizer/NormalizerGenerator.php
+++ b/src/Symfony/Component/AstGenerator/Normalizer/NormalizerGenerator.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\AstGenerator\Normalizer;
 
+use PhpParser\Comment;
 use PhpParser\Node\Name;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt;
@@ -58,6 +59,10 @@ class NormalizerGenerator implements AstGeneratorInterface
             new Name($context['name']),
             [
                 'stmts' => [
+                    new Stmt\Use_(array(
+                        new Name('\Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait'),
+                        new Name('\Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait'),
+                    )),
                     $this->createSupportsNormalizationMethod($object),
                     $this->createSupportsDenormalizationMethod($object),
                     $this->createNormalizeMethod($object, array_merge($context, [
@@ -71,8 +76,11 @@ class NormalizerGenerator implements AstGeneratorInterface
                     new Name('\Symfony\Component\Serializer\Normalizer\DenormalizerInterface'),
                     new Name('\Symfony\Component\Serializer\Normalizer\NormalizerInterface'),
                     new Name('\Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface'),
+                    new Name('\Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface'),
                 ],
-                'uses' => new Name('\Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait'),
+            ],
+            [
+                'comments' => [new Comment("/**\n * This class is generated.\n * Please do not update it manually.\n */")],
             ]
         )];
     }
@@ -163,10 +171,12 @@ class NormalizerGenerator implements AstGeneratorInterface
             'stmts' => array_merge($this->normalizeStatementsGenerator->generate($class, array_merge($context, [
                 'input' => $input,
                 'output' => $output,
-                'normalizer' => new Expr\MethodCall(
-                    new Expr\Variable('$this'),
-                    'getNormalizer'
-                )
+                'normalizer' => new Expr\PropertyFetch(
+                    new Expr\Variable('this'),
+                    'normalizer'
+                ),
+                'format' => new Expr\Variable(new Name('format')),
+                'context' => new Expr\Variable(new Name('context')),
             ])), [
                 new Stmt\Return_($output)
             ])
@@ -197,6 +207,12 @@ class NormalizerGenerator implements AstGeneratorInterface
             'stmts' => array_merge($this->denormalizeStatementsGenerator->generate($class, array_merge($context, [
                 'input' => $input,
                 'output' => $output,
+                'denormalizer' => new Expr\PropertyFetch(
+                    new Expr\Variable('this'),
+                    'denormalizer'
+                ),
+                'format' => new Expr\Variable(new Name('format')),
+                'context' => new Expr\Variable(new Name('context')),
             ])), [
                 new Stmt\Return_($output),
             ]),

--- a/src/Symfony/Component/AstGenerator/README.md
+++ b/src/Symfony/Component/AstGenerator/README.md
@@ -1,0 +1,8 @@
+AstGenerator Component
+======================
+
+AstGenerator allows to generate PHP AST for several Component:
+
+ * Transform class, properties and types extracted from the PropertyInfo Component into POPO objects ans Normalizers
+ compatible with Serializer Component
+

--- a/src/Symfony/Component/AstGenerator/Tests/AstGeneratorChainTest.php
+++ b/src/Symfony/Component/AstGenerator/Tests/AstGeneratorChainTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AstGenerator\Tests;
+
+use Symfony\Component\AstGenerator\AstGeneratorChain;
+use Symfony\Component\AstGenerator\AstGeneratorInterface;
+
+class AstGeneratorChainTest extends \PHPUnit_Framework_TestCase
+{
+    public function testEmpty()
+    {
+        $generator = new AstGeneratorChain();
+
+        $this->assertFalse($generator->supportsGeneration("dummy"));
+        $this->assertEmpty($generator->generate("dummy"));
+    }
+
+    public function testSupports()
+    {
+        $generatorSub = $this->prophesize(AstGeneratorInterface::class);
+        $generatorSub->supportsGeneration("dummy")->willReturn(true);
+        $generatorSub->generate("dummy", [])->willReturn(["ast"]);
+
+        $generator = new AstGeneratorChain([$generatorSub->reveal()]);
+        $this->assertTrue($generator->supportsGeneration("dummy"));
+        $this->assertEquals(["ast"], $generator->generate("dummy"));
+    }
+
+    public function testMultiSupports()
+    {
+        $generatorSub1 = $this->prophesize(AstGeneratorInterface::class);
+        $generatorSub1->supportsGeneration("dummy")->willReturn(true);
+        $generatorSub1->generate("dummy", [])->willReturn(["ast1"]);
+
+        $generatorSub2 = $this->prophesize(AstGeneratorInterface::class);
+        $generatorSub2->supportsGeneration("dummy")->willReturn(true);
+        $generatorSub2->generate("dummy", [])->willReturn(["ast2"]);
+
+        $generator = new AstGeneratorChain([$generatorSub1->reveal(), $generatorSub2->reveal()]);
+        $this->assertTrue($generator->supportsGeneration("dummy"));
+        $this->assertEquals(["ast1", "ast2"], $generator->generate("dummy"));
+    }
+
+    public function testPartialSupports()
+    {
+        $generatorSub1 = $this->prophesize(AstGeneratorInterface::class);
+        $generatorSub1->supportsGeneration("dummy")->willReturn(true);
+        $generatorSub1->generate("dummy", [])->willReturn(["ast1"]);
+
+        $generatorSub2 = $this->prophesize(AstGeneratorInterface::class);
+        $generatorSub2->supportsGeneration("dummy")->willReturn(false);
+
+        $generator = new AstGeneratorChain([$generatorSub1->reveal(), $generatorSub2->reveal()]);
+        $this->assertTrue($generator->supportsGeneration("dummy"));
+        $this->assertEquals(["ast1"], $generator->generate("dummy"));
+    }
+
+    public function testMultiSupportsWithFirstReturn()
+    {
+        $generatorSub1 = $this->prophesize(AstGeneratorInterface::class);
+        $generatorSub1->supportsGeneration("dummy")->willReturn(true);
+        $generatorSub1->generate("dummy", [])->willReturn(["ast1"]);
+
+        $generatorSub2 = $this->prophesize(AstGeneratorInterface::class);
+        $generatorSub2->supportsGeneration("dummy")->willReturn(true);
+        $generatorSub2->generate("dummy", [])->willReturn(["ast2"]);
+
+        $generator = new AstGeneratorChain([$generatorSub1->reveal(), $generatorSub2->reveal()], true);
+        $this->assertTrue($generator->supportsGeneration("dummy"));
+        $this->assertEquals(["ast1"], $generator->generate("dummy"));
+    }
+}

--- a/src/Symfony/Component/AstGenerator/Tests/AstGeneratorChainTest.php
+++ b/src/Symfony/Component/AstGenerator/Tests/AstGeneratorChainTest.php
@@ -20,62 +20,62 @@ class AstGeneratorChainTest extends \PHPUnit_Framework_TestCase
     {
         $generator = new AstGeneratorChain();
 
-        $this->assertFalse($generator->supportsGeneration("dummy"));
-        $this->assertEmpty($generator->generate("dummy"));
+        $this->assertFalse($generator->supportsGeneration('dummy'));
+        $this->assertEmpty($generator->generate('dummy'));
     }
 
     public function testSupports()
     {
         $generatorSub = $this->prophesize(AstGeneratorInterface::class);
-        $generatorSub->supportsGeneration("dummy")->willReturn(true);
-        $generatorSub->generate("dummy", [])->willReturn(["ast"]);
+        $generatorSub->supportsGeneration('dummy')->willReturn(true);
+        $generatorSub->generate('dummy', [])->willReturn(['ast']);
 
         $generator = new AstGeneratorChain([$generatorSub->reveal()]);
-        $this->assertTrue($generator->supportsGeneration("dummy"));
-        $this->assertEquals(["ast"], $generator->generate("dummy"));
+        $this->assertTrue($generator->supportsGeneration('dummy'));
+        $this->assertEquals(['ast'], $generator->generate('dummy'));
     }
 
     public function testMultiSupports()
     {
         $generatorSub1 = $this->prophesize(AstGeneratorInterface::class);
-        $generatorSub1->supportsGeneration("dummy")->willReturn(true);
-        $generatorSub1->generate("dummy", [])->willReturn(["ast1"]);
+        $generatorSub1->supportsGeneration('dummy')->willReturn(true);
+        $generatorSub1->generate('dummy', [])->willReturn(['ast1']);
 
         $generatorSub2 = $this->prophesize(AstGeneratorInterface::class);
-        $generatorSub2->supportsGeneration("dummy")->willReturn(true);
-        $generatorSub2->generate("dummy", [])->willReturn(["ast2"]);
+        $generatorSub2->supportsGeneration('dummy')->willReturn(true);
+        $generatorSub2->generate('dummy', [])->willReturn(['ast2']);
 
         $generator = new AstGeneratorChain([$generatorSub1->reveal(), $generatorSub2->reveal()]);
-        $this->assertTrue($generator->supportsGeneration("dummy"));
-        $this->assertEquals(["ast1", "ast2"], $generator->generate("dummy"));
+        $this->assertTrue($generator->supportsGeneration('dummy'));
+        $this->assertEquals(['ast1', 'ast2'], $generator->generate('dummy'));
     }
 
     public function testPartialSupports()
     {
         $generatorSub1 = $this->prophesize(AstGeneratorInterface::class);
-        $generatorSub1->supportsGeneration("dummy")->willReturn(true);
-        $generatorSub1->generate("dummy", [])->willReturn(["ast1"]);
+        $generatorSub1->supportsGeneration('dummy')->willReturn(true);
+        $generatorSub1->generate('dummy', [])->willReturn(['ast1']);
 
         $generatorSub2 = $this->prophesize(AstGeneratorInterface::class);
-        $generatorSub2->supportsGeneration("dummy")->willReturn(false);
+        $generatorSub2->supportsGeneration('dummy')->willReturn(false);
 
         $generator = new AstGeneratorChain([$generatorSub1->reveal(), $generatorSub2->reveal()]);
-        $this->assertTrue($generator->supportsGeneration("dummy"));
-        $this->assertEquals(["ast1"], $generator->generate("dummy"));
+        $this->assertTrue($generator->supportsGeneration('dummy'));
+        $this->assertEquals(['ast1'], $generator->generate('dummy'));
     }
 
     public function testMultiSupportsWithFirstReturn()
     {
         $generatorSub1 = $this->prophesize(AstGeneratorInterface::class);
-        $generatorSub1->supportsGeneration("dummy")->willReturn(true);
-        $generatorSub1->generate("dummy", [])->willReturn(["ast1"]);
+        $generatorSub1->supportsGeneration('dummy')->willReturn(true);
+        $generatorSub1->generate('dummy', [])->willReturn(['ast1']);
 
         $generatorSub2 = $this->prophesize(AstGeneratorInterface::class);
-        $generatorSub2->supportsGeneration("dummy")->willReturn(true);
-        $generatorSub2->generate("dummy", [])->willReturn(["ast2"]);
+        $generatorSub2->supportsGeneration('dummy')->willReturn(true);
+        $generatorSub2->generate('dummy', [])->willReturn(['ast2']);
 
         $generator = new AstGeneratorChain([$generatorSub1->reveal(), $generatorSub2->reveal()], true);
-        $this->assertTrue($generator->supportsGeneration("dummy"));
-        $this->assertEquals(["ast1"], $generator->generate("dummy"));
+        $this->assertTrue($generator->supportsGeneration('dummy'));
+        $this->assertEquals(['ast1'], $generator->generate('dummy'));
     }
 }

--- a/src/Symfony/Component/AstGenerator/Tests/AstGeneratorChainTest.php
+++ b/src/Symfony/Component/AstGenerator/Tests/AstGeneratorChainTest.php
@@ -26,41 +26,41 @@ class AstGeneratorChainTest extends \PHPUnit_Framework_TestCase
 
     public function testSupports()
     {
-        $generatorSub = $this->getGeneratorMock(true, ['ast']);
+        $generatorSub = $this->getGeneratorMock(true, array('ast'));
 
-        $generator = new AstGeneratorChain([$generatorSub]);
+        $generator = new AstGeneratorChain(array($generatorSub));
         $this->assertTrue($generator->supportsGeneration('dummy'));
-        $this->assertEquals(['ast'], $generator->generate('dummy'));
+        $this->assertEquals(array('ast'), $generator->generate('dummy'));
     }
 
     public function testMultiSupports()
     {
-        $generatorSub1 = $this->getGeneratorMock(true, ['ast1']);
-        $generatorSub2 = $this->getGeneratorMock(true, ['ast2']);
+        $generatorSub1 = $this->getGeneratorMock(true, array('ast1'));
+        $generatorSub2 = $this->getGeneratorMock(true, array('ast2'));
 
-        $generator = new AstGeneratorChain([$generatorSub1, $generatorSub2]);
+        $generator = new AstGeneratorChain(array($generatorSub1, $generatorSub2));
         $this->assertTrue($generator->supportsGeneration('dummy'));
-        $this->assertEquals(['ast1', 'ast2'], $generator->generate('dummy'));
+        $this->assertEquals(array('ast1', 'ast2'), $generator->generate('dummy'));
     }
 
     public function testPartialSupports()
     {
-        $generatorSub1 = $this->getGeneratorMock(true, ['ast1']);
+        $generatorSub1 = $this->getGeneratorMock(true, array('ast1'));
         $generatorSub2 = $this->getGeneratorMock(false);
 
-        $generator = new AstGeneratorChain([$generatorSub1, $generatorSub2]);
+        $generator = new AstGeneratorChain(array($generatorSub1, $generatorSub2));
         $this->assertTrue($generator->supportsGeneration('dummy'));
-        $this->assertEquals(['ast1'], $generator->generate('dummy'));
+        $this->assertEquals(array('ast1'), $generator->generate('dummy'));
     }
 
     public function testMultiSupportsWithFirstReturn()
     {
-        $generatorSub1 = $this->getGeneratorMock(true, ['ast1']);
-        $generatorSub2 = $this->getGeneratorMock(true, ['ast2']);
+        $generatorSub1 = $this->getGeneratorMock(true, array('ast1'));
+        $generatorSub2 = $this->getGeneratorMock(true, array('ast2'));
 
-        $generator = new AstGeneratorChain([$generatorSub1, $generatorSub2], true);
+        $generator = new AstGeneratorChain(array($generatorSub1, $generatorSub2), true);
         $this->assertTrue($generator->supportsGeneration('dummy'));
-        $this->assertEquals(['ast1'], $generator->generate('dummy'));
+        $this->assertEquals(array('ast1'), $generator->generate('dummy'));
     }
 
     private function getGeneratorMock($support, $return = null)

--- a/src/Symfony/Component/AstGenerator/Tests/Hydrate/AbstractHydratorTest.php
+++ b/src/Symfony/Component/AstGenerator/Tests/Hydrate/AbstractHydratorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AstGenerator\Tests\Hydrate;
+
+use PhpParser\Node\Expr;
+use PhpParser\PrettyPrinter\Standard;
+use Symfony\Component\AstGenerator\AstGeneratorInterface;
+use Symfony\Component\AstGenerator\Hydrate\ArrayHydrateGenerator;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
+use Symfony\Component\PropertyInfo\Type;
+
+abstract class AbstractHydratorTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var Standard */
+    protected $printer;
+
+    protected function setUp()
+    {
+        $this->printer = new Standard();
+    }
+
+    protected function getPropertyInfoExtractor($inputClass)
+    {
+        $propertyInfoExtractor = $this->getMockBuilder(PropertyInfoExtractorInterface::class)->getMock();
+        $propertyInfoExtractor
+            ->expects($this->any())
+            ->method('getProperties')
+            ->with($inputClass, $this->isType('array'))
+            ->willReturn(['foo', 'bar']);
+        $propertyInfoExtractor
+            ->expects($this->any())
+            ->method('isReadable')
+            ->with($inputClass, $this->logicalOr('foo', 'bar'), $this->isType('array'))
+            ->will($this->returnCallback(function ($class, $property) {
+                return 'foo' === $property;
+            }));
+        $propertyInfoExtractor
+            ->expects($this->any())
+            ->method('isWritable')
+            ->with($inputClass, $this->logicalOr('foo', 'bar'), $this->isType('array'))
+            ->will($this->returnCallback(function ($class, $property) {
+                return 'bar' === $property;
+            }));
+        $propertyInfoExtractor
+            ->expects($this->any())
+            ->method('getTypes')
+            ->with($inputClass, $this->logicalOr('foo', 'bar'), $this->isType('array'))
+            ->willReturn([new Type('string')]);
+
+        return $propertyInfoExtractor;
+    }
+}

--- a/src/Symfony/Component/AstGenerator/Tests/Hydrate/ArrayHydrateGeneratorTest.php
+++ b/src/Symfony/Component/AstGenerator/Tests/Hydrate/ArrayHydrateGeneratorTest.php
@@ -45,8 +45,9 @@ class ArrayHydrateGeneratorTest extends \PHPUnit_Framework_TestCase
         $dummyObject = new Dummy();
         $dummyObject->foo = "test";
 
-        $dummyArray = eval($this->printer->prettyPrint($hydrateGenerator->generate(Dummy::class, [
-            'input' => new Expr\Variable('dummyObject')
+        eval($this->printer->prettyPrint($hydrateGenerator->generate(Dummy::class, [
+            'input' => new Expr\Variable('dummyObject'),
+            'output' => new Expr\Variable('dummyArray')
         ])));
 
         $this->assertInternalType('array', $dummyArray);
@@ -62,6 +63,16 @@ class ArrayHydrateGeneratorTest extends \PHPUnit_Framework_TestCase
         $propertyInfoExtractor = $this->prophesize(PropertyInfoExtractorInterface::class);
         $hydrateGenerator = new ArrayHydrateGenerator($propertyInfoExtractor->reveal(), new DummyTypeGenerator());
         $hydrateGenerator->generate(Dummy::class);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\AstGenerator\Exception\MissingContextException
+     */
+    public function testNoOutput()
+    {
+        $propertyInfoExtractor = $this->prophesize(PropertyInfoExtractorInterface::class);
+        $hydrateGenerator = new ArrayHydrateGenerator($propertyInfoExtractor->reveal(), new DummyTypeGenerator());
+        $hydrateGenerator->generate(Dummy::class, ['input' => new Expr\Variable("test")]);
     }
 }
 

--- a/src/Symfony/Component/AstGenerator/Tests/Hydrate/ArrayHydrateGeneratorTest.php
+++ b/src/Symfony/Component/AstGenerator/Tests/Hydrate/ArrayHydrateGeneratorTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AstGenerator\Tests\Hydrate;
+
+use PhpParser\Node\Expr;
+use PhpParser\PrettyPrinter\Standard;
+use Prophecy\Argument;
+use Symfony\Component\AstGenerator\AstGeneratorInterface;
+use Symfony\Component\AstGenerator\Hydrate\ArrayHydrateGenerator;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
+use Symfony\Component\PropertyInfo\Type;
+
+class ArrayHydrateGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var Standard */
+    protected $printer;
+
+    public function setUp()
+    {
+        $this->printer = new Standard();
+    }
+
+    public function testHydrateGenerator()
+    {
+        $propertyInfoExtractor = $this->prophesize(PropertyInfoExtractorInterface::class);
+        $propertyInfoExtractor->getProperties(Dummy::class, Argument::type('array'))->willReturn(['foo', 'bar']);
+        $propertyInfoExtractor->isReadable(Dummy::class, 'foo', Argument::type('array'))->willReturn(true);
+        $propertyInfoExtractor->isReadable(Dummy::class, 'bar', Argument::type('array'))->willReturn(false);
+        $propertyInfoExtractor->getTypes(Dummy::class, 'foo', Argument::type('array'))->willReturn([
+            new Type('string')
+        ]);
+        $hydrateGenerator = new ArrayHydrateGenerator($propertyInfoExtractor->reveal(), new DummyTypeGenerator());
+
+        $this->assertTrue($hydrateGenerator->supportsGeneration(Dummy::class));
+
+        $dummyObject = new Dummy();
+        $dummyObject->foo = "test";
+
+        $dummyArray = eval($this->printer->prettyPrint($hydrateGenerator->generate(Dummy::class, [
+            'input' => new Expr\Variable('dummyObject')
+        ])));
+
+        $this->assertInternalType('array', $dummyArray);
+        $this->assertArrayHasKey('foo', $dummyArray);
+        $this->assertEquals('test', $dummyArray['foo']);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\AstGenerator\Exception\MissingContextException
+     */
+    public function testNoInput()
+    {
+        $propertyInfoExtractor = $this->prophesize(PropertyInfoExtractorInterface::class);
+        $hydrateGenerator = new ArrayHydrateGenerator($propertyInfoExtractor->reveal(), new DummyTypeGenerator());
+        $hydrateGenerator->generate(Dummy::class);
+    }
+}
+
+class Dummy
+{
+    public $foo;
+
+    public $bar;
+
+    /**
+     * @return mixed
+     */
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+
+    /**
+     * @param mixed $bar
+     */
+    public function setBar($bar)
+    {
+        $this->bar = $bar;
+    }
+}
+
+class DummyTypeGenerator implements AstGeneratorInterface
+{
+    public function generate($object, array $context = [])
+    {
+        if (!isset($context['input'])) {
+            throw new \Exception('no input');
+        }
+
+        if (!isset($context['output'])) {
+            throw new \Exception('no output');
+        }
+
+        return [new Expr\Assign($context['output'], $context['input'])];
+    }
+
+    public function supportsGeneration($object)
+    {
+        return true;
+    }
+}

--- a/src/Symfony/Component/AstGenerator/Tests/Hydrate/ArrayHydrateGeneratorTest.php
+++ b/src/Symfony/Component/AstGenerator/Tests/Hydrate/ArrayHydrateGeneratorTest.php
@@ -36,18 +36,18 @@ class ArrayHydrateGeneratorTest extends \PHPUnit_Framework_TestCase
         $propertyInfoExtractor->isReadable(Dummy::class, 'foo', Argument::type('array'))->willReturn(true);
         $propertyInfoExtractor->isReadable(Dummy::class, 'bar', Argument::type('array'))->willReturn(false);
         $propertyInfoExtractor->getTypes(Dummy::class, 'foo', Argument::type('array'))->willReturn([
-            new Type('string')
+            new Type('string'),
         ]);
         $hydrateGenerator = new ArrayHydrateGenerator($propertyInfoExtractor->reveal(), new DummyTypeGenerator());
 
         $this->assertTrue($hydrateGenerator->supportsGeneration(Dummy::class));
 
         $dummyObject = new Dummy();
-        $dummyObject->foo = "test";
+        $dummyObject->foo = 'test';
 
         eval($this->printer->prettyPrint($hydrateGenerator->generate(Dummy::class, [
             'input' => new Expr\Variable('dummyObject'),
-            'output' => new Expr\Variable('dummyArray')
+            'output' => new Expr\Variable('dummyArray'),
         ])));
 
         $this->assertInternalType('array', $dummyArray);
@@ -72,7 +72,7 @@ class ArrayHydrateGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $propertyInfoExtractor = $this->prophesize(PropertyInfoExtractorInterface::class);
         $hydrateGenerator = new ArrayHydrateGenerator($propertyInfoExtractor->reveal(), new DummyTypeGenerator());
-        $hydrateGenerator->generate(Dummy::class, ['input' => new Expr\Variable("test")]);
+        $hydrateGenerator->generate(Dummy::class, ['input' => new Expr\Variable('test')]);
     }
 }
 

--- a/src/Symfony/Component/AstGenerator/Tests/Hydrate/ArrayHydrateGeneratorTest.php
+++ b/src/Symfony/Component/AstGenerator/Tests/Hydrate/ArrayHydrateGeneratorTest.php
@@ -13,32 +13,17 @@ namespace Symfony\Component\AstGenerator\Tests\Hydrate;
 
 use PhpParser\Node\Expr;
 use PhpParser\PrettyPrinter\Standard;
-use Prophecy\Argument;
 use Symfony\Component\AstGenerator\AstGeneratorInterface;
 use Symfony\Component\AstGenerator\Hydrate\ArrayHydrateGenerator;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
 use Symfony\Component\PropertyInfo\Type;
 
-class ArrayHydrateGeneratorTest extends \PHPUnit_Framework_TestCase
+class ArrayHydrateGeneratorTest extends AbstractHydratorTest
 {
-    /** @var Standard */
-    protected $printer;
-
-    public function setUp()
-    {
-        $this->printer = new Standard();
-    }
-
     public function testHydrateGenerator()
     {
-        $propertyInfoExtractor = $this->prophesize(PropertyInfoExtractorInterface::class);
-        $propertyInfoExtractor->getProperties(Dummy::class, Argument::type('array'))->willReturn(['foo', 'bar']);
-        $propertyInfoExtractor->isReadable(Dummy::class, 'foo', Argument::type('array'))->willReturn(true);
-        $propertyInfoExtractor->isReadable(Dummy::class, 'bar', Argument::type('array'))->willReturn(false);
-        $propertyInfoExtractor->getTypes(Dummy::class, 'foo', Argument::type('array'))->willReturn([
-            new Type('string'),
-        ]);
-        $hydrateGenerator = new ArrayHydrateGenerator($propertyInfoExtractor->reveal(), new DummyTypeGenerator());
+        $propertyInfoExtractor = $this->getPropertyInfoExtractor(Dummy::class);
+        $hydrateGenerator = new ArrayHydrateGenerator($propertyInfoExtractor, new DummyTypeGenerator());
 
         $this->assertTrue($hydrateGenerator->supportsGeneration(Dummy::class));
 
@@ -60,8 +45,8 @@ class ArrayHydrateGeneratorTest extends \PHPUnit_Framework_TestCase
      */
     public function testNoInput()
     {
-        $propertyInfoExtractor = $this->prophesize(PropertyInfoExtractorInterface::class);
-        $hydrateGenerator = new ArrayHydrateGenerator($propertyInfoExtractor->reveal(), new DummyTypeGenerator());
+        $propertyInfoExtractor = $this->getMockBuilder(PropertyInfoExtractorInterface::class)->getMock();
+        $hydrateGenerator = new ArrayHydrateGenerator($propertyInfoExtractor, new DummyTypeGenerator());
         $hydrateGenerator->generate(Dummy::class);
     }
 
@@ -70,8 +55,8 @@ class ArrayHydrateGeneratorTest extends \PHPUnit_Framework_TestCase
      */
     public function testNoOutput()
     {
-        $propertyInfoExtractor = $this->prophesize(PropertyInfoExtractorInterface::class);
-        $hydrateGenerator = new ArrayHydrateGenerator($propertyInfoExtractor->reveal(), new DummyTypeGenerator());
+        $propertyInfoExtractor = $this->getMockBuilder(PropertyInfoExtractorInterface::class)->getMock();
+        $hydrateGenerator = new ArrayHydrateGenerator($propertyInfoExtractor, new DummyTypeGenerator());
         $hydrateGenerator->generate(Dummy::class, ['input' => new Expr\Variable('test')]);
     }
 }

--- a/src/Symfony/Component/AstGenerator/Tests/Hydrate/ObjectHydrateFromArrayGeneratorTest.php
+++ b/src/Symfony/Component/AstGenerator/Tests/Hydrate/ObjectHydrateFromArrayGeneratorTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AstGenerator\Tests\Hydrate;
+
+use PhpParser\Node\Expr;
+use PhpParser\PrettyPrinter\Standard;
+use Prophecy\Argument;
+use Symfony\Component\AstGenerator\AstGeneratorInterface;
+use Symfony\Component\AstGenerator\Hydrate\ObjectHydrateFromArrayGenerator;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
+use Symfony\Component\PropertyInfo\Type;
+
+class ObjectHydrateFromArrayGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var Standard */
+    protected $printer;
+
+    public function setUp()
+    {
+        $this->printer = new Standard();
+    }
+
+    public function testHydrateGenerator()
+    {
+        $propertyInfoExtractor = $this->prophesize(PropertyInfoExtractorInterface::class);
+        $propertyInfoExtractor->getProperties(DummyObjectArray::class, Argument::type('array'))->willReturn(['foo', 'bar']);
+        $propertyInfoExtractor->isWritable(DummyObjectArray::class, 'foo', Argument::type('array'))->willReturn(false);
+        $propertyInfoExtractor->isWritable(DummyObjectArray::class, 'bar', Argument::type('array'))->willReturn(true);
+        $propertyInfoExtractor->getTypes(DummyObjectArray::class, 'bar', Argument::type('array'))->willReturn([
+            new Type('string'),
+        ]);
+        $hydrateGenerator = new ObjectHydrateFromArrayGenerator($propertyInfoExtractor->reveal(), new DummyObjectArrayTypeGenerator());
+
+        $this->assertTrue($hydrateGenerator->supportsGeneration(DummyObjectArray::class));
+
+        $array = [
+            'bar' => 'test'
+        ];
+
+        eval($this->printer->prettyPrint($hydrateGenerator->generate(DummyObjectArray::class, [
+            'input' => new Expr\Variable('array'),
+            'output' => new Expr\Variable('object'),
+        ])));
+
+        $this->assertInstanceOf(DummyObjectArray::class, $object);
+        $this->assertEquals('test', $object->bar);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\AstGenerator\Exception\MissingContextException
+     */
+    public function testNoInput()
+    {
+        $propertyInfoExtractor = $this->prophesize(PropertyInfoExtractorInterface::class);
+        $hydrateGenerator = new ObjectHydrateFromArrayGenerator($propertyInfoExtractor->reveal(), new DummyObjectArrayTypeGenerator());
+        $hydrateGenerator->generate(DummyObjectArray::class);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\AstGenerator\Exception\MissingContextException
+     */
+    public function testNoOutput()
+    {
+        $propertyInfoExtractor = $this->prophesize(PropertyInfoExtractorInterface::class);
+        $hydrateGenerator = new ObjectHydrateFromArrayGenerator($propertyInfoExtractor->reveal(), new DummyObjectArrayTypeGenerator());
+        $hydrateGenerator->generate(DummyObjectArray::class, ['input' => new Expr\Variable('test')]);
+    }
+}
+
+class DummyObjectArray
+{
+    public $foo;
+
+    public $bar;
+
+    /**
+     * @return mixed
+     */
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+
+    /**
+     * @param mixed $bar
+     */
+    public function setBar($bar)
+    {
+        $this->bar = $bar;
+    }
+}
+
+class DummyObjectArrayTypeGenerator implements AstGeneratorInterface
+{
+    public function generate($object, array $context = [])
+    {
+        if (!isset($context['input'])) {
+            throw new \Exception('no input');
+        }
+
+        if (!isset($context['output'])) {
+            throw new \Exception('no output');
+        }
+
+        return [new Expr\Assign($context['output'], $context['input'])];
+    }
+
+    public function supportsGeneration($object)
+    {
+        return true;
+    }
+}

--- a/src/Symfony/Component/AstGenerator/Tests/Hydrate/ObjectHydrateFromArrayGeneratorTest.php
+++ b/src/Symfony/Component/AstGenerator/Tests/Hydrate/ObjectHydrateFromArrayGeneratorTest.php
@@ -19,26 +19,12 @@ use Symfony\Component\AstGenerator\Hydrate\ObjectHydrateFromArrayGenerator;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
 use Symfony\Component\PropertyInfo\Type;
 
-class ObjectHydrateFromArrayGeneratorTest extends \PHPUnit_Framework_TestCase
+class ObjectHydrateFromArrayGeneratorTest extends AbstractHydratorTest
 {
-    /** @var Standard */
-    protected $printer;
-
-    public function setUp()
-    {
-        $this->printer = new Standard();
-    }
-
     public function testHydrateGenerator()
     {
-        $propertyInfoExtractor = $this->prophesize(PropertyInfoExtractorInterface::class);
-        $propertyInfoExtractor->getProperties(DummyObjectArray::class, Argument::type('array'))->willReturn(['foo', 'bar']);
-        $propertyInfoExtractor->isWritable(DummyObjectArray::class, 'foo', Argument::type('array'))->willReturn(false);
-        $propertyInfoExtractor->isWritable(DummyObjectArray::class, 'bar', Argument::type('array'))->willReturn(true);
-        $propertyInfoExtractor->getTypes(DummyObjectArray::class, 'bar', Argument::type('array'))->willReturn([
-            new Type('string'),
-        ]);
-        $hydrateGenerator = new ObjectHydrateFromArrayGenerator($propertyInfoExtractor->reveal(), new DummyObjectArrayTypeGenerator());
+        $propertyInfoExtractor = $this->getPropertyInfoExtractor(DummyObjectArray::class);
+        $hydrateGenerator = new ObjectHydrateFromArrayGenerator($propertyInfoExtractor, new DummyObjectArrayTypeGenerator());
 
         $this->assertTrue($hydrateGenerator->supportsGeneration(DummyObjectArray::class));
 
@@ -60,8 +46,8 @@ class ObjectHydrateFromArrayGeneratorTest extends \PHPUnit_Framework_TestCase
      */
     public function testNoInput()
     {
-        $propertyInfoExtractor = $this->prophesize(PropertyInfoExtractorInterface::class);
-        $hydrateGenerator = new ObjectHydrateFromArrayGenerator($propertyInfoExtractor->reveal(), new DummyObjectArrayTypeGenerator());
+        $propertyInfoExtractor = $this->getMockBuilder(PropertyInfoExtractorInterface::class)->getMock();
+        $hydrateGenerator = new ObjectHydrateFromArrayGenerator($propertyInfoExtractor, new DummyObjectArrayTypeGenerator());
         $hydrateGenerator->generate(DummyObjectArray::class);
     }
 
@@ -70,8 +56,8 @@ class ObjectHydrateFromArrayGeneratorTest extends \PHPUnit_Framework_TestCase
      */
     public function testNoOutput()
     {
-        $propertyInfoExtractor = $this->prophesize(PropertyInfoExtractorInterface::class);
-        $hydrateGenerator = new ObjectHydrateFromArrayGenerator($propertyInfoExtractor->reveal(), new DummyObjectArrayTypeGenerator());
+        $propertyInfoExtractor = $this->getMockBuilder(PropertyInfoExtractorInterface::class)->getMock();
+        $hydrateGenerator = new ObjectHydrateFromArrayGenerator($propertyInfoExtractor, new DummyObjectArrayTypeGenerator());
         $hydrateGenerator->generate(DummyObjectArray::class, ['input' => new Expr\Variable('test')]);
     }
 }

--- a/src/Symfony/Component/AstGenerator/Tests/Hydrate/ObjectHydrateFromStdClassGeneratorTest.php
+++ b/src/Symfony/Component/AstGenerator/Tests/Hydrate/ObjectHydrateFromStdClassGeneratorTest.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AstGenerator\Tests\Hydrate;
+
+use PhpParser\Node\Expr;
+use PhpParser\PrettyPrinter\Standard;
+use Prophecy\Argument;
+use Symfony\Component\AstGenerator\AstGeneratorInterface;
+use Symfony\Component\AstGenerator\Hydrate\ObjectHydrateFromStdClassGenerator;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
+use Symfony\Component\PropertyInfo\Type;
+
+class ObjectHydrateFromStdClassGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var Standard */
+    protected $printer;
+
+    public function setUp()
+    {
+        $this->printer = new Standard();
+    }
+
+    public function testHydrateGenerator()
+    {
+        $propertyInfoExtractor = $this->prophesize(PropertyInfoExtractorInterface::class);
+        $propertyInfoExtractor->getProperties(DummyObjectStdClass::class, Argument::type('array'))->willReturn(['foo', 'bar']);
+        $propertyInfoExtractor->isWritable(DummyObjectStdClass::class, 'foo', Argument::type('array'))->willReturn(false);
+        $propertyInfoExtractor->isWritable(DummyObjectStdClass::class, 'bar', Argument::type('array'))->willReturn(true);
+        $propertyInfoExtractor->getTypes(DummyObjectStdClass::class, 'bar', Argument::type('array'))->willReturn([
+            new Type('string'),
+        ]);
+        $hydrateGenerator = new ObjectHydrateFromStdClassGenerator($propertyInfoExtractor->reveal(), new DummyObjectStdClassTypeGenerator());
+
+        $this->assertTrue($hydrateGenerator->supportsGeneration(DummyObjectStdClass::class));
+
+        $stdClass = new \stdClass();
+        $stdClass->bar = "test";
+
+        eval($this->printer->prettyPrint($hydrateGenerator->generate(DummyObjectStdClass::class, [
+            'input' => new Expr\Variable('stdClass'),
+            'output' => new Expr\Variable('object'),
+        ])));
+
+        $this->assertInstanceOf(DummyObjectStdClass::class, $object);
+        $this->assertEquals('test', $object->bar);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\AstGenerator\Exception\MissingContextException
+     */
+    public function testNoInput()
+    {
+        $propertyInfoExtractor = $this->prophesize(PropertyInfoExtractorInterface::class);
+        $hydrateGenerator = new ObjectHydrateFromStdClassGenerator($propertyInfoExtractor->reveal(), new DummyObjectStdClassTypeGenerator());
+        $hydrateGenerator->generate(DummyObjectStdClass::class);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\AstGenerator\Exception\MissingContextException
+     */
+    public function testNoOutput()
+    {
+        $propertyInfoExtractor = $this->prophesize(PropertyInfoExtractorInterface::class);
+        $hydrateGenerator = new ObjectHydrateFromStdClassGenerator($propertyInfoExtractor->reveal(), new DummyObjectStdClassTypeGenerator());
+        $hydrateGenerator->generate(DummyObjectStdClass::class, ['input' => new Expr\Variable('test')]);
+    }
+}
+
+class DummyObjectStdClass
+{
+    public $foo;
+
+    public $bar;
+
+    /**
+     * @return mixed
+     */
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+
+    /**
+     * @param mixed $bar
+     */
+    public function setBar($bar)
+    {
+        $this->bar = $bar;
+    }
+}
+
+class DummyObjectStdClassTypeGenerator implements AstGeneratorInterface
+{
+    public function generate($object, array $context = [])
+    {
+        if (!isset($context['input'])) {
+            throw new \Exception('no input');
+        }
+
+        if (!isset($context['output'])) {
+            throw new \Exception('no output');
+        }
+
+        return [new Expr\Assign($context['output'], $context['input'])];
+    }
+
+    public function supportsGeneration($object)
+    {
+        return true;
+    }
+}

--- a/src/Symfony/Component/AstGenerator/Tests/Hydrate/ObjectHydrateFromStdClassGeneratorTest.php
+++ b/src/Symfony/Component/AstGenerator/Tests/Hydrate/ObjectHydrateFromStdClassGeneratorTest.php
@@ -19,26 +19,12 @@ use Symfony\Component\AstGenerator\Hydrate\ObjectHydrateFromStdClassGenerator;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
 use Symfony\Component\PropertyInfo\Type;
 
-class ObjectHydrateFromStdClassGeneratorTest extends \PHPUnit_Framework_TestCase
+class ObjectHydrateFromStdClassGeneratorTest extends AbstractHydratorTest
 {
-    /** @var Standard */
-    protected $printer;
-
-    public function setUp()
-    {
-        $this->printer = new Standard();
-    }
-
     public function testHydrateGenerator()
     {
-        $propertyInfoExtractor = $this->prophesize(PropertyInfoExtractorInterface::class);
-        $propertyInfoExtractor->getProperties(DummyObjectStdClass::class, Argument::type('array'))->willReturn(['foo', 'bar']);
-        $propertyInfoExtractor->isWritable(DummyObjectStdClass::class, 'foo', Argument::type('array'))->willReturn(false);
-        $propertyInfoExtractor->isWritable(DummyObjectStdClass::class, 'bar', Argument::type('array'))->willReturn(true);
-        $propertyInfoExtractor->getTypes(DummyObjectStdClass::class, 'bar', Argument::type('array'))->willReturn([
-            new Type('string'),
-        ]);
-        $hydrateGenerator = new ObjectHydrateFromStdClassGenerator($propertyInfoExtractor->reveal(), new DummyObjectStdClassTypeGenerator());
+        $propertyInfoExtractor = $this->getPropertyInfoExtractor(DummyObjectStdClass::class);
+        $hydrateGenerator = new ObjectHydrateFromStdClassGenerator($propertyInfoExtractor, new DummyObjectStdClassTypeGenerator());
 
         $this->assertTrue($hydrateGenerator->supportsGeneration(DummyObjectStdClass::class));
 
@@ -59,8 +45,8 @@ class ObjectHydrateFromStdClassGeneratorTest extends \PHPUnit_Framework_TestCase
      */
     public function testNoInput()
     {
-        $propertyInfoExtractor = $this->prophesize(PropertyInfoExtractorInterface::class);
-        $hydrateGenerator = new ObjectHydrateFromStdClassGenerator($propertyInfoExtractor->reveal(), new DummyObjectStdClassTypeGenerator());
+        $propertyInfoExtractor = $this->getMockBuilder(PropertyInfoExtractorInterface::class)->getMock();
+        $hydrateGenerator = new ObjectHydrateFromStdClassGenerator($propertyInfoExtractor, new DummyObjectStdClassTypeGenerator());
         $hydrateGenerator->generate(DummyObjectStdClass::class);
     }
 
@@ -69,8 +55,8 @@ class ObjectHydrateFromStdClassGeneratorTest extends \PHPUnit_Framework_TestCase
      */
     public function testNoOutput()
     {
-        $propertyInfoExtractor = $this->prophesize(PropertyInfoExtractorInterface::class);
-        $hydrateGenerator = new ObjectHydrateFromStdClassGenerator($propertyInfoExtractor->reveal(), new DummyObjectStdClassTypeGenerator());
+        $propertyInfoExtractor = $this->getMockBuilder(PropertyInfoExtractorInterface::class)->getMock();
+        $hydrateGenerator = new ObjectHydrateFromStdClassGenerator($propertyInfoExtractor, new DummyObjectStdClassTypeGenerator());
         $hydrateGenerator->generate(DummyObjectStdClass::class, ['input' => new Expr\Variable('test')]);
     }
 }

--- a/src/Symfony/Component/AstGenerator/Tests/Hydrate/StdClassHydrateGeneratorTest.php
+++ b/src/Symfony/Component/AstGenerator/Tests/Hydrate/StdClassHydrateGeneratorTest.php
@@ -36,18 +36,18 @@ class StdClassHydrateGeneratorTest extends \PHPUnit_Framework_TestCase
         $propertyInfoExtractor->isReadable(Foo::class, 'foo', Argument::type('array'))->willReturn(true);
         $propertyInfoExtractor->isReadable(Foo::class, 'bar', Argument::type('array'))->willReturn(false);
         $propertyInfoExtractor->getTypes(Foo::class, 'foo', Argument::type('array'))->willReturn([
-            new Type('string')
+            new Type('string'),
         ]);
         $hydrateGenerator = new StdClassHydrateGenerator($propertyInfoExtractor->reveal(), new FooTypeGenerator());
 
         $this->assertTrue($hydrateGenerator->supportsGeneration(Foo::class));
 
         $fooObject = new Foo();
-        $fooObject->foo = "test";
+        $fooObject->foo = 'test';
 
         eval($this->printer->prettyPrint($hydrateGenerator->generate(Foo::class, [
             'input' => new Expr\Variable('fooObject'),
-            'output' => new Expr\Variable('dummyStdClass')
+            'output' => new Expr\Variable('dummyStdClass'),
         ])));
 
         $this->assertInstanceOf('stdClass', $dummyStdClass);
@@ -72,7 +72,7 @@ class StdClassHydrateGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $propertyInfoExtractor = $this->prophesize(PropertyInfoExtractorInterface::class);
         $hydrateGenerator = new StdClassHydrateGenerator($propertyInfoExtractor->reveal(), new FooTypeGenerator());
-        $hydrateGenerator->generate(Foo::class, ['input' => new Expr\Variable("test")]);
+        $hydrateGenerator->generate(Foo::class, ['input' => new Expr\Variable('test')]);
     }
 }
 

--- a/src/Symfony/Component/AstGenerator/Tests/Hydrate/StdClassHydrateGeneratorTest.php
+++ b/src/Symfony/Component/AstGenerator/Tests/Hydrate/StdClassHydrateGeneratorTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AstGenerator\Tests\Hydrate;
+
+use PhpParser\Node\Expr;
+use PhpParser\PrettyPrinter\Standard;
+use Prophecy\Argument;
+use Symfony\Component\AstGenerator\AstGeneratorInterface;
+use Symfony\Component\AstGenerator\Hydrate\StdClassHydrateGenerator;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
+use Symfony\Component\PropertyInfo\Type;
+
+class StdClassHydrateGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var Standard */
+    protected $printer;
+
+    public function setUp()
+    {
+        $this->printer = new Standard();
+    }
+
+    public function testHydrateGenerator()
+    {
+        $propertyInfoExtractor = $this->prophesize(PropertyInfoExtractorInterface::class);
+        $propertyInfoExtractor->getProperties(Foo::class, Argument::type('array'))->willReturn(['foo', 'bar']);
+        $propertyInfoExtractor->isReadable(Foo::class, 'foo', Argument::type('array'))->willReturn(true);
+        $propertyInfoExtractor->isReadable(Foo::class, 'bar', Argument::type('array'))->willReturn(false);
+        $propertyInfoExtractor->getTypes(Foo::class, 'foo', Argument::type('array'))->willReturn([
+            new Type('string')
+        ]);
+        $hydrateGenerator = new StdClassHydrateGenerator($propertyInfoExtractor->reveal(), new FooTypeGenerator());
+
+        $this->assertTrue($hydrateGenerator->supportsGeneration(Foo::class));
+
+        $fooObject = new Foo();
+        $fooObject->foo = "test";
+
+        $dummyStdClass = eval($this->printer->prettyPrint($hydrateGenerator->generate(Foo::class, [
+            'input' => new Expr\Variable('fooObject')
+        ])));
+
+        $this->assertInstanceOf('stdClass', $dummyStdClass);
+        $this->assertObjectHasAttribute('foo', $dummyStdClass);
+        $this->assertEquals('test', $dummyStdClass->foo);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\AstGenerator\Exception\MissingContextException
+     */
+    public function testNoInput()
+    {
+        $propertyInfoExtractor = $this->prophesize(PropertyInfoExtractorInterface::class);
+        $hydrateGenerator = new StdClassHydrateGenerator($propertyInfoExtractor->reveal(), new FooTypeGenerator());
+        $hydrateGenerator->generate(Foo::class);
+    }
+}
+
+class Foo
+{
+    public $foo;
+
+    public $bar;
+
+    /**
+     * @return mixed
+     */
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+
+    /**
+     * @param mixed $bar
+     */
+    public function setBar($bar)
+    {
+        $this->bar = $bar;
+    }
+}
+
+class FooTypeGenerator implements AstGeneratorInterface
+{
+    public function generate($object, array $context = [])
+    {
+        if (!isset($context['input'])) {
+            throw new \Exception('no input');
+        }
+
+        if (!isset($context['output'])) {
+            throw new \Exception('no output');
+        }
+
+        return [new Expr\Assign($context['output'], $context['input'])];
+    }
+
+    public function supportsGeneration($object)
+    {
+        return true;
+    }
+}

--- a/src/Symfony/Component/AstGenerator/Tests/Hydrate/StdClassHydrateGeneratorTest.php
+++ b/src/Symfony/Component/AstGenerator/Tests/Hydrate/StdClassHydrateGeneratorTest.php
@@ -45,8 +45,9 @@ class StdClassHydrateGeneratorTest extends \PHPUnit_Framework_TestCase
         $fooObject = new Foo();
         $fooObject->foo = "test";
 
-        $dummyStdClass = eval($this->printer->prettyPrint($hydrateGenerator->generate(Foo::class, [
-            'input' => new Expr\Variable('fooObject')
+        eval($this->printer->prettyPrint($hydrateGenerator->generate(Foo::class, [
+            'input' => new Expr\Variable('fooObject'),
+            'output' => new Expr\Variable('dummyStdClass')
         ])));
 
         $this->assertInstanceOf('stdClass', $dummyStdClass);
@@ -62,6 +63,16 @@ class StdClassHydrateGeneratorTest extends \PHPUnit_Framework_TestCase
         $propertyInfoExtractor = $this->prophesize(PropertyInfoExtractorInterface::class);
         $hydrateGenerator = new StdClassHydrateGenerator($propertyInfoExtractor->reveal(), new FooTypeGenerator());
         $hydrateGenerator->generate(Foo::class);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\AstGenerator\Exception\MissingContextException
+     */
+    public function testNoOutput()
+    {
+        $propertyInfoExtractor = $this->prophesize(PropertyInfoExtractorInterface::class);
+        $hydrateGenerator = new StdClassHydrateGenerator($propertyInfoExtractor->reveal(), new FooTypeGenerator());
+        $hydrateGenerator->generate(Foo::class, ['input' => new Expr\Variable("test")]);
     }
 }
 

--- a/src/Symfony/Component/AstGenerator/Tests/Hydrate/StdClassHydrateGeneratorTest.php
+++ b/src/Symfony/Component/AstGenerator/Tests/Hydrate/StdClassHydrateGeneratorTest.php
@@ -19,26 +19,12 @@ use Symfony\Component\AstGenerator\Hydrate\StdClassHydrateGenerator;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
 use Symfony\Component\PropertyInfo\Type;
 
-class StdClassHydrateGeneratorTest extends \PHPUnit_Framework_TestCase
+class StdClassHydrateGeneratorTest extends AbstractHydratorTest
 {
-    /** @var Standard */
-    protected $printer;
-
-    public function setUp()
-    {
-        $this->printer = new Standard();
-    }
-
     public function testHydrateGenerator()
     {
-        $propertyInfoExtractor = $this->prophesize(PropertyInfoExtractorInterface::class);
-        $propertyInfoExtractor->getProperties(Foo::class, Argument::type('array'))->willReturn(['foo', 'bar']);
-        $propertyInfoExtractor->isReadable(Foo::class, 'foo', Argument::type('array'))->willReturn(true);
-        $propertyInfoExtractor->isReadable(Foo::class, 'bar', Argument::type('array'))->willReturn(false);
-        $propertyInfoExtractor->getTypes(Foo::class, 'foo', Argument::type('array'))->willReturn([
-            new Type('string'),
-        ]);
-        $hydrateGenerator = new StdClassHydrateGenerator($propertyInfoExtractor->reveal(), new FooTypeGenerator());
+        $propertyInfoExtractor = $this->getPropertyInfoExtractor(Foo::class);
+        $hydrateGenerator = new StdClassHydrateGenerator($propertyInfoExtractor, new FooTypeGenerator());
 
         $this->assertTrue($hydrateGenerator->supportsGeneration(Foo::class));
 
@@ -60,8 +46,8 @@ class StdClassHydrateGeneratorTest extends \PHPUnit_Framework_TestCase
      */
     public function testNoInput()
     {
-        $propertyInfoExtractor = $this->prophesize(PropertyInfoExtractorInterface::class);
-        $hydrateGenerator = new StdClassHydrateGenerator($propertyInfoExtractor->reveal(), new FooTypeGenerator());
+        $propertyInfoExtractor = $this->getMockBuilder(PropertyInfoExtractorInterface::class)->getMock();
+        $hydrateGenerator = new StdClassHydrateGenerator($propertyInfoExtractor, new FooTypeGenerator());
         $hydrateGenerator->generate(Foo::class);
     }
 
@@ -70,8 +56,8 @@ class StdClassHydrateGeneratorTest extends \PHPUnit_Framework_TestCase
      */
     public function testNoOutput()
     {
-        $propertyInfoExtractor = $this->prophesize(PropertyInfoExtractorInterface::class);
-        $hydrateGenerator = new StdClassHydrateGenerator($propertyInfoExtractor->reveal(), new FooTypeGenerator());
+        $propertyInfoExtractor = $this->getMockBuilder(PropertyInfoExtractorInterface::class)->getMock();
+        $hydrateGenerator = new StdClassHydrateGenerator($propertyInfoExtractor, new FooTypeGenerator());
         $hydrateGenerator->generate(Foo::class, ['input' => new Expr\Variable('test')]);
     }
 }

--- a/src/Symfony/Component/AstGenerator/Tests/Hydrate/Type/CollectionTypeGeneratorTest.php
+++ b/src/Symfony/Component/AstGenerator/Tests/Hydrate/Type/CollectionTypeGeneratorTest.php
@@ -1,0 +1,153 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AstGenerator\Tests\Hydrate\Type;
+
+use PhpParser\Node\Expr;
+use PhpParser\PrettyPrinter\Standard;
+use Prophecy\Argument;
+use Symfony\Component\AstGenerator\AstGeneratorInterface;
+use Symfony\Component\AstGenerator\Hydrate\Type\CollectionTypeGenerator;
+use Symfony\Component\PropertyInfo\Type;
+
+class CollectionTypeGeneratorTest  extends \PHPUnit_Framework_TestCase
+{
+    /** @var Standard */
+    protected $printer;
+
+    public function setUp()
+    {
+        $this->printer = new Standard();
+    }
+
+    /**
+     * @expectedException \Symfony\Component\AstGenerator\Exception\MissingContextException
+     */
+    public function testNoInput()
+    {
+        $itemGenerator = $this->prophesize(AstGeneratorInterface::class);
+        $hydrateGenerator = new CollectionTypeGenerator($itemGenerator->reveal());
+        $hydrateGenerator->generate(new Type('array', false, null, true));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\AstGenerator\Exception\MissingContextException
+     */
+    public function testNoOutput()
+    {
+        $itemGenerator = $this->prophesize(AstGeneratorInterface::class);
+        $hydrateGenerator = new CollectionTypeGenerator($itemGenerator->reveal());
+        $hydrateGenerator->generate(new Type('array', false, null, true), ['input' => new Expr\Variable('test')]);
+    }
+
+    public function testDefaultWithNumericalArray()
+    {
+        $collectionKeyType = new Type('int');
+        $collectionValueType = new Type('string');
+        $type = new Type('array', false, null, true, $collectionKeyType, $collectionValueType);
+
+        $itemGenerator = $this->prophesize(AstGeneratorInterface::class);
+        $itemGenerator->supportsGeneration($collectionValueType)->willReturn(true);
+        $itemGenerator->generate($collectionValueType, Argument::type('array'))->will(function ($args) {
+            return [new Expr\Assign($args[1]['output'], $args[1]['input'])];
+        });
+
+        $generator = new CollectionTypeGenerator($itemGenerator->reveal());
+
+        $this->assertTrue($generator->supportsGeneration($type));
+
+        $input = [
+            'foo',
+            'bar',
+        ];
+
+        eval($this->printer->prettyPrint($generator->generate($type, [
+            'input' => new Expr\Variable('input'),
+            'output' => new Expr\Variable('output'),
+        ])));
+
+        $this->assertInternalType('array', $output);
+        $this->assertCount(2, $output);
+        $this->assertEquals('foo', $output[0]);
+        $this->assertEquals('bar', $output[1]);
+    }
+
+    public function testDefaultWithMapArray()
+    {
+        $collectionKeyType = new Type('string');
+        $collectionValueType = new Type('string');
+        $type = new Type('array', false, null, true, $collectionKeyType, $collectionValueType);
+
+        $itemGenerator = $this->prophesize(AstGeneratorInterface::class);
+        $itemGenerator->supportsGeneration($collectionValueType)->willReturn(true);
+        $itemGenerator->generate($collectionValueType, Argument::type('array'))->will(function ($args) {
+            return [new Expr\Assign($args[1]['output'], $args[1]['input'])];
+        });
+
+        $generator = new CollectionTypeGenerator($itemGenerator->reveal());
+
+        $this->assertTrue($generator->supportsGeneration($type));
+
+        $input = [
+            'foo' => 'foo',
+            'bar' => 'bar',
+        ];
+
+        eval($this->printer->prettyPrint($generator->generate($type, [
+            'input' => new Expr\Variable('input'),
+            'output' => new Expr\Variable('output'),
+        ])));
+
+        $this->assertInstanceOf('\stdClass', $output);
+        $this->assertObjectHasAttribute('foo', $output);
+        $this->assertObjectHasAttribute('bar', $output);
+        $this->assertEquals('foo', $output->foo);
+        $this->assertEquals('bar', $output->bar);
+    }
+
+    public function testCustomObject()
+    {
+        $collectionKeyType = new Type('string');
+        $collectionValueType = new Type('string');
+        $type = new Type('array', false, null, true, $collectionKeyType, $collectionValueType);
+
+        $itemGenerator = $this->prophesize(AstGeneratorInterface::class);
+        $itemGenerator->supportsGeneration($collectionValueType)->willReturn(true);
+        $itemGenerator->generate($collectionValueType, Argument::type('array'))->will(function ($args) {
+            return [new Expr\Assign($args[1]['output'], $args[1]['input'])];
+        });
+
+        $generator = new CollectionTypeGenerator(
+            $itemGenerator->reveal(),
+            CollectionTypeGenerator::COLLECTION_WITH_OBJECT,
+            '\ArrayObject',
+            CollectionTypeGenerator::OBJECT_ASSIGNMENT_ARRAY
+        );
+
+        $this->assertTrue($generator->supportsGeneration($type));
+
+        $input = [
+            'foo' => 'foo',
+            'bar' => 'bar',
+        ];
+
+        eval($this->printer->prettyPrint($generator->generate($type, [
+            'input' => new Expr\Variable('input'),
+            'output' => new Expr\Variable('output'),
+        ])));
+
+        $this->assertInstanceOf('\ArrayObject', $output);
+        $this->assertArrayHasKey('foo', $output);
+        $this->assertArrayHasKey('bar', $output);
+        $this->assertEquals('foo', $output['foo']);
+        $this->assertEquals('bar', $output['bar']);
+    }
+}

--- a/src/Symfony/Component/AstGenerator/Tests/Hydrate/Type/TypeGeneratorTest.php
+++ b/src/Symfony/Component/AstGenerator/Tests/Hydrate/Type/TypeGeneratorTest.php
@@ -11,6 +11,258 @@
 
 namespace Symfony\Component\AstGenerator\Tests\Hydrate\Type;
 
-class TypeGeneratorTest
+use PhpParser\Node\Expr;
+use PhpParser\PrettyPrinter\Standard;
+use Symfony\Component\AstGenerator\Hydrate\Type\TypeGenerator;
+use Symfony\Component\PropertyInfo\Type;
+
+class TypeGeneratorTest extends \PHPUnit_Framework_TestCase
 {
+    /** @var Standard */
+    protected $printer;
+
+    /** @var TypeGenerator */
+    private $typeGenerator;
+
+    public function setUp()
+    {
+        $this->typeGenerator = new TypeGenerator();
+        $this->printer = new Standard();
+    }
+
+    /**
+     * @expectedException \Symfony\Component\AstGenerator\Exception\MissingContextException
+     */
+    public function testNoInput()
+    {
+        $this->typeGenerator->generate(new Type('string'));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\AstGenerator\Exception\MissingContextException
+     */
+    public function testNoOutput()
+    {
+        $this->typeGenerator->generate(new Type('string'), ['input' => new Expr\Variable('inputData')]);
+    }
+
+    public function testString()
+    {
+        $type = new Type('string');
+        $input = new Expr\Variable('inputData');
+        $output = new Expr\Variable('outputData');
+
+        $inputData = "test";
+        $outputData = null;
+
+        $this->assertTrue($this->typeGenerator->supportsGeneration($type));
+
+        eval($this->printer->prettyPrint($this->typeGenerator->generate($type, ['input' => $input, 'output' => $output])));
+
+        $this->assertSame($inputData, $outputData);
+    }
+
+    public function testInteger()
+    {
+        $type = new Type('int');
+        $input = new Expr\Variable('inputData');
+        $output = new Expr\Variable('outputData');
+
+        $inputData = 40;
+        $outputData = null;
+
+        $this->assertTrue($this->typeGenerator->supportsGeneration($type));
+
+        eval($this->printer->prettyPrint($this->typeGenerator->generate($type, ['input' => $input, 'output' => $output])));
+
+        $this->assertSame($inputData, $outputData);
+    }
+
+    public function testNull()
+    {
+        $type = new Type('null');
+        $input = new Expr\Variable('inputData');
+        $output = new Expr\Variable('outputData');
+
+        $inputData = null;
+        $outputData = "test";
+
+        $this->assertTrue($this->typeGenerator->supportsGeneration($type));
+
+        eval($this->printer->prettyPrint($this->typeGenerator->generate($type, ['input' => $input, 'output' => $output])));
+
+        $this->assertSame($inputData, $outputData);
+    }
+
+    public function testFloat()
+    {
+        $type = new Type('float');
+        $input = new Expr\Variable('inputData');
+        $output = new Expr\Variable('outputData');
+
+        $inputData = 2.5;
+        $outputData = null;
+
+        $this->assertTrue($this->typeGenerator->supportsGeneration($type));
+
+        eval($this->printer->prettyPrint($this->typeGenerator->generate($type, ['input' => $input, 'output' => $output])));
+
+        $this->assertSame($inputData, $outputData);
+    }
+
+    public function testBool()
+    {
+        $type = new Type('bool');
+        $input = new Expr\Variable('inputData');
+        $output = new Expr\Variable('outputData');
+
+        $inputData = true;
+        $outputData = null;
+
+        $this->assertTrue($this->typeGenerator->supportsGeneration($type));
+
+        eval($this->printer->prettyPrint($this->typeGenerator->generate($type, ['input' => $input, 'output' => $output])));
+
+        $this->assertSame($inputData, $outputData);
+    }
+
+    public function testStringConditionOk()
+    {
+        $type = new Type('string');
+        $input = new Expr\Variable('inputData');
+        $output = new Expr\Variable('outputData');
+
+        $inputData = "test";
+        $outputData = null;
+
+        eval($this->printer->prettyPrint($this->typeGenerator->generate($type, ['condition' => true, 'input' => $input, 'output' => $output])));
+
+        $this->assertSame($inputData, $outputData);
+    }
+
+    public function testIntegerConditionOk()
+    {
+        $type = new Type('int');
+        $input = new Expr\Variable('inputData');
+        $output = new Expr\Variable('outputData');
+
+        $inputData = 40;
+        $outputData = null;
+
+        eval($this->printer->prettyPrint($this->typeGenerator->generate($type, ['condition' => true,'input' => $input, 'output' => $output])));
+
+        $this->assertSame($inputData, $outputData);
+    }
+
+    public function testNullConditionOk()
+    {
+        $type = new Type('null');
+        $input = new Expr\Variable('inputData');
+        $output = new Expr\Variable('outputData');
+
+        $inputData = null;
+        $outputData = "test";
+
+        eval($this->printer->prettyPrint($this->typeGenerator->generate($type, ['condition' => true,'input' => $input, 'output' => $output])));
+
+        $this->assertSame($inputData, $outputData);
+    }
+
+    public function testFloatConditionOk()
+    {
+        $type = new Type('float');
+        $input = new Expr\Variable('inputData');
+        $output = new Expr\Variable('outputData');
+
+        $inputData = 2.5;
+        $outputData = null;
+
+        eval($this->printer->prettyPrint($this->typeGenerator->generate($type, ['condition' => true,'input' => $input, 'output' => $output])));
+
+        $this->assertSame($inputData, $outputData);
+    }
+
+    public function testBoolConditionOk()
+    {
+        $type = new Type('bool');
+        $input = new Expr\Variable('inputData');
+        $output = new Expr\Variable('outputData');
+
+        $inputData = true;
+        $outputData = null;
+
+        eval($this->printer->prettyPrint($this->typeGenerator->generate($type, ['condition' => true, 'input' => $input, 'output' => $output])));
+
+        $this->assertSame($inputData, $outputData);
+    }
+
+    public function testStringConditionNOK()
+    {
+        $type = new Type('string');
+        $input = new Expr\Variable('inputData');
+        $output = new Expr\Variable('outputData');
+
+        $inputData = 1;
+        $outputData = null;
+
+        eval($this->printer->prettyPrint($this->typeGenerator->generate($type, ['condition' => true, 'input' => $input, 'output' => $output])));
+
+        $this->assertNull($outputData);
+    }
+
+    public function testIntegerConditionNOK()
+    {
+        $type = new Type('int');
+        $input = new Expr\Variable('inputData');
+        $output = new Expr\Variable('outputData');
+
+        $inputData = "test";
+        $outputData = null;
+
+        eval($this->printer->prettyPrint($this->typeGenerator->generate($type, ['condition' => true,'input' => $input, 'output' => $output])));
+
+        $this->assertNull($outputData);
+    }
+
+    public function testNullConditionNOK()
+    {
+        $type = new Type('null');
+        $input = new Expr\Variable('inputData');
+        $output = new Expr\Variable('outputData');
+
+        $inputData = "test";
+        $outputData = "test";
+
+        eval($this->printer->prettyPrint($this->typeGenerator->generate($type, ['condition' => true,'input' => $input, 'output' => $output])));
+
+        $this->assertNotNull($outputData);
+    }
+
+    public function testFloatConditionNOK()
+    {
+        $type = new Type('float');
+        $input = new Expr\Variable('inputData');
+        $output = new Expr\Variable('outputData');
+
+        $inputData = "test";
+        $outputData = null;
+
+        eval($this->printer->prettyPrint($this->typeGenerator->generate($type, ['condition' => true,'input' => $input, 'output' => $output])));
+
+        $this->assertNull($outputData);
+    }
+
+    public function testBoolConditionNOK()
+    {
+        $type = new Type('bool');
+        $input = new Expr\Variable('inputData');
+        $output = new Expr\Variable('outputData');
+
+        $inputData = "test";
+        $outputData = null;
+
+        eval($this->printer->prettyPrint($this->typeGenerator->generate($type, ['condition' => true, 'input' => $input, 'output' => $output])));
+
+        $this->assertNull($outputData);
+    }
 }

--- a/src/Symfony/Component/AstGenerator/Tests/Hydrate/Type/TypeGeneratorTest.php
+++ b/src/Symfony/Component/AstGenerator/Tests/Hydrate/Type/TypeGeneratorTest.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AstGenerator\Tests\Hydrate\Type;
+
+class TypeGeneratorTest
+{
+}

--- a/src/Symfony/Component/AstGenerator/Tests/Normalizer/NormalizerGeneratorTest.php
+++ b/src/Symfony/Component/AstGenerator/Tests/Normalizer/NormalizerGeneratorTest.php
@@ -13,10 +13,9 @@ namespace Symfony\Component\AstGenerator\Tests\Normalizer;
 
 use PhpParser\PrettyPrinter\Standard;
 use PhpParser\Node\Name;
-use PhpParser\Node\Param;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Expr;
-use PhpParser\Node\Scalar;
+use Prophecy\Argument;
 use Symfony\Component\AstGenerator\AstGeneratorInterface;
 use Symfony\Component\AstGenerator\Normalizer\NormalizerGenerator;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -37,13 +36,13 @@ class NormalizerGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $normalizerStatementsGenerator = $this->prophesize(AstGeneratorInterface::class);
         $normalizerStatementsGenerator->supportsGeneration(Dummy::class)->willReturn(true);
-        $normalizerStatementsGenerator->generate(Dummy::class, ['name' => 'DummyNormalizer'])->willReturn([
+        $normalizerStatementsGenerator->generate(Dummy::class, Argument::type('array'))->willReturn([
             new Stmt\Return_(new Expr\New_(new Name("\\stdClass")))
         ]);
 
         $denormalizerStatementsGenerator = $this->prophesize(AstGeneratorInterface::class);
         $denormalizerStatementsGenerator->supportsGeneration(Dummy::class)->willReturn(true);
-        $denormalizerStatementsGenerator->generate(Dummy::class, ['name' => 'DummyNormalizer'])->willReturn([
+        $denormalizerStatementsGenerator->generate(Dummy::class, Argument::type('array'))->willReturn([
             new Stmt\Return_(new Expr\New_(new Name('\\'. Dummy::class)))
         ]);
 

--- a/src/Symfony/Component/AstGenerator/Tests/Normalizer/NormalizerGeneratorTest.php
+++ b/src/Symfony/Component/AstGenerator/Tests/Normalizer/NormalizerGeneratorTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AstGenerator\Tests\Normalizer;
+
+use PhpParser\PrettyPrinter\Standard;
+use PhpParser\Node\Name;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Scalar;
+use Symfony\Component\AstGenerator\AstGeneratorInterface;
+use Symfony\Component\AstGenerator\Normalizer\NormalizerGenerator;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\SerializerAwareInterface;
+
+class NormalizerGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var Standard */
+    protected $printer;
+
+    public function setUp()
+    {
+        $this->printer = new Standard();
+    }
+
+    public function testGenerateDummyNormalizer()
+    {
+        $normalizerStatementsGenerator = $this->prophesize(AstGeneratorInterface::class);
+        $normalizerStatementsGenerator->supportsGeneration(Dummy::class)->willReturn(true);
+        $normalizerStatementsGenerator->generate(Dummy::class, ['name' => 'DummyNormalizer'])->willReturn([
+            new Stmt\Return_(new Expr\New_(new Name("\\stdClass")))
+        ]);
+
+        $denormalizerStatementsGenerator = $this->prophesize(AstGeneratorInterface::class);
+        $denormalizerStatementsGenerator->supportsGeneration(Dummy::class)->willReturn(true);
+        $denormalizerStatementsGenerator->generate(Dummy::class, ['name' => 'DummyNormalizer'])->willReturn([
+            new Stmt\Return_(new Expr\New_(new Name('\\'. Dummy::class)))
+        ]);
+
+        $normalizerGenerator = new NormalizerGenerator($normalizerStatementsGenerator->reveal(), $denormalizerStatementsGenerator->reveal());
+
+        $this->assertTrue($normalizerGenerator->supportsGeneration(Dummy::class));
+
+        eval($this->printer->prettyPrint($normalizerGenerator->generate(Dummy::class)));
+
+        $this->assertTrue(class_exists('DummyNormalizer'));
+
+        $dummyNormalizer = new \DummyNormalizer();
+
+        $this->assertInstanceOf(NormalizerInterface::class, $dummyNormalizer);
+        $this->assertInstanceOf(DenormalizerInterface::class, $dummyNormalizer);
+        $this->assertInstanceOf(SerializerAwareInterface::class, $dummyNormalizer);
+
+        $this->assertTrue($dummyNormalizer->supportsNormalization(new Dummy()));
+        $this->assertTrue($dummyNormalizer->supportsDenormalization([], Dummy::class));
+
+        $normalized = $dummyNormalizer->normalize(new Dummy());
+        $denormalized = $dummyNormalizer->denormalize(new \stdClass(), Dummy::class);
+
+        $this->assertInstanceOf(\stdClass::class, $normalized);
+        $this->assertInstanceOf(Dummy::class, $denormalized);
+    }
+}
+
+class Dummy
+{
+}

--- a/src/Symfony/Component/AstGenerator/Tests/Normalizer/NormalizerGeneratorTest.php
+++ b/src/Symfony/Component/AstGenerator/Tests/Normalizer/NormalizerGeneratorTest.php
@@ -37,13 +37,13 @@ class NormalizerGeneratorTest extends \PHPUnit_Framework_TestCase
         $normalizerStatementsGenerator = $this->prophesize(AstGeneratorInterface::class);
         $normalizerStatementsGenerator->supportsGeneration(Dummy::class)->willReturn(true);
         $normalizerStatementsGenerator->generate(Dummy::class, Argument::type('array'))->willReturn([
-            new Stmt\Return_(new Expr\New_(new Name("\\stdClass")))
+            new Stmt\Return_(new Expr\New_(new Name('\\stdClass'))),
         ]);
 
         $denormalizerStatementsGenerator = $this->prophesize(AstGeneratorInterface::class);
         $denormalizerStatementsGenerator->supportsGeneration(Dummy::class)->willReturn(true);
         $denormalizerStatementsGenerator->generate(Dummy::class, Argument::type('array'))->willReturn([
-            new Stmt\Return_(new Expr\New_(new Name('\\'. Dummy::class)))
+            new Stmt\Return_(new Expr\New_(new Name('\\'.Dummy::class))),
         ]);
 
         $normalizerGenerator = new NormalizerGenerator($normalizerStatementsGenerator->reveal(), $denormalizerStatementsGenerator->reveal());

--- a/src/Symfony/Component/AstGenerator/Tests/Normalizer/NormalizerGeneratorTest.php
+++ b/src/Symfony/Component/AstGenerator/Tests/Normalizer/NormalizerGeneratorTest.php
@@ -19,7 +19,9 @@ use Prophecy\Argument;
 use Symfony\Component\AstGenerator\AstGeneratorInterface;
 use Symfony\Component\AstGenerator\Normalizer\NormalizerGenerator;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\SerializerAwareInterface;
 
 class NormalizerGeneratorTest extends \PHPUnit_Framework_TestCase
@@ -74,7 +76,8 @@ class NormalizerGeneratorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(NormalizerInterface::class, $dummyNormalizer);
         $this->assertInstanceOf(DenormalizerInterface::class, $dummyNormalizer);
-        $this->assertInstanceOf(SerializerAwareInterface::class, $dummyNormalizer);
+        $this->assertInstanceOf(DenormalizerAwareInterface::class, $dummyNormalizer);
+        $this->assertInstanceOf(NormalizerAwareInterface::class, $dummyNormalizer);
 
         $this->assertTrue($dummyNormalizer->supportsNormalization(new Dummy()));
         $this->assertTrue($dummyNormalizer->supportsDenormalization([], Dummy::class));

--- a/src/Symfony/Component/AstGenerator/Tests/Normalizer/NormalizerGeneratorTest.php
+++ b/src/Symfony/Component/AstGenerator/Tests/Normalizer/NormalizerGeneratorTest.php
@@ -34,19 +34,35 @@ class NormalizerGeneratorTest extends \PHPUnit_Framework_TestCase
 
     public function testGenerateDummyNormalizer()
     {
-        $normalizerStatementsGenerator = $this->prophesize(AstGeneratorInterface::class);
-        $normalizerStatementsGenerator->supportsGeneration(Dummy::class)->willReturn(true);
-        $normalizerStatementsGenerator->generate(Dummy::class, Argument::type('array'))->willReturn([
-            new Stmt\Return_(new Expr\New_(new Name('\\stdClass'))),
-        ]);
+        $normalizerStatementsGenerator = $this->getMockBuilder(AstGeneratorInterface::class)->getMock();
+        $normalizerStatementsGenerator
+            ->expects($this->any())
+            ->method('supportsGeneration')
+            ->with(Dummy::class)
+            ->willReturn(true);
+        $normalizerStatementsGenerator
+            ->expects($this->any())
+            ->method('generate')
+            ->with(Dummy::class, $this->isType('array'))
+            ->willReturn([
+                new Stmt\Return_(new Expr\New_(new Name('\\stdClass'))),
+            ]);
 
-        $denormalizerStatementsGenerator = $this->prophesize(AstGeneratorInterface::class);
-        $denormalizerStatementsGenerator->supportsGeneration(Dummy::class)->willReturn(true);
-        $denormalizerStatementsGenerator->generate(Dummy::class, Argument::type('array'))->willReturn([
-            new Stmt\Return_(new Expr\New_(new Name('\\'.Dummy::class))),
-        ]);
+        $denormalizerStatementsGenerator = $this->getMockBuilder(AstGeneratorInterface::class)->getMock();
+        $denormalizerStatementsGenerator
+            ->expects($this->any())
+            ->method('supportsGeneration')
+            ->with(Dummy::class)
+            ->willReturn(true);
+        $denormalizerStatementsGenerator
+            ->expects($this->any())
+            ->method('generate')
+            ->with(Dummy::class, $this->isType('array'))
+            ->willReturn([
+                new Stmt\Return_(new Expr\New_(new Name('\\'.Dummy::class))),
+            ]);
 
-        $normalizerGenerator = new NormalizerGenerator($normalizerStatementsGenerator->reveal(), $denormalizerStatementsGenerator->reveal());
+        $normalizerGenerator = new NormalizerGenerator($normalizerStatementsGenerator, $denormalizerStatementsGenerator);
 
         $this->assertTrue($normalizerGenerator->supportsGeneration(Dummy::class));
 

--- a/src/Symfony/Component/AstGenerator/Tests/UniqueVariableScopeTest.php
+++ b/src/Symfony/Component/AstGenerator/Tests/UniqueVariableScopeTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AstGenerator\Tests;
+
+use Symfony\Component\AstGenerator\UniqueVariableScope;
+
+class UniqueVariableScopeTest extends \PHPUnit_Framework_TestCase
+{
+    public function testUniqueVariable()
+    {
+        $uniqueVariableScope = new UniqueVariableScope();
+
+        $name = $uniqueVariableScope->getUniqueName('name');
+        $this->assertEquals('name', $name);
+
+        $name = $uniqueVariableScope->getUniqueName('name');
+        $this->assertEquals('name_1', $name);
+
+        $name = $uniqueVariableScope->getUniqueName('name');
+        $this->assertEquals('name_2', $name);
+    }
+}

--- a/src/Symfony/Component/AstGenerator/UniqueVariableScope.php
+++ b/src/Symfony/Component/AstGenerator/UniqueVariableScope.php
@@ -12,14 +12,14 @@
 namespace Symfony\Component\AstGenerator;
 
 /**
- * Allow to get a unique variable name for a scope (like a method)
+ * Allow to get a unique variable name for a scope (like a method).
  */
 class UniqueVariableScope
 {
     private $registry = [];
 
     /**
-     * Return an unique name for a variable
+     * Return an unique name for a variable.
      *
      * @param string $name Name of the variable
      *
@@ -33,7 +33,7 @@ class UniqueVariableScope
             return $name;
         }
 
-        $this->registry[$name]++;
+        ++$this->registry[$name];
 
         return sprintf('%s_%s', $name, $this->registry[$name]);
     }

--- a/src/Symfony/Component/AstGenerator/UniqueVariableScope.php
+++ b/src/Symfony/Component/AstGenerator/UniqueVariableScope.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\AstGenerator;
+
+/**
+ * Allow to get a unique variable name for a scope (like a method)
+ */
+class UniqueVariableScope
+{
+    private $registry = [];
+
+    /**
+     * Return an unique name for a variable
+     *
+     * @param string $name Name of the variable
+     *
+     * @return string if not found return the $name given, if not return the name suffixed with a number
+     */
+    public function getUniqueName($name)
+    {
+        if (!isset($this->registry[$name])) {
+            $this->registry[$name] = 0;
+
+            return $name;
+        }
+
+        $this->registry[$name]++;
+
+        return sprintf('%s_%s', $name, $this->registry[$name]);
+    }
+}

--- a/src/Symfony/Component/AstGenerator/UniqueVariableScope.php
+++ b/src/Symfony/Component/AstGenerator/UniqueVariableScope.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\AstGenerator;
  */
 class UniqueVariableScope
 {
-    private $registry = [];
+    private $registry = array();
 
     /**
      * Return an unique name for a variable.

--- a/src/Symfony/Component/AstGenerator/composer.json
+++ b/src/Symfony/Component/AstGenerator/composer.json
@@ -19,6 +19,9 @@
         "php": ">=5.5.9",
         "nikic/php-parser": "~2.0"
     },
+    "require-dev": {
+        "symfony/serializer": "~2.8|~3.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\AstGenerator\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/AstGenerator/composer.json
+++ b/src/Symfony/Component/AstGenerator/composer.json
@@ -1,0 +1,34 @@
+{
+    "name": "symfony/ast-generator",
+    "type": "library",
+    "description": "Symfony component to generate AST from and to various others components",
+    "keywords": ["symfony", "ast", "generator"],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Joel Wurtz",
+            "email": "joel.wurtz@gmail.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=5.5.9",
+        "nikic/php-parser": "~2.0"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\AstGenerator\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.1-dev"
+        }
+    }
+}

--- a/src/Symfony/Component/AstGenerator/composer.json
+++ b/src/Symfony/Component/AstGenerator/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "nikic/php-parser": "~2.0"
+        "nikic/php-parser": "~2.0",
+        "symfony/property-info": "~2.8|~3.0"
     },
     "require-dev": {
         "symfony/serializer": "~2.8|~3.0"

--- a/src/Symfony/Component/AstGenerator/phpunit.xml.dist
+++ b/src/Symfony/Component/AstGenerator/phpunit.xml.dist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony AstGenerator Component Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This new component brings the concept of generating code in an AST representation into Symfony.

The original idea of doing it comes from the following discussion : https://github.com/api-platform/schema-generator/issues/42

The first focus is to be able to generate `Normalizer` from existing class by extracting property and types with the `PropertyInfo` Component, so the following class : 

``` php
class Foo
{
     /**
      * @var string
      */
     private $a;

     /**
      * @var array
      */
     private $array;

     /**
      * @var Dummy Dummy link
      */
     private $c;

     // Classic set / get operations
     ...
}
```

will generate the following normalizer:

``` php
class FooNormalizer implements NormalizerInterface, DenormalizerInterface
{
    public function supportsDenormalization($data, $type, $format = null)
    {
        if ($type !== 'Foo') {
            return false;
        }
        return true;
    }

    public function supportsNormalization($data, $format = null)
    {
        if ($data instanceof Foo) {
            return true;
        }
        return false;
    }

    public function denormalize($data, $class, $format = null, array $context = [])
    {
        $object = new Foo();
        $object->setA($data->{'a'});
        $object->setB($data->{'b'});
        $object->setC($this->serializer->denormalize($data->{'c'}, 'Dummy'));
        return $object;
    }

    public function normalize($object, $format = null, array $context = [])
    {
        $data = new \stdClass();
        $data->{'a'} = $object->getA();
        $data->{'b'} = $object->getB();
        $data->{'c'} = $this->serializer->normalize($object->getC());
        return $data;
    }
}
```
## Why ?

There is some PR and discussion about making the serialization faster, i believe, by generating such a normalizer, the speed could not be faster as all the logic will be computed in the generation process and not a the runtime.
## What is done

For the moment this library generate 2 things:
- Normalizer class with its methods 
- Hydration statements which will be used by the normalizer generator for the body of normalize and denormalize methods. Hydration as been separated as i believe it can serve other component / library than Normalization (like doctrine, elasticsearch, everything that is data / model related).
## What is left

There is still some works to do, but this is a first preview so we can talk about it more without going too far, here is what's left from my point of view:
- [ ] Add generation for object type in hydration with inline mode (in the same context) but would be subject to circular loop
- [ ] Add generation for object type in hydration with `call` mode (like using the serializer or other services)
- [ ] Add the discriminant type to PropertyInfo (so when there is an inheritance model, normalizer can know which class to denormalize with a `type` variable)
- [ ] Link to the Symfony Framework (other PR ?)
## Issues to address

There is some issues than need to be adressed to have a robust generation:
- [ ] Better Property extracted from PropertyInfo, it's actually missing the way of reading and/or writing to a property, also some others features would be nice (like having a different serialized name for special characters)
- [ ] Add a NormalizerAware class or a Raw decode mode in the Serializer Component for normalization of sub object see #17545 
- [ ] Conflict with php-parser version from suggested dependency of property info see #17531
## Interface

This library declare a new interface `AstGeneratorInterface` it's enough generic to be used for each kind of generation and also with the usage of `AstGeneratorChain` it will be easy for user to hook into the generation process.
## Hydration

On the hydration part the plan is to be able to transform:
- from object to array
- from object to stdClass instance
- from array to object
- from stdClass instance to object

Even if `array` is the standard in the serializer component, stdClass is needed IMO, as it's the only possible solution to distinct between an empty object or an empty array in the JSON wrold (`{}` vs `[]`}
## Others ideas

I have plenty of ideas for this component but i want to keep the scope small at the moment and will do others PR: 
- Ast Optimisation: By using AST it would be possible to add a layer of optimisation when generating the code, like direct resolving of values if the argument is static (should be done in a new component IMO)
- Class Extractor / Generator: Ability to extract classes from a model (Think of schema.org, json schema, doctrine mapping file, ...) and generate the associated class with its getter / setter
- Validator Generator: Ability to generate a plain validator php file for a class
