### PR TITLE
Change couple of occurences of a public setUp() method to protected

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
@@ -13,7 +13,7 @@ class AppVariableTest extends \PHPUnit_Framework_TestCase
      */
     protected $appVariable;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->appVariable = new AppVariable();
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ExtensionCompilerPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ExtensionCompilerPassTest.php
@@ -21,7 +21,7 @@ class ExtensionCompilerPassTest extends \PHPUnit_Framework_TestCase
     private $container;
     private $pass;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
         $this->pass = new ExtensionCompilerPass();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

`setUp()` is a protected method. There's no occurrences on the 2.3 branch.
