### PR TITLE
[Security] clarify the accepted argument type

### DIFF
--- a/src/Symfony/Component/Security/Core/Role/RoleHierarchy.php
+++ b/src/Symfony/Component/Security/Core/Role/RoleHierarchy.php
@@ -24,7 +24,7 @@ class RoleHierarchy implements RoleHierarchyInterface
     /**
      * Constructor.
      *
-     * @param array $hierarchy An array defining the hierarchy
+     * @param RoleInterface[] $hierarchy An array defining the hierarchy
      */
     public function __construct(array $hierarchy)
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets |  |
| License | MIT |

The class can only accept roles that implement the `RoleInterface` as
that is the type required by the implemented interface to be returned
by the `getReachableRoles()` method.
