### PR TITLE
[HttpKernel] Deprecate passing objects as URI attributes to the ESI and SSI renderers

### DIFF
--- a/UPGRADE-3.1.md
+++ b/UPGRADE-3.1.md
@@ -16,6 +16,13 @@ Form
  * The `choices_as_values` option of the `ChoiceType` has been deprecated and
    will be removed in Symfony 4.0.
 
+HttpKernel
+----------
+
+ * Passing objects as URI attributes to the ESI and SSI renderers has been
+   deprecated and will be removed in Symfony 4.0. The inline fragment
+   renderer should be used with object attributes.
+
 Serializer
 ----------
 

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+3.1.0
+-----
+ * deprecated passing objects as URI attributes to the ESI and SSI renderers
+
 3.0.0
 -----
 

--- a/src/Symfony/Component/HttpKernel/Fragment/AbstractSurrogateFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/AbstractSurrogateFragmentRenderer.php
@@ -64,6 +64,10 @@ abstract class AbstractSurrogateFragmentRenderer extends RoutableFragmentRendere
     public function render($uri, Request $request, array $options = array())
     {
         if (!$this->surrogate || !$this->surrogate->hasSurrogateCapability($request)) {
+            if ($uri instanceof ControllerReference && $this->containsNonScalars($uri->attributes)) {
+                @trigger_error('Passing objects as part of URI attributes to the ESI and SSI rendering strategies is deprecated since version 3.1, and will be removed in 4.0. Use a different rendering strategy or pass scalar values.', E_USER_DEPRECATED);
+            }
+
             return $this->inlineStrategy->render($uri, $request, $options);
         }
 
@@ -91,5 +95,18 @@ abstract class AbstractSurrogateFragmentRenderer extends RoutableFragmentRendere
         $fragmentUri = $this->signer->sign($this->generateFragmentUri($uri, $request, true));
 
         return substr($fragmentUri, strlen($request->getSchemeAndHttpHost()));
+    }
+
+    private function containsNonScalars(array $values)
+    {
+        foreach ($values as $value) {
+            if (is_array($value) && $this->containsNonScalars($value)) {
+                return true;
+            } elseif (!is_scalar($value) && null !== $value) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/EsiFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/EsiFragmentRendererTest.php
@@ -25,6 +25,32 @@ class EsiFragmentRendererTest extends \PHPUnit_Framework_TestCase
         $strategy->render('/', Request::create('/'));
     }
 
+    /**
+     * @group legacy
+     */
+    public function testRenderFallbackWithObjectAttributesIsDeprecated()
+    {
+        $deprecations = array();
+        set_error_handler(function ($type, $message) use (&$deprecations) {
+            if (E_USER_DEPRECATED === $type) {
+                $deprecations[] = $message;
+            }
+        });
+
+        $strategy = new EsiFragmentRenderer(new Esi(), $this->getInlineStrategy(true), new UriSigner('foo'));
+
+        $request = Request::create('/');
+
+        $reference = new ControllerReference('main_controller', array('foo' => array('a' => array(), 'b' => new \stdClass())), array());
+
+        $strategy->render($reference, $request);
+
+        $this->assertCount(1, $deprecations);
+        $this->assertContains('Passing objects as part of URI attributes to the ESI and SSI rendering strategies is deprecated', $deprecations[0]);
+
+        restore_error_handler();
+    }
+
     public function testRender()
     {
         $strategy = new EsiFragmentRenderer(new Esi(), $this->getInlineStrategy());


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #15056 |
| License | MIT |
| Doc PR | - |
