### PR TITLE
remove obsolete apcu polyfill

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,6 @@
         "doctrine/common": "~2.4",
         "twig/twig": "~1.23|~2.0",
         "psr/log": "~1.0",
-        "symfony/security-acl": "~2.7",
-        "symfony/polyfill-apcu": "~1.0,>=1.0.2",
         "symfony/polyfill-intl-icu": "~1.0",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/polyfill-php56": "~1.0",

--- a/src/Symfony/Component/ClassLoader/Tests/ApcClassLoaderTest.php
+++ b/src/Symfony/Component/ClassLoader/Tests/ApcClassLoaderTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\ClassLoader\ApcClassLoader;
 use Symfony\Component\ClassLoader\ClassLoader;
 
 /**
- * @requires extension apc
+ * @requires extension apcu
  */
 class ApcClassLoaderTest extends \PHPUnit_Framework_TestCase
 {

--- a/src/Symfony/Component/ClassLoader/composer.json
+++ b/src/Symfony/Component/ClassLoader/composer.json
@@ -17,8 +17,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.5.9",
-        "symfony/polyfill-apcu": "~1.0,>=1.0.2"
+        "php": ">=5.5.9"
     },
     "require-dev": {
         "symfony/finder": "~2.8|~3.0"


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

As @gapple pointed out in #17396

> APC is PHP <=5.4, so symfony/polyfill-apcu shouldn't be a dependency on 3.0 or master
