### PR TITLE
[Filesystem] Added 2 new methods, isDir() and isFile().

### DIFF
--- a/src/Symfony/Component/Filesystem/CHANGELOG.md
+++ b/src/Symfony/Component/Filesystem/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * removed `$mode` argument from `Filesystem::dumpFile()`
+ * added isDir() and isFile() methods
 
 2.8.0
 -----

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -577,6 +577,7 @@ class Filesystem
 
     /**
      * Checks if given path is a file.
+     *
      * @param string $path
      *
      * @return bool

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -37,14 +37,14 @@ class Filesystem
      */
     public function copy($originFile, $targetFile, $override = false)
     {
-        if (stream_is_local($originFile) && !is_file($originFile)) {
+        if (stream_is_local($originFile) && !$this->isFile($originFile)) {
             throw new FileNotFoundException(sprintf('Failed to copy "%s" because file does not exist.', $originFile), 0, null, $originFile);
         }
 
         $this->mkdir(dirname($targetFile));
 
         $doCopy = true;
-        if (!$override && null === parse_url($originFile, PHP_URL_HOST) && is_file($targetFile)) {
+        if (!$override && null === parse_url($originFile, PHP_URL_HOST) && $this->isFile($targetFile)) {
             $doCopy = filemtime($originFile) > filemtime($targetFile);
         }
 
@@ -64,7 +64,7 @@ class Filesystem
             fclose($target);
             unset($source, $target);
 
-            if (!is_file($targetFile)) {
+            if (!$this->isFile($targetFile)) {
                 throw new IOException(sprintf('Failed to copy "%s" to "%s".', $originFile, $targetFile), 0, null, $originFile);
             }
 
@@ -88,13 +88,13 @@ class Filesystem
     public function mkdir($dirs, $mode = 0777)
     {
         foreach ($this->toIterator($dirs) as $dir) {
-            if (is_dir($dir)) {
+            if ($this->isDir($dir)) {
                 continue;
             }
 
             if (true !== @mkdir($dir, $mode, true)) {
                 $error = error_get_last();
-                if (!is_dir($dir)) {
+                if (!$this->isDir($dir)) {
                     // The directory was not created by a concurrent process. Let's throw an exception with a developer friendly error message if we have one
                     if ($error) {
                         throw new IOException(sprintf('Failed to create "%s": %s.', $dir, $error['message']), 0, null, $dir);
@@ -158,7 +158,7 @@ class Filesystem
                 continue;
             }
 
-            if (is_dir($file) && !is_link($file)) {
+            if ($this->isDir($file) && !is_link($file)) {
                 $this->remove(new \FilesystemIterator($file));
 
                 if (true !== @rmdir($file)) {
@@ -166,7 +166,7 @@ class Filesystem
                 }
             } else {
                 // https://bugs.php.net/bug.php?id=52176
-                if ('\\' === DIRECTORY_SEPARATOR && is_dir($file)) {
+                if ('\\' === DIRECTORY_SEPARATOR && $this->isDir($file)) {
                     if (true !== @rmdir($file)) {
                         throw new IOException(sprintf('Failed to remove file "%s".', $file), 0, null, $file);
                     }
@@ -195,7 +195,7 @@ class Filesystem
             if (true !== @chmod($file, $mode & ~$umask)) {
                 throw new IOException(sprintf('Failed to chmod file "%s".', $file), 0, null, $file);
             }
-            if ($recursive && is_dir($file) && !is_link($file)) {
+            if ($recursive && $this->isDir($file) && !is_link($file)) {
                 $this->chmod(new \FilesystemIterator($file), $mode, $umask, true);
             }
         }
@@ -213,7 +213,7 @@ class Filesystem
     public function chown($files, $user, $recursive = false)
     {
         foreach ($this->toIterator($files) as $file) {
-            if ($recursive && is_dir($file) && !is_link($file)) {
+            if ($recursive && $this->isDir($file) && !is_link($file)) {
                 $this->chown(new \FilesystemIterator($file), $user, true);
             }
             if (is_link($file) && function_exists('lchown')) {
@@ -240,7 +240,7 @@ class Filesystem
     public function chgrp($files, $group, $recursive = false)
     {
         foreach ($this->toIterator($files) as $file) {
-            if ($recursive && is_dir($file) && !is_link($file)) {
+            if ($recursive && $this->isDir($file) && !is_link($file)) {
                 $this->chgrp(new \FilesystemIterator($file), $group, true);
             }
             if (is_link($file) && function_exists('lchgrp')) {
@@ -413,9 +413,9 @@ class Filesystem
             $target = str_replace($originDir, $targetDir, $file->getPathname());
 
             if ($copyOnWindows) {
-                if (is_link($file) || is_file($file)) {
+                if (is_link($file) || $this->isFile($file)) {
                     $this->copy($file, $target, isset($options['override']) ? $options['override'] : false);
-                } elseif (is_dir($file)) {
+                } elseif ($this->isDir($file)) {
                     $this->mkdir($target);
                 } else {
                     throw new IOException(sprintf('Unable to guess "%s" file type.', $file), 0, null, $file);
@@ -423,9 +423,9 @@ class Filesystem
             } else {
                 if (is_link($file)) {
                     $this->symlink($file->getLinkTarget(), $target);
-                } elseif (is_dir($file)) {
+                } elseif ($this->isDir($file)) {
                     $this->mkdir($target);
-                } elseif (is_file($file)) {
+                } elseif ($this->isFile($file)) {
                     $this->copy($file, $target, isset($options['override']) ? $options['override'] : false);
                 } else {
                     throw new IOException(sprintf('Unable to guess "%s" file type.', $file), 0, null, $file);
@@ -516,7 +516,7 @@ class Filesystem
     {
         $dir = dirname($filename);
 
-        if (!is_dir($dir)) {
+        if (!$this->isDir($dir)) {
             $this->mkdir($dir);
         } elseif (!is_writable($dir)) {
             throw new IOException(sprintf('Unable to write to the "%s" directory.', $dir), 0, null, $dir);
@@ -561,5 +561,28 @@ class Filesystem
         $components = explode('://', $filename, 2);
 
         return 2 === count($components) ? array($components[0], $components[1]) : array(null, $components[0]);
+    }
+
+    /**
+     * Checks if given path is a directory.
+     *
+     * @param string $path Path to test
+     *
+     * @return bool
+     */
+    public function isDir($path)
+    {
+        return is_dir($path);
+    }
+
+    /**
+     * Checks if given path is a file.
+     * @param string $path
+     *
+     * @return bool
+     */
+    public function isFile($path)
+    {
+        return is_file($path);
     }
 }

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -16,6 +16,18 @@ namespace Symfony\Component\Filesystem\Tests;
  */
 class FilesystemTest extends FilesystemTestCase
 {
+    public function testIsDir()
+    {
+        $this->assertFalse($this->filesystem->isDir(__FILE__));
+        $this->assertTrue($this->filesystem->isDir(__DIR__));
+    }
+
+    public function testIsFile()
+    {
+        $this->assertTrue($this->filesystem->isFile(__FILE__));
+        $this->assertFalse($this->filesystem->isFile(__DIR__));
+    }
+
     public function testCopyCreatesNewFile()
     {
         $sourceFilePath = $this->workspace.DIRECTORY_SEPARATOR.'copy_source_file';


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Those 2 methods are checking if a given path is a directory or a file.

Since we are using Symfony Filesystem component to decouple filesystem from our code, I felt those 2 methods are missing and should be there. People should use them in their code, and then they will be able to mock filesystem dependency in their tests completely.
