### PR TITLE
Try to delete broken symlinks

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -172,7 +172,14 @@ class Filesystem
                     }
                 } else {
                     if (true !== @unlink($file)) {
-                        throw new IOException(sprintf('Failed to remove file "%s".', $file), 0, null, $file);
+                        // handle broken symlinks on Windows systems
+                        if (is_link($file) && false === @readlink($file)) {
+                            if (true !== @rmdir($file)) {
+                                throw new IOException(sprintf('Failed to remove broken symlink "%s".', $file), 0, null, $file);
+                            }
+                        } else {
+                            throw new IOException(sprintf('Failed to remove file "%s".', $file), 0, null, $file);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
If you delete the target of a symlink (at least on Windows systems) you
don't get the kind of the target anymore (obviously). Therefore it might
happen that a broken symlink to a directory should be removed with
unlink() which fails. This patch adds another check for a broken symlink
and tries to remove with rmdir() before throwing an exception. It helps
to clean up test folders on Windows systems (so already proofed by the
existing tests).
