### PR TITLE
Microoptimization for UrlMatcher dumped as PHP code

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -91,8 +91,6 @@ EOF;
     {
         \$allow = array();
         \$pathinfo = rawurldecode(\$pathinfo);
-        \$isPathMissingTrailingSlash = substr(\$pathinfo, -1) !== '/';
-        \$pathWithTrailingSlash = \$isPathMissingTrailingSlash ? \$pathinfo.'/' : \$pathinfo;
         \$pathWithoutTrailingSlash = rtrim(\$pathinfo, '/');
 
 $code
@@ -275,8 +273,8 @@ EOF;
 
         if ($hasTrailingSlash) {
             $code .= <<<EOF
-            if (\$isPathMissingTrailingSlash) {
-                return \$this->redirect(\$pathWithTrailingSlash, '$name');
+            if (substr(\$pathinfo, -1) !== '/') {
+                return \$this->redirect(\$pathinfo.'/', '$name');
             }
 
 

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -91,6 +91,9 @@ EOF;
     {
         \$allow = array();
         \$pathinfo = rawurldecode(\$pathinfo);
+        \$isPathMissingTrailingSlash = substr(\$pathinfo, -1) !== '/';
+        \$pathWithTrailingSlash = \$isPathMissingTrailingSlash ? \$pathinfo.'/' : \$pathinfo;
+        \$pathWithoutTrailingSlash = rtrim(\$pathinfo, '/');
 
 $code
 
@@ -213,7 +216,7 @@ EOF;
 
         if (!count($compiledRoute->getPathVariables()) && false !== preg_match('#^(.)\^(?P<url>.*?)\$\1#', $compiledRoute->getRegex(), $m)) {
             if ($supportsTrailingSlash && substr($m['url'], -1) === '/') {
-                $conditions[] = sprintf("rtrim(\$pathinfo, '/') === %s", var_export(rtrim(str_replace('\\', '', $m['url']), '/'), true));
+                $conditions[] = sprintf("\$pathWithoutTrailingSlash === %s", var_export(rtrim(str_replace('\\', '', $m['url']), '/'), true));
                 $hasTrailingSlash = true;
             } else {
                 $conditions[] = sprintf('$pathinfo === %s', var_export(str_replace('\\', '', $m['url']), true));
@@ -272,8 +275,8 @@ EOF;
 
         if ($hasTrailingSlash) {
             $code .= <<<EOF
-            if (substr(\$pathinfo, -1) !== '/') {
-                return \$this->redirect(\$pathinfo.'/', '$name');
+            if (\$isPathMissingTrailingSlash) {
+                return \$this->redirect(\$pathWithTrailingSlash, '$name');
             }
 
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
@@ -24,6 +24,9 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
     {
         $allow = array();
         $pathinfo = rawurldecode($pathinfo);
+        $isPathMissingTrailingSlash = substr($pathinfo, -1) !== '/';
+        $pathWithTrailingSlash = $isPathMissingTrailingSlash ? $pathinfo.'/' : $pathinfo;
+        $pathWithoutTrailingSlash = rtrim($pathinfo, '/');
 
         // foo
         if (0 === strpos($pathinfo, '/foo') && preg_match('#^/foo/(?P<bar>baz|symfony)$#s', $pathinfo, $matches)) {

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
@@ -24,8 +24,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
     {
         $allow = array();
         $pathinfo = rawurldecode($pathinfo);
-        $isPathMissingTrailingSlash = substr($pathinfo, -1) !== '/';
-        $pathWithTrailingSlash = $isPathMissingTrailingSlash ? $pathinfo.'/' : $pathinfo;
         $pathWithoutTrailingSlash = rtrim($pathinfo, '/');
 
         // foo

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
@@ -24,8 +24,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
     {
         $allow = array();
         $pathinfo = rawurldecode($pathinfo);
-        $isPathMissingTrailingSlash = substr($pathinfo, -1) !== '/';
-        $pathWithTrailingSlash = $isPathMissingTrailingSlash ? $pathinfo.'/' : $pathinfo;
         $pathWithoutTrailingSlash = rtrim($pathinfo, '/');
 
         // foo
@@ -72,8 +70,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
                 // baz3
                 if ($pathWithoutTrailingSlash === '/test/baz3') {
-                    if ($isPathMissingTrailingSlash) {
-                        return $this->redirect($pathWithTrailingSlash, 'baz3');
+                    if (substr($pathinfo, -1) !== '/') {
+                        return $this->redirect($pathinfo.'/', 'baz3');
                     }
 
                     return array('_route' => 'baz3');
@@ -83,8 +81,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
             // baz4
             if (preg_match('#^/test/(?P<foo>[^/]++)/?$#s', $pathinfo, $matches)) {
-                if ($isPathMissingTrailingSlash) {
-                    return $this->redirect($pathWithTrailingSlash, 'baz4');
+                if (substr($pathinfo, -1) !== '/') {
+                    return $this->redirect($pathinfo.'/', 'baz4');
                 }
 
                 return $this->mergeDefaults(array_replace($matches, array('_route' => 'baz4')), array ());
@@ -176,8 +174,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
             // hey
             if ($pathWithoutTrailingSlash === '/multi/hey') {
-                if ($isPathMissingTrailingSlash) {
-                    return $this->redirect($pathWithTrailingSlash, 'hey');
+                if (substr($pathinfo, -1) !== '/') {
+                    return $this->redirect($pathinfo.'/', 'hey');
                 }
 
                 return array('_route' => 'hey');

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
@@ -24,6 +24,9 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
     {
         $allow = array();
         $pathinfo = rawurldecode($pathinfo);
+        $isPathMissingTrailingSlash = substr($pathinfo, -1) !== '/';
+        $pathWithTrailingSlash = $isPathMissingTrailingSlash ? $pathinfo.'/' : $pathinfo;
+        $pathWithoutTrailingSlash = rtrim($pathinfo, '/');
 
         // foo
         if (0 === strpos($pathinfo, '/foo') && preg_match('#^/foo/(?P<bar>baz|symfony)$#s', $pathinfo, $matches)) {
@@ -68,9 +71,9 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                 }
 
                 // baz3
-                if (rtrim($pathinfo, '/') === '/test/baz3') {
-                    if (substr($pathinfo, -1) !== '/') {
-                        return $this->redirect($pathinfo.'/', 'baz3');
+                if ($pathWithoutTrailingSlash === '/test/baz3') {
+                    if ($isPathMissingTrailingSlash) {
+                        return $this->redirect($pathWithTrailingSlash, 'baz3');
                     }
 
                     return array('_route' => 'baz3');
@@ -80,8 +83,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
             // baz4
             if (preg_match('#^/test/(?P<foo>[^/]++)/?$#s', $pathinfo, $matches)) {
-                if (substr($pathinfo, -1) !== '/') {
-                    return $this->redirect($pathinfo.'/', 'baz4');
+                if ($isPathMissingTrailingSlash) {
+                    return $this->redirect($pathWithTrailingSlash, 'baz4');
                 }
 
                 return $this->mergeDefaults(array_replace($matches, array('_route' => 'baz4')), array ());
@@ -172,9 +175,9 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
             }
 
             // hey
-            if (rtrim($pathinfo, '/') === '/multi/hey') {
-                if (substr($pathinfo, -1) !== '/') {
-                    return $this->redirect($pathinfo.'/', 'hey');
+            if ($pathWithoutTrailingSlash === '/multi/hey') {
+                if ($isPathMissingTrailingSlash) {
+                    return $this->redirect($pathWithTrailingSlash, 'hey');
                 }
 
                 return array('_route' => 'hey');

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
@@ -24,8 +24,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
     {
         $allow = array();
         $pathinfo = rawurldecode($pathinfo);
-        $isPathMissingTrailingSlash = substr($pathinfo, -1) !== '/';
-        $pathWithTrailingSlash = $isPathMissingTrailingSlash ? $pathinfo.'/' : $pathinfo;
         $pathWithoutTrailingSlash = rtrim($pathinfo, '/');
 
         if (0 === strpos($pathinfo, '/rootprefix')) {

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
@@ -24,6 +24,9 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
     {
         $allow = array();
         $pathinfo = rawurldecode($pathinfo);
+        $isPathMissingTrailingSlash = substr($pathinfo, -1) !== '/';
+        $pathWithTrailingSlash = $isPathMissingTrailingSlash ? $pathinfo.'/' : $pathinfo;
+        $pathWithoutTrailingSlash = rtrim($pathinfo, '/');
 
         if (0 === strpos($pathinfo, '/rootprefix')) {
             // static


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12099 |
| License | MIT |
| Doc PR | - |

I know that micro-optimizations are controversial. If you don't agree with it, feel free to close it.

---

The PHP code used to match URLs to routes repeats this structure a lot of times:

``` php
if (rtrim($pathinfo, '/') === '...') {
    if (substr($pathinfo, -1) !== '/') {
        return $this->redirect($pathinfo.'/', '...');
    }

    // ...
}
```

We could improve this code by introducing 3 variables that are calculated only once:

``` php
$isPathMissingTrailingSlash = substr($pathinfo, -1) !== '/';
$pathWithTrailingSlash = $isPathMissingTrailingSlash ? $pathinfo.'/' : $pathinfo;
$pathWithoutTrailingSlash = rtrim($pathinfo, '/');
```

Then the previous structure stops performing the same operations once and again:

``` php
if ($pathWithoutTrailingSlash === '...') {
    if ($isPathMissingTrailingSlash) {
        return $this->redirect($pathWithTrailingSlash, '...');
    }

    // ...
}
```

---

For other use cases this micro-optimization would be useless. But it could be worth for UrlMatcher because it is a critical piece of Symfony and it's executed for every request.
