### PR TITLE
[CSS] Remove duplicate cursor property

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -59,7 +59,6 @@
 
 .sf-toolbarreset .hide-button {
     background: #444;
-    cursor: pointer;
     display: block;
     position: absolute;
     top: 0;


### PR DESCRIPTION
The "cursor: pointer;" property was present 2 times in the css class.
