### PR TITLE
[Asset] Version as service

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -364,6 +364,7 @@ class Configuration implements ConfigurationInterface
                     ->canBeUnset()
                     ->fixXmlConfig('base_url')
                     ->children()
+                        ->scalarNode('version_strategy')->defaultNull()->end()
                         ->scalarNode('version')->defaultNull()->end()
                         ->scalarNode('version_format')->defaultValue('%%s?%%s')->end()
                         ->scalarNode('base_path')->defaultValue('')->end()
@@ -376,6 +377,12 @@ class Configuration implements ConfigurationInterface
                             ->prototype('scalar')->end()
                         ->end()
                     ->end()
+                    ->validate()
+                        ->ifTrue(function ($v) {
+                            return (null !== $v['version_strategy'] && null !== $v['version']);
+                        })
+                        ->thenInvalid('You cannot use version_strategy and version settings in assets configuration.')
+                    ->end()
                     ->fixXmlConfig('package')
                     ->children()
                         ->arrayNode('packages')
@@ -383,6 +390,7 @@ class Configuration implements ConfigurationInterface
                             ->prototype('array')
                                 ->fixXmlConfig('base_url')
                                 ->children()
+                                    ->scalarNode('version_strategy')->defaultNull()->end()
                                     ->scalarNode('version')->defaultNull()->end()
                                     ->scalarNode('version_format')->defaultNull()->end()
                                     ->scalarNode('base_path')->defaultValue('')->end()
@@ -394,6 +402,12 @@ class Configuration implements ConfigurationInterface
                                         ->end()
                                         ->prototype('scalar')->end()
                                     ->end()
+                                ->end()
+                                ->validate()
+                                    ->ifTrue(function ($v) {
+                                        return (null !== $v['version_strategy'] && null !== $v['version']);
+                                    })
+                                    ->thenInvalid('You cannot use version_strategy and version settings in same package.')
                                 ->end()
                             ->end()
                         ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -407,7 +407,7 @@ class Configuration implements ConfigurationInterface
                                     ->ifTrue(function ($v) {
                                         return (null !== $v['version_strategy'] && null !== $v['version']);
                                     })
-                                    ->thenInvalid('You cannot use both "version_strategy" and "version" at the same time under "assets" for the "%s" package.')
+                                    ->thenInvalid('You cannot use both "version_strategy" and "version" at the same time under "assets" packages.')
                                 ->end()
                             ->end()
                         ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -381,7 +381,7 @@ class Configuration implements ConfigurationInterface
                         ->ifTrue(function ($v) {
                             return (null !== $v['version_strategy'] && null !== $v['version']);
                         })
-                        ->thenInvalid('You cannot use version_strategy and version settings in assets configuration.')
+                        ->thenInvalid('You cannot use both "version_strategy" and "version" at the same time under "assets".')
                     ->end()
                     ->fixXmlConfig('package')
                     ->children()
@@ -407,7 +407,7 @@ class Configuration implements ConfigurationInterface
                                     ->ifTrue(function ($v) {
                                         return (null !== $v['version_strategy'] && null !== $v['version']);
                                     })
-                                    ->thenInvalid('You cannot use version_strategy and version settings in same package.')
+                                    ->thenInvalid('You cannot use both "version_strategy" and "version" at the same time under "assets" for the "%s" package.')
                                 ->end()
                             ->end()
                         ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -576,7 +576,7 @@ class FrameworkExtension extends Extension
         foreach ($config['packages'] as $name => $package) {
             if (null !== $package['version_strategy']) {
                 $version = new Reference($package['version_strategy']);
-            } else if (null === $package['version']) {
+            } elseif (null === $package['version']) {
                 $version = $defaultVersion;
             } else {
                 $format = $package['version_format'] ?: $config['version_format'];

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -561,14 +561,22 @@ class FrameworkExtension extends Extension
     {
         $loader->load('assets.xml');
 
-        $defaultVersion = $this->createVersion($container, $config['version'], $config['version_format'], '_default');
+        $defaultVersion = null;
+
+        if ($config['version_strategy']) {
+            $defaultVersion = new Reference($config['version_strategy']);
+        } else {
+            $defaultVersion = $this->createVersion($container, $config['version'], $config['version_format'], '_default');
+        }
 
         $defaultPackage = $this->createPackageDefinition($config['base_path'], $config['base_urls'], $defaultVersion);
         $container->setDefinition('assets._default_package', $defaultPackage);
 
         $namedPackages = array();
         foreach ($config['packages'] as $name => $package) {
-            if (null === $package['version']) {
+            if (null !== $package['version_strategy']) {
+                $version = new Reference($package['version_strategy']);
+            } else if (null === $package['version']) {
                 $version = $defaultVersion;
             } else {
                 $format = $package['version_format'] ?: $config['version_format'];

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -126,6 +126,7 @@
         </xsd:sequence>
 
         <xsd:attribute name="base-path" type="xsd:string" />
+        <xsd:attribute name="version-strategy" type="xsd:string" />
         <xsd:attribute name="version" type="xsd:string" />
         <xsd:attribute name="version-format" type="xsd:string" />
     </xsd:complexType>
@@ -137,6 +138,7 @@
 
         <xsd:attribute name="name" type="xsd:string" use="required" />
         <xsd:attribute name="base-path" type="xsd:string" />
+        <xsd:attribute name="version-strategy" type="xsd:string" />
         <xsd:attribute name="version" type="xsd:string" />
         <xsd:attribute name="version-format" type="xsd:string" />
     </xsd:complexType>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -139,7 +139,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage  You cannot use both "version_strategy" and "version" at the same time under "assets" for the "{"base_urls":["\/\/example.com"],"version":1,"version_strategy":"foo","version_format":null,"base_path":""}" package.
+     * @expectedExceptionMessage  You cannot use both "version_strategy" and "version" at the same time under "assets" packages.
      */
     public function testInvalidPackageVersionStrategy()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -91,6 +91,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
     {
         $processor = new Processor();
         $configuration = new Configuration(true);
+
         $processor->processConfiguration($configuration, array(
             array(
                 'secret' => 's3cr3t',
@@ -119,46 +120,47 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage You cannot use version_strategy and version settings in assets configuration.
+     * @expectedExceptionMessage You cannot use both "version_strategy" and "version" at the same time under "assets".
      */
     public function testInvalidVersionStrategy()
     {
         $processor = new Processor();
         $configuration = new Configuration(true);
         $processor->processConfiguration($configuration, array(
-                array(
-                    'assets' => array(
-                        'base_urls' => '//example.com',
-                        'version' => 1,
-                        'version_strategy' => 'foo',
-                    ),
+            array(
+                'assets' => array(
+                    'base_urls' => '//example.com',
+                    'version' => 1,
+                    'version_strategy' => 'foo',
                 ),
-            ));
+            ),
+        ));
     }
 
     /**
      * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage You cannot use version_strategy and version settings in same package.
+     * @expectedExceptionMessage  You cannot use both "version_strategy" and "version" at the same time under "assets" for the "{"base_urls":["\/\/example.com"],"version":1,"version_strategy":"foo","version_format":null,"base_path":""}" package.
      */
     public function testInvalidPackageVersionStrategy()
     {
         $processor = new Processor();
         $configuration = new Configuration(true);
+
         $processor->processConfiguration($configuration, array(
-                array(
-                    'assets' => array(
-                        'base_urls' => '//example.com',
-                        'version' => 1,
-                        'packages' => array(
-                            'foo' => array(
-                                'base_urls' => '//example.com',
-                                'version' => 1,
-                                'version_strategy' => 'foo',
-                            ),
+            array(
+                'assets' => array(
+                    'base_urls' => '//example.com',
+                    'version' => 1,
+                    'packages' => array(
+                        'foo' => array(
+                            'base_urls' => '//example.com',
+                            'version' => 1,
+                            'version_strategy' => 'foo',
                         ),
                     ),
                 ),
-            ));
+            ),
+        ));
     }
 
     protected static function getBundleDefaultConfig()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -106,6 +106,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $config = $processor->processConfiguration($configuration, array(array('assets' => null)));
 
         $defaultConfig = array(
+            'version_strategy' => null,
             'version' => null,
             'version_format' => '%%s?%%s',
             'base_path' => '',
@@ -114,6 +115,50 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals($defaultConfig, $config['assets']);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage You cannot use version_strategy and version settings in assets configuration.
+     */
+    public function testInvalidVersionStrategy()
+    {
+        $processor = new Processor();
+        $configuration = new Configuration(true);
+        $processor->processConfiguration($configuration, array(
+                array(
+                    'assets' => array(
+                        'base_urls' => '//example.com',
+                        'version' => 1,
+                        'version_strategy' => 'foo',
+                    ),
+                ),
+            ));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage You cannot use version_strategy and version settings in same package.
+     */
+    public function testInvalidPackageVersionStrategy()
+    {
+        $processor = new Processor();
+        $configuration = new Configuration(true);
+        $processor->processConfiguration($configuration, array(
+                array(
+                    'assets' => array(
+                        'base_urls' => '//example.com',
+                        'version' => 1,
+                        'packages' => array(
+                            'foo' => array(
+                                'base_urls' => '//example.com',
+                                'version' => 1,
+                                'version_strategy' => 'foo',
+                            ),
+                        ),
+                    ),
+                ),
+            ));
     }
 
     protected static function getBundleDefaultConfig()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/assets.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/assets.php
@@ -20,6 +20,10 @@ $container->loadFromExtension('framework', array(
             'bar' => array(
                 'base_urls' => array('https://bar2.example.com'),
             ),
+            'bar_version_strategy' => array(
+                'base_urls' => array('https://bar2.example.com'),
+                'version_strategy' => 'assets.custom_version_strategy',
+            ),
         ),
     ),
 ));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/assets_version_strategy_as_service.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/assets_version_strategy_as_service.php
@@ -1,0 +1,8 @@
+<?php
+
+$container->loadFromExtension('framework', array(
+    'assets' => array(
+        'version_strategy' => 'assets.custom_version_strategy',
+        'base_urls' => 'http://cdn.example.com',
+    ),
+));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/assets.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/assets.xml
@@ -18,6 +18,9 @@
             <framework:package name="bar">
                 <framework:base-url>https://bar2.example.com</framework:base-url>
             </framework:package>
+            <framework:package name="bar_version_strategy" version-strategy="assets.custom_version_strategy">
+                <framework:base-url>https://bar_version_strategy.example.com</framework:base-url>
+            </framework:package>
         </framework:assets>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/assets_version_strategy_as_service.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/assets_version_strategy_as_service.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+        <framework:assets version-strategy="assets.custom_version_strategy">
+            <framework:base-url>http://cdn.example.com</framework:base-url>
+        </framework:assets>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/assets.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/assets.yml
@@ -14,3 +14,6 @@ framework:
                 version_format: %%s-%%s
             bar:
                 base_urls: ["https://bar2.example.com"]
+            bar_version_strategy:
+                base_urls: ["https://bar_version_strategy.example.com"]
+                version_strategy: assets.custom_version_strategy

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/assets_version_strategy_as_service.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/assets_version_strategy_as_service.yml
@@ -1,0 +1,4 @@
+framework:
+    assets:
+        version_strategy: assets.custom_version_strategy
+        base_urls: http://cdn.example.com

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -209,7 +209,7 @@ abstract class FrameworkExtensionTest extends TestCase
 
         // packages
         $packages = $packages->getArgument(1);
-        $this->assertCount(4, $packages);
+        $this->assertCount(5, $packages);
 
         $package = $container->getDefinition($packages['images_path']);
         $this->assertPathPackage($container, $package, '/foo', 'SomeVersionScheme', '%%s?version=%%s');
@@ -222,6 +222,19 @@ abstract class FrameworkExtensionTest extends TestCase
 
         $package = $container->getDefinition($packages['bar']);
         $this->assertUrlPackage($container, $package, array('https://bar2.example.com'), 'SomeVersionScheme', '%%s?version=%%s');
+
+        $package = $container->getDefinition($packages['bar_version_strategy']);
+        $this->assertEquals('assets.custom_version_strategy', (string) $package->getArgument(1));
+    }
+
+    public function testAssetsDefaultVersionStrategyAsService()
+    {
+        $container = $this->createContainerFromFile('assets_version_strategy_as_service');
+        $packages = $container->getDefinition('assets.packages');
+
+        // default package
+        $defaultPackage = $container->getDefinition($packages->getArgument(0));
+        $this->assertEquals('assets.custom_version_strategy', (string) $defaultPackage->getArgument(1));
     }
 
     public function testTranslator()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

While I working on #14832 I realize that all this problems and hidden magic can be avoided, if we will have ability to set asset version strategy as service.

This PR implementation of this idea.

Now it is possible to do something like this:

``` yaml
framework:
    assets:
        version_strategy: assets.custom_version_strategy
        base_urls: http://cdn.example.com
        packages:
            foo:
                base_urls: ["https://example.com"]
                version_strategy: assets.custom_version_strategy        
```

There is can be some conflicts with #16511 when it will be in master
