### PR TITLE
[Form] Remove unused private method

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -1137,19 +1137,4 @@ class Form implements \IteratorAggregate, FormInterface
 
         return $value;
     }
-
-    /**
-     * Utility function for indenting multi-line strings.
-     *
-     * @param string $string The string
-     * @param int    $level  The number of spaces to use for indentation
-     *
-     * @return string The indented string
-     */
-    private static function indent($string, $level)
-    {
-        $indentation = str_repeat(' ', $level);
-
-        return rtrim($indentation.str_replace("\n", "\n".$indentation, $string), ' ');
-    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | FormValidatorTest::testMissingConstraintIndex() failed, but not relevant |
| Fixed tickets | #1234 |
| License | MIT |
| Doc PR | - |

In 3.0 there is no reference to the private [indent method](https://github.com/symfony/symfony/blob/3.0/src/Symfony/Component/Form/Form.php#L1149).

There was only [one reference in 2.8](https://github.com/symfony/symfony/blob/2.8/src/Symfony/Component/Form/Form.php#L843), but it has been removed.
