### PR TITLE
[Translation] Add resources from fallback locale to parent catalogue

### DIFF
--- a/src/Symfony/Component/Translation/Tests/TranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorTest.php
@@ -239,6 +239,30 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
         $translator->trans('foo');
     }
 
+    public function testFallbackCatalogueResources()
+    {
+        $translator = new Translator('en_GB', new MessageSelector());
+        $translator->addLoader('yml', new \Symfony\Component\Translation\Loader\YamlFileLoader());
+        $translator->addResource('yml', __DIR__.'/fixtures/empty.yml', 'en_GB');
+        $translator->addResource('yml', __DIR__.'/fixtures/resources.yml', 'en');
+
+        // force catalogue loading
+        $this->assertEquals('bar', $translator->trans('foo', array()));
+
+        $cataloguesProperty = new \ReflectionProperty($translator, 'catalogues');
+        $cataloguesProperty->setAccessible(true);
+        $catalogues = $cataloguesProperty->getValue($translator);
+
+        $resources = $catalogues['en']->getResources();
+        $this->assertCount(1, $resources);
+        $this->assertContains( __DIR__.'/fixtures/resources.yml', $resources);
+
+        $resources = $catalogues['en_GB']->getResources();
+        $this->assertCount(2, $resources);
+        $this->assertContains( __DIR__.'/fixtures/empty.yml', $resources);
+        $this->assertContains( __DIR__.'/fixtures/resources.yml', $resources);
+    }
+
     /**
      * @dataProvider getTransTests
      */

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -255,6 +255,9 @@ class Translator implements TranslatorInterface
             }
 
             $fallbackCatalogue = new MessageCatalogue($fallback, $this->catalogues[$fallback]->all());
+            foreach ($this->catalogues[$fallback]->getResources() as $resource) {
+                $fallbackCatalogue->addResource($resource);
+            }
             $current->addFallbackCatalogue($fallbackCatalogue);
             $current = $fallbackCatalogue;
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The resources representing a locale includes those of the fallback locale. However, `getCatalogue()->getResources()` only returns the resources belonging specifically to the selected locale.

Example: The locale `en_GB` falls back to `en`. I use the locale `en_GB`. During development, when I modify the `en_GB` translation file, the changes appear instantly when reloading the page. If I modify the `en` translation file, I need to manually clear the cache in order for the new translation to appear.

I believe this is a regression that was introduced in #15527.

This patch is for the 2.3 branch. For 2.6 and later, the test can be updated to use the getCatalogue() method instead of using ReflectionProperty.
