### PR TITLE
Don't cap the exit code of commands

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -138,10 +138,6 @@ class Application
         }
 
         if ($this->autoExit) {
-            if ($exitCode > 255) {
-                $exitCode = 255;
-            }
-
             exit($exitCode);
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #13996 |
| License | MIT |
| Doc PR | - |

I haven't added a test because it would require `setAutoExit(true)`
