### PR TITLE
[Process] Allow disableing enhanced windows compability

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -129,17 +129,17 @@ class Process
     /**
      * Constructor.
      *
-     * @param string         $commandline               The command line to run
-     * @param string|null    $cwd                       The working directory or null to use the working dir of the current PHP process
-     * @param array|null     $env                       The environment variables or null to use the same environment as the current PHP process
-     * @param string|null    $input                     The input
-     * @param int|float|null $timeout                   The timeout in seconds or null to disable
-     * @param array          $options                   An array of options for proc_open
-     * @param bool           $enhanceWindowsCompability Enhance windows compability
+     * @param string         $commandline                 The command line to run
+     * @param string|null    $cwd                         The working directory or null to use the working dir of the current PHP process
+     * @param array|null     $env                         The environment variables or null to use the same environment as the current PHP process
+     * @param string|null    $input                       The input
+     * @param int|float|null $timeout                     The timeout in seconds or null to disable
+     * @param array          $options                     An array of options for proc_open
+     * @param bool           $enhanceWindowsCompatibility Enhance windows compatibility
      *
      * @throws RuntimeException When proc_open is not installed
      */
-    public function __construct($commandline, $cwd = null, array $env = null, $input = null, $timeout = 60, array $options = array(), $enhanceWindowsCompability = true)
+    public function __construct($commandline, $cwd = null, array $env = null, $input = null, $timeout = 60, array $options = array(), $enhanceWindowsCompatibility = true)
     {
         if (!function_exists('proc_open')) {
             throw new RuntimeException('The Process class relies on proc_open, which is not available on your PHP installation.');
@@ -163,7 +163,7 @@ class Process
         $this->setTimeout($timeout);
         $this->useFileHandles = '\\' === DIRECTORY_SEPARATOR;
         $this->pty = false;
-        $this->enhanceWindowsCompatibility = $enhanceWindowsCompability;
+        $this->enhanceWindowsCompatibility = $enhanceWindowsCompatibility;
         $this->enhanceSigchildCompatibility = '\\' !== DIRECTORY_SEPARATOR && $this->isSigchildEnabled();
         $this->options = array_replace(array('suppress_errors' => true, 'binary_pipes' => true), $options);
     }

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -129,12 +129,12 @@ class Process
     /**
      * Constructor.
      *
-     * @param string         $commandline The command line to run
-     * @param string|null    $cwd         The working directory or null to use the working dir of the current PHP process
-     * @param array|null     $env         The environment variables or null to use the same environment as the current PHP process
-     * @param string|null    $input       The input
-     * @param int|float|null $timeout     The timeout in seconds or null to disable
-     * @param array          $options     An array of options for proc_open
+     * @param string         $commandline               The command line to run
+     * @param string|null    $cwd                       The working directory or null to use the working dir of the current PHP process
+     * @param array|null     $env                       The environment variables or null to use the same environment as the current PHP process
+     * @param string|null    $input                     The input
+     * @param int|float|null $timeout                   The timeout in seconds or null to disable
+     * @param array          $options                   An array of options for proc_open
      * @param bool           $enhanceWindowsCompability Enhance windows compability
      *
      * @throws RuntimeException When proc_open is not installed

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -135,10 +135,11 @@ class Process
      * @param string|null    $input       The input
      * @param int|float|null $timeout     The timeout in seconds or null to disable
      * @param array          $options     An array of options for proc_open
+     * @param bool           $enhanceWindowsCompability Enhance windows compability
      *
      * @throws RuntimeException When proc_open is not installed
      */
-    public function __construct($commandline, $cwd = null, array $env = null, $input = null, $timeout = 60, array $options = array())
+    public function __construct($commandline, $cwd = null, array $env = null, $input = null, $timeout = 60, array $options = array(), $enhanceWindowsCompability = true)
     {
         if (!function_exists('proc_open')) {
             throw new RuntimeException('The Process class relies on proc_open, which is not available on your PHP installation.');
@@ -162,7 +163,7 @@ class Process
         $this->setTimeout($timeout);
         $this->useFileHandles = '\\' === DIRECTORY_SEPARATOR;
         $this->pty = false;
-        $this->enhanceWindowsCompatibility = true;
+        $this->enhanceWindowsCompatibility = $enhanceWindowsCompability;
         $this->enhanceSigchildCompatibility = '\\' !== DIRECTORY_SEPARATOR && $this->isSigchildEnabled();
         $this->options = array_replace(array('suppress_errors' => true, 'binary_pipes' => true), $options);
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17590 |
| License | MIT |
| Doc PR |  |

In some windows settings (eg. ConEmu + Git bash + [Gow](https://github.com/bmatzelle/gow)) when useing a diffrent shell it is not desired to tweak the command for windows compability. This optional argument allows disableing this functionality.

The default value is set to true (as it was before).
