### PR TITLE
[FrameworkBundle] remove default null value for asset version

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -558,7 +558,6 @@ class Configuration implements ConfigurationInterface
                                 ->fixXmlConfig('base_url')
                                 ->children()
                                     ->scalarNode('version')
-                                        ->defaultNull()
                                         ->beforeNormalization()
                                         ->ifTrue(function ($v) { return '' === $v; })
                                         ->then(function ($v) { return; })


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Setting `null` as the version of a package means that it uses the empty
version strategy. However, omitting the `version` option entirely was
meant to fall back to the default version strategy. This is not possible
when the default version value is `null` as there is no way to remove
it.
