### PR TITLE
[Serializer] Add normalizer / denormalizer awarness

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -17,14 +17,18 @@ use Symfony\Component\Serializer\Exception\RuntimeException;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\Mapping\AttributeMetadataInterface;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
+use Symfony\Component\Serializer\SerializerAwareInterface;
+use Symfony\Component\Serializer\SerializerAwareTrait;
 
 /**
  * Normalizer implementation.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-abstract class AbstractNormalizer extends SerializerAwareNormalizer implements NormalizerInterface, DenormalizerInterface
+abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerInterface, SerializerAwareInterface
 {
+    use SerializerAwareTrait;
+
     const CIRCULAR_REFERENCE_LIMIT = 'circular_reference_limit';
     const OBJECT_TO_POPULATE = 'object_to_populate';
     const GROUPS = 'groups';

--- a/src/Symfony/Component/Serializer/Normalizer/CustomNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/CustomNormalizer.php
@@ -11,11 +11,16 @@
 
 namespace Symfony\Component\Serializer\Normalizer;
 
+use Symfony\Component\Serializer\SerializerAwareInterface;
+use Symfony\Component\Serializer\SerializerAwareTrait;
+
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
-class CustomNormalizer extends SerializerAwareNormalizer implements NormalizerInterface, DenormalizerInterface
+class CustomNormalizer implements NormalizerInterface, DenormalizerInterface, SerializerAwareInterface
 {
+    use SerializerAwareTrait;
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizerAwareInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizerAwareInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Normalizer;
+
+/**
+ * Class accepting a denormalizer.
+ *
+ * @author Joel Wurtz <joel.wurtz@gmail.com>
+ */
+interface DenormalizerAwareInterface
+{
+    /**
+     * Sets the owning Denormalizer object.
+     *
+     * @param DenormalizerInterface $denormalizer
+     */
+    public function setDenormalizer(DenormalizerInterface $denormalizer);
+}

--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizerAwareTrait.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizerAwareTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Normalizer;
+
+/**
+ * DenormalizerAware trait.
+ *
+ * @author Joel Wurtz <joel.wurtz@gmail.com>
+ */
+trait DenormalizerAwareTrait
+{
+    /**
+     * @var DenormalizerInterface
+     */
+    protected $denormalizer;
+
+    /**
+     * Sets the Denormalizer.
+     *
+     * @param DenormalizerInterface $denormalizer A DenormalizerInterface instance
+     */
+    public function setSerializer(DenormalizerInterface $denormalizer)
+    {
+        $this->denormalizer = $denormalizer;
+    }
+}

--- a/src/Symfony/Component/Serializer/Normalizer/NormalizerAwareInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizerAwareInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Normalizer;
+
+/**
+ * Class accepting a normalizer.
+ *
+ * @author Joel Wurtz <joel.wurtz@gmail.com>
+ */
+interface NormalizerAwareInterface
+{
+    /**
+     * Sets the owning Normalizer object.
+     *
+     * @param NormalizerInterface $normalizer
+     */
+    public function setNormalizer(NormalizerInterface $normalizer);
+}

--- a/src/Symfony/Component/Serializer/Normalizer/NormalizerAwareTrait.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizerAwareTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Normalizer;
+
+/**
+ * NormalizerAware trait.
+ *
+ * @author Joel Wurtz <joel.wurtz@gmail.com>
+ */
+trait NormalizerAwareTrait
+{
+    /**
+     * @var NormalizerInterface
+     */
+    protected $normalizer;
+
+    /**
+     * Sets the normalizer.
+     *
+     * @param NormalizerInterface $normalizer A NormalizerInterface instance
+     */
+    public function setSerializer(NormalizerInterface $normalizer)
+    {
+        $this->normalizer = $normalizer;
+    }
+}

--- a/src/Symfony/Component/Serializer/Normalizer/SerializerAwareNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/SerializerAwareNormalizer.php
@@ -11,26 +11,17 @@
 
 namespace Symfony\Component\Serializer\Normalizer;
 
-use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Serializer\SerializerAwareTrait;
 use Symfony\Component\Serializer\SerializerAwareInterface;
 
 /**
  * SerializerAware Normalizer implementation.
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * @deprecated since version 3.1, to be removed in 4.0. Use the SerializerAwareTrait instead.
  */
 abstract class SerializerAwareNormalizer implements SerializerAwareInterface
 {
-    /**
-     * @var SerializerInterface
-     */
-    protected $serializer;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setSerializer(SerializerInterface $serializer)
-    {
-        $this->serializer = $serializer;
-    }
+    use SerializerAwareTrait;
 }

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -15,6 +15,8 @@ use Symfony\Component\Serializer\Encoder\ChainDecoder;
 use Symfony\Component\Serializer\Encoder\ChainEncoder;
 use Symfony\Component\Serializer\Encoder\EncoderInterface;
 use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Exception\LogicException;
@@ -67,6 +69,14 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
         foreach ($normalizers as $normalizer) {
             if ($normalizer instanceof SerializerAwareInterface) {
                 $normalizer->setSerializer($this);
+            }
+
+            if ($normalizer instanceof DenormalizerAwareInterface) {
+                $normalizer->setDenormalizer($this);
+            }
+
+            if ($normalizer instanceof NormalizerAwareInterface) {
+                $normalizer->setNormalizer($this);
             }
         }
         $this->normalizers = $normalizers;

--- a/src/Symfony/Component/Serializer/SerializerAwareTrait.php
+++ b/src/Symfony/Component/Serializer/SerializerAwareTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer;
+
+/**
+ * SerializerAware trait.
+ *
+ * @author Joel Wurtz <joel.wurtz@gmail.com>
+ */
+trait SerializerAwareTrait
+{
+    /**
+     * @var SerializerInterface
+     */
+    protected $serializer;
+
+    /**
+     * Sets the serializer.
+     *
+     * @param SerializerInterface $serializer A SerializerInterface instance
+     */
+    public function setSerializer(SerializerInterface $serializer)
+    {
+        $this->serializer = $serializer;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -12,6 +12,10 @@
 namespace Symfony\Component\Serializer\Tests;
 
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
 use Symfony\Component\Serializer\Serializer;
@@ -311,6 +315,26 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
             $expectedData,
             $serializer->deserialize($jsonData, __NAMESPACE__.'\Model[]', 'json')
         );
+    }
+
+    public function testNormalizerAware()
+    {
+        $normalizerAware = $this->getMock(NormalizerAwareInterface::class);
+        $normalizerAware->expects($this->once())
+            ->method('setNormalizer')
+            ->with($this->isInstanceOf(NormalizerInterface::class));
+
+        new Serializer([$normalizerAware]);
+    }
+
+    public function testDenormalizerAware()
+    {
+        $denormalizerAware = $this->getMock(DenormalizerAwareInterface::class);
+        $denormalizerAware->expects($this->once())
+            ->method('setDenormalizer')
+            ->with($this->isInstanceOf(DenormalizerInterface::class));
+
+        new Serializer([$denormalizerAware]);
     }
 }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

SerializerAwareInterface is not really usable in a decode -> normalize context, as if we need to transform a subproperty with another class, we only have the context of a serialize however the data is already decoded so it will fail.

This interfaces allow a normalizer / denormalizer to have a sub normalization / denormalization process context and not the whole context with serializer.

I have also add a `AwareNormalizer` which is an abstract class implementing the 3 aware interfaces like it was done with the SerializerAwareNormalizer, since it's a standard way to implement this interfaces.

This is needed for #17516, other solution would be to have a RawDecoder which don't decode and return the input as it is, but really not a fan of this solution.
