### PR TITLE
[WebProfilerBundle] Fix design issue in profiler when having errors in forms

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
@@ -156,15 +156,13 @@
             color: #999;
         }
         .badge-error {
+            float: right;
             background: #B0413E;
             color: #FFF;
             padding: 1px 4px;
             font-size: 10px;
             font-weight: bold;
             vertical-align: middle;
-            position: absolute;
-            top: 7px;
-            right: 7px;
         }
         .errors h3 {
             color: #B0413E;
@@ -429,6 +427,10 @@
     {% import _self as tree %}
     <li>
         <div class="tree-inner" data-tab-target-id="{{ data.id }}-details">
+            {% if data.errors is defined and data.errors|length > 0 %}
+                <div class="badge-error">{{ data.errors|length }}</div>
+            {% endif %}
+
             {% if data.children is not empty %}
                 <a class="toggle-button" data-toggle-target-id="{{ data.id }}-children" href="#"><span class="toggle-icon"></span></a>
             {% else %}
@@ -436,10 +438,6 @@
             {% endif %}
 
             {{ name|default('(no name)') }} {% if data.type_class is defined and data.type is defined %}[<abbr title="{{ data.type_class }}">{{ data.type|split('\\')|last }}</abbr>]{% endif %}
-
-            {% if data.errors is defined and data.errors|length > 0 %}
-                <div class="badge-error">{{ data.errors|length }}</div>
-            {% endif %}
         </div>
 
         {% if data.children is not empty %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
@@ -156,13 +156,15 @@
             color: #999;
         }
         .badge-error {
-            float: right;
             background: #B0413E;
             color: #FFF;
             padding: 1px 4px;
             font-size: 10px;
             font-weight: bold;
             vertical-align: middle;
+            position: absolute;
+            top: 7px;
+            right: 7px;
         }
         .errors h3 {
             color: #B0413E;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This error occurs mostly when having long form field names or types, 

**Before:**
![before](https://cloud.githubusercontent.com/assets/3369266/12610913/89bddfd8-c4ea-11e5-9372-2b7740d8c4b3.png)

**After:**
![after](https://cloud.githubusercontent.com/assets/3369266/12610915/8ae22a4a-c4ea-11e5-94ce-9257a9409b4a.png)

That said, I don't know what to do about z-index, whether the error count prevails on the type or _vice-versa_ :confused: 

@javiereguiluz, an idea ?
