### PR TITLE
Exclude testMirrorCopiesRelativeLinkedContents on Windows systems

### DIFF
--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -913,6 +913,10 @@ class FilesystemTest extends FilesystemTestCase
 
     public function testMirrorCopiesRelativeLinkedContents()
     {
+        if ('\\' === DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('Windows does not support creating relative symlinks');
+        }
+
         $this->markAsSkippedIfSymlinkIsMissing();
 
         $sourcePath = $this->workspace.DIRECTORY_SEPARATOR.'source'.DIRECTORY_SEPARATOR;


### PR DESCRIPTION
symlink() is not working properly with relative links. There seems to
be some problems with chdir() and symlink() which leads to an error that
symlink cannot read the source. There are some special rare cases
which seems to work if your source points out to the drive root and goes
back into (another) folder, but I would not trust in this case and simply
skip the test.
