### PR TITLE
[WebProfilerBundle] Don't inherit CSS text-transform property for the toolbar.

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -45,6 +45,7 @@
     position: fixed;
     right: 0;
     text-align: left;
+    text-transform: none;
     z-index: 99999;
 }
 .sf-toolbarreset abbr {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

When the `body` element has the CSS rule `text-transform: uppercase`, this is also applied to the toolbar.
We could add a style to prevent that from happening but would mean the CSS is now writing rules for a framework's dev tools.

Given the information in the toolbar may be case-sensitive, best thing to prevent text transformations by explicitly declaring `text-transform: none`.

![symfony-toolbar-very-shouty](https://cloud.githubusercontent.com/assets/5972864/12579702/cdaebcf4-c421-11e5-8300-e858f85beb26.png)
