### PR TITLE
[Validator] Added a format option to the DateTime constraint.

### DIFF
--- a/UPGRADE-3.1.md
+++ b/UPGRADE-3.1.md
@@ -112,3 +112,9 @@ Yaml
 
  * The `!!php/object` tag to indicate dumped PHP objects has been deprecated
    and will be removed in Symfony 4.0. Use the `!php/object` tag instead.
+
+Validator
+---------
+
+ * The `DateTimeValidator::PATTERN` constant is deprecated and will be removed in
+   Symfony 4.0.

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -109,3 +109,8 @@ Yaml
 
  * The `!!php/object` tag to indicate dumped PHP objects was removed in favor of
    the `!php/object` tag.
+
+Validator
+---------
+
+ * The `DateTimeValidator::PATTERN` constant was removed.

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+3.1.0
+-----
+
+ * deprecated `DateTimeValidator::PATTERN` constant
+ * added a `format` option to the `DateTime` constraint
+
 2.8.0
 -----
 

--- a/src/Symfony/Component/Validator/Constraints/DateTime.php
+++ b/src/Symfony/Component/Validator/Constraints/DateTime.php
@@ -31,5 +31,6 @@ class DateTime extends Constraint
         self::INVALID_TIME_ERROR => 'INVALID_TIME_ERROR',
     );
 
+    public $format = 'Y-m-d H:i:s';
     public $message = 'This value is not a valid datetime.';
 }

--- a/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
@@ -16,9 +16,13 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
+ * @author Diego Saint Esteben <diego@saintesteben.me>
  */
 class DateTimeValidator extends DateValidator
 {
+    /**
+     * @deprecated since version 3.1, to be removed in 4.0.
+     */
     const PATTERN = '/^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})$/';
 
     /**
@@ -40,7 +44,11 @@ class DateTimeValidator extends DateValidator
 
         $value = (string) $value;
 
-        if (!preg_match(static::PATTERN, $value, $matches)) {
+        \DateTime::createFromFormat($constraint->format, $value);
+
+        $errors = \DateTime::getLastErrors();
+
+        if (0 < $errors['error_count']) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $this->formatValue($value))
                 ->setCode(DateTime::INVALID_FORMAT_ERROR)
@@ -49,18 +57,23 @@ class DateTimeValidator extends DateValidator
             return;
         }
 
-        if (!DateValidator::checkDate($matches[1], $matches[2], $matches[3])) {
-            $this->context->buildViolation($constraint->message)
-                ->setParameter('{{ value }}', $this->formatValue($value))
-                ->setCode(DateTime::INVALID_DATE_ERROR)
-                ->addViolation();
-        }
-
-        if (!TimeValidator::checkTime($matches[4], $matches[5], $matches[6])) {
-            $this->context->buildViolation($constraint->message)
-                ->setParameter('{{ value }}', $this->formatValue($value))
-                ->setCode(DateTime::INVALID_TIME_ERROR)
-                ->addViolation();
+        foreach ($errors['warnings'] as $warning) {
+            if ('The parsed date was invalid' === $warning) {
+                $this->context->buildViolation($constraint->message)
+                    ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(DateTime::INVALID_DATE_ERROR)
+                    ->addViolation();
+            } elseif ('The parsed time was invalid' === $warning) {
+                $this->context->buildViolation($constraint->message)
+                    ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(DateTime::INVALID_TIME_ERROR)
+                    ->addViolation();
+            } else {
+                $this->context->buildViolation($constraint->message)
+                    ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setCode(DateTime::INVALID_FORMAT_ERROR)
+                    ->addViolation();
+            }
         }
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
@@ -50,12 +50,30 @@ class DateTimeValidatorTest extends AbstractConstraintValidatorTest
         $this->validator->validate(new \stdClass(), new DateTime());
     }
 
+    public function testDateTimeWithDefaultFormat()
+    {
+        $this->validator->validate('1995-05-10 19:33:00', new DateTime());
+
+        $this->assertNoViolation();
+
+        $this->validator->validate('1995-03-24', new DateTime());
+
+        $this->buildViolation('This value is not a valid datetime.')
+            ->setParameter('{{ value }}', '"1995-03-24"')
+            ->setCode(DateTime::INVALID_FORMAT_ERROR)
+            ->assertRaised();
+    }
+
     /**
      * @dataProvider getValidDateTimes
      */
-    public function testValidDateTimes($dateTime)
+    public function testValidDateTimes($format, $dateTime)
     {
-        $this->validator->validate($dateTime, new DateTime());
+        $constraint = new DateTime(array(
+            'format' => $format,
+        ));
+
+        $this->validator->validate($dateTime, $constraint);
 
         $this->assertNoViolation();
     }
@@ -63,19 +81,22 @@ class DateTimeValidatorTest extends AbstractConstraintValidatorTest
     public function getValidDateTimes()
     {
         return array(
-            array('2010-01-01 01:02:03'),
-            array('1955-12-12 00:00:00'),
-            array('2030-05-31 23:59:59'),
+            array('Y-m-d H:i:s e', '1995-03-24 00:00:00 UTC'),
+            array('Y-m-d H:i:s', '2010-01-01 01:02:03'),
+            array('Y/m/d H:i', '2010/01/01 01:02'),
+            array('F d, Y', 'December 31, 1999'),
+            array('d-m-Y', '10-05-1995'),
         );
     }
 
     /**
      * @dataProvider getInvalidDateTimes
      */
-    public function testInvalidDateTimes($dateTime, $code)
+    public function testInvalidDateTimes($format, $dateTime, $code)
     {
         $constraint = new DateTime(array(
             'message' => 'myMessage',
+            'format' => $format,
         ));
 
         $this->validator->validate($dateTime, $constraint);
@@ -89,16 +110,16 @@ class DateTimeValidatorTest extends AbstractConstraintValidatorTest
     public function getInvalidDateTimes()
     {
         return array(
-            array('foobar', DateTime::INVALID_FORMAT_ERROR),
-            array('2010-01-01', DateTime::INVALID_FORMAT_ERROR),
-            array('00:00:00', DateTime::INVALID_FORMAT_ERROR),
-            array('2010-01-01 00:00', DateTime::INVALID_FORMAT_ERROR),
-            array('2010-13-01 00:00:00', DateTime::INVALID_DATE_ERROR),
-            array('2010-04-32 00:00:00', DateTime::INVALID_DATE_ERROR),
-            array('2010-02-29 00:00:00', DateTime::INVALID_DATE_ERROR),
-            array('2010-01-01 24:00:00', DateTime::INVALID_TIME_ERROR),
-            array('2010-01-01 00:60:00', DateTime::INVALID_TIME_ERROR),
-            array('2010-01-01 00:00:60', DateTime::INVALID_TIME_ERROR),
+            array('Y-m-d', 'foobar', DateTime::INVALID_FORMAT_ERROR),
+            array('H:i', '00:00:00', DateTime::INVALID_FORMAT_ERROR),
+            array('Y-m-d', '2010-01-01 00:00', DateTime::INVALID_FORMAT_ERROR),
+            array('Y-m-d e', '2010-01-01 TCU', DateTime::INVALID_FORMAT_ERROR),
+            array('Y-m-d H:i:s', '2010-13-01 00:00:00', DateTime::INVALID_DATE_ERROR),
+            array('Y-m-d H:i:s', '2010-04-32 00:00:00', DateTime::INVALID_DATE_ERROR),
+            array('Y-m-d H:i:s', '2010-02-29 00:00:00', DateTime::INVALID_DATE_ERROR),
+            array('Y-m-d H:i:s', '2010-01-01 24:00:00', DateTime::INVALID_TIME_ERROR),
+            array('Y-m-d H:i:s', '2010-01-01 00:60:00', DateTime::INVALID_TIME_ERROR),
+            array('Y-m-d H:i:s', '2010-01-01 00:00:60', DateTime::INVALID_TIME_ERROR),
         );
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #14521 |
| License | MIT |

This PR adds a `format` option to the `DateTime` constraint, this allows to validate dates in custom formats, for example:

``` php
use Symfony\Component\Validator\Constraints\DateTime;
use Symfony\Component\Validator\Validation;

$validator = Validation::createValidator();

$validator->validate('December 31, 1999', new DateTime(['format' => 'F d, Y']));
$validator->validate('01:02:03', new DateTime(['format' => 'H:i:s']));
$validator->validate('2010/01/01 01:02', new DateTime(['format' => 'Y/m/d H:i']));
```

As you can see this new option allows to use the `DateTime` constraint to validate dates and times, so, maybe the `Date` and `Time` constraints can be deprecated in this PR.
