### PR TITLE
Increase the inlining YAML level for config:debug

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
@@ -85,7 +85,7 @@ EOF
             $io->title(sprintf('Current configuration for "%s"', $name));
         }
 
-        $io->writeln(Yaml::dump(array($extension->getAlias() => $config), 6));
+        $io->writeln(Yaml::dump(array($extension->getAlias() => $config), 10));
     }
 
     private function compileContainer()

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
@@ -85,7 +85,7 @@ EOF
             $io->title(sprintf('Current configuration for "%s"', $name));
         }
 
-        $io->writeln(Yaml::dump(array($extension->getAlias() => $config), 3));
+        $io->writeln(Yaml::dump(array($extension->getAlias() => $config), 6));
     }
 
     private function compileContainer()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16882 |
| License | MIT |
| Doc PR | - |
### Before

![debug_before](https://cloud.githubusercontent.com/assets/73419/12575512/52862d3c-c40d-11e5-9bc9-45e24c14b6e2.png)
### After

![debug_after](https://cloud.githubusercontent.com/assets/73419/12575515/5607b868-c40d-11e5-9578-5f004e4ad8df.png)

The new `6` number is completely arbitrary. I chose it because it's the minimum level that makes all the default Symfony services look right. I'm open to better recommendations.
