### PR TITLE
[FrameworkBundle] read commands from bundles when accessing list

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -11,14 +11,14 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Console;
 
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\HttpKernel\KernelInterface;
-use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
  * Application.
@@ -69,12 +69,6 @@ class Application extends BaseApplication
     {
         $this->kernel->boot();
 
-        if (!$this->commandsRegistered) {
-            $this->registerCommands();
-
-            $this->commandsRegistered = true;
-        }
-
         $container = $this->kernel->getContainer();
 
         foreach ($this->all() as $command) {
@@ -96,8 +90,34 @@ class Application extends BaseApplication
         return parent::doRun($input, $output);
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function get($name)
+    {
+        $this->registerCommands();
+
+        return parent::get($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function all($namespace = null)
+    {
+        $this->registerCommands();
+
+        return parent::all($namespace);
+    }
+
     protected function registerCommands()
     {
+        if ($this->commandsRegistered) {
+            return;
+        }
+
+        $this->commandsRegistered = true;
+
         foreach ($this->kernel->getBundles() as $bundle) {
             if ($bundle instanceof Bundle) {
                 $bundle->registerCommands($this);

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -436,7 +436,7 @@ class Application
     public function getNamespaces()
     {
         $namespaces = array();
-        foreach ($this->commands as $command) {
+        foreach ($this->all() as $command) {
             $namespaces = array_merge($namespaces, $this->extractAllNamespaces($command->getName()));
 
             foreach ($command->getAliases() as $alias) {
@@ -530,7 +530,7 @@ class Application
 
         // name
         $commands = array();
-        foreach ($this->commands as $command) {
+        foreach ($this->all() as $command) {
             $extractedNamespace = $this->extractNamespace($command->getName());
             if ($extractedNamespace === $namespace
                || !empty($namespace) && 0 === strpos($extractedNamespace, $namespace)
@@ -556,7 +556,7 @@ class Application
 
         // aliases
         $aliases = array();
-        foreach ($this->commands as $command) {
+        foreach ($this->all() as $command) {
             foreach ($command->getAliases() as $alias) {
                 $extractedNamespace = $this->extractNamespace($alias);
                 if ($extractedNamespace === $namespace
@@ -1028,7 +1028,7 @@ class Application
             return $item->getName();
         };
 
-        return $this->findAlternatives($name, $this->commands, $abbrevs, $callback);
+        return $this->findAlternatives($name, $this->all(), $abbrevs, $callback);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This allows access to the list of commands registered by the kernel (bundle and later service ids) programmatically when you do not `run` the application.
