### PR TITLE
[SecurityBundle] Fix HTTP Digest auth not being passed user checker

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpDigestFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpDigestFactory.php
@@ -29,6 +29,7 @@ class HttpDigestFactory implements SecurityFactoryInterface
         $container
             ->setDefinition($provider, new DefinitionDecorator('security.authentication.provider.dao'))
             ->replaceArgument(0, new Reference($userProvider))
+            ->replaceArgument(1, new Reference('security.user_checker.'.$id))
             ->replaceArgument(2, $id)
         ;
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Wasn't sure if this was a bug so posted here http://stackoverflow.com/q/35022776/727236. However, after comparing the 2.3 branch and 2.8 branch I think it was a bug.

When trying to use `http_digest` on Symfony 2.8 you're greeted with the error `Argument 2 passed to Symfony\Component\Security\Core\Authentication\Provider\DaoAuthenticationProvider::__construct() must be an instance of Symfony\Component\Security\Core\User\UserCheckerInterface`. 

The exact same `security.yml` works fine on v2.3.37.  

Comparing the branches for the SecurityBundle I found that commit 05be5da1710ab681a04334d58126f8c3d431e3cb added the ability to configure a user checker on a per firewall basis. It seems that this commit seems to have missed updating the HttpDigestFactory (although it did update the other factories such as the [HttpBasicFactory](https://github.com/symfony/security-bundle/commit/05be5da1710ab681a04334d58126f8c3d431e3cb#diff-5f3e10fcc9de40dd09a8f3df3bdc9316)).

Testing this in my Symfony 2.8 app now works. However, I haven't been able to figure out what unit tests to write confirming this, does anyone with more experience on the SecurityBundle have any pointers?
