### PR TITLE
[DependencyInjection] simplify the BC layer

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveReferencesToAliasesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveReferencesToAliasesPass.php
@@ -44,10 +44,7 @@ class ResolveReferencesToAliasesPass implements CompilerPassInterface
             $definition->setMethodCalls($this->processArguments($definition->getMethodCalls()));
             $definition->setProperties($this->processArguments($definition->getProperties()));
             $definition->setFactory($this->processFactory($definition->getFactory()));
-
-            if (null !== $factoryService = $definition->getFactoryService(false)) {
-                $definition->setFactoryService($this->processFactoryService($factoryService));
-            }
+            $definition->setFactoryService($this->processFactoryService($definition->getFactoryService(false)), false);
         }
 
         foreach ($container->getAliases() as $id => $alias) {

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -194,9 +194,11 @@ class Definition
      *
      * @deprecated since version 2.6, to be removed in 3.0.
      */
-    public function setFactoryService($factoryService)
+    public function setFactoryService($factoryService, $triggerDeprecationError = true)
     {
-        @trigger_error(sprintf('%s(%s) is deprecated since version 2.6 and will be removed in 3.0. Use Definition::setFactory() instead.', __METHOD__, $factoryService), E_USER_DEPRECATED);
+        if ($triggerDeprecationError) {
+            @trigger_error(sprintf('%s(%s) is deprecated since version 2.6 and will be removed in 3.0. Use Definition::setFactory() instead.', __METHOD__, $factoryService), E_USER_DEPRECATED);
+        }
 
         $this->factoryService = $factoryService;
 

--- a/src/Symfony/Component/DependencyInjection/DefinitionDecorator.php
+++ b/src/Symfony/Component/DependencyInjection/DefinitionDecorator.php
@@ -99,7 +99,7 @@ class DefinitionDecorator extends Definition
     /**
      * {@inheritdoc}
      */
-    public function setFactoryService($service)
+    public function setFactoryService($service, $triggerDeprecationError = true)
     {
         $this->changes['factory_service'] = true;
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The change to the `setFactoryService()` method is consistent with what
we did with the `getFactoryService()` before (and how we handle the
deprecation of strict references in Symfony 2.8).
