### PR TITLE
[WIP] [3.2] [Form] add 'empty_view' option in FormType

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
@@ -232,6 +232,18 @@
     </div>
 {%- endblock radio_row %}
 
+{# Support #}
+
+{% block empty_row -%}
+    {%- set translation_domain = translation_domain ?: 'sf_form' -%}
+    {%- set attr = attr|merge({class: (attr.class|default('') ~ ' form-control')|trim}) %}
+    <div {{ block('widget_container_attributes') }}>
+        <p>
+            <em>{{- translation_domain is same as(false) ? empty_view : empty_view|trans({}, translation_domain) -}}</em>
+        </p>
+    </div>
+{%- endblock empty_row %}
+
 {# Errors #}
 
 {% block form_errors -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -2,7 +2,12 @@
 
 {%- block form_widget -%}
     {% if compound %}
-        {{- block('form_widget_compound') -}}
+        {%- if empty_view %}
+            {{- block('empty_row') -}}
+            {{ form_rest(form) }}
+        {%- else -%}
+            {{- block('form_widget_compound') -}}
+        {%- endif -%}
     {% else %}
         {{- block('form_widget_simple') -}}
     {% endif %}
@@ -35,11 +40,15 @@
 {%- endblock textarea_widget -%}
 
 {%- block choice_widget -%}
-    {% if expanded %}
-        {{- block('choice_widget_expanded') -}}
-    {% else %}
-        {{- block('choice_widget_collapsed') -}}
-    {% endif %}
+    {%- if empty_view is defined and empty_view -%}
+        {{- block('empty_row') -}}
+    {%- else -%}
+        {%- if expanded -%}
+            {{- block('choice_widget_expanded') -}}
+        {%- else -%}
+            {{- block('choice_widget_collapsed') -}}
+        {%- endif -%}
+    {%- endif -%}
 {%- endblock choice_widget -%}
 
 {%- block choice_widget_expanded -%}
@@ -312,6 +321,13 @@
         {{- form_row(child) -}}
     {% endfor %}
 {%- endblock form_rows -%}
+
+{%- block empty_row -%}
+    {%- set translation_domain = translation_domain ?: 'sf_form' -%}
+    <div {{ block('widget_container_attributes') }}>
+        <em>{{- translation_domain is same as(false) ? empty_view : empty_view|trans({}, translation_domain) -}}</em>
+    </div>
+{%- endblock empty_row -%}
 
 {%- block widget_attributes -%}
     id="{{ id }}" name="{{ full_name }}"

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_table_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_table_layout.html.twig
@@ -42,3 +42,14 @@
         {{- form_rest(form) -}}
     </table>
 {%- endblock form_widget_compound -%}
+
+{%- block empty_row -%}
+    {%- set translation_domain = translation_domain ?: 'sf_form' -%}
+    <table {{ block('widget_container_attributes') }}>
+        <tr>
+            <td colspan="2">
+                <em>{{ translation_domain is same as(false) ? empty_view : empty_view|trans({}, translation_domain) }}</em>
+            </td>
+        </tr>
+    </table>
+{%- endblock empty_row -%}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/foundation_5_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/foundation_5_layout.html.twig
@@ -184,6 +184,19 @@
     {% endif %}
 {%- endblock choice_widget_expanded %}
 
+{% block choice_widget_empty -%}
+    {%- if empty_choices is empty %}
+        {%- set empty_choices = 'No choice available' %}
+        {%- set choice_translation_domain = 'sf_form' %}
+    {%- endif -%}
+    {%- set attr = attr|merge({class: (attr.class|default('') ~ ' form-control')|trim}) %}
+    <div {{ block('widget_container_attributes') }}>
+        <p>
+            {{- choice_translation_domain is same as(false) ? empty_choices : empty_choices|trans({}, choice_translation_domain) -}}
+        </p>
+    </div>
+{%- endblock %}
+
 {% block checkbox_widget -%}
     {% set parent_label_class = parent_label_class|default('') %}
     {% if errors|length > 0 -%}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/choice_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/choice_widget.html.php
@@ -1,5 +1,9 @@
-<?php if ($expanded): ?>
-<?php echo $view['form']->block($form, 'choice_widget_expanded') ?>
+<?php if (isset($empty_view)  && $empty_view): ?>
+    <?php echo $view['form']->block($form, 'empty_row')?>
 <?php else: ?>
-<?php echo $view['form']->block($form, 'choice_widget_collapsed') ?>
+    <?php if ($expanded): ?>
+        <?php echo $view['form']->block($form, 'choice_widget_expanded') ?>
+    <?php else: ?>
+        <?php echo $view['form']->block($form, 'choice_widget_collapsed') ?>
+    <?php endif ?>
 <?php endif ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/empty_row.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/empty_row.html.php
@@ -1,0 +1,9 @@
+<?php $translation_domain = $translation_domain ?: 'sf_form'; ?>
+<div <?php echo $view['form']->block($form, 'widget_container_attributes') ?>>
+    <em>
+        <?php echo $view->escape(false !== $translation_domain
+            ? $view['translator']->trans($empty_view, array(), $translation_domain)
+            : $empty_view
+        ); ?>
+    </em>
+</div>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_widget.html.php
@@ -1,5 +1,10 @@
 <?php if ($compound): ?>
-<?php echo $view['form']->block($form, 'form_widget_compound')?>
+    <?php if (isset($empty_view)  && $empty_view): ?>
+        <?php echo $view['form']->block($form, 'empty_row')?>
+        <?php echo $view['form']->rest($form) ?>
+    <?php else: ?>
+        <?php echo $view['form']->block($form, 'form_widget_compound')?>
+    <?php endif ?>
 <?php else: ?>
 <?php echo $view['form']->block($form, 'form_widget_simple')?>
 <?php endif ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/FormTable/empty_row.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/FormTable/empty_row.html.php
@@ -1,0 +1,13 @@
+<?php $translation_domain = $translation_domain ?: 'sf_form'; ?>
+<table <?php echo $view['form']->block($form, 'widget_container_attributes') ?>>
+    <tr>
+        <td colspan="2">
+            <em>
+                <?php echo $view->escape(false !== $translation_domain
+                    ? $view['translator']->trans($empty_view, array(), $translation_domain)
+                    : $empty_view
+                ); ?>
+            </em>
+        </td>
+    </tr>
+</table>

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -244,6 +244,18 @@ class ChoiceType extends AbstractType
                 $childView->vars['full_name'] = $childName;
             }
         }
+
+        // We have to override parent {@link FormType} condition of the empty_view option here,
+        // even if there is no choices the field view may not be empty because:
+        //
+        //  - a select input is not "compound" but should be considered as any empty HTML tag,
+        //
+        //  - when expanded it could hold a placeholder which has been counted as a children,
+        //    we should ignore it in any case since its role is to be a "null" alternative to
+        //    choices, not a choice itself. Think of "Choose something" with no choices.
+        if (array() === $view->vars['choices'] && array() === $view->vars['preferred_choices']) {
+            $view->vars['empty_view'] = $options['empty_view'];
+        }
     }
 
     /**
@@ -323,6 +335,7 @@ class ChoiceType extends AbstractType
             'preferred_choices' => array(),
             'group_by' => null,
             'empty_data' => $emptyData,
+            'empty_view' => 'No choice available',
             'placeholder' => $placeholderDefault,
             'error_bubbling' => false,
             'compound' => $compound,

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -113,6 +113,10 @@ class FormType extends BaseType
         }
 
         $view->vars['multipart'] = $multipart;
+
+        if ($form->getConfig()->getCompound()) {
+            $view->vars['empty_view'] = (bool) $view->count() ? false : $options['empty_view'];
+        }
     }
 
     /**
@@ -142,6 +146,12 @@ class FormType extends BaseType
             };
         };
 
+        // For any compound form which has no children, show some text
+        // instead of an empty HTML tag by default
+        $emptyView = function (Options $options) {
+            return $options['compound'] ? 'No fields' : false;
+        };
+
         // For any form that is not represented by a single HTML control,
         // errors should bubble up by default
         $errorBubbling = function (Options $options) {
@@ -157,6 +167,7 @@ class FormType extends BaseType
         $resolver->setDefaults(array(
             'data_class' => $dataClass,
             'empty_data' => $emptyData,
+            'empty_view' => $emptyView,
             'trim' => true,
             'required' => true,
             'property_path' => null,
@@ -175,6 +186,7 @@ class FormType extends BaseType
         ));
 
         $resolver->setAllowedTypes('label_attr', 'array');
+        $resolver->setAllowedTypes('empty_view', array('null', 'string', 'bool'));
     }
 
     /**

--- a/src/Symfony/Component/Form/Resources/translations/sf_form.en.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/sf_form.en.xlf
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>No choice available</source>
+                <target>No choice available</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/sf_form.fr.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/sf_form.fr.xlf
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>No choice available</source>
+                <target>Aucun choix disponible</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/src/Symfony/Component/Form/Tests/AbstractBootstrap3LayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractBootstrap3LayoutTest.php
@@ -250,6 +250,27 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
         );
     }
 
+    public function testSingleChoiceWithoutChoices()
+    {
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
+            'choices' => array(),
+            'multiple' => false,
+            'expanded' => false,
+            'required' => true,
+            'attr' => array('class' => 'my&class'),
+        ));
+
+        $this->assertMatchesXpath($this->renderWidget($form->createView()),
+'/div
+    [@class="my&class form-control"]
+    [not(@required)]
+    [
+        ./p/em/.="[trans]No choice available[/trans]"
+    ]
+'
+        );
+    }
+
     public function testSingleChoiceWithoutTranslation()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', array(
@@ -808,6 +829,27 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
                     ]
             ]
         /following-sibling::input[@type="hidden"][@id="name__token"]
+    ]
+'
+        );
+    }
+
+    public function testSingleChoiceExpandedWithoutChoices()
+    {
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
+            'choices' => array(),
+            'multiple' => false,
+            'expanded' => true,
+            'required' => true,
+            'attr' => array('class' => 'my&class'),
+        ));
+
+        $this->assertMatchesXpath($this->renderWidget($form->createView()),
+'/div
+    [@class="my&class form-control"]
+    [not(@required)]
+    [
+        ./p/em/.="[trans]No choice available[/trans]"
     ]
 '
         );

--- a/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
@@ -327,10 +327,15 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
             'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
         ));
 
-        $this->assertWidgetMatchesXpath($form->createView(), array(),
+        $this->assertWidgetMatchesXpath($form->createView(), array('id' => 'my&id', 'attr' => array('class' => 'my&class')),
 '/div
-    [./input[@type="hidden"][@id="names__token"]]
+    [@id="my&id"]
+    [@class="my&class"]
+    [
+        /em[.="[trans]No fields[/trans]"]
+    ]
     [count(./div)=0]
+/following-sibling::input[@type="hidden"][@id="names__token"]
 '
         );
     }

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -536,6 +536,23 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         );
     }
 
+    public function testSingleChoiceWithoutChoices()
+    {
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
+            'choices' => array(),
+            'multiple' => false,
+            'expanded' => false,
+            'required' => true,
+        ));
+
+        $this->assertWidgetMatchesXpath($form->createView(), array(),
+'/div
+    [not(@required)]
+    /em[.="[trans]No choice available[/trans]"]
+'
+        );
+    }
+
     public function testSingleChoiceWithoutTranslation()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', array(
@@ -951,6 +968,23 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         /following-sibling::input[@type="hidden"][@id="name__token"]
     ]
     [count(./input)=3]
+'
+        );
+    }
+
+    public function testSingleChoiceExpandedWithoutChoices()
+    {
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
+            'choices' => array(),
+            'multiple' => false,
+            'expanded' => true,
+            'required' => true,
+        ));
+
+        $this->assertWidgetMatchesXpath($form->createView(), array(),
+'/div
+    [not(@required)]
+    /em[.="[trans]No choice available[/trans]"]
 '
         );
     }

--- a/src/Symfony/Component/Form/Tests/AbstractTableLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractTableLayoutTest.php
@@ -216,10 +216,56 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
             'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
         ));
 
+        $this->assertWidgetMatchesXpath($form->createView(), array('id' => 'my&id', 'attr' => array('class' => 'my&class')),
+'/table
+    [
+        ./tr
+            [
+                ./td[@colspan="2"]/em[.="[trans]No fields[/trans]"]
+            ]
+    ]
+    [@id="my&id"]
+    [@class="my&class"]
+/following-sibling::tr[@style="display: none"]
+    [
+        ./td[@colspan="2"]/input[@type="hidden"][@id="names__token"]
+    ]
+'
+        );
+    }
+
+    public function testSingleChoiceWithoutChoices()
+    {
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
+            'choices' => array(),
+            'multiple' => false,
+            'expanded' => false,
+            'required' => true,
+        ));
+
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/table
-    [./tr[@style="display: none"][./td[@colspan="2"]/input[@type="hidden"][@id="names__token"]]]
-    [count(./tr[./td/input])=1]
+    [
+        ./tr/td[@colspan="2"]/em[.="[trans]No choice available[/trans]"]
+    ]
+'
+        );
+    }
+
+    public function testSingleChoiceExpandedWithoutChoices()
+    {
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
+            'choices' => array(),
+            'multiple' => false,
+            'expanded' => true,
+            'required' => true,
+        ));
+
+        $this->assertWidgetMatchesXpath($form->createView(), array(),
+'/table
+    [
+        ./tr/td[@colspan="2"]/em[.="[trans]No choice available[/trans]"]
+    ]
 '
         );
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17579, #18804 |
| License | MIT |
| Doc PR | todo |
- [x]  Gather feedback
- [x]  Use translation for default message
- [x]  Add some tests
- [x]  Update foundation 5 theme
- [ ] Make tests pass
- [ ]  Add missing translations
- [ ]  Doc PR

The `empty_view` option can be a `string`, or a `boolean`. By default it is `'No field'` when compound and `false` otherwise. It uses the `translation_domain` option for its translation.

`CollectionType` inherits it but this can be avoid be setting `empty_view` to `false`.

The `empty_view` is defined in `FormType::finishView()` and overriden in `ChoiceType::finishView()` to be defined when `choices` and `preferred_choices` view vars are empty.

In the templates, the old behaviour is kept explicitly set to `false`.

So 2 ways of using it:
- passing a translatable simple string to custom a message instead of an empty `div` or an empty `select` input :

``` php
// src/AppBundle/Form/Type/TenantType.php
// ...
$builder->add('cars', \Symfony\Bridge\Doctrine\Form\Type\EntityType::class, array(
    'class' => \AppBundle\Entity\Cars::class,
    'empty_view' => 'No cars available', // will be escaped
    // ...
));
```
- overriding the `empty_row` to use custom `html` :

``` twig
{# 'default/rent_a_car.html.twig #}
{# ... #}
{% form_theme _self %}
{% block 'empty_row' %}
    {# custom html with access to 'full_name', 'attr', and 'empty_view' view vars #}
{% endblock %}
{{ form(form) }}
```

What do you think ?
