### PR TITLE
Escape the delimiter in Glob::toRegex

### DIFF
--- a/src/Symfony/Component/Finder/Glob.php
+++ b/src/Symfony/Component/Finder/Glob.php
@@ -66,7 +66,7 @@ class Glob
                 $firstByte = true;
             }
 
-            if ('.' === $car || '(' === $car || ')' === $car || '|' === $car || '+' === $car || '^' === $car || '$' === $car) {
+            if ($delimiter === $car || '.' === $car || '(' === $car || ')' === $car || '|' === $car || '+' === $car || '^' === $car || '$' === $car) {
                 $regex .= "\\$car";
             } elseif ('*' === $car) {
                 $regex .= $escaping ? '\\*' : ($strictWildcardSlash ? '[^/]*' : '.*');

--- a/src/Symfony/Component/Finder/Tests/GlobTest.php
+++ b/src/Symfony/Component/Finder/Tests/GlobTest.php
@@ -17,6 +17,7 @@ class GlobTest extends \PHPUnit_Framework_TestCase
 {
     public function testGlobToRegexDelimiters()
     {
+        $this->assertEquals('#^(?=[^\.])\#$#', Glob::toRegex('#'));
         $this->assertEquals('#^\.[^/]*$#', Glob::toRegex('.*'));
         $this->assertEquals('^\.[^/]*$', Glob::toRegex('.*', true, true, ''));
         $this->assertEquals('/^\.[^/]*$/', Glob::toRegex('.*', true, true, '/'));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #13531 |
| License | MIT |
| Doc PR | - |
