### PR TITLE
[Form] Add time zone translations

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
@@ -38,7 +38,7 @@ class TimezoneType extends AbstractType
         $resolver->setDefaults(array(
             'choices' => self::getFlippedTimezones(),
             'choices_as_values' => true,
-            'choice_translation_domain' => false,
+            'choice_translation_domain' => 'timezones',
         ));
     }
 

--- a/src/Symfony/Component/Form/Resources/translations-source/generate-timezones-translations.php
+++ b/src/Symfony/Component/Form/Resources/translations-source/generate-timezones-translations.php
@@ -1,0 +1,171 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Generates translation files for use in TimezoneType based on the Unicode 
+ * Common Locale Data Repository.
+ *
+ * The generates files are written to ../translations and should be committed to
+ * Git.
+ *
+ * Before running the script, download core.zip from the latest CLDR release
+ * from http://cldr.unicode.org/index/downloads. Unzip the file into a
+ * subdirectory of the directory containing this PHP script.
+ *
+ * Run the following commands inside the translations-source directory:
+ * $ mkdir cldr
+ * $ wget http://unicode.org/Public/cldr/XXX/core.zip  <-- replace XXX with the latest version
+ * $ unzip core.zip
+ */
+require_once '../../../../../../vendor/autoload.php';
+
+use Symfony\Component\Translation\Dumper\XliffFileDumper;
+use Symfony\Component\Translation\Loader\XliffFileLoader;
+use Symfony\Component\Translation\MessageCatalogue;
+
+/**
+ * Translates a time zone identifier into an English string.
+ *
+ * Uses the algorithm used in TimezoneType::getTimezones().
+ *
+ * @param string $identifier
+ *
+ * @return string
+ */
+function getSourceName($identifier)
+{
+    $parts = explode('/', $identifier);
+
+    if (count($parts) > 2) {
+        $name = $parts[1].' - '.$parts[2];
+    } elseif (count($parts) > 1) {
+        $name = $parts[1];
+    } else {
+        $name = $parts[0];
+    }
+
+    return str_replace('_', ' ', $name);
+}
+
+$locales = [
+    // English must be processed first.
+    'en' => 'en',
+
+    // We only support a small subset of the many locales included in CLDR.
+    'ar' => 'ar',
+    'az' => 'az',
+    'bg' => 'bg',
+    'ca' => 'ca',
+    'cs' => 'cs',
+    'da' => 'da',
+    'de' => 'de',
+    'el' => 'el',
+    'en' => 'en',
+    'es' => 'es',
+    'et' => 'et',
+    'eu' => 'eu',
+    'fa' => 'fa',
+    'fi' => 'fi',
+    'fr' => 'fr',
+    'gl' => 'gl',
+    'he' => 'he',
+    'hr' => 'hr',
+    'hu' => 'hu',
+    'hy' => 'hy',
+    'id' => 'id',
+    'it' => 'it',
+    'ja' => 'ja',
+    'lb' => 'lb',
+    'lt' => 'lt',
+    'lv' => 'lv',
+    'mn' => 'mn',
+    'nb' => 'nb',
+    'nl' => 'nl',
+    'pl' => 'pl',
+    'pt_BR' => 'pt_BR',
+    'pt' => 'pt',
+    'ro' => 'ro',
+    'ru' => 'ru',
+    'sk' => 'sk',
+    'sl' => 'sl',
+    'sr_Cyrl' => 'sr',
+    'sr_Latn' => 'sr_Latn',
+    'sv' => 'sv',
+    'uk' => 'uk',
+    'zh_CN' => 'zh_Hans_CN',
+];
+
+$options = array(
+    'path' => __DIR__.'/../translations',
+    'default_locale' => 'en',
+    'tool_info' => array(
+        'tool-id' => basename(__FILE__),
+        'tool-name' => 'Time zone translation generator',
+    ),
+);
+
+// The source names are generated from the list identifiers. They are English
+// names, except they miss some punctuation and diacritics. E.g. the identifier
+// America/St_Barthelemy has the source name "St Barthelemy", but the proper
+// English name is "St. Barthélemy".
+$sourceNames = array();
+foreach (\DateTimeZone::listIdentifiers(\DateTimeZone::ALL_WITH_BC) as $identifier) {
+    $sourceNames[$identifier] = getSourceName($identifier);
+}
+
+$domain = 'timezones';
+$dumper = new XliffFileDumper();
+$loader = new XliffFileLoader();
+
+foreach ($locales as $locale => $cldrLocale) {
+    $localeNames = array();
+
+    $cldrFile = __DIR__.'/cldr/common/main/'.$cldrLocale.'.xml';
+    if (!file_exists($cldrFile)) {
+        throw new \RuntimeException('Source file not found: '.$cldrFile);
+    }
+
+    $xml = simplexml_load_file($cldrFile);
+
+    if (!isset($xml->dates->timeZoneNames)) {
+        $cldrLocale = (string) $xml->identity->language->attributes()->type;
+        $cldrFile = __DIR__.'/cldr/common/main/'.$cldrLocale.'.xml';
+        if (!file_exists($cldrFile)) {
+            throw new \RuntimeException('Fallback source file not found: '.$cldrFile);
+        }
+
+        $xml = simplexml_load_file($cldrFile);
+
+        if (!isset($xml->dates->timeZoneNames)) {
+            throw new \RuntimeException('No time zone info defined in fallback locale: '.$cldrFile);
+        }
+    }
+
+    foreach ($xml->dates->timeZoneNames->zone as $zone) {
+        $identifier = (string) $zone->attributes()->type;
+        $localeName = (string) $zone->exemplarCity;
+
+        // Add time zones that exist in the CLDR data but is not (yet) known by
+        // PHP on this computer.
+        if ($locale == 'en' && !isset($sourceNames[$identifier])) {
+            $sourceNames[$identifier] = getSourceName($identifier);
+        }
+
+        if ($localeName && isset($sourceNames[$identifier])) {
+            $enName = $sourceNames[$identifier];
+            $localeNames[$enName] = $localeName;
+        }
+    }
+
+    $catalogue = new MessageCatalogue($locale);
+    $catalogue->add($localeNames, $domain);
+
+    // Load additional translations (including continent names) and overrides.
+    $extraFile = __DIR__.'/timezones.'.$locale.'.xlf';
+    if (file_exists($extraFile)) {
+        $extraCatalogue = $loader->load($extraFile, $locale, $domain);
+        $catalogue->addCatalogue($extraCatalogue);
+    }
+
+    $dumper->dump($catalogue, $options);
+}

--- a/src/Symfony/Component/Form/Resources/translations-source/timezones.da.xlf
+++ b/src/Symfony/Component/Form/Resources/translations-source/timezones.da.xlf
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="da" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="1">
+        <source>Africa</source>
+        <target>Afrika</target>
+      </trans-unit>
+      <trans-unit id="2">
+        <source>Antarctica</source>
+        <target>Antarktis</target>
+      </trans-unit>
+      <trans-unit id="3">
+        <source>Arctic</source>
+        <target>Arktis</target>
+      </trans-unit>
+      <trans-unit id="4">
+        <source>Atlantic</source>
+        <target>Atlanterhavet</target>
+      </trans-unit>
+      <trans-unit id="5">
+        <source>Australia</source>
+        <target>Australien</target>
+      </trans-unit>
+      <trans-unit id="6">
+        <source>Europe</source>
+        <target>Europa</target>
+      </trans-unit>
+      <trans-unit id="7">
+        <source>Indian</source>
+        <target>Indiske Ocean</target>
+      </trans-unit>
+      <trans-unit id="8">
+        <source>Pacific</source>
+        <target>Stillehavet</target>
+      </trans-unit>
+      <trans-unit id="9">
+        <source>Other</source>
+        <target>Øvrige</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.ar.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.ar.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="ar" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>مدينة غير معروفة</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>أندورا</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>دبي</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>كابول</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>أنتيغوا</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>أنغيلا</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>تيرانا</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>يريفان</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>لواندا</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>روثيرا</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>بالمير</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>ترول</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>سايووا</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>ماوسون</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>دافيز</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>فوستوك</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>كاساي</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>دي مونت دو روفيل</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>ماك موردو</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>ريو جالييوس</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>ميندوزا</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>سان خوان</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>أشوا</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>لا ريوجا</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>سان لويس</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>كاتاماركا</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>سالطا</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>جوجو</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>تاكمان</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>كوردوبا</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>بوينوس أيرس</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>باغو باغو</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>فيينا</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>برثا</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>أوكلا</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>دارون</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>أديليد</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>بروكن هيل</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>كوري</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>ميلبورن</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>هوبارت</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>ليندمان</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>سيدني</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>برسيبان</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>ماكواري</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>لورد هاو</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>أروبا</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>ماريهامن</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>باكو</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>سراييفو</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>بربادوس</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>دكا</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>بروكسل</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>واغادوغو</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>صوفيا</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>البحرين</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>بوجومبورا</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>بورتو نوفو</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>سانت بارتيليمي</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>برمودا</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>بروناي</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>لا باز</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>كرالنديك</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>ايرونبي</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>ريوبرانكو</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>بورتو فيلو</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>باو فيستا</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>ماناوس</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>كيابا</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>سانتاريم</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>كومبو جراند</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>بلم</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>أروجوانيا</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>ساو باولو</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>باهيا</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>فورتاليزا</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>ماشيو</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>ريسيف</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>نوروناه</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>ناسو</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>تيمفو</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>غابورون</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>مينسك</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>بليز</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>داوسان</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>وايت هورس</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>اينوفيك</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>فانكوفر</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>داوسن كريك</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>كريستون</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>يلونيف</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>ايدمونتون</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>سوفت كارنت</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>كامبرديج باي</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>ريجينا</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>وينيبيج</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>ريزولوت</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>راني ريفر</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>رانكن انلت</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>كورال هاربر</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>ثندر باي</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>نيبيجون</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>تورونتو</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>اكويلت</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>بانجينتينج</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>وينكتون</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>هاليفاكس</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>جوس باي</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>جلاس باي</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>بلانك-سابلون</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>سانت جونس</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>كوكوس</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>كينشاسا</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>لومبباشا</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>بانغوي</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>برازافيل</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>زيورخ</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>أبيدجان</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>راروتونغا</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>استر</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>سانتياغو</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>دوالا</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>أرومكي</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>شنغهاي</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>بوغوتا</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>كوستاريكا</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>هافانا</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>الرأس الأخضر</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>كوراكاو</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>كريسماس</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>نيقوسيا</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>براغ</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>بوسنغن</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>برلين</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>جيبوتي</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>كوبنهاغن</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>دومينيكا</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>سانتو دومينغو</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>الجزائر</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>جلاباجوس</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>غواياكويل</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>تالين</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>القاهرة</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>العيون</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>أسمرة</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>كناري</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>سيتا</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>مدريد</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>أديس أبابا</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>هلسنكي</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>فيجي</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>استانلي</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>ترك</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>باناب</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>كوسرا</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>فارو</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>باريس</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>ليبرفيل</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>لندن</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>غرينادا</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>تبليسي</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>كايين</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>غيرنسي</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>أكرا</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>جبل طارق</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>ثيل</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>غودثاب</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>سكورسبيسند</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>دانمرك شافن</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>بانجول</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>كوناكري</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>غوادلوب</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>مالابو</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>أثينا</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>جورجيا الجنوبية</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>غواتيمالا</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>غوام</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>بيساو</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>غيانا</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>هونغ كونغ</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>تيغوسيغالبا</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>زغرب</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>بورت أو برنس</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>بودابست</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>جاكرتا</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>بونتيانك</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>ماكسار</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>جايابيورا</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>دبلن</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>القدس</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>جزيرة مان</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>كالكتا</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>تشاغوس</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>بغداد</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>طهران</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>ريكيافيك</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>روما</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>جيرسي</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>جامايكا</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>عمان</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>طوكيو</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>نيروبي</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>بشكيك</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>بنوم بنه</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>اندربيرج</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>كيريتي ماتي</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>تاراوا</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>جزر القمر</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>سانت كيتس</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>بيونغ يانغ</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>سول</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>الكويت</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>كيمان</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>أكتاو</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>أورال</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>أكتوب</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>كيزيلوردا</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>ألماتي</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>فيانتيان</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>بيروت</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>سانت لوشيا</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>فادوز</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>كولومبو</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>مونروفيا</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>ماسيرو</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>فيلنيوس</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>لوكسمبورغ</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>ريغا</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>طرابلس</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>الدار البيضاء</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>موناكو</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>تشيسيناو</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>بودغوريكا</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>ماريغوت</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>أنتاناناريفو</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>كواجالين</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>ماجورو</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>سكوبي</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>باماكو</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>رانغون</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>هوفد</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>آلانباتار</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>تشوبالسان</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>ماكاو</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>سايبان</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>المارتينيك</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>نواكشوط</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>مونتسيرات</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>مالطة</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>موريشيوس</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>المالديف</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>بلانتاير</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>تيخوانا</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>سانتا إيزابيل</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>هيرموسيلو</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>مازاتلان</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>تشيواوا</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>باهيا بانديراس</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>أوجيناجا</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>مونتيري</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>مدينة المكسيك</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>ماتاموروس</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>ميريدا</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>كانكون</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>كوالا لامبور</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>كيشينج</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>مابوتو</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>ويندهوك</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>نوميا</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>نيامي</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>نورفولك</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>لاغوس</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>ماناغوا</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>أمستردام</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>أوسلو</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>كاتماندو</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>ناورو</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>نيوي</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>تشاثام</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>أوكلاند</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>مسقط</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>بنما</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>ليما</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>تاهيتي</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>ماركيساس</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>جامبير</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>بور مورسبي</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>بوغانفيل</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>مانيلا</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>كراتشي</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>وارسو</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>ميكولن</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>بيتكيرن</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>بورتوريكو</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>غزة</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>هيبرون (مدينة الخليل)</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>أزورس</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>ماديرا</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>لشبونة</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>بالاو</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>أسونسيون</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>قطر</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>ريونيون</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>بوخارست</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>بلغراد</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>كالينجراد</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>سيمفروبول</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>موسكو</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>فولوجراد</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>سمراء</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>يكاترنبيرج</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>أومسك</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>نوفوسبيرسك</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>نوفوكوزنتسك</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>كراسنويارسك</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>ايركيتسك</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>تشيتا</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>ياكتسك</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>فلاديفوستك</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>خانديجا</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>سكالين</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>أوست نيرا</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>مجادن</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>سريدنكوليمسك</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>كامتشاتكا</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>أندير</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>كيغالي</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>الرياض</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>غوادالكانال</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>ماهي</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>الخرطوم</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>ستوكهولم</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>سنغافورة</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>سانت هيلينا</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>ليوبليانا</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>لونجيربين</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>براتيسلافا</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>فري تاون</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>سان مارينو</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>داكار</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>مقديشيو</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>باراماريبو</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>جوبا</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>ساو تومي</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>السلفادور</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>حي الأمير السفلي</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>دمشق</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>مباباني</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>غراند ترك</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>نجامينا</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>كيرغويلين</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>لومي</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>بانكوك</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>دوشانبي</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>فاكاوفو</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>ديلي</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>عشق آباد</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>تونس</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>تونغاتابو</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>إسطنبول</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>بورت أوف سبين</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>فونافوتي</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>تايبيه</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>دار السلام</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>أوزجرود</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>كييف</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>زابوروزي</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>كامبالا</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>ميدواي</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>جونستون</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>واك</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>أداك</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>نوم</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>هونولولو</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>أنشوراج</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>ياكوتات</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>سيتكا</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>جوني</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>ميتلاكاتلا</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>لوس انجلوس</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>بويس</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>فينكس</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>دنفر</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>بيولا، داكوتا الشمالية</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>نيو ساليم</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>سنتر</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>شيكاغو</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>مينوميني</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>فينسينس</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>بيترسبرغ</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>مدينة تل، إنديانا</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>كونكس</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>ويناماك</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>مارنجو</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>إنديانابوليس</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>لويس فيل</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>فيفاي</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>مونتيسيلو</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>ديترويت</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>نيويورك</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>مونتفيديو</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>سمرقند</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>طشقند</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>الفاتيكان</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>سانت فنسنت</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>كاراكاس</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>تورتولا</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>سانت توماس</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>مدينة هو تشي منة</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>إيفات</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>واليس</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>أبيا</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>عدن</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>مايوت</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>جوهانسبرغ</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>لوساكا</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>هراري</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.az.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.az.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="az" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>Naməlum Şəhər</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Andorra</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Dubay</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Kabil</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Antiqua</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Angilya</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Tirana</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Yerevan</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Luanda</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Rothera</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Palmer</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Troll</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Syova</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Mouson</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Deyvis</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Vostok</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Keysi</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Dumont d’Urvil</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>Mak Murdo</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Rio Qalyeqos</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Mendoza</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>San Xuan</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Uşuaya</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>Rioxa</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>San Luis</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Katamarka</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Salta</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Jujuy</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Tukuman</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Kordoba</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Buenos Ayres</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Paqo Paqo</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Vyana</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Perth</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Yukla</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Darvin</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Adelaida</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Broken Hill</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Kuriye</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Melburn</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Hobart</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Lindeman</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Sidney</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Brisbeyn</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Makuari</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Lord Hau</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Aruba</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Mariham</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Bakı</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Sarayevo</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Barbados</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Dəkkə</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Brüssel</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Uqaduqu</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>Sofia</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Bəhreyn</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Bujumbura</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Porto-Novo</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>San Bartolomey</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Bermuda</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Brunei</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>La Pas</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Kralendik</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>İrunepe</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Rio Branko</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Porto Velyo</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Boa Vista</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Manaus</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Kuyaba</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Santarem</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Kampo Qrande</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Belem</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Araguayna</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>San Paulo</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Bahiya</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Fortaleza</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Maseyo</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Resif</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Noronya</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Nassau</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Thimphu</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Qaboron</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Minsk</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Beliz</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Douson</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Uaythors</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>İnuvik</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Vankuver</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Douson Krik</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Kreston</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Yelounayf</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Edmondton</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Svift Kurent</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Kembric Körfəzi</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Recina</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Vinipeq</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Rezolyut</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Reyni Çayı</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Rankin Girişi</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Atikokan</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>İldırım Körfəzi</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Nipiqon</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Toronto</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>İqaluit</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Panqnirtanq</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Monkton</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Halifaks</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Quz Körfəzi</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Qleys Körfəzi</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Blank-Sablon</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>Sent Cons</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Kokos</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Kinşasa</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Lubumbaşi</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Banqui</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Brazzavil</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Sürix</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Abican</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Rarotonqa</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Pasxa</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Santyaqo</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Duala</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Urumçi</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Şanxay</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Boqota</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Kosta Rika</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Havana</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Kape Verde</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Kurasao</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Milad</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Nikosia</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Praqa</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Busingen</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Berlin</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Cibuti</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Kopenhagen</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Dominika</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Santo Dominqo</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Əlcəzair</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Qalapaqos</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Quayakil</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Tallin</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Qahirə</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>Əl Əyun</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Əsmərə</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Kanar</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Seuta</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Madrid</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Əddis Əbəbə</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Helsinki</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Fici</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Stenli</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Çuuk</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Pohnpei</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Kosraye</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Farer</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>Paris</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Librevil</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>London</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Qrenada</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Tbilisi</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Kayen</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Gernzey</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Akkra</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Gibraltar</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Tul</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Nuuk</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Skoresbisund</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Danmarkşavn</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Bancul</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Konakri</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Qvadelupa</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Malabo</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Afina</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Cənubi Corciya</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Qvatemala</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Quam</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Bissau</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Qayana</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Honq Konq</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Tequsiqalpa</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Zaqreb</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Port-o-Prins</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Budapeşt</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Cakarta</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Pontianak</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Makasar</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Cayapura</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Dublin</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Yerusəlim</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Men Adası</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Kolkata</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Çaqos</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Bağdad</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Tehran</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Reykyavik</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Roma</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Cersi</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Yamayka</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Amman</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Tokyo</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Nairobi</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Bişkek</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Pnom Pen</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Enderböri</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Kirimati</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Tarava</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Komoro</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>San Kits</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Pxenyan</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Seul</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Küveyt</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Kayman</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Aktau</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Oral</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Aqtobe</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Qızılorda</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Almatı</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Vyentyan</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Beyrut</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>San Lüsiya</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Vaduts</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Kolombo</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Monrovia</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Maseru</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Vilnyus</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Lüksemburq</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Riqa</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Tripoli</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Kasablanka</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Monako</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Kişinyov</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Podqoritsa</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Mariqot</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Antananarivo</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Kvajaleyn</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Macuro</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Skopye</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Bamako</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Ranqun</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Hovd</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Ulanbator</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Çoybalsan</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Makao</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Saipan</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Martinik</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Nouakşot</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Monserat</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Malta</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Mavriki</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Maldiv</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Blantir</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Tixuana</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Santa Isabel</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Hermosilo</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Mazaltan</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Çihuahua</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Bahia Banderas</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Ocinaqa</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Monterey</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Mexiko</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Matamoros</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Merida</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Kankun</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Kuala Lumpur</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Kuçinq</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Maputo</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Vindhuk</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Noumea</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Niamey</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Norfolk</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Laqos</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Manaqua</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Amsterdam</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Oslo</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Katmandu</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Nauru</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Niue</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Çatam</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Aukland</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Muskat</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Panama</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Lima</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Tahiti</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Markesas</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Qambiyer</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Port Moresbi</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>Buqanvil</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Manila</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Karaçi</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Varşava</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Mikelon</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Pitkern</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Puerto Riko</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Qəza</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Hebron</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Azor</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Madeyra</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Lissabon</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Palau</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Asunsion</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Qatar</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Reunion</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Buxarest</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Belqrad</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Kalininqrad</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Simferopol</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Moskva</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Volqoqrad</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Samara</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Yekaterinburq</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Omsk</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Novosibirsk</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Novokuznetsk</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Krasnoyarsk</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>İrkutsk</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>Çita</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Yakutsk</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Vladivostok</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Xandıqa</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Saxalin</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Ust-Nera</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Maqadan</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>Srednekolımsk</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Kamçatka</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Anadır</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Kiqali</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Riyad</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Quadalkanal</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Mahe</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Xartum</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Stokholm</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Sinqapur</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>Müqəddəs Yelena</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Lyublyana</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Lonqyir</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Bratislava</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Fritaun</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>San Marino</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Dakar</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Moqadişu</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Paramaribo</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Juba</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>San Tom</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>Salvador</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Aşağı Prins Kvartalı</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Dəməşq</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Mbabane</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Qrand Turk</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>Ncamena</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Kergelen</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Lome</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Banqkok</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Düşənbə</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Fakaofo</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Dili</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Aşqabat</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Tunis</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Tonqapatu</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Istanbul</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>İspan Limanı</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Funafuti</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Taipei</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Dar es Salam</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Ujgorod</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Kiyev</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Zaporojye</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Kampala</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Midvey</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Conston</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Veyk</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Adak</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Nom</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Honolulu</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Ankorac</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Yakutat</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Sitka</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Cuno</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Metlakatla</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Los Anceles</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Boyse</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Feniks</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Denver</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Beulah, Şimali Dakota</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>Nyu Salem</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Mərkəz, Şimal Dakota</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Cikaqo</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Menomini</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Vinsen</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Pitersburq</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Tell</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Noks</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Vinamak</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Marenqo</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>İndianapolis</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Luisvil</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Vivey</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Montiçello</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Detroyt</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>Nyu York</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Montevideo</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Səmərqənd</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Daşkənd</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Vatikan</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>San Vinsent</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Karakas</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Tortola</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>San Tomas</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Ho Şi Min</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Efate</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Uollis</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Apia</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Aden</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Mayot</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Yohanesburq</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Lusaka</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Harare</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.bg.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.bg.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="bg" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>неизвестен</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Андора</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Дубай</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Кабул</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Антигуа</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Ангуила</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Тирана</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Ереван</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Луанда</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Ротера</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Палмър</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Трол</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Шова</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Моусън</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Дейвис</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Восток</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Кейси</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Дюмон Дюрвил</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>Макмърдо</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Рио Галегос</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Мендоса</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>Сан Хуан</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ушуая</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>Ла Риоха</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>Сан Луис</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Катамарка</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Салта</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Хухуй</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Тукуман</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Кордоба</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Буенос Айрес</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Паго Паго</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Виена</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Пърт</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Юкла</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Дарвин</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Аделаида</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Броукън Хил</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Къри</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Мелбърн</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Хобарт</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Линдеман</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Сидни</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Бризбейн</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Маккуори</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Лорд Хау</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Аруба</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Мариехамн</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Баку</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Сараево</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Барбадос</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Дака</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Брюксел</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Уагадугу</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>София</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Бахрейн</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Бужумбура</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Порто Ново</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>Сен Бартелеми</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Бермудски острови</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Бруней</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>Ла Пас</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Кралендейк</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Ейрунепе</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Рио Бранко</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Порто Вельо</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Боа Виста</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Манаус</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Чуяба</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Сантарем</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Кампо Гранде</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Белем</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Арагуайна</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>Сао Пауло</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Баия</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Форталеза</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Масейо</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Ресифе</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Нороня</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Насау</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Тхимпху</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Габороне</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Минск</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Белиз</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Доусън</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Уайтхорс</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Инувик</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Ванкувър</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Доусън Крийк</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Крестън</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Йелоунайф</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Едмънтън</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Суифт Кърент</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Кеймбридж Бей</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Риджайна</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Уинипег</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Резолют</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Рейни Ривър</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Ранкин Инлет</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Корал Харбър</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Тъндър Бей</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Нипигон</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Торонто</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Иквалуит</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Пангниртунг</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Монктон</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Халифакс</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Гус Бей</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Глейс Бей</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Блан-Саблон</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>Сейнт Джонс</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Кокосови острови</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Киншаса</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Лубумбаши</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Бангуи</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Бразавил</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Цюрих</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Абиджан</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Раротонга</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Великденски о-в</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Сантяго</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Дуала</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Урумчи</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Шанхай</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Богота</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Коста Рика</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Хавана</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Кабо Верде</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Кюрасао</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Рождество</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Никозия</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Прага</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Бюзинген</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Берлин</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Джибути</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Копенхаген</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Доминика</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Санто Доминго</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Алжир</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Галапагоски о-ви</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Гуаякил</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Талин</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Кайро</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>Ел Аюн</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Асмара</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Канарски о-ви</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Сеута</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Мадрид</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Адис Абеба</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Хелзинки</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Фиджи</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Стенли</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Чуюк</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Понпей</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Кошрай</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Фарьорски острови</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>Париж</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Либревил</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>Лондон</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Гренада</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Тбилиси</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Кайен</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Гърнси</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Акра</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Гибралтар</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Туле</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Нуук</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Сгорсбисон</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Данмарксхавн</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Банджул</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Конакри</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Гваделупа</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Малабо</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Атина</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Южна Джорджия</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Гватемала</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Гуам</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Бисау</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Гаяна</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Хонконг</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Тегусигалпа</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Загреб</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Порт-о-Пренс</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Будапеща</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Джакарта</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Понтианак</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Макасар</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Джаяпура</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Дъблин</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Йерусалим</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>о-в Ман</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Колката</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Чагос</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Багдад</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Техеран</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Рейкявик</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Рим</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Джърси</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Ямайка</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Аман</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Токио</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Найроби</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Бишкек</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Пном Пен</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Ендърбъри</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Киритимати</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Тарауа</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Коморски острови</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>Сейнт Китс</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Пхенян</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Сеул</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Кувейт</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Кайманови острови</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Актау</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Арал</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Актобе</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Къзълорда</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Алмати</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Виентян</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Бейрут</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>Сейнт Лусия</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Вадуц</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Коломбо</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Монровия</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Масеру</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Вилнюс</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Люксембург</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Рига</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Триполи</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Казабланка</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Монако</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Кишинев</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Подгорица</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Мариго</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Антананариво</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Куаджалин</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Маджуро</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Скопие</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Бамако</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Рангун</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Ховд</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Улан Батор</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Чойбалсан</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Макао</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Сайпан</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Мартиника</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Нуакшот</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Монтсерат</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Малта</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Мавриций</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Малдиви</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Блантайър</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Тихуана</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Санта Исабел</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Ермосильо</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Масатлан</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Чиуауа</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Баия де Бандерас</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Охинага</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Монтерей</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Мексико Сити</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Матаморос</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Мерида</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Канкун</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Куала Лумпур</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Кучин</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Мапуто</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Виндхук</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Нумеа</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Ниамей</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Норфолк</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Лагос</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Манагуа</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Амстердам</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Осло</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Катманду</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Науру</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Ниуе</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Чатам</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Окланд</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Мускат</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Панама</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Лима</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Таити</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Маркизки о-ви</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Гамбие</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Порт Морсби</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>Бугенвил</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Манила</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Карачи</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Варшава</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Микелон</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Питкерн</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Пуерто Рико</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Газа</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Хеброн</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Азорски о-ви</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Мадейра</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Лисабон</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Палау</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Асунсион</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Катар</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Реюнион</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Букурещ</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Белград</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Калининград</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Севастопол</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Москва</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Волгоград</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Самара</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Екатеринбург</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Омск</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Новосибирск</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Новокузнецк</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Красноярск</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Иркутск</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>Чита</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Якутск</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Владивосток</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Хандига</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Сахалин</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Уст-Нера</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Магадан</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>Среднеколимск</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Камчатка</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Анадир</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Кигали</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Рияд</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Гуадалканал</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Мае</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Хартум</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Стокхолм</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Сингапур</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>Света Елена</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Любляна</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Лонгирбюен</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Братислава</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Фрийтаун</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>Сан Марино</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Дакар</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Могадишу</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Парамарибо</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Джуба</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>Сао Томе</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>Салвадор</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Лоуър принсес куотър</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Дамаск</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Мбабане</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Гранд Търк</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>Нджамена</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Кергелен</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Ломе</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Банкок</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Душанбе</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Факаофо</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Дили</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Ашхабад</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Тунис</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Тонгатапу</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Истанбул</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Порт ъф Спейн</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Фунафути</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Тайпе</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Дар ес Салам</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Ужгород</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Киев</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Запорожие</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Кампала</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Мидуей</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Джонстън</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Уейк</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Адак</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Ноум</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Хонолулу</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Анкъридж</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Якутат</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Ситка</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Джуно</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Метлакатла</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Лос Анджелис</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Бойси</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Финикс</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Денвър</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Бюла</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>Ню Сейлъм</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Сентър</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Чикаго</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Меномини</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Винсенс</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Питърсбърг</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Тел Сити</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Нокс</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Уинамак</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Маренго</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Индианаполис</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Луисвил</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Виви</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Монтичело</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Детройт</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>Ню Йорк</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Монтевидео</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Самарканд</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Ташкент</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Ватикан</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>Сейнт Винсънт</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Каракас</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Тортола</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>Сейнт Томас</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Хошимин</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Ефате</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Уолис</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Апия</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Аден</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Майот</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Йоханесбург</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Лусака</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Хараре</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.ca.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.ca.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="ca" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>Ciutat desconeguda</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Andorra</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Dubai</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Kābul</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Antigua</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Anguilla</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Tirana</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Erevan</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Luanda</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Rothera</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Palmer</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Troll</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Syowa</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Mawson</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Davis</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Vostok</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Casey</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Dumont d’Urville</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>McMurdo</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Río Gallegos</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Mendoza</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>San Juan</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ushuaia</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>La Rioja</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>San Luis</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Catamarca</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Salta</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Jujuy</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Tucumán</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Córdoba</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Buenos Aires</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Pago Pago</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Viena</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Perth</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Eucla</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Darwin</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Adelaide</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Broken Hill</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Currie</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Melbourne</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Hobart</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Lindeman</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Sydney</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Brisbane</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Macquarie</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Lord Howe</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Aruba</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Maarianhamina</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Bakú</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Sarajevo</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Barbados</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Dacca</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Brussel·les</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Ouagadougou</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>Sofia</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Bahrain</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Bujumbura</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Porto-Novo</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>Saint Barthélemy</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Bermudes</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Brunei</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>La Paz</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Kralendijk</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Eirunepé</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Río Branco</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Porto Velho</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Boa Vista</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Manaus</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Cuiabá</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Santarém</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Campo Grande</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Belém</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Araguaína</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>São Paulo</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Bahia</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Fortaleza</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Maceió</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Recife</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Noronha</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Nassau</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Thimbu</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Gaborone</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Minsk</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Belize</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Dawson</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Whitehorse</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Inuvik</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Vancouver</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Dawson Creek</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Creston</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Yellowknife</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Edmonton</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Swift Current</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Cambridge Bay</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Regina</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Winnipeg</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Resolute</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Rainy River</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Rankin Inlet</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Atikokan</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Thunder Bay</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Nipigon</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Toronto</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Iqaluit</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Pangnirtung</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Moncton</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Halifax</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Goose Bay</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Glace Bay</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Blanc Sablon</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>Saint John’s</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Cocos</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Kinshasa</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Lubumbashi</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Bangui</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Brazzaville</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Zuric</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Abidjan</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Rarotonga</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Illa de Pasqua</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Santiago</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Douala</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Urumchi</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Xangai</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Bogotà</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Costa Rica</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Havana</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Cap Verd</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Curaçao</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Christmas</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Nicòsia</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Praga</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Busingen</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Berlín</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Djibouti</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Copenhagen</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Dominica</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Santo Domingo</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Alger</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Galápagos</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Guayaquil</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Tallinn</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Caire, el</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>Al-aaiun</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Asmara</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Illes Canàries</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Ceuta</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Madrid</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Addis Abeba</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Hèlsinki</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Fiji</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Stanley</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Chuuk</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Pohnpei</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Kosrae</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Illes Fèroe</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>París</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Libreville</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>Londres</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Grenada</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Tbilisi</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Caiena</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Guernsey</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Accra</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Gibraltar</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Thule</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Nuuk</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Scoresbysund</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Danmarkshavn</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Banjul</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Conakry</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Guadeloupe</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Malabo</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Atenes</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Geòrgia del Sud</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Guatemala</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Guam</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Bissau</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Guyana</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Hong Kong</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Tegucigalpa</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Zagreb</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Port-au-Prince</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Budapest</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Jakarta</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Pontianak</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Makasar</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Jaipur</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Dublín</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Jerusalem</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Man</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Calcuta</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Chagos</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Bagdad</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Teheran</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Reykjavik</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Roma</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Jersey</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Jamaica</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Amman</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Tòquio</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Nairobi</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Bixkek</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Phnom Penh</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Enderbury</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Kiritimati</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Tarawa</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Comoro</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>Saint Kitts</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Pyongyang</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Seül</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Kuwait</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Caiman</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Aqtaū</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Oral</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Aqtobe</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Kizilordà</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Almaty</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Vientiane</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Beirut</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>Saint Lucia</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Vaduz</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Colombo</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Monrovia</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Maseru</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Vílnius</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Luxemburg</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Riga</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Trípoli</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Casablanca</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Mònaco</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Chisinau</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Podgorica</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Marigot</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Antananarivo</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Kwajalein</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Majuro</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Skopje</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Bamako</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Rangoon</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Hovd</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Ulaanbaatar</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Choibalsan</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Macau</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Saipan</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Martinica</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Nouakchott</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Montserrat</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Malta</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Maurici</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Maldives</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Blantyre</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Tijuana</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Santa Isabel</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Hermosillo</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Mazatlán</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Chihuahua</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>bahía de Banderas</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Ojinaga</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Monterrey</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Ciutat de Mèxic</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Matamoros</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Mérida</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Cancun</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Kuala Lumpur</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Kuching</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Maputo</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Windhoek</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Nouméa</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Niamey</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Norfolk</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Lagos</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Managua</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Amsterdam</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Oslo</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Katmandú</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Nauru</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Niue</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Chatham</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Auckland</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Masqat</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Panamà</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Lima</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Tahití</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Marqueses</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Gambier</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Port Moresby</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>Bougainville</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Manila</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Karachi</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Varsòvia</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Miquelon</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Pitcairn</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Puerto Rico</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Gaza</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Hebron</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Açores</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Madeira</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Lisboa</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Palau</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Asunción</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Qatar</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Reunió</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Bucarest</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Belgrad</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Kaliningrad</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Simferopol</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Moscou</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Volgograd</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Samara</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Jekaterinburg</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Omsk</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Novosibirsk</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Novokuznetsk</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Krasnoiarsk</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Irkutsk</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>Txità</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Jakutsk</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Vladivostok</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Khandyga</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Sakhalin</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Ust’-Nera</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Magadan</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>Srednekolimsk</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Kamtxatka</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Anadyr’</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Kigali</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Al-Riyād</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Guadalcanal</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Mahe</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Khartum</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Estocolm</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Singapur</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>Saint Helena</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Ljubljana</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Longyearbyen</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Bratislava</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Freetown</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>San Marino</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Dakar</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Muqdiisho</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Paramaribo</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Juba</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>São Tomé</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>El Salvador</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Lower Prince’s Quarter</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Damasc</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Mbabane</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Grand Turk</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>Ndjamena</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Kerguelen</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Lome</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Bangkok</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Dushanbe</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Fakaofo</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Dili</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Ashgabat</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Tunis</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Tongatapu</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Istanbul</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Port of Spain</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Funafuti</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Taipei</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Dar es Salaam</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Uzhgorod</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Kíev</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Zaporíjia</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Kampala</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Midway</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Johnston</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Wake</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Adak</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Nome</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Honolulu</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Anchorage</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Yakutat</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Sitka</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Juneau</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Metlakatla</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Los Angeles</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Boise</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Phoenix</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Denver</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Beulah, Dakota del Nord</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>New Salem, Dakota del Nord</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Center, Dakota del Nord</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Xicago</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Menominee</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Vincennes, Indiana</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Petersburg, Indiana</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Tell City, Indiana</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Knox, Indiana</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Winamac, Indiana</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Marengo, Indiana</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Indianapolis</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Louisville</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Vevay, Indiana</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Monticello, Kentucky</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Detroit</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>Nova York</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Montevideo</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Samarcanda</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Taixkent</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Vaticà</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>Saint Vincent</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Caracas</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Tortola</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>Saint Thomas</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Ho Chi Minh</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Efate</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Wallis</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Apia</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Aden</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Mayotte</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Johannesburg</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Lusaka</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Harare</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.cs.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.cs.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="cs" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>Neznámé město</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Andorra</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Dubaj</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Kábul</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Antigua</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Anguilla</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Tirana</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Jerevan</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Luanda</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Rothera</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Palmer</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Troll</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Syowa</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Mawson</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Davis</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Vostok</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Casey</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Dumont d’Urville</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>McMurdo</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Rio Gallegos</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Mendoza</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>San Juan</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ushuaia</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>La Rioja</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>San Luis</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Catamarca</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Salta</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Jujuy</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Tucuman</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Córdoba</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Buenos Aires</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Pago Pago</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Vídeň</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Perth</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Eucla</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Darwin</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Adelaide</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Broken Hill</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Currie</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Melbourne</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Hobart</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Lindeman</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Sydney</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Brisbane</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Macquarie</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Lord Howe</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Aruba</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Mariehamn</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Baku</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Sarajevo</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Barbados</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Dháka</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Brusel</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Ouagadougou</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>Sofie</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Bahrajn</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Bujumbura</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Porto-Novo</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>Svatý Bartoloměj</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Bermudy</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Brunej</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>La Paz</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Kralendijk</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Eirunepe</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Rio Branco</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Porto Velho</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Boa Vista</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Manaus</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Cuiaba</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Santarém</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Campo Grande</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Belém</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Araguaina</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>São Paulo</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Bahía</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Fortaleza</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Maceio</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Recife</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Noronha</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Nassau</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Thimbú</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Gaborone</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Minsk</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Belize</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Dawson</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Whitehorse</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Inuvik</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Vancouver</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Dawson Creek</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Creston</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Yellowknife</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Edmonton</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Swift Current</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Cambridge Bay</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Regina</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Winnipeg</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Resolute</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Rainy River</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Rankin Inlet</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Atikokan</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Thunder Bay</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Nipigon</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Toronto</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Iqaluit</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Pangnirtung</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Moncton</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Halifax</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Goose Bay</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Glace Bay</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Blanc-Sablon</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>St. John’s</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Kokosové ostrovy</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Kinshasa</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Lubumbashi</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Bangui</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Brazzaville</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Curych</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Abidžan</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Rarotonga</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Velikonoční ostrov</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Santiago</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Douala</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Urumči</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Šanghaj</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Bogotá</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Kostarika</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Havana</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Kapverdy</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Curaçao</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Vánoční ostrov</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Nikósie</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Praha</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Busingen</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Berlín</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Džibuti</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Kodaň</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Dominika</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Santo Domingo</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Alžír</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Galapágy</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Guayaquil</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Tallinn</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Káhira</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>El Aaiun</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Asmara</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Kanárské ostrovy</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Ceuta</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Madrid</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Addis Abeba</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Helsinky</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Fidži</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Stanley</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Chuukské ostrovy</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Pohnpei</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Kosrae</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Faerské ostrovy</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>Paříž</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Libreville</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>Londýn</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Grenada</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Tbilisi</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Cayenne</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Guernsey</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Accra</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Gibraltar</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Thule</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Nuuk</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Ittoqqortoormiit</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Danmarkshavn</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Banjul</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Conakry</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Guadeloupe</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Malabo</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Athény</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Jižní Georgie</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Guatemala</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Guam</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Bissau</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Guyana</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Hongkong</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Tegucigalpa</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Záhřeb</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Port-au-Prince</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Budapešť</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Jakarta</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Pontianak</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Makassar</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Jayapura</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Dublin</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Jeruzalém</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Ostrov Man</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Kalkata</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Chagos</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Bagdád</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Teherán</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Reykjavík</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Řím</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Jersey</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Jamajka</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Ammán</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Tokio</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Nairobi</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Biškek</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Phnompenh</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Enderbury</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Kiritimati</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Tarawa</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Komory</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>Svatý Kryštof</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Pchjongjang</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Soul</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Kuvajt</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Kajmanské ostrovy</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Aktau</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Uralsk</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Aktobe</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Kyzylorda</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Almaty</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Vientiane</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Bejrút</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>Svatá Lucie</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Vaduz</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Kolombo</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Monrovia</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Maseru</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Vilnius</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Lucemburk</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Riga</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Tripolis</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Casablanca</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Monako</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Kišiněv</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Podgorica</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Marigot</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Antananarivo</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Kwajalein</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Majuro</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Skopje</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Bamako</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Rangún</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Hovd</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Ulánbátar</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Čojbalsan</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Macao</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Saipan</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Martinik</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Nuakšott</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Montserrat</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Malta</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Mauricius</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Maledivy</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Blantyre</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Tijuana</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Santa Isabel</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Hermosillo</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Mazatlán</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Chihuahua</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Bahia Banderas</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Ojinaga</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Monterrey</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>México</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Matamoros</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Merida</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Cancún</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Kuala Lumpur</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Kučing</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Maputo</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Windhoek</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Nouméa</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Niamey</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Norfolk</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Lagos</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Managua</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Amsterdam</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Oslo</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Káthmándú</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Nauru</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Niue</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Chathamské ostrovy</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Auckland</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Maskat</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Panama</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Lima</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Tahiti</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Markézy</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Gambierovy ostrovy</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Port Moresby</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>Bougainville</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Manila</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Karáčí</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Varšava</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Miquelon</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Pitcairnovy ostrovy</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Portoriko</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Gaza</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Hebron</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Azorské ostrovy</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Madeira</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Lisabon</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Palau</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Asunción</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Katar</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Réunion</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Bukurešť</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Bělehrad</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Kaliningrad</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Simferopol</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Moskva</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Volgograd</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Samara</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Jekatěrinburg</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Omsk</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Novosibirsk</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Novokuzněck</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Krasnojarsk</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Irkutsk</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>Čita</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Jakutsk</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Vladivostok</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Chandyga</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Sachalin</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Ust-Nera</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Magadan</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>Sredněkolymsk</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Kamčatka</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Anadyr</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Kigali</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Rijád</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Guadalcanal</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Mahé</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Chartúm</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Stockholm</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Singapur</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>Svatá Helena</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Lublaň</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Longyearbyen</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Bratislava</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Freetown</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>San Marino</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Dakar</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Mogadišu</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Paramaribo</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Juba</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>Svatý Tomáš</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>Salvador</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Lower Prince’s Quarter</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Damašek</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Mbabane</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Grand Turk</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>Ndžamena</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Kerguelenovy ostrovy</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Lomé</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Bangkok</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Dušanbe</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Fakaofo</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Dili</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Ašchabad</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Tunis</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Tongatapu</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Istanbul</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Port of Spain</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Funafuti</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Tchaj-pej</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Dar es Salaam</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Užhorod</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Kyjev</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Záporoží</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Kampala</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Midway</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Johnston</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Wake</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Adak</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Nome</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Honolulu</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Anchorage</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Yakutat</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Sitka</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Juneau</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Metlakatla</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Los Angeles</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Boise</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Phoenix</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Denver</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Beulah, Severní Dakota</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>New Salem, Severní Dakota</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Center, Severní Dakota</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Chicago</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Menominee</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Vincennes, Indiana</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Petersburg, Indiana</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Tell City, Indiana</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Knox, Indiana</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Winamac, Indiana</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Marengo, Indiana</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Indianapolis</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Louisville</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Vevay, Indiana</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Monticello, Kentucky</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Detroit</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>New York</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Montevideo</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Samarkand</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Taškent</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Vatikán</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>Svatý Vincenc</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Caracas</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Tortola</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>Svatý Tomáš (Karibik)</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Ho Či Minovo město</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Éfaté</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Wallis</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Apia</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Aden</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Mayotte</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Johannesburg</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Lusaka</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Harare</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.da.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.da.xlf
@@ -1,0 +1,1711 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="da" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>Ukendt by</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Andorra</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Dubai</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Kabul</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Antigua</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Anguilla</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Tirane</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Yerevan</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Luanda</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Rothera</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Palmer</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Troll</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Syowa</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Mawson</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Davis</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Vostok</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Casey</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Dumont d’Urville</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>McMurdo</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Rio Gallegos</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Mendoza</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>San Juan</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ushuaia</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>La Rioja</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>San Luis</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Catamarca</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Salta</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Jujuy</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Tucuman</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Cordoba</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Buenos Aires</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Pago Pago</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Wien</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Perth</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Eucla</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Darwin</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Adelaide</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Broken Hill</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Currie</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Melbourne</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Hobart</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Lindeman</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Sydney</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Brisbane</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Macquarie</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Lord Howe</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Aruba</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Mariehamn</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Baku</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Sarajevo</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Barbados</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Dhaka</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Bruxelles</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Ouagadougou</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>Sofia</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Bahrain</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Bujumbura</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Porto-Novo</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>Saint-Barthélemy</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Bermuda</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Brunei</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>La Paz</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Kralendijk</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Eirunepe</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Rio Branco</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Porto Velho</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Boa Vista</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Manaus</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Cuiaba</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Santarem</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Campo Grande</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Belem</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Araguaina</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>São Paulo</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Bahia</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Fortaleza</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Maceio</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Recife</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Noronha</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Nassau</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Thimphu</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Gaborone</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Minsk</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Belize</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Dawson</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Whitehorse</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Inuvik</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Vancouver</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Dawson Creek</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Creston</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Yellowknife</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Edmonton</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Swift Current</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Cambridge Bay</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Regina</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Winnipeg</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Resolute</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Rainy River</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Rankin Inlet</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Atikokan</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Thunder Bay</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Nipigon</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Toronto</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Iqaluit</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Pangnirtung</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Moncton</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Halifax</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Goose Bay</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Glace Bay</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Blanc-Sablon</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>St. John’s</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Cocos</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Kinshasa</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Lubumbashi</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Bangui</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Brazzaville</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Zürich</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Abidjan</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Rarotonga</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Påskeøen</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Santiago</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Douala</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Urumqi</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Shanghai</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Bogota</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Costa Rica</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Havana</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Kap Verde</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Curaçao</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Christmas</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Nicosia</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Prag</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Busingen</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Berlin</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Djibouti</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>København</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Dominica</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Santo Domingo</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Algier</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Galapagos</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Guayaquil</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Tallinn</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Cairo</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>El Aaiun</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Asmara</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>De Kanariske Øer</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Ceuta</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Madrid</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Addis Abeba</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Helsinki</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Fiji</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Stanley</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Chuuk</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Pohnpei</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Kosrae</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Færøerne</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>Paris</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Libreville</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>London</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Grenada</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Tbilisi</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Cayenne</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Guernsey</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Accra</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Gibraltar</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Thule</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Nuuk</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Ittoqqortoormiit</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Danmarkshavn</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Banjul</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Conakry</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Guadeloupe</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Malabo</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Athen</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>South Georgia</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Guatemala</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Guam</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Bissau</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Guyana</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Hongkong</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Tegucigalpa</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Zagreb</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Port-au-Prince</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Budapest</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Jakarta</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Pontianak</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Makassar</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Jayapura</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Dublin</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Jerusalem</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Isle of Man</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Kolkata</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Chagos</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Baghdad</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Teheran</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Reykjavik</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Rom</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Jersey</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Jamaica</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Amman</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Tokyo</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Nairobi</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Bishkek</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Phnom Penh</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Enderbury</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Kiritimati</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Tarawa</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Comoro</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>St. Kitts</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Pyongyang</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Seoul</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Kuwait</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Cayman</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Aqtau</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Oral</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Aqtobe</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Qyzylorda</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Almaty</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Vientiane</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Beirut</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>St. Lucia</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Vaduz</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Colombo</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Monrovia</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Maseru</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Vilnius</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Luxembourg</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Riga</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Tripoli</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Casablanca</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Monaco</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Chisinau</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Podgorica</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Marigot</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Antananarivo</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Kwajalein</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Majuro</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Skopje</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Bamako</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Rangoon</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Hovd</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Ulaanbaatar</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Choibalsan</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Macao</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Saipan</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Martinique</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Nouakchott</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Montserrat</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Malta</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Mauritius</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Maldiverne</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Blantyre</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Tijuana</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Santa Isabel</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Hermosillo</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Mazatlan</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Chihuahua</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Bahia Banderas</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Ojinaga</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Monterrey</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Mexico City</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Matamoros</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Merida</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Cancun</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Kuala Lumpur</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Kuching</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Maputo</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Windhoek</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Noumea</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Niamey</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Norfolk</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Lagos</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Managua</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Amsterdam</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Oslo</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Katmandu</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Nauru</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Niue</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Chatham</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Auckland</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Muscat</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Panama</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Lima</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Tahiti</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Marquesas</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Gambier</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Port Moresby</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>Bougainville</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Manila</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Karachi</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Warszawa</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Miquelon</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Pitcairn</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Puerto Rico</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Gaza</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Hebron</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Azorerne</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Madeira</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Lissabon</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Palau</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Asunción</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Qatar</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Réunion</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Bukarest</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Beograd</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Kaliningrad</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Simferopol</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Moskva</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Volgograd</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Samara</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Jekaterinburg</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Omsk</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Novosibirsk</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Novokuznetsk</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Krasnoyarsk</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Irkutsk</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>Chita</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Jakutsk</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Vladivostok</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Khandyga</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Sakhalin</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Ust-Nera</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Magadan</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>Srednekolymsk</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Kamchatka</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Anadyr</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Kigali</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Riyadh</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Guadalcanal</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Mahe</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Khartoum</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Stockholm</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Singapore</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>St. Helena</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Ljubljana</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Longyearbyen</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Bratislava</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Freetown</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>San Marino</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Dakar</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Mogadishu</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Paramaribo</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Juba</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>São Tomé</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>El Salvador</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Lower Prince’s Quarter</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Damaskus</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Mbabane</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Grand Turk</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>Ndjamena</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Kerguelen</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Lome</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Bangkok</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Dushanbe</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Fakaofo</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Dili</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Ashgabat</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Tunis</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Tongatapu</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Istanbul</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Port of Spain</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Funafuti</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Taipei</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Dar es Salaam</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Uzhgorod</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Kiev</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Zaporizjzja</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Kampala</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Midway</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Johnston</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Wake</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Adak</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Nome</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Honolulu</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Anchorage</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Yakutat</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Sitka</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Juneau</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Metlakatla</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Los Angeles</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Boise</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Phoenix</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Denver</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Beulah, North Dakota</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>New Salem, North Dakota</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Center, North Dakota</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Chicago</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Menominee</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Vincennes, Indiana</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Petersburg, Indiana</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Tell City, Indiana</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Knox, Indiana</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Winamac, Indiana</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Marengo, Indiana</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Indianapolis</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Louisville</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Vevay, Indiana</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Monticello, Kentucky</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Detroit</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>New York</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Montevideo</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Samarkand</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Tasjkent</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Vatikanet</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>St. Vincent</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Caracas</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Tortola</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>St. Thomas</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Ho Chi Minh City</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Efate</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Wallis</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Apia</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Aden</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Mayotte</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Johannesburg</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Lusaka</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Harare</target>
+      </trans-unit>
+      <trans-unit id="f5cd262901883dff68d06b215fb0f28e" resname="Africa">
+        <source>Africa</source>
+        <target>Afrika</target>
+      </trans-unit>
+      <trans-unit id="44b439ba9975f8e802b456777c54a854" resname="Antarctica">
+        <source>Antarctica</source>
+        <target>Antarktis</target>
+      </trans-unit>
+      <trans-unit id="443531f5f05df188d6a311cfa1123b73" resname="Arctic">
+        <source>Arctic</source>
+        <target>Arktis</target>
+      </trans-unit>
+      <trans-unit id="f17af17f6b59b4e7f1d4a6e99fbf7675" resname="Atlantic">
+        <source>Atlantic</source>
+        <target>Atlanterhavet</target>
+      </trans-unit>
+      <trans-unit id="4442e4af0916f53a07fb8ca9a49b98ed" resname="Australia">
+        <source>Australia</source>
+        <target>Australien</target>
+      </trans-unit>
+      <trans-unit id="912d59cdf1d3f551fae21f6f0062258f" resname="Europe">
+        <source>Europe</source>
+        <target>Europa</target>
+      </trans-unit>
+      <trans-unit id="b5f6e3ec74afdaf0ada5500babfa8d52" resname="Indian">
+        <source>Indian</source>
+        <target>Indiske Ocean</target>
+      </trans-unit>
+      <trans-unit id="501a92c9b793cb44dfbfe0ca9ffee563" resname="Pacific">
+        <source>Pacific</source>
+        <target>Stillehavet</target>
+      </trans-unit>
+      <trans-unit id="6311ae17c1ee52b36e68aaf4ad066387" resname="Other">
+        <source>Other</source>
+        <target>Øvrige</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.de.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.de.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="de" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>Unbekannt</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Andorra</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Dubai</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Kabul</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Antigua</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Anguilla</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Tirana</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Eriwan</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Luanda</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Rothera</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Palmer</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Troll</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Syowa</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Mawson</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Davis</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Wostok</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Casey</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Dumont d’Urville</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>McMurdo</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Rio Gallegos</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Mendoza</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>San Juan</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ushuaia</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>La Rioja</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>San Luis</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Catamarca</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Salta</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Jujuy</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Tucuman</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Córdoba</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Buenos Aires</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Pago Pago</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Wien</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Perth</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Eucla</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Darwin</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Adelaide</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Broken Hill</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Currie</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Melbourne</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Hobart</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Lindeman</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Sydney</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Brisbane</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Macquarie</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Lord Howe</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Aruba</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Mariehamn</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Baku</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Sarajevo</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Barbados</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Dhaka</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Brüssel</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Ouagadougou</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>Sofia</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Bahrain</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Bujumbura</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Porto Novo</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>Saint-Barthélemy</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Bermudas</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Brunei</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>La Paz</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Kralendijk</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Eirunepe</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Rio Branco</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Porto Velho</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Boa Vista</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Manaus</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Cuiaba</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Santarem</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Campo Grande</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Belem</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Araguaina</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>São Paulo</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Bahia</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Fortaleza</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Maceio</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Recife</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Noronha</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Nassau</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Thimphu</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Gaborone</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Minsk</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Belize</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Dawson</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Whitehorse</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Inuvik</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Vancouver</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Dawson Creek</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Creston</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Yellowknife</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Edmonton</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Swift Current</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Cambridge Bay</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Regina</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Winnipeg</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Resolute</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Rainy River</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Rankin Inlet</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Atikokan</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Thunder Bay</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Nipigon</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Toronto</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Iqaluit</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Pangnirtung</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Moncton</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Halifax</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Goose Bay</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Glace Bay</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Blanc-Sablon</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>St. John’s</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Cocos</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Kinshasa</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Lubumbashi</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Bangui</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Brazzaville</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Zürich</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Abidjan</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Rarotonga</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Osterinsel</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Santiago</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Douala</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Ürümqi</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Shanghai</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Bogotá</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Costa Rica</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Havanna</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Kap Verde</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Curaçao</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Weihnachtsinsel</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Nikosia</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Prag</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Büsingen</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Berlin</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Dschibuti</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Kopenhagen</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Dominica</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Santo Domingo</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Algier</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Galapagos</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Guayaquil</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Tallinn</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Kairo</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>El Aaiún</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Asmara</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Kanaren</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Ceuta</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Madrid</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Addis Abeba</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Helsinki</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Fidschi</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Stanley</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Chuuk</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Pohnpei</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Kosrae</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Färöer</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>Paris</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Libreville</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>London</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Grenada</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Tiflis</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Cayenne</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Guernsey</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Accra</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Gibraltar</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Thule</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Nuuk</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Ittoqqortoormiit</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Danmarkshavn</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Banjul</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Conakry</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Guadeloupe</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Malabo</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Athen</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Südgeorgien</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Guatemala</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Guam</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Bissau</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Guyana</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Hongkong</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Tegucigalpa</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Zagreb</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Port-au-Prince</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Budapest</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Jakarta</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Pontianak</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Makassar</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Jayapura</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Dublin</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Jerusalem</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Isle of Man</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Kalkutta</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Chagos</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Bagdad</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Teheran</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Reyk­ja­vík</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Rom</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Jersey</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Jamaika</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Amman</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Tokio</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Nairobi</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Bischkek</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Phnom Penh</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Enderbury</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Kiritimati</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Tarawa</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Komoren</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>St. Kitts</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Pjöngjang</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Seoul</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Kuwait</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Kaimaninseln</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Aqtau</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Oral</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Aktobe</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Qysylorda</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Almaty</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Vientiane</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Beirut</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>St. Lucia</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Vaduz</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Colombo</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Monrovia</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Maseru</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Vilnius</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Luxemburg</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Riga</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Tripolis</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Casablanca</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Monaco</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Kischinau</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Podgorica</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Marigot</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Antananarivo</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Kwajalein</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Majuro</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Skopje</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Bamako</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Rangun</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Chowd</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Ulaanbaatar</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Tschoibalsan</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Macao</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Saipan</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Martinique</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Nouakchott</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Montserrat</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Malta</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Mauritius</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Malediven</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Blantyre</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Tijuana</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Santa Isabel</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Hermosillo</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Mazatlan</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Chihuahua</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Bahia Banderas</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Ojinaga</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Monterrey</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Mexiko-Stadt</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Matamoros</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Merida</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Cancún</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Kuala Lumpur</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Kuching</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Maputo</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Windhoek</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Noumea</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Niamey</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Norfolk</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Lagos</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Managua</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Amsterdam</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Oslo</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Kathmandu</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Nauru</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Niue</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Chatham</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Auckland</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Maskat</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Panama</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Lima</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Tahiti</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Marquesas</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Gambier</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Port Moresby</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>Bougainville</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Manila</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Karatschi</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Warschau</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Miquelon</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Pitcairn</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Puerto Rico</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Gaza</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Hebron</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Azoren</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Madeira</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Lissabon</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Palau</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Asunción</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Katar</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Réunion</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Bukarest</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Belgrad</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Kaliningrad</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Simferopol</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Moskau</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Wolgograd</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Samara</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Jekaterinburg</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Omsk</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Nowosibirsk</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Nowokuznetsk</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Krasnojarsk</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Irkutsk</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>Tschita</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Jakutsk</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Wladiwostok</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Chandyga</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Sachalin</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Ust-Nera</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Magadan</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>Srednekolymsk</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Kamtschatka</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Anadyr</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Kigali</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Riad</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Guadalcanal</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Mahe</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Khartum</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Stockholm</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Singapur</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>St. Helena</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Ljubljana</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Longyearbyen</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Bratislava</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Freetown</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>San Marino</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Dakar</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Mogadischu</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Paramaribo</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Juba</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>São Tomé</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>El Salvador</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Lower Prince’s Quarter</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Damaskus</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Mbabane</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Grand Turk</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>N’Djamena</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Kerguelen</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Lomé</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Bangkok</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Duschanbe</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Fakaofo</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Dili</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Aşgabat</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Tunis</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Tongatapu</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Istanbul</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Port of Spain</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Funafuti</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Taipeh</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Daressalam</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Uschgorod</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Kiew</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Saporischja</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Kampala</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Midway</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Johnston</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Wake</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Adak</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Nome</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Honolulu</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Anchorage</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Yakutat</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Sitka</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Juneau</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Metlakatla</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Los Angeles</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Boise</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Phoenix</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Denver</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Beulah, North Dakota</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>New Salem, North Dakota</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Center, North Dakota</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Chicago</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Menominee</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Vincennes, Indiana</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Petersburg, Indiana</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Tell City, Indiana</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Knox, Indiana</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Winamac, Indiana</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Marengo, Indiana</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Indianapolis</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Louisville</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Vevay, Indiana</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Monticello, Kentucky</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Detroit</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>New York</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Montevideo</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Samarkand</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Taschkent</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Vatikan</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>St. Vincent</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Caracas</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Tortola</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>St. Thomas</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Ho-Chi-Minh-Stadt</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Efate</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Wallis</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Apia</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Aden</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Mayotte</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Johannesburg</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Lusaka</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Harare</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.el.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.el.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="el" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>Άγνωστη πόλη</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Ανδόρα</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Ντουμπάι</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Καμπούλ</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Αντίγκουα</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Ανγκουίλα</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Τίρανα</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Γερεβάν</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Λουάντα</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Ροθέρα</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Πάλμερ</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Τρολ</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Σίοβα</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Μόουσον</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Ντέιβις</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Βόστοκ</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Κάσεϊ</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Ντιμόντ Ντερβίλ</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>Μακμέρντο</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Ρίο Γκαγιέγκος</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Μεντόζα</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>Σαν Χουάν</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ουσουάια</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>Λα Ριόχα</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>Σαν Λούις</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Καταμάρκα</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Σάλτα</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Χουχούι</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Τουκουμάν</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Κόρδοβα</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Μπουένος Άιρες</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Πάγκο Πάγκο</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Βιέννη</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Περθ</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Εούκλα</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Ντάργουιν</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Αδελαΐδα</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Μπρόκεν Χιλ</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Κιουρί</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Μελβούρνη</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Χόμπαρτ</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Λίντεμαν</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Σίδνεϊ</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Μπρισμπέιν</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Μακουάρι</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Λορντ Χάουι</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Αρούμπα</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Μαριέχαμν</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Μπακού</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Σαράγεβο</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Μπαρμπάντος</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Ντάκα</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Βρυξέλλες</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Ουαγκαντούγκου</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>Σόφια</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Μπαχρέιν</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Μπουζουμπούρα</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Πόρτο-Νόβο</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>Άγιος Βαρθολομαίος</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Βερμούδα</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Μπρουνέι</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>Λα Παζ</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Κραλέντικ</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Εϊρουνέπε</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Ρίο Μπράνκο</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Πόρτο Βέλο</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Μπόα Βίστα</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Μανάος</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Κουϊάμπα</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Σανταρέμ</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Κάμπο Γκράντε</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Μπέλεμ</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Αραγκουάινα</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>Σάο Πάολο</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Μπάχια</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Φορταλέζα</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Μασέιο</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Ρεσίφε</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Νορόνχα</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Νασάου</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Τρίμφου</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Γκαμπορόνε</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Μινσκ</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Μπελίζ</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Ντόσον</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Γουάιτχορς</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Ινούβικ</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Βανκούβερ</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Ντόσον Κρικ</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Κρέστον</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Γέλοουναϊφ</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Έντμοντον</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Σουίφτ Κάρρεντ</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Κέμπριτζ Μπέι</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Ρετζίνα</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Γουίνιπεγκ</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Ρέσολουτ</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Ρέινι Ρίβερ</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Ρέινκιν Ίνλετ</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Κόραλ Χάρμπουρ</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Θάντερ Μπέι</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Νιπιγκόν</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Τορόντο</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Ικαλούτ</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Πανγκνίρτουνγκ</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Μονκτόν</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Χάλιφαξ</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Γκους Μπέι</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Γκλέις Μπέι</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Μπλαν Σαμπλόν</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>Σεντ Τζονς</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Κόκος</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Κινσάσα</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Λουμπουμπάσι</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Μπανγκί</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Μπράζαβιλ</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Ζυρίχη</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Αμπιτζάν</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Ραροτόνγκα</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Νήσος Πάσχα</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Σαντιάγκο</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Ντουάλα</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Ουρουμκί</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Σανγκάη</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Μπογκοτά</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Κόστα Ρίκα</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Αβάνα</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Πράσινο Ακρωτήριο</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Κουρασάο</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Χριστούγεννα</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Λευκωσία</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Πράγα</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Μπίσινγκεν</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Βερολίνο</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Τζιμπουτί</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Κοπεγχάγη</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Δομινίκα</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Άγιος Δομίνικος</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Αλγέρι</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Γκαλαπάγκος</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Γκουαγιακύλ</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Ταλίν</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Κάιρο</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>Ελ Αγιούν</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Ασμάρα</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Κανάρια</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Κέουτα</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Μαδρίτη</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Αντίς Αμπέμπα</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Ελσίνκι</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Φίτζι</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Στάνλεϋ</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Τσουκ</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Πονάπε</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Κοσράη</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Φερόες</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>Παρίσι</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Λιμπρεβίλ</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>Λονδίνο</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Γρενάδα</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Τιφλίδα</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Καγιένε</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Γκέρνσεϊ</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Άκρα</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Γιβραλτάρ</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Τούλε</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Γκόνθαμπ</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Σκορεσμπίσουντ</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Ντανμαρκσάβν</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Μπάνζουλ</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Κόνακρι</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Γουαδελούπη</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Μαλάμπο</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Αθήνα</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Νότια Γεωργία</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Γουατεμάλα</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Γκουάμ</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Μπισάου</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Γουιάνα</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Χονγκ Κονγκ</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Τεγκουσιγκάλπα</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Ζάγκρεμπ</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Πορτ-ο-Πρενς</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Βουδαπέστη</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Τζακάρτα</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Πόντιανακ</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Μακασάρ</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Χαγιαπούρα</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Δουβλίνο</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Ιερουσαλήμ</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Νήσος του Μαν</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Καλκούτα</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Τσάγκος</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Βαγδάτη</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Τεχεράνη</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Ρέυκιαβικ</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Ρώμη</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Τζέρσεϊ</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Τζαμάικα</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Αμμάν</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Τόκυο</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Ναϊρόμπι</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Μπισκέκ</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Πνομ Πενχ</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Εντερμπέρυ</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Κιριτιμάτι</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Ταράουα</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Κομόρο</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>Άγιος Χριστόφορος (Σαιντ Κιτς)</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Πιονγκγιάνγκ</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Σεούλ</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Κουβέιτ</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Κέιμαν</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Ακτάου</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Όραλ</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Ακτόμπε</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Κτζιλ-Ορντά</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Αλμάτυ</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Βιεντιάνε</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Βυρητός</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>Αγία Λουκία</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Βαντούζ</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Κολόμπο</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Μονρόβια</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Μασέρου</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Βίλνιους</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Λουξεμβούργο</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Ρίγα</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Τρίπολη</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Καζαμπλάνκα</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Μονακό</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Κισινάου</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Ποντγκόριτσα</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Μάριγκοτ</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Ανταναναρίβο</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Κουαχαλέιν</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Μαχούρο</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Σκόπια</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Μπαμάκο</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Ρανγκούν</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Χοβντ</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Ουλάν Μπατόρ</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Χόιμπαλσαν</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Μακάο</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Σάιπαν</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Μαρτινίκα</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Νουακσότ</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Μονσεράτ</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Μάλτα</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Μαυρίκιος</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Μαλδίβες</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Μπλαντάιρ</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Τιχουάνα</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Σάντα Ιζαμπέλ</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Ερμοσίγιο</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Μαζατλάν</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Τσιουάουα</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Μπαχία Ντε Μπαντέρας</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Οχινάγκα</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Μοντερέι</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Πόλη του Μεξικού</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Ματαμόρος</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Μέριντα</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Κανκούν</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Κουάλα Λουμπούρ</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Κουτσίνγκ</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Μαπούτο</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Βίντχουκ</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Νουμέα</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Νιαμέι</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Νόρφολκ</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Λάγκος</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Μανάγκουα</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Άμστερνταμ</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Όσλο</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Κατμαντού</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Ναούρου</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Νιούε</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Τσάταμ</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Όκλαντ</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Μασκάτ</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Παναμάς</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Λίμα</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Ταϊτή</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Μαρκέσας</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Γκάμπιερ</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Πορτ Μόρεσμπυ</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>Μπουγκενβίλ</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Μανίλα</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Καράτσι</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Βαρσοβία</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Μικελόν</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Πίτκερν</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Πουέρτο Ρίκο</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Γάζα</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Χεμπρόν</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Αζόρες</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Μαδέρα</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Λισαβόνα</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Παλάου</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Ασουνσιόν</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Κατάρ</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Ρεϊνιόν</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Βουκουρέστι</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Βελιγράδι</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Καλίνινγκραντ</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Συμφερόπολη</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Μόσχα</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Βόλγκοκραντ</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Σαμάρα</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Αικατερίνμπουργκ</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Ομσκ</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Νοβοσιμπίρσκ</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Νοβοκουζνέτσκ</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Κρασνογιάρσκ</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Ιρκούτσκ</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>Τσίτα</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Γιάκουτσκ</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Βλαδιβοστόκ</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Χαντίγκα</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Σακαλίνσκ</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Ουστ-Νερά</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Μαγκαντάν</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>Σρεντνεκόλιμσκ</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Καμτσάτκα</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Αναντίρ</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Κιγκάλι</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Ριάντ</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Γκουανταλκανάλ</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Μάχε</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Χαρτούμ</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Στοκχόλμη</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Σιγκαπούρη</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>Αγ. Ελένη</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Λιουμπλιάνα</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Λόνγκιεαρμπιεν</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Μπρατισλάβα</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Φρίταουν</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>Άγιος Μαρίνος</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Ντακάρ</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Μογκαντίσου</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Παραμαρίμπο</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Γιούμπα</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>Σάο Τομέ</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>Ελ Σαλβαδόρ</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Άγιος Μαρτίνος Ολλανδίας</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Δαμασκός</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Μπαμπάνε</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Γκραντ Τουρκ</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>Ντζαμένα</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Κέργκουελεν</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Λομέ</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Μπανγκόκ</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Ντουσάμπε</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Φακαόφο</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Ντίλι</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Ασχαμπάτ</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Τύνιδα</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Τονγκατάπου</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Κωνσταντινούπολη</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Πορτ οφ Σπέιν</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Φουναφούτι</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Ταϊπέι</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Νταρ Ες Σαλάμ</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Ουζκόροντ</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Κίεβο</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Ζαπορόζιε</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Καμπάλα</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Μίντγουεϊ</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Τζόνστον</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Γουέικ</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Άντακ</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Νόμε</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Χονολουλού</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Άνκορατζ</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Γιακούτατ</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Σίτκα</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Τζούνο</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Μετλακάτλα</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Λος Άντζελες</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Μπόιζ</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Φοίνιξ</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Ντένβερ</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Μπέουλαχ, Βόρεια Ντακότα</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>Νιου Σάλεμ, Βόρεια Ντακότα</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Κέντρο, Βόρεια Ντακότα</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Σικάγο</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Μενομίνε</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Βίνκενες, Ιντιάνα</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Πίτερσμπεργκ, Ιντιάνα</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Τελ Σίτυ, Ιντιάνα</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Νοξ, Ιντιάνα</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Γουίναμακ, Ιντιάνα</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Μαρένγκο, Ιντιάνα</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Ιντιανάπολις</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Λούισβιλ</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Βεβάι, Ιντιάνα</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Μοντιτσέλο, Κεντάκι</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Ντιτρόιτ</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>Νέα Υόρκη</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Μοντεβιδέο</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Σαμαρκάνδη</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Τασκένδη</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Βατικανό</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>Άγιος Βικέντιος</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Καράκας</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Τορτόλα</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>Άγιος Θωμάς</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Πόλη Χο Τσι Μινχ</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Εφάτε</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Γουόλις</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Άπια</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Άντεν</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Μαγιότε</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Γιοχάνεσμπουργκ</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Λουζάκα</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Χαράρε</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.en.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.en.xlf
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="en" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>Unknown City</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Dumont d’Urville</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>St. Barthélemy</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Curaçao</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Asunción</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Réunion</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>São Tomé</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Uzhhorod</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Ho Chi Minh City</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.es.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.es.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="es" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>ciudad desconocida</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Andorra</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Dubái</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Kabul</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Antigua</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Anguila</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Tirana</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Ereván</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Luanda</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Rothera</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Palmer</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Troll</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Syowa</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Mawson</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Davis</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Vostok</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Casey</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Dumont d’Urville</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>McMurdo</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Río Gallegos</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Mendoza</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>San Juan</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ushuaia</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>La Rioja</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>San Luis</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Catamarca</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Salta</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Jujuy</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Tucumán</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Córdoba</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Buenos Aires</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Pago Pago</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Viena</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Perth</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Eucla</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Darwin</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Adelaida</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Broken Hill</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Currie</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Melbourne</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Hobart</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Lindeman</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Sídney</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Brisbane</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Macquarie</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Lord Howe</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Aruba</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Mariehamn</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Bakú</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Sarajevo</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Barbados</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Dacca</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Bruselas</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Uagadugú</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>Sofía</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Baréin</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Bujumbura</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Portonovo</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>San Bartolomé</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Bermudas</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Brunéi</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>La Paz</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Kralendijk</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Eirunepé</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Río Branco</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Porto Velho</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Boa Vista</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Manaos</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Cuiabá</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Santarém</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Campo Grande</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Belén</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Araguaína</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>São Paulo</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Bahía</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Fortaleza</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Maceió</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Recife</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Noronha</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Nassau</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Timbu</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Gaborone</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Minsk</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Belice</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Dawson</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Whitehorse</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Inuvik</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Vancouver</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Dawson Creek</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Creston</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Yellowknife</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Edmonton</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Swift Current</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Cambridge Bay</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Regina</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Winnipeg</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Resolute</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Rainy River</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Rankin Inlet</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Atikokan</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Thunder Bay</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Nipigon</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Toronto</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Iqaluit</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Pangnirtung</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Moncton</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Halifax</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Goose Bay</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Glace Bay</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Blanc-Sablon</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>St. John’s</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Cocos</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Kinshasa</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Lubumbashi</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Bangui</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Brazzaville</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Zúrich</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Abiyán</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Rarotonga</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Isla de Pascua</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Santiago</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Duala</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Ürümqi</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Shanghái</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Bogotá</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Costa Rica</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>La Habana</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Cabo Verde</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Curazao</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Christmas</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Nicosia</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Praga</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Busingen</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Berlín</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Yibuti</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Copenhague</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Dominica</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Santo Domingo</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Argel</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Galápagos</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Guayaquil</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Tallin</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>El Cairo</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>El Aaiún</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Asmara</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Islas Canarias</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Ceuta</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Madrid</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Addis Abeba</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Helsinki</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Fiyi</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Stanley</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Chuuk</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Pohnpei</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Kosrae</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Islas Feroe</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>París</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Libreville</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>Londres</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Granada</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Tiflis</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Cayena</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Guernsey</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Accra</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Gibraltar</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Thule</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Nuuk</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Ittoqqortoormiit</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Danmarkshavn</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Banjul</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Conakry</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Guadalupe</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Malabo</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Atenas</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Georgia del Sur</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Guatemala</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Guam</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Bisáu</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Guyana</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Hong Kong</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Tegucigalpa</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Zagreb</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Puerto Príncipe</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Budapest</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Yakarta</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Pontianak</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Makasar</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Jayapura</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Dublín</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Jerusalén</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Isla de Man</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Calcuta</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Chagos</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Bagdad</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Teherán</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Reikiavik</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Roma</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Jersey</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Jamaica</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Ammán</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Tokio</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Nairobi</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Bishkek</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Phnom Penh</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Enderbury</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Kiritimati</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Tarawa</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Comoras</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>St. Kitts</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Pyongyang</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Seúl</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Kuwait</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Caimán</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Aktau</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Oral</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Aktobe</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Qyzylorda</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Almaty</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Vientián</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Beirut</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>Santa Lucía</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Vaduz</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Colombo</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Monrovia</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Maseru</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Vilna</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Luxemburgo</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Riga</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Trípoli</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Casablanca</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Mónaco</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Chisinau</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Podgorica</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Marigot</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Antananarivo</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Kwajalein</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Majuro</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Skopie</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Bamako</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Rangún</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Hovd</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Ulán Bator</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Choibalsan</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Macao</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Saipán</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Martinica</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Nuakchot</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Montserrat</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Malta</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Mauricio</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Maldivas</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Blantyre</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Tijuana</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Santa Isabel</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Hermosillo</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Mazatlán</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Chihuahua</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Bahía de Banderas</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Ojinaga</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Monterrey</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Ciudad de México</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Matamoros</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Mérida</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Cancún</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Kuala Lumpur</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Kuching</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Maputo</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Windhoek</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Numea</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Niamey</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Norfolk</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Lagos</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Managua</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Ámsterdam</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Oslo</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Katmandú</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Nauru</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Niue</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Chatham</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Auckland</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Mascate</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Panamá</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Lima</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Tahití</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Marquesas</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Gambier</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Port Moresby</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>Bougainville</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Manila</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Karachi</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Varsovia</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Miquelón</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Pitcairn</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Puerto Rico</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Gaza</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Hebrón</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Azores</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Madeira</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Lisboa</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Palaos</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Asunción</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Catar</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Reunión</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Bucarest</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Belgrado</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Kaliningrado</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Simferopol</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Moscú</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Volgogrado</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Samara</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Yekaterinburgo</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Omsk</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Novosibirsk</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Novokuznetsk</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Krasnoyarsk</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Irkutsk</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>Chitá</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Yakutsk</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Vladivostok</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Khandyga</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Sajalín</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Ust-Nera</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Magadán</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>Srednekolimsk</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Kamchatka</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Anadyr</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Kigali</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Riad</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Guadalcanal</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Mahé</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Jartún</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Estocolmo</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Singapur</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>Santa Helena</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Liubliana</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Longyearbyen</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Bratislava</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Freetown</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>San Marino</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Dakar</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Mogadiscio</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Paramaribo</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Juba</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>Santo Tomé</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>El Salvador</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Lower Prince’s Quarter</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Damasco</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Mbabane</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Gran Turca</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>Yamena</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Kerguelen</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Lomé</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Bangkok</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Duchanbé</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Fakaofo</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Dili</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Asjabad</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Túnez</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Tongatapu</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Estambul</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Puerto España</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Funafuti</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Taipéi</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Dar es Salaam</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Uzhgorod</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Kiev</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Zaporizhia</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Kampala</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Midway</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Johnston</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Wake</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Adak</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Nome</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Honolulú</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Anchorage</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Yakutat</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Sitka</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Juneau</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Metlakatla</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Los Ángeles</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Boise</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Phoenix</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Denver</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Beulah, Dakota del Norte</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>New Salem, Dakota del Norte</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Center, Dakota del Norte</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Chicago</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Menominee</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Vincennes, Indiana</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Petersburg, Indiana</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Tell City, Indiana</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Knox, Indiana</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Winamac, Indiana</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Marengo, Indiana</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Indianápolis</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Louisville</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Vevay, Indiana</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Monticello, Kentucky</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Detroit</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>Nueva York</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Montevideo</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Samarcanda</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Tashkent</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>El Vaticano</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>San Vicente</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Caracas</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Tórtola</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>St. Thomas</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Ciudad Ho Chi Minh</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Efate</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Wallis</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Apia</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Adén</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Mayotte</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Johannesburgo</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Lusaka</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Harare</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.et.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.et.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="et" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>määramata linn</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Andorra</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Dubai</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Kabul</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Antigua</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Anguilla</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Tirana</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Jerevan</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Luanda</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Rothera</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Palmer</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Troll</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Syowa</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Mawson</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Davis</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Vostok</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Casey</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Dumont d’Urville</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>McMurdo</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Río Gallegos</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Mendoza</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>San Juan</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ushuaia</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>La Rioja</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>San Luis</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Catamarca</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Salta</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Jujuy</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Tucumán</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Córdoba</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Buenos Aires</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Pago Pago</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Viin</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Perth</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Eucla</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Darwin</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Adelaide</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Broken Hill</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Currie</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Melbourne</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Hobart</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Lindeman</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Sydney</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Brisbane</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Macquarie</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Lord Howe</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Aruba</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Maarianhamina</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Bakuu</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Sarajevo</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Barbados</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Dhaka</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Brüssel</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Ouagadougou</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>Sofia</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Bahrein</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Bujumbura</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Porto-Novo</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>Saint Barthélemy</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Bermuda</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Brunei</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>La Paz</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Kralendijk</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Eirunepé</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Rio Branco</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Porto Velho</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Boa Vista</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Manaus</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Cuiabá</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Santarém</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Campo Grande</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Belém</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Araguaína</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>São Paulo</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Bahia</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Fortaleza</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Maceió</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Recife</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Noronha</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Nassau</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Thimphu</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Gaborone</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Minsk</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Belize</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Dawson</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Whitehorse</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Inuvik</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Vancouver</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Dawson Creek</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Creston</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Yellowknife</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Edmonton</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Swift Current</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Cambridge Bay</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Regina</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Winnipeg</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Resolute</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Rainy River</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Rankin Inlet</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Atikokan</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Thunder Bay</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Nipigon</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Toronto</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Iqaluit</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Pangnirtung</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Moncton</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Halifax</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Goose Bay</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Glace Bay</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Blanc-Sablon</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>Saint John’s</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Cocos</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Kinshasa</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Lubumbashi</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Bangui</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Brazzaville</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Zürich</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Abidjan</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Rarotonga</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Lihavõttesaar</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Santiago</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Douala</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Ürümqi</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Shanghai</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Bogotá</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Costa Rica</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Havanna</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Roheneemesaared</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Curaçao</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Jõulusaar</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Nikosia</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Praha</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Busingen</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Berliin</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Djibouti</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Kopenhaagen</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Dominica</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Santo Domingo</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Alžiir</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Galápagos</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Guayaquil</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Tallinn</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Kairo</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>El Aaiun</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Asmara</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Kanaari saared</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Ceuta</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Madrid</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Addis Abeba</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Helsingi</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Fidži</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Stanley</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Chuuk</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Pohnpei</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Kosrae</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Fääri</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>Pariis</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Libreville</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>London</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Grenada</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Thbilisi</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Cayenne</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Guernsey</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Accra</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Gibraltar</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Thule</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Nuuk</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Ittoqqortoormiit</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Danmarkshavn</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Banjul</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Conakry</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Guadeloupe</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Malabo</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Ateena</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Lõuna-Georgia</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Guatemala</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Guam</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Bissau</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Guyana</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Hongkong</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Tegucigalpa</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Zagreb</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Port-au-Prince</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Budapest</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Jakarta</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Pontianak</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Makassar</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Jayapura</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Dublin</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Jeruusalemm</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Mani saar</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Kolkata</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Chagos</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Bagdad</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Teheran</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Reykjavík</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Rooma</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Jersey</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Jamaica</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Amman</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Tōkyō</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Nairobi</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Biškek</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Phnom Penh</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Enderbury</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Kiritimati</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Tarawa</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Comoro</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>Saint Kitts</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Pyongyang</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Soul</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Kuveit</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Cayman</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Aktau</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Oral</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Aktöbe</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Kõzõlorda</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Almatõ</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Vientiane</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Beirut</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>Saint Lucia</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Vaduz</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Colombo</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Monrovia</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Maseru</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Vilnius</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Luxembourg</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Riia</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Tripoli</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Casablanca</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Monaco</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Chișinău</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Podgorica</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Marigot</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Antananarivo</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Kwajalein</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Majuro</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Skopje</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Bamako</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Yangon</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Hovd</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Ulaanbaatar</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Tšojbalsan</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Macau</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Saipan</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Martinique</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Nouakchott</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Montserrat</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Malta</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Mauritius</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Maldiivid</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Blantyre</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Tijuana</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Santa Isabel</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Hermosillo</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Mazatlán</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Chihuahua</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Bahia Banderas</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Ojinaga</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Monterrey</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>México</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Matamoros</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Mérida</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Cancún</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Kuala Lumpur</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Kuching</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Maputo</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Windhoek</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Noumea</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Niamey</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Norfolk</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Lagos</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Managua</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Amsterdam</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Oslo</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Katmandu</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Nauru</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Niue</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Chatham</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Auckland</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Masqaţ</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Panama</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Lima</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Tahiti</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Marquesas</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Gambier</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Port Moresby</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>Bougainville</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Manila</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Karachi</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Varssavi</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Miquelon</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Pitcairn</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Puerto Rico</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Gaza</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Hebron</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Assoorid</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Madeira</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Lissabon</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Palau</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Asunción</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Katar</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Réunion</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Bukarest</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Belgrad</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Kaliningrad</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Simferopol</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Moskva</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Volgograd</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Samara</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Jekaterinburg</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Omsk</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Novosibirsk</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Novokuznetsk</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Krasnojarsk</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Irkutsk</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>Tšita</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Jakutsk</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Vladivostok</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Handõga</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Sahhalin</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Ust-Nera</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Magadan</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>Srednekolõmsk</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Kamtšatka</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Anadõr</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Kigali</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Ar-Riyāḑ</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Guadalcanal</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Mahe</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Khartoum</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Stockholm</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Singapur</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>Saint Helena</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Ljubljana</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Longyearbyen</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Bratislava</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Freetown</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>San Marino</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Dakar</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Mogadishu</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Paramaribo</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Juba</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>São Tomé</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>El Salvador</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Lower Prince’s Quarter</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Damaskus</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Mbabane</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Grand Turk</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>Ndjamena</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Kerguelen</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Lome</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Bangkok</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Dušanbe</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Fakaofo</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Dili</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Aşgabat</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Tunis</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Tongatapu</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>İstanbul</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Port of Spain</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Funafuti</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Taipei</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Dar es Salaam</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Užgorod</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Kiiev</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Zaporožje</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Kampala</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Midway</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Johnston</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Wake</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Adak</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Nome</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Honolulu</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Anchorage</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Yakutat</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Sitka</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Juneau</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Metlakatla</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Los Angeles</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Boise</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Phoenix</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Denver</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Beulah, North Dakota</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>New Salem, North Dakota</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Center, North Dakota</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Chicago</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Menominee</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Vincennes, Indiana</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Petersburg, Indiana</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Tell City, Indiana</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Knox, Indiana</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Winamac, Indiana</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Marengo, Indiana</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Indianapolis</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Louisville</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Vevay, Indiana</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Monticello, Kentucky</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Detroit</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>New York</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Montevideo</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Samarkand</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Taškent</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Vatikan</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>Saint Vincent</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Caracas</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Tortola</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>Saint Thomas</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Ho Chi Minh</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Efate</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Wallis</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Apia</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Aden</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Mayotte</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Johannesburg</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Lusaka</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Harare</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.eu.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.eu.xlf
@@ -1,0 +1,1663 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="eu" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>Hiri ezezaguna</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Andorra</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Dubai</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Kabul</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Antigua</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Anguilla</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Tirana</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Yerevan</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Luanda</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Rothera</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Palmer</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Troll</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Syowa</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Mawson</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Davis</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Vostok</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Casey</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Dumont d’Urville</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>McMurdo</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Rio Gallegos</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Mendoza</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>San Juan</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ushuaia</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>La Rioja</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>San Luis</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Catamarca</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Salta</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Jujuy</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Tucuman</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Cordoba</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Buenos Aires</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Pago Pago</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Viena</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Perth</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Eucla</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Darwin</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Adelaida</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Broken Hill</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Currie</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Melbourne</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Hobart</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Lindeman</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Sydney</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Brisbane</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Macquarie</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Lord Howe</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Aruba</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Mariehamn</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Baku</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Sarajevo</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Barbados</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Dhaka</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Brusela</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Ouagadougou</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>Sofia</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Bahrain</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Bujumbura</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Porto-Novo</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>Saint Barthélemy</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Bermuda</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Brunei</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>La Paz</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Kralendijk</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Eirunepe</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Rio Branco</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Porto Velho</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Boa Vista</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Manaus</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Cuiaba</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Santarem</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Campo Grande</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Belem</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Araguaina</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>Sao Paulo</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Bahia</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Fortaleza</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Maceio</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Recife</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Noronha</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Nassau</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Thimphu</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Gaborone</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Minsk</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Belize</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Dawson</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Whitehorse</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Inuvik</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Vancouver</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Dawson Creek</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Creston</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Yellowknife</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Edmonton</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Swift Current</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Cambridge Bay</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Regina</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Winnipeg</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Resolute</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Rainy River</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Rankin Inlet</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Atikokan</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Thunder Bay</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Nipigon</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Toronto</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Iqaluit</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Pangnirtung</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Moncton</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Halifax</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Goose Bay</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Glace Bay</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Blanc-Sablon</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>St. John’s</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Cocos</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Kinshasa</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Lubumbashi</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Bangui</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Brazzaville</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Zurich</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Abidjan</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Rarotonga</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Easter</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Santiago</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Douala</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Urumqi</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Shanghai</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Bogota</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Costa Rica</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Havana</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Cabo Verde</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Curaçao</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Christmas</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Nicosia</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Praga</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Busingen</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Berlin</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Djibouti</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Kopenhage</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Dominika</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Santo Domingo</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Aljer</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Galapagoak</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Guayaquil</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Tallinn</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Kairo</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>El Aaiun</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Asmara</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Kanariak</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Ceuta</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Madril</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Addis Abeba</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Helsinki</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Fiji</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Stanley</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Chuuk</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Pohnpei</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Kosrae</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Faroe</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>Paris</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Libreville</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>Londres</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Grenada</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Tbilisi</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Cayenne</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Guernsey</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Accra</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Gibraltar</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Thule</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Nuuk</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Ittoqqortoormiit</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Danmarkshavn</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Banjul</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Conakry</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Guadalupe</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Malabo</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Atenas</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>South Georgia</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Guatemala</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Guam</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Bissau</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Guyana</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Hong Kong</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Tegucigalpa</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Zagreb</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Port-au-Prince</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Budapest</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Jakarta</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Pontianak</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Makassar</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Jayapura</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Dublin</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Jerusalem</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Man uhartea</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Kolkata</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Chagos</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Baghdad</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Tehran</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Reykjavik</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Erroma</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Jersey</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Jamaika</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Amman</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Tokio</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Nairobi</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Bishkek</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Phnom Penh</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Enderbury</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Kiritimati</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Tarawa</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Comoro</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>St. Kitts</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Pyongyang</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Seul</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Kuwait</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Cayman</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Aqtau</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Oral</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Aqtobe</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Qyzylorda</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Almaty</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Vientiane</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Beirut</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>St. Lucia</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Vaduz</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Colombo</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Monrovia</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Maseru</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Vilnius</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Luxenburgo</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Riga</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Tripoli</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Casablanca</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Monako</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Chisinau</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Podgorica</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Marigot</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Antananarivo</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Kwajalein</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Majuro</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Skopje</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Bamako</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Rangun</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Hovd</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Ulan Bator</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Choibalsan</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Macau</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Saipan</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Martinika</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Nouakchott</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Montserrat</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Malta</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Maurizio</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Maldivak</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Blantyre</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Tijuana</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Santa Isabel</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Hermosillo</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Mazatlan</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Chihuahua</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Bahia Banderas</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Ojinaga</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Monterrey</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Mexico Hiria</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Matamoros</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Merida</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Cancun</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Kuala Lumpur</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Kuching</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Maputo</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Windhoek</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Noumea</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Niamey</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Norfolk</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Lagos</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Managua</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Amsterdam</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Oslo</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Kathmandu</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Nauru</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Niue</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Chatham</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Auckland</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Muscat</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Panama</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Lima</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Tahiti</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Marquesas</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Gambier</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Port Moresby</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Manila</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Karachi</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Varsovia</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Mikelune</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Pitcairn</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Puerto Rico</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Gaza</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Hebron</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Azoreak</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Madeira</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Lisboa</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Palau</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Asunción</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Qatar</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Reunion</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Bukarest</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Belgrado</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Kaliningrad</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Simferopol</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Mosku</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Volgograd</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Samara</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Yekaterinburg</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Omsk</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Novosibirsk</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Novokuznetsk</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Krasnoyarsk</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Irkutsk</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Yakutsk</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Vladivostok</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Khandyga</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Sakhalin</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Ust-Nera</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Magadan</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Kamchatka</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Anadyr</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Kigali</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Riyadh</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Guadalcanal</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Mahe</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Khartoum</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Stockholm</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Singapur</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>St. Helena</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Ljubljana</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Longyearbyen</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Bratislava</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Freetown</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>San Marino</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Dakar</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Mogadishu</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Paramaribo</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Juba</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>São Tomé</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>El Salvador</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Lower Prince’s Quarter</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Damasko</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Mbabane</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Grand Turk</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>Ndjamena</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Kerguelen</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Lome</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Bangkok</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Dushanbe</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Fakaofo</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Dili</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Ashgabat</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Tunis</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Tongatapu</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Istanbul</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Port of Spain</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Funafuti</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Taipei</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Dar es Salaam</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Uzhgorod</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Kiev</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Zaporozhye</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Kampala</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Midway</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Johnston</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Wake</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Adak</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Nome</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Honolulu</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Anchorage</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Yakutat</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Sitka</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Juneau</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Metlakatla</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Los Angeles</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Boise</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Phoenix</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Denver</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Beulah, Ipar Dakota</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>New Salem, Ipar Dakota</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Erdialdea, Ipar Dakota</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Chicago</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Menominee</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Vincennes, Indiana</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Petersburg, Indiana</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Tell City, Indiana</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Knox, Indiana</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Winamac, Indiana</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Marengo, Indiana</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Indianapolis</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Louisville</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Vevay, Indiana</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Monticello, Kentucky</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Detroit</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>New York</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Montevideo</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Samarkand</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Tashkent</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Vaticano Hiria</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>St. Vincent</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Caracas</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Tortola</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>St. Thomas</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Ho Chi Minh</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Efate</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Wallis</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Apia</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Aden</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Mayotte</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Johannesburgo</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Lusaka</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Harare</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.fa.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.fa.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="fa" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>شهر نامشخص</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>آندورا</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>دبی</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>کابل</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>آنتیگوا</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>آنگوئیلا</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>تیرانا</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>ایروان</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>لواندا</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>روترا</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>پالمر</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>ترول</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>شووا</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>ماوسون</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>دیویس</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>ووستوک</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>کیسی</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>دومون دورویل</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>مک‌موردو</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>ریوگالگوس</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>مندوسا</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>سن‌خوان</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>اوشوایا</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>لاریوخا</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>سن‌لوئیس</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>کاتامارکا</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>سالتا</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>خوخوی</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>توکومن</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>کوردووا</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>بوئنوس‌آیرس</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>پاگوپاگو</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>وین</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>پرت</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>اوکلا</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>داروین</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>آدلاید</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>بروکن‌هیل</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>کوری</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>ملبورن</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>هوبارت</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>لیندمن</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>سیدنی</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>بریسبین</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>مکواری</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>لردهاو</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>اروبا</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>ماریه‌هامن</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>باکو</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>سارایوو</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>باربادوس</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>داکا</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>بروکسل</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>اوآگادوگو</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>صوفیه</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>بحرین</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>بوجومبورا</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>پورتو نووو</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>سنت بارتلمی</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>برمودا</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>برونئی</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>لاپاز</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>کرالندیک</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>ایرونپه</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>ریوبرانکو</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>پورتوولیو</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>بوئاویستا</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>ماناوس</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>کویاوا</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>سنتارم</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>کمپو گرانده</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>بلم</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>آراگواینا</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>سائوپائولو</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>بایا</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>فورتالزا</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>ماسیو</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>ریسیفی</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>نورونیا</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>ناسائو</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>تیمفو</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>گابورون</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>مینسک</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>بلیز</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>داوسن</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>وایت‌هورس</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>اینوویک</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>ونکوور</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>داوسن کریک</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>کرستون</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>یلونایف</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>ادمونتون</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>سویفت‌کارنت</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>کمبریج‌بی</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>رجاینا</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>وینیپگ</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>رزولوت</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>رینی‌ریور</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>خلیجک رنکین</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>اتکوکان</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>تاندربی</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>نیپیگان</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>تورنتو</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>ایکلوئت</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>پانگنیرتونگ</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>مانکتون</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>هلیفکس</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>گوس‌بی</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>گلیس‌بی</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>بلان‐سابلون</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>سنت جان</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>کوکوس</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>کینشاسا</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>لوبومباشی</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>بانگی</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>برازویل</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>زوریخ</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>آبیجان</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>راروتونگا</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>ایستر</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>سانتیاگو</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>دوآلا</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>ارومچی</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>شانگهای</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>بوگوتا</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>کاستاریکا</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>هاوانا</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>کیپ‌ورد</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>کوراسائو</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>کریسمس</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>نیکوزیا</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>پراگ</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>بازنگن</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>برلین</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>جیبوتی</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>کپنهاگ</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>دومینیکا</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>سانتو دومینگو</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>الجزیره</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>گالاپاگوس</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>گوایاکیل</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>تالین</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>قاهره</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>العیون</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>اسمره</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>قناری</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>سبته</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>مادرید</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>آدیس آبابا</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>هلسینکی</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>فیجی</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>استانلی</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>چوک</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>پانپی</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>کوسرای</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>فارو</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>پاریس</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>لیبرویل</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>لندن</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>گرنادا</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>تفلیس</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>کاین</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>گرنزی</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>اکرا</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>جبل‌الطارق</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>تول</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>نووک</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>اسکورسبیسوند</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>دانمارکس‌هاون</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>بانجول</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>کوناکری</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>گوادلوپ</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>مالابو</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>آتن</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>جورجیای جنوبی</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>گواتمالا</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>گوام</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>بیسائو</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>گویان</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>هنگ‌کنگ</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>تگوسیگالپا</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>زاگرب</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>پورتوپرنس</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>بوداپست</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>جاکارتا</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>پونتیاناک</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>ماکاسار</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>جایاپورا</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>دوبلین</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>اورشلیم</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>جزیرهٔ من</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>کلکته</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>شاگوس</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>بغداد</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>تهران</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>ریکیاویک</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>رم</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>جرزی</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>جامائیکا</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>عمّان</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>توکیو</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>نایروبی</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>بیشکک</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>پنوم‌پن</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>اندربری</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>کریتیماتی</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>تاراوا</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>کومورو</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>سنت کیتس</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>پیونگ‌یانگ</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>سئول</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>کویت</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>کیمن</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>آقتاو</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>اورال</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>آقتوبه</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>قیزیل‌اوردا</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>آلماتی</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>وینتیان</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>بیروت</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>سنت لوسیا</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>فادوتس</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>کلمبو</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>مونروویا</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>ماسرو</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>ویلنیوس</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>لوکزامبورگ</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>ریگا</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>طرابلس</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>کازابلانکا</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>موناکو</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>کیشیناو</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>پادگاریتسا</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>ماریگات</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>آنتاناناریوو</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>کواجیلین</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>ماجورو</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>اسکوپیه</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>باماکو</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>یانگون</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>خوود</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>اولان‌باتور</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>چویبالسان</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>ماکائو</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>سایپان</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>مارتینیک</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>نوآکشوت</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>مونتسرات</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>مالت</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>موریس</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>مالدیو</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>بلانتیره</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>تیخوانا</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>سانتا ایزابل</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>ارموسیو</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>ماساتلان</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>چیواوا</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>باهیا باندراس</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>اخیناگا</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>مونتری</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>مکزیکوسیتی</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>ماتاموروس</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>مریدا</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>کانکون</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>کوالالامپور</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>کوچینگ</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>ماپوتو</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>ویندهوک</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>نومئا</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>نیامی</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>نورفولک</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>لاگوس</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>ماناگوا</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>آمستردام</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>اسلو</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>کاتماندو</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>نائورو</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>نیوئه</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>چتم</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>اوکلند</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>مسقط</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>پاناما</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>لیما</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>تاهیتی</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>مارکوزه</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>گامبیر</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>پورت‌مورزبی</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>بوگنویل</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>مانیل</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>کراچی</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>ورشو</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>میکلون</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>پیت‌کرن</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>پورتوریکو</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>غزه</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>الخلیل</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>آزور</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>مادیرا</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>لیسبون</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>پالائو</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>آسونسیون</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>قطر</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>رئونیون</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>بخارست</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>بلگراد</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>کالینینگراد</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>سیمفروپل</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>مسکو</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>ولگاگراد</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>سامارا</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>یکاترینبرگ</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>اومسک</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>نووسیبیریسک</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>نوووکوزنتسک</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>کراسنویارسک</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>ایرکوتسک</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>چیتا</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>یاکوتسک</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>ولادی‌وستوک</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>خاندیگا</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>ساخالین</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>اوست نرا</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>ماگادان</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>اسردنکولیمسک</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>کامچاتکا</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>آنادیر</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>کیگالی</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>ریاض</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>گوادال‌کانال</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>ماهه</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>خارطوم</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>استکهلم</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>سنگاپور</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>سنت هلنا</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>لیوبلیانا</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>لانگ‌یربین</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>براتیسلاوا</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>فری‌تاون</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>سان‌مارینو</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>داکار</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>موگادیشو</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>پاراماریبو</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>جوبا</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>سائوتومه</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>السالوادور</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>بخش شاهزاده‌‌نشین پایین</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>دمشق</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>مبابانه</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>گراند تورک</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>انجامنا</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>کرگولن</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>لومه</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>بانکوک</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>دوشنبه</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>فاکائوفو</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>دیلی</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>عشق‌آباد</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>شهر تونس</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>تونگاتاپو</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>استانبول</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>پورت‌آواسپین</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>فونافوتی</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>تایپه</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>دارالسلام</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>اوژگورود</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>کیف</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>زاپوروژیا</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>کامپالا</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>میدوی</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>جانستون</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>ویک</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>ایدک</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>نوم</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>هونولولو</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>انکوریج</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>یاکوتات</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>سیتکا</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>جونو</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>متالاکاتلا</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>لوس‌آنجلس</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>بویسی</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>فینکس</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>دنور</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>بیولا، داکوتای شمالی</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>نیوسالم، داکوتای شمالی</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>سنتر، داکوتای شمالی</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>شیکاگو</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>منامینی</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>وینسنس، اندیانا</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>پیترزبرگ، ایندیانا</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>تل‌سیتی، ایندیانا</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>ناکس، ایندیانا</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>ویناماک، ایندیانا</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>مارنگو، ایندیانا</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>ایندیاناپولیس</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>لوئیزویل</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>ویوی، ایندیانا</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>مانتیسلو، کنتاکی</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>دترویت</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>نیویورک</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>مونته‌ویدئو</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>سمرقند</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>تاشکند</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>واتیکان</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>سنت وینسنت</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>کاراکاس</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>تورتولا</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>سنت توماس</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>هوشی‌مین‌سیتی</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>افاته</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>والیس</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>آپیا</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>عدن</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>مایوت</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>ژوهانسبورگ</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>لوزاکا</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>هراره</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.fi.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.fi.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="fi" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>tuntematon</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Andorra</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Dubai</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Kabul</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Antigua</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Anguilla</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Tirana</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Jerevan</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Luanda</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Rothera</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Palmer</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Troll</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Syowa</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Mawson</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Davis</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Vostok</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Casey</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Dumont d’Urville</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>McMurdo</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Rio Gallegos</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Mendoza</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>San Juan</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ushuaia</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>La Rioja</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>San Luis</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Catamarca</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Salta</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Jujuy</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Tucumán</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Córdoba</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Buenos Aires</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Pago Pago</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Wien</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Perth</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Eucla</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Darwin</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Adelaide</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Broken Hill</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Currie</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Melbourne</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Hobart</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Lindeman</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Sydney</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Brisbane</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Macquariensaari</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Lord Howe</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Aruba</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Maarianhamina</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Baku</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Sarajevo</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Barbados</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Dhaka</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Bryssel</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Ouagadougou</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>Sofia</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Bahrain</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Bujumbura</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Porto-Novo</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>Saint-Barthélemy</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Bermuda</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Brunei</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>La Paz</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Kralendijk</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Eirunepé</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Rio Branco</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Porto Velho</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Boa Vista</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Manaus</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Cuiabá</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Santarém</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Campo Grande</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Belem</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Araguaína</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>São Paulo</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Bahia</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Fortaleza</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Maceió</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Recife</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Noronha</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Nassau</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Thimphu</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Gaborone</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Minsk</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Belize</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Dawson</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Whitehorse</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Inuvik</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Vancouver</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Dawson Creek</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Creston</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Yellowknife</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Edmonton</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Swift Current</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Cambridge Bay</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Regina</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Winnipeg</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Resolute</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Rainy River</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Rankin Inlet</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Atikokan</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Thunder Bay</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Nipigon</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Toronto</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Iqaluit</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Pangnirtung</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Moncton</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Halifax</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Goose Bay</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Glace Bay</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Blanc-Sablon</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>St. John’s</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Kookossaaret</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Kinshasa</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Lubumbashi</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Bangui</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Brazzaville</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Zürich</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Abidjan</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Rarotonga</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Pääsiäissaari</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Santiago de Chile</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Douala</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Ürümqi</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Shanghai</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Bogotá</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Costa Rica</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Havanna</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Kap Verde</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Curaçao</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Joulusaari</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Nikosia</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Praha</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Busingen</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Berliini</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Djibouti</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Kööpenhamina</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Dominica</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Santo Domingo</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Alger</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Galapagos</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Guayaquil</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Tallinna</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Kairo</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>El Aaiún</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Asmara</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Kanariansaaret</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Ceuta</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Madrid</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Addis Abeba</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Helsinki</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Fidži</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Stanley</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Chuuk</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Pohnpei</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Kosrae</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Färsaaret</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>Pariisi</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Libreville</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>Lontoo</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Grenada</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Tbilisi</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Cayenne</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Guernsey</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Accra</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Gibraltar</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Thule</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Nuuk</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Ittoqqortoormiit</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Danmarkshavn</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Banjul</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Conakry</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Guadeloupe</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Malabo</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Ateena</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Etelä-Georgia</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Guatemala</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Guam</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Bissau</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Guyana</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Hongkong</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Tegucigalpa</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Zagreb</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Port-au-Prince</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Budapest</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Jakarta</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Pontianak</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Makassar</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Jayapura</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Dublin</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Jerusalem</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Mansaari</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Kalkutta</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Chagos</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Bagdad</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Teheran</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Reykjavík</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Rooma</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Jersey</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Jamaika</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Amman</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Tokio</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Nairobi</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Biškek</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Phnom Penh</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Enderbury</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Kiritimati</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Tarawa</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Komorit</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>Saint Kitts</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Pjongjang</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Soul</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Kuwait</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Cayman</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Aqtaw</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Uralsk</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Aqtöbe</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Qızılorda</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Almaty</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Vientiane</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Beirut</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>Saint Lucia</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Vaduz</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Colombo</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Monrovia</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Maseru</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Vilna</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Luxemburg</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Riika</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Tripoli</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Casablanca</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Monaco</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Chişinău</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Podgorica</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Marigot</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Antananarivo</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Kwajalein</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Majuro</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Skopje</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Bamako</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Yangon</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Hovd</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Ulan Bator</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Tšoibalsa</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Macao</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Saipan</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Martinique</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Nouakchott</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Montserrat</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Malta</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Mauritius</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Malediivit</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Blantyre</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Tijuana</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Santa Isabel</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Hermosillo</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Mazatlán</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Chihuahua</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Bahía de Banderas</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Ojinaga</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Monterrey</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Ciudad de México</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Matamoros</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Mérida</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Cancún</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Kuala Lumpur</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Kuching</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Maputo</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Windhoek</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Nouméa</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Niamey</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Norfolk</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Lagos</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Managua</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Amsterdam</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Oslo</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Kathmandu</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Nauru</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Niue</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Chathamsaaret</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Auckland</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Muscat</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Panama</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Lima</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Tahiti</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Marquesassaaret</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Gambiersaaret</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Port Moresby</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>Bougainville</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Manila</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Karachi</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Varsova</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Miquelon</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Pitcairn</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Puerto Rico</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Gaza</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Hebron</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Azorit</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Madeira</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Lissabon</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Palau</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Asunción</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Qatar</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Réunion</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Bukarest</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Belgrad</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Kaliningrad</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Simferopol</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Moskova</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Volgograd</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Samara</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Jekaterinburg</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Omsk</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Novosibirsk</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Novokuznetsk</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Krasnojarsk</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Irkutsk</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>Tšita</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Jakutsk</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Vladivostok</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Handyga</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Sahalin</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Ust-Nera</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Magadan</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>Srednekolymsk</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Kamtšatka</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Anadyr</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Kigali</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Riad</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Guadalcanal</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Mahé</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Khartum</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Tukholma</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Singapore</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>Saint Helena</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Ljubljana</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Longyearbyen</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Bratislava</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Freetown</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>San Marino</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Dakar</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Mogadishu</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Paramaribo</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Juba</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>São Tomé</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>El Salvador</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Lower Prince’s Quarter</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Damaskos</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Mbabane</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Grand Turk</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>N’Djamena</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Kerguelensaaret</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Lomé</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Bangkok</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Dušanbe</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Fakaofo</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Dili</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Ašgabat</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Tunis</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Tongatapu</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Istanbul</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Port of Spain</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Funafuti</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Taipei</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Dar es Salaam</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Užgorod</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Kiova</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Zaporižžja</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Kampala</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Midway</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Johnston</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Wake</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Adak</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Nome</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Honolulu</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Anchorage</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Yakutat</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Sitka</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Juneau</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Metlakatla</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Los Angeles</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Boise</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Phoenix</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Denver</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Beulah, Pohjois-Dakota</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>New Salem, Pohjois-Dakota</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Center, Pohjois-Dakota</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Chicago</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Menominee</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Vincennes, Indiana</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Petersburg, Indiana</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Tell City, Indiana</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Knox, Indiana</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Winamac, Indiana</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Marengo, Indiana</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Indianapolis</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Louisville</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Vevay, Indiana</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Monticello, Kentucky</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Detroit</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>New York</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Montevideo</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Samarkand</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Taškent</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Vatikaani</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>Saint Vincent</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Caracas</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Tortola</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>Saint Thomas</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Hồ Chí Minhin kaupunki</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Efate</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Wallis</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Apia</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Aden</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Mayotte</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Johannesburg</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Lusaka</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Harare</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.fr.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.fr.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="fr" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>ville inconnue</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Andorre</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Dubaï</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Kaboul</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Antigua</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Anguilla</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Tirana</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Erevan</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Luanda</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Rothera</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Palmer</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Troll</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Showa</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Mawson</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Davis</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Vostok</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Casey</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Dumont d’Urville</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>McMurdo</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Río Gallegos</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Mendoza</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>San Juan</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ushuaïa</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>La Rioja</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>San Luis</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Catamarca</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Salta</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Jujuy</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Tucumán</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Córdoba</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Buenos Aires</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Pago Pago</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Vienne</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Perth</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Eucla</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Darwin</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Adélaïde</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Broken Hill</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Currie</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Melbourne</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Hobart</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Lindeman</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Sydney</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Brisbane</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Macquarie</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Lord Howe</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Aruba</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Mariehamn</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Bakou</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Sarajevo</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>La Barbade</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Dhaka</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Bruxelles</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Ouagadougou</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>Sofia</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Bahreïn</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Bujumbura</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Porto-Novo</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>Saint-Barthélemy</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Bermudes</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Brunei</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>La Paz</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Kralendijk</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Eirunepé</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Rio Branco</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Porto Velho</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Boa Vista</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Manaos</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Cuiabá</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Santarém</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Campo Grande</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Belém</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Araguaína</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>São Paulo</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Bahia</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Fortaleza</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Maceió</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Recife</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Noronha</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Nassau</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Thimphu</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Gaborone</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Minsk</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Belize</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Dawson</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Whitehorse</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Inuvik</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Vancouver</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Dawson Creek</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Creston</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Yellowknife</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Edmonton</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Swift Current</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Cambridge Bay</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Regina</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Winnipeg</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Resolute</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Rainy River</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Rankin Inlet</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Atikokan</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Thunder Bay</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Nipigon</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Toronto</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Iqaluit</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Pangnirtung</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Moncton</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Halifax</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Goose Bay</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Glace Bay</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Blanc-Sablon</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>Saint-Jean de Terre-Neuve</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Cocos</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Kinshasa</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Lubumbashi</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Bangui</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Brazzaville</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Zurich</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Abidjan</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Rarotonga</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Île de Pâques</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Santiago</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Douala</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Ürümqi</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Shanghai</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Bogota</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Costa Rica</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>La Havane</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Cap-Vert</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Curaçao</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Christmas</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Nicosie</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Prague</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Büsingen</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Berlin</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Djibouti</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Copenhague</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Dominique</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Saint-Domingue</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Alger</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Galápagos</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Guayaquil</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Tallinn</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Le Caire</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>Laâyoune</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Asmara</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Îles Canaries</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Ceuta</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Madrid</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Addis-Abeba</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Helsinki</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Fidji</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Stanley</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Chuuk</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Pohnpei</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Kosrae</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Féroé</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>Paris</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Libreville</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>Londres</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Grenade</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Tbilissi</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Cayenne</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Guernesey</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Accra</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Gibraltar</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Thulé</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Nuuk</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Ittoqqortoormiit</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Danmarkshavn</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Banjul</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Conakry</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Guadeloupe</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Malabo</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Athènes</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Géorgie du Sud</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Guatemala</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Guam</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Bissau</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Guyana</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Hong Kong</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Tégucigalpa</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Zagreb</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Port-au-Prince</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Budapest</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Jakarta</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Pontianak</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Macassar</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Jayapura</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Dublin</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Jérusalem</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Île de Man</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Calcutta</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Chagos</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Bagdad</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Téhéran</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Reykjavik</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Rome</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Jersey</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Jamaïque</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Amman</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Tokyo</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Nairobi</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Bichkek</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Phnom Penh</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Enderbury</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Kiritimati</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Tarawa</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Comores</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>Saint-Kitts</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Pyongyang</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Séoul</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Koweït</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Caïmans</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Aktaou</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Ouralsk</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Aktioubinsk</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Kzyl Orda</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Alma Ata</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Vientiane</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Beyrouth</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>Sainte-Lucie</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Vaduz</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Colombo</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Monrovia</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Maseru</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Vilnius</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Luxembourg</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Riga</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Tripoli (Libye)</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Casablanca</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Monaco</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Chisinau</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Podgorica</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Marigot</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Antananarivo</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Kwajalein</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Majuro</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Skopje</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Bamako</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Rangoun</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Hovd</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Oulan-Bator</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Tchoïbalsan</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Macao</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Saipan</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Martinique</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Nouakchott</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Montserrat</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Malte</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Maurice</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Maldives</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Blantyre</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Tijuana</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Santa Isabel</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Hermosillo</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Mazatlán</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Chihuahua</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Bahia de Banderas</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Ojinaga</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Monterrey</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Mexico</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Matamoros</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Mérida</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Cancún</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Kuala Lumpur</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Kuching</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Maputo</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Windhoek</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Nouméa</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Niamey</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Norfolk</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Lagos</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Managua</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Amsterdam</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Oslo</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Katmandou</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Nauru</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Niue</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Chatham</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Auckland</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Mascate</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Panama</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Lima</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Tahiti</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Marquises</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Gambier</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Port Moresby</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>Bougainville</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Manille</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Karachi</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Varsovie</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Miquelon</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Pitcairn</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Porto Rico</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Gaza</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Hébron</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Açores</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Madère</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Lisbonne</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Palau</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Asunción</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Qatar</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>La Réunion</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Bucarest</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Belgrade</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Kaliningrad</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Simferopol</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Moscou</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Volgograd</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Samara</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Ekaterinbourg</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Omsk</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Novossibirsk</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Novokuznetsk</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Krasnoïarsk</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Irkoutsk</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>Tchita</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Iakoutsk</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Vladivostok</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Khandyga</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Sakhaline</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Ust-Nera</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Magadan</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>Srednekolymsk</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Kamtchatka</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Anadyr</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Kigali</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Riyad</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Guadalcanal</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Mahé</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Khartoum</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Stockholm</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Singapour</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>Sainte-Hélène</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Ljubljana</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Longyearbyen</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Bratislava</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Freetown</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>Saint-Marin</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Dakar</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Mogadiscio</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Paramaribo</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Juba</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>São Tomé</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>El Salvador</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Lower Prince’s Quarter</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Damas</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Mbabane</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Grand Turk</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>N’Djamena</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Kerguelen</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Lomé</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Bangkok</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Douchanbé</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Fakaofo</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Dili</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Achgabat</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Tunis</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Tongatapu</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Istanbul</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Port-d’Espagne</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Funafuti</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Taipei</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Dar es Salaam</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Oujgorod</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Kiev</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Zaporojie</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Kampala</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Midway</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Johnston</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Wake</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Adak</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Nome</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Honolulu</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Anchorage</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Yakutat</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Sitka</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Juneau</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Metlakatla</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Los Angeles</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Boise</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Phoenix</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Denver</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Beulah (Dakota du Nord)</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>New Salem (Dakota du Nord)</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Center (Dakota du Nord)</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Chicago</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Menominee</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Vincennes [Indiana]</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Petersburg [Indiana]</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Tell City [Indiana]</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Knox [Indiana]</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Winamac [Indiana]</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Marengo [Indiana]</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Indianapolis</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Louisville</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Vevay [Indiana]</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Monticello [Kentucky]</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Détroit</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>New York</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Montevideo</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Samarcande</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Tachkent</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Le Vatican</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>Saint-Vincent</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Caracas</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Tortola</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>Saint-Thomas</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Hô-Chi-Minh-Ville</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Éfaté</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Wallis</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Apia</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Aden</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Mayotte</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Johannesburg</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Lusaka</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Harare</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.gl.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.gl.xlf
@@ -1,0 +1,1663 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="gl" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>Cidade descoñecida</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Andorra</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Dubai</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Cabul</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Antiga</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Anguila</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Tirana</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Iereván</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Luanda</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Rothera</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Palmer</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Troll</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Syowa</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Mawson</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Davis</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Vostok</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Casey</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Dumont-d’Urville</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>McMurdo</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Río Gallegos</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Mendoza</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>San Juan</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ushuaia</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>La Rioja</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>San Luis</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Catamarca</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Salta</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Jujuy</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Tucumán</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Córdoba</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Bos Aires</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Pago Pago</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Viena</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Perth</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Eucla</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Darwin</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Adelaide</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Broken Hill</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Currie</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Melbourne</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Hobart</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Lindeman</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Sidney</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Brisbane</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Macquarie</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Lord Howe</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Aruba</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Mariehamn</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Bacú</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Sarajevo</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Barbados</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Dhaka</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Bruxelas</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Uagadugú</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>Sofia</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Bahrain</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Bujumbura</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Porto Novo</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>San Bartolomé</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Bermudas</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Brunei</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>La Paz</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Kralendijk</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Eirunepe</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Río Branco</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Porto Velho</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Boa Vista</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Manaus</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Cuiabá</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Santarem</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Campo Grande</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Belém</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Araguaína</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>São Paulo</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Bahia</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Fortaleza</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Maceió</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Recife</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Noronha</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Nassau</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Timbu</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Gaborone</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Minsk</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Belice</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Dawson</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Whitehorse</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Inuvik</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Vancouver</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Dawson Creek</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Creston</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Yellowknife</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Edmonton</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Swift Current</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Abadía de Cambridge</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Regina</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Winnipeg</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Resolute</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Rainy River</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Rankin Inlet</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Atikokan</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Thunder Bay</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Nipigon</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Toronto</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Iqaluit</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Pangnirtung</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Moncton</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Halifax</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Goose Bay</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Glace Bay</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Blanc-Sablon</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>St. John’s</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Cocos</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Kinshasa</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Lubumbashi</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Bangui</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Brazzaville</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Zúric</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Abidjan</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Rarotonga</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Illa de Pascua</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Santiago</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Douala</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Urumqi</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Shanghai</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Bogotá</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Costa Rica</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Habana</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Cabo Verde</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Curaçao</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Illa de Nadal</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Nicosia</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Praga</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Busingen</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Berlín</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Xibutí</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Copenhaguen</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Dominica</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Santo Domingo</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Alxer</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Illas Galápagos</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Guayaquil</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Talín</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Cairo</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>O Aiún</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Asmak</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Illas Canarias</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Ceuta</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Madrid</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Adís Abeba</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Helsinki</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Fidxi</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Stanley</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Chuuk</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Pohnpei</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Kosrae</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Faroe</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>París</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Libreville</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>Londres</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Granada</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Tbilisi</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Caiena</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Guernesei</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Acra</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Xibraltar</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Thule</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Nuuk</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Ittoqqortoormiit</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Danmarkshavn</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Banjul</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Conakry</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Guadalupe</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Malabo</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Athens</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Xeorxia do Sur</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Guatemala</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Guam</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Bissau</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Güiana</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Hong Kong</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Tegucigalpa</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Zagreb</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Porto Príncipe</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Budapest</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Iacarta</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Pontianak</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Makassar</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Jaiapura</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Dublín</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Jerusalem</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Illa de Man</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Calcuta</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Chagos</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Bagdad</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Tehran</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Reiquiavik</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Rome</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Jersey</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Xamaica</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Amán</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Toquio</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Nairobi</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Bishkek</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Phnom Penh</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Enderbury</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Kiritimati</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Tarawa</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Illas Comores</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>San Cristovo</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Pyongyang</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Seúl</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Kuwait</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Caimán</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Aqtau</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Oral</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Aqtobe</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Qyzylorda</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Almati</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Vientiane</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Beirut</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>St. Lucia</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Vaduz</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Colombo</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Monrovia</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Maseru</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Vilnius</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Luxemburgo</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Riga</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Trípoli</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Casablanca</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Mónaco</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Chisinau</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Podgorica</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Marigot</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Antananarivo</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Kwajalein</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Majuro</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Skopje</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Bamaco</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Rangoon</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Hovd</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Ulán Bátor</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Choibalsan</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Macau</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Saipán</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Martinica</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Nouakchott</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Montserrat</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Malta</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Mauricio</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Maldivas</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Blantyre</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Tijuana</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Santa Isabel</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Hermosillo</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Mazatlán</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Chihuahua</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Baía de Bandeiras</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Ojinaga</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Monterrei</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Cidade de México</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Matamoros</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Mérida</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Cancún</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Kuala Lumpur</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Kuching</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Maputo</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Windhoek</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Noumea</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Niamey</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Norfolk</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Lagos</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Managua</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Ámsterdan</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Oslo</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Kathmandu</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Nauru</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Niue</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Chatham</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Auckland</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Mascat</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Panamá</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Lima</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Tahití</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Marquesas</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Gambier</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Port Moresby</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Manila</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Karachi</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Varsovia</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Miquelon</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Pitcairn</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Porto Rico</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Gaza</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Hebron</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Azores</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Madeira</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Lisboa</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Palau</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Asunción</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Qatar</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Reunión</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Bucarest</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Belgrado</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Kaliningrado</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Simferopol</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Moscova</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Volgogrado</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Samara</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Ecaterinburgo</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Omsk</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Novosibirsk</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Novokuznetsk</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Krasnoyarsk</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Irkutsk</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Yakutsk</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Vladivostok</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Khandyga</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Sakhalin</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Ust-Nera</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Magadan</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Kamchatka</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Anadir</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Kigali</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Riad</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Guadalcanal</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Mahe</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Khartún</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Stockholm</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Singapur</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>Santa Helena</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Liubliana</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Longyearbyen</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Bratislava</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Freetown</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>San Marino</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Dacar</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Mogadixo</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Paramaribo</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Juba</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>São Tomé</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>O Salvador</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Lower Prince’s Quarter</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Damasco</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Mbabane</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Gran Turca</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>Xamena</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Kerguelen</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Lomé</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Bangkok</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Dushanbe</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Fakaofo</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Dili</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Ashgabat</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Túnez</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Tongatapu</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Estanbul</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Porto España</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Funafuti</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Taipei</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Dar es Salaam</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Uzhgorod</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Kiev</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Zaporizhia</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Kampala</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Midway</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Johnston</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Wake</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Adak</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Nome</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Honolulú</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Anchorage</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Yakutat</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Sitka</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Juneau</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Metlakatla</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Os Ánxeles</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Boise</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Phoenix</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Denver</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Beulah, Dakota do Norte</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>New Salem, Dakota do Norte</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Center, Dakota do Norte</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Chicago</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Menominee</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Vincennes, Indiana</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Petersburgo, Indiana</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Tell City, Indiana</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Knox, Indiana</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Winamac, Indiana</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Marengo, Indiana</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Indianápolis</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Louisville</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Vevay, Indiana</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Monticello, Kentucky</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Detroit</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>Nova York</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Montevideo</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Samarcanda</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Tashkent</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Vaticano</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>San Vicente</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Caracas</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Tortola</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>San Tomé</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Ho Chi Minh</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Efate</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Wallis</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Apia</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Adén</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Mayotte</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Xohanesburgo</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Lusaca</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Harare</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.he.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.he.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="he" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>עיר לא ידועה</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>אנדורה</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>דובאי</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>קאבול</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>אנטיגואה</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>אנגווילה</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>טיראנה</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>ירוואן</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>לואנדה</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>רות׳רה</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>פאלמר</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>טרול</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>שויה</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>מאוסון</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>דייויס</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>ווסטוק</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>קאסיי</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>דומון ד׳אורווי</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>מקמרדו</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>ריו גאייגוס</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>מנדוזה</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>סן חואן</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>אושוואיה</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>לה ריוחה</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>סן לואיס</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>קטמרקה</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>סלטה</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>חוחוי</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>טוקומן</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>קורדובה</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>בואנוס איירס</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>פאגו פאגו</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>וינה</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>פרת׳</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>יוקלה</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>דרווין</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>אדלייד</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>ברוקן היל</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>קרי</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>מלבורן</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>הוברט</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>לינדמן</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>סידני</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>בריסביין</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>מקרי</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>לורד האו</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>ארובה</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>מריהמן</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>באקו</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>סרייבו</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>ברבדוס</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>דאקה</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>בריסל</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>וואגאדוגו</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>סופיה</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>בחריין</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>בוג׳ומבורה</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>פורטו נובו</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>סנט ברתלמי</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>ברמודה</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>ברוניי</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>לה פאס</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>קרלנדייק</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>אירונפי</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>ריו ברנקו</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>פורטו וולהו</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>בואה ויסטה</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>מנאוס</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>קויאבה</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>סנטרם</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>קמפו גרנדה</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>בלם</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>אראגואינה</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>סאו פאולו</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>בהיאה</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>פורטאלזה</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>מאסיו</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>רסיפה</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>נורונהה</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>נסאו</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>ת׳ימפו</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>גבורונה</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>מינסק</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>בליז</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>דוסון</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>ווייטהורס</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>אינוויק</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>ונקובר</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>דוסון קריק</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>קרסטון</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>ילונייף</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>אדמונטון</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>סוויפט קרנט</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>קיימברידג׳ ביי</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>רג׳ינה</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>וויניפג</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>רזולוט</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>רייני ריבר</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>רנקין אינלט</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>אטיקוקן</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>ת׳אנדר ביי</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>ניפיגון</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>טורונטו</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>איקלואיט</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>פנגנירטונג</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>מונקטון</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>הליפקס</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>גוס ביי</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>גלייס ביי</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>בלאן-סבלון</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>סנט ג׳ונס</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>קוקוס</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>קינשסה</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>לובומבאשי</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>בנגואי</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>ברזוויל</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>ציריך</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>אביג׳אן</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>רארוטונגה</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>אי הפסחא</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>סנטיאגו</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>דואלה</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>אורומקי</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>שנחאי</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>בוגוטה</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>קוסטה ריקה</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>הוואנה</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>כף ורדה</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>קוראסאו</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>אי חג המולד</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>ניקוסיה</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>פראג</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>בוזינגן</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>ברלין</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>ג׳יבוטי</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>קופנהגן</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>דומיניקה</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>סנטו דומינגו</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>אלג׳יר</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>גלפאגוס</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>גואיאקיל</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>טלין</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>קהיר</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>אל עיון</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>אסמרה</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>האיים הקנריים</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>סאוטה</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>מדריד</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>אדיס אבבה</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>הלסינקי</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>פיג׳י</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>סטנלי</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>טרוק</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>פונפה</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>קוסרה</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>פארו</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>פריז</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>ליברוויל</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>לונדון</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>גרנדה</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>טביליסי</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>קאיין</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>גרנזי</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>אקרה</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>גיברלטר</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>טולה</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>נואוק</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>סקורסביסונד</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>דנמרקסהוון</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>בנג׳ול</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>קונאקרי</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>גואדלופ</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>מלבו</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>אתונה</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>דרום גיאורגיה</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>גואטמלה</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>גואם</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>ביסאו</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>גיאנה</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>הונג קונג</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>טגוסיגלפה</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>זאגרב</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>פורט או פראנס</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>בודפשט</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>ג׳קרטה</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>פונטיאנק</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>מאקאסאר</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>ג׳איאפורה</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>דבלין</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>ירושלים</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>האי מאן</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>קולקטה</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>צ׳אגוס</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>בגדד</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>טהרן</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>רייקיאוויק</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>רומא</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>ג׳רסי</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>ג׳מייקה</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>עמאן</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>טוקיו</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>ניירובי</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>בישקק</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>פנום פן</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>אנדרבורי</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>קיריטימאטי</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>טאראווה</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>קומורו</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>סנט קיטס</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>פיונגיאנג</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>סיאול</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>כווית</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>קיימן</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>אקטאו</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>אורל</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>אקטובה</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>קיזילורדה</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>אלמאטי</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>האנוי</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>ביירות</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>סנט לוסיה</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>ואדוז</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>קולומבו</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>מונרוביה</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>מסרו</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>וילנה</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>לוקסמבורג</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>ריגה</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>טריפולי</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>קזבלנקה</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>מונקו</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>קישינב</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>פודגוריקה</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>מריגו</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>אנטננריבו</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>קוואג׳ליין</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>מאג׳ורו</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>סקופיה</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>במאקו</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>רנגון</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>חובד</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>אולאאנבטאר</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>צ׳ואיבלסאן</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>מקאו</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>סייפן</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>מרטיניק</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>נואקצ׳וט</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>מונסראט</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>מלטה</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>מאוריציוס</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>האיים המלדיביים</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>בלנטיר</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>טיחואנה</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>סנטה איסבל</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>הרמוסיו</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>מזטלן</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>צ׳יוואווה</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>באהיה בנדרס</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>אוג׳ינאגה</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>מונטריי</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>מקסיקו סיטי</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>מטמורוס</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>מרידה</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>קנקון</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>קואלה לומפור</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>קוצ׳ינג</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>מאפוטו</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>וינדהוק</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>נומאה</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>ניאמיי</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>נורפוק</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>לגוס</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>מנגואה</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>אמסטרדם</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>אוסלו</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>קטמנדו</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>נאורו</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>ניווה</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>צ׳אטהאם</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>אוקלנד</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>מוסקט</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>פנמה</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>לימה</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>טהיטי</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>איי מרקיז</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>איי גמביר</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>פורט מורסבי</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>בוגנוויל</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>מנילה</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>קרצ׳י</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>ורשה</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>מיקלון</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>פיטקרן</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>פוארטו ריקו</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>עזה</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>חברון</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>האיים האזוריים</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>מדיירה</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>ליסבון</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>פלאו</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>אסונסיון</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>קטאר</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>ראוניון</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>בוקרשט</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>בלגרד</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>קלינינגרד</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>סימפרופול</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>מוסקבה</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>וולגוגרד</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>סמרה</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>יקטרינבורג</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>אומסק</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>נובוסיבירסק</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>נובוקוזנטסק</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>קרסנויארסק</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>אירקוטסק</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>צ׳יטה</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>יקוטסק</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>ולדיווסטוק</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>חנדיגה</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>סחלין</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>אוסט-נרה</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>מגדן</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>סרדנייקולימסק</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>קמצ׳טקה</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>אנדיר</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>קיגלי</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>ריאד</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>גוודלקנאל</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>מהא</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>חרטום</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>שטוקהולם</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>סינגפור</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>סנט הלנה</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>לובליאנה</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>לונגיירביאן</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>ברטיסלבה</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>פריטאון</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>סן מרינו</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>דקאר</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>מוגדישו</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>פרמריבו</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>ג׳ובה</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>סאו טומה</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>אל סלבדור</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>לואוור פרינסס קוורטר</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>דמשק</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>אמבאבאנה</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>גרנד טורק</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>נג׳מנה</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>קרגוולן</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>לומה</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>בנגקוק</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>דושנבה</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>פקאופו</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>דילי</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>אשגבט</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>תוניס</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>טונגטפו</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>איסטנבול</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>פורט אוף ספיין</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>פונפוטי</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>טאיפיי</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>דאר א-סלאם</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>אוז׳הורוד</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>קייב</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>זפוריז׳יה</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>קמפאלה</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>מידוויי</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>ג׳ונסטון</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>וואק</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>אדאק</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>נום</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>הונולולו</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>אנקורג׳</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>יקוטאט</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>סיטקה</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>ג׳ונו</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>מטלקטלה</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>לוס אנג׳לס</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>בויסי</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>פיניקס</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>דנוור</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>ביולה, צפון דקוטה</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>ניו סיילם, צפון דקוטה</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>סנטר, צפון דקוטה</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>שיקגו</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>מנומיני</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>וינסנס, אינדיאנה</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>פיטרסבורג, אינדיאנה</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>טל סיטי, אינדיאנה</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>נוקס, אינדיאנה</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>וינמאק, אינדיאנה</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>מרנגו, אינדיאנה</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>אינדיאנפוליס</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>לואיוויל</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>ויוואיי, אינדיאנה</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>מונטיצ׳לו, קנטאקי</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>דטרויט</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>ניו יורק</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>מונטווידאו</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>סמרקנד</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>טשקנט</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>הוותיקן</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>סנט וינסנט</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>קראקס</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>טורטולה</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>סנט תומאס</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>הו צ׳י מין סיטי</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>אפטה</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>ווליס</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>אפיה</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>עדן</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>מאיוט</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>יוהנסבורג</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>לוסקה</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>הרארה</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.hr.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.hr.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="hr" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>Nepoznati grad</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Andora</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Dubai</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Kabul</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Antigua</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Angvila</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Tirana</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Erevan</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Luanda</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Rothera</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Palmer</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Troll</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Syowa</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Mawson</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Davis</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Vostok</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Casey</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Dumont d’Urville</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>McMurdo</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Rio Gallegos</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Mendoza</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>San Juan</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ushuaia</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>La Rioja</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>San Luis</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Catamarca</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Salta</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Jujuy</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Tucuman</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Cordoba</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Buenos Aires</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Pago Pago</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Beč</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Perth</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Eucla</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Darwin</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Adelaide</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Broken Hill</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Currie</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Melbourne</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Hobart</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Lindeman</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Sydney</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Brisbane</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Macquarie</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Lord Howe</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Aruba</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Mariehamn</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Baku</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Sarajevo</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Barbados</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Dhaka</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Bruxelles</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Ouagadougou</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>Sofija</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Bahrein</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Bujumbura</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Porto-Novo</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>Saint Barthélemy</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Bermuda</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Brunej</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>La Paz</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Kralendijk</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Eirunepe</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Rio Branco</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Porto Velho</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Boa Vista</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Manaus</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Cuiaba</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Santarem</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Campo Grande</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Belem</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Araguaina</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>Sao Paulo</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Bahia</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Fortaleza</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Maceio</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Recife</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Noronha</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Nassau</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Thimphu</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Gaborone</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Minsk</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Belize</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Dawson</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Whitehorse</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Inuvik</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Vancouver</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Dawson Creek</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Creston</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Yellowknife</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Edmonton</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Swift Current</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Cambridge Bay</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Regina</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Winnipeg</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Resolute</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Rainy River</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Rankin Inlet</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Atikokan</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Thunder Bay</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Nipigon</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Toronto</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Iqaluit</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Pangnirtung</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Moncton</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Halifax</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Goose Bay</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Glace Bay</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Blanc-Sablon</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>St. John’s</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Kokosovi otoci</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Kinšasa</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Lubumbaši</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Bangui</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Brazzaville</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Zürich</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Abidjan</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Rarotonga</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Uskrsni Otok</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Santiago</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Douala</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Urumqi</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Šangaj</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Bogota</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Kostarika</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Havana</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Zelenortski Otoci</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Curaçao</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Božićni otok</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Nikozija</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Prag</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Busingen</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Berlin</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Džibuti</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Kopenhagen</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Dominika</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Santo Domingo</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Alžir</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Galapagos</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Guayaquil</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Tallinn</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Kairo</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>El Aaiun</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Asmara</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Kanari</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Ceuta</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Madrid</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Addis Abeba</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Helsinki</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Fidži</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Stanley</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Chuuk</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Pohnpei</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Kosrae</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Ferojski otoci</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>Pariz</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Libreville</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>London</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Grenada</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Tbilisi</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Cayenne</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Guernsey</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Accra</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Gibraltar</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Thule</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Nuuk</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Ittoqqortoormiit</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Danmarkshavn</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Banjul</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Conakry</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Guadalupa</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Malabo</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Atena</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Južna Georgija</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Gvatemala</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Guam</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Bissau</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Gvajana</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Hong Kong</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Tegucigalpa</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Zagreb</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Port-au-Prince</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Budimpešta</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Džakarta</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Pontianak</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Makassar</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Jayapura</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Dublin</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Jeruzalem</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Otok Man</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Kolkata</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Chagos</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Bagdad</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Teheran</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Reykjavik</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Rim</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Jersey</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Jamajka</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Amman</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Tokio</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Nairobi</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Biškek</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Phnom Penh</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Enderbury</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Kiritimati</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Tarawa</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Komori</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>St. Kitts</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Pjongjang</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Seoul</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Kuvajt</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Kajman</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Aktau</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Oral</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Aktobe</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Kizilorda</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Alma Ata</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Vientiane</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Beirut</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>St. Lucia</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Vaduz</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Colombo</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Monrovia</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Maseru</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Vilnius</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Luksemburg</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Riga</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Tripoli</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Casablanca</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Monako</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Chisinau</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Podgorica</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Marigot</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Antananarivo</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Kwajalein</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Majuro</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Skopje</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Bamako</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Rangoon</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Hovd</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Ulan Bator</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Choibalsan</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Makao</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Saipan</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Martinik</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Nouakchott</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Montserrat</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Malta</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Mauricijus</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Maldivi</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Blantyre</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Tijuana</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Santa Isabel</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Hermosillo</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Mazatlan</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Chihuahua</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Bahia Banderas</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Ojinaga</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Monterrey</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Ciudad de México</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Matamoros</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Merida</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Cancun</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Kuala Lumpur</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Kuching</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Maputo</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Windhoek</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Noumea</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Niamey</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Norfolk</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Lagos</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Managua</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Amsterdam</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Oslo</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Kathmandu</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Nauru</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Niue</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Chatham</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Auckland</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Muscat</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Panama</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Lima</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Tahiti</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Markižansko otočje</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Gambier</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Port Moresby</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>Bougainville</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Manila</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Karachi</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Varšava</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Miquelon</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Pitcairn</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Portoriko</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Gaza</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Hebron</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Azorski otoci</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Madeira</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Lisabon</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Palau</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Asunción</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Katar</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Réunion</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Bukurešt</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Beograd</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Kalinjingrad</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Simferopol</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Moskva</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Volgograd</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Samara</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Ekaterinburg</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Omsk</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Novosibirsk</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Novokuznjeck</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Krasnojarsk</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Irkutsk</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>Chita</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Jakutsk</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Vladivostok</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Handiga</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Sahalin</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Ust-Nera</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Magadan</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>Srednekolimsk</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Kamčatka</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Anadir</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Kigali</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Rijad</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Guadalcanal</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Mahe</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Kartum</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Stockholm</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Singapur</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>St. Helena</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Ljubljana</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Longyearbyen</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Bratislava</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Freetown</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>San Marino</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Dakar</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Mogadishu</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Paramaribo</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Juba</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>São Tomé</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>El Salvador</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Lower Prince’s Quarter</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Damask</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Mbabane</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Grand Turk</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>Ndjamena</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Kerguelen</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Lome</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Bangkok</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Dušanbe</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Fakaofo</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Dili</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Ashgabat</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Tunis</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Tongatapu</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Istanbul</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Port of Spain</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Funafuti</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Taipei</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Dar es Salaam</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Uzgorod</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Kijev</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Zaporožje</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Kampala</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Midway</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Johnston</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Wake</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Adak</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Nome</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Honolulu</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Anchorage</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Yakutat</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Sitka</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Juneau</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Metlakatla</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Los Angeles</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Boise</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Phoenix</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Denver</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Beulah, Sjeverna Dakota</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>New Salem, Sjeverna Dakota</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Center, Sjeverna Dakota</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Chicago</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Menominee</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Vincennes, Indiana</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Petersburg, Indiana</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Tell City, Indiana</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Knox, Indiana</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Winamac, Indiana</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Marengo, Indiana</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Indianapolis</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Louisville</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Vevay, Indiana</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Monticello, Kentucky</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Detroit</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>New York</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Montevideo</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Samarkand</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Taškent</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Vatikan</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>St. Vincent</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Caracas</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Tortola</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>St. Thomas</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Ho Ši Min</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Efate</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Wallis</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Apia</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Aden</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Mayotte</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Johannesburg</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Lusaka</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Harare</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.hu.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.hu.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="hu" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>Ismeretlen város</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Andorra</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Dubai</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Kabul</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Antigua</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Anguilla</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Tirana</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Jereván</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Luanda</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Rothera</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Palmer</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Troll</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Syowa</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Mawson</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Davis</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Vosztok</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Casey</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Dumont d’Urville</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>McMurdo</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Río Gallegos</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Mendoza</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>San Juan</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ushuaia</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>La Rioja</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>San Luis</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Catamarca</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Salta</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Jujuy</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Tucumán</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Córdoba</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Buenos Aires</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Pago Pago</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Bécs</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Perth</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Eucla</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Darwin</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Adelaide</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Broken Hill</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Currie</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Melbourne</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Hobart</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Lindeman</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Sydney</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Brisbane</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Macquarie</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Lord Howe</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Aruba</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Mariehamn</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Baku</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Szarajevó</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Barbados</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Dháka</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Brüsszel</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Ouagadougou</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>Szófia</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Bahrein</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Bujumbura</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Porto-Novo</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>Saint-Barthélemy</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Bermuda</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Brunei</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>La Paz</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Kralendijk</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Eirunepé</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Río Branco</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Porto Velho</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Boa Vista</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Manaus</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Cuiabá</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Santarem</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Campo Grande</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Belém</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Araguaína</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>São Paulo</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Bahia</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Fortaleza</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Maceió</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Recife</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Noronha</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Nassau</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Thimphu</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Gaborone</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Minszk</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Belize</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Dawson</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Whitehorse</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Inuvik</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Vancouver</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Dawson Creek</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Creston</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Yellowknife</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Edmonton</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Swift Current</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Cambridge Bay</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Regina</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Winnipeg</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Resolute</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Rainy River</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Rankin Inlet</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Atikokan</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Thunder Bay</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Nipigon</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Toronto</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Iqaluit</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Pangnirtung</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Moncton</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Halifax</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Goose Bay</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Glace Bay</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Blanc-Sablon</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>St. John’s</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Kókusz-sziget</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Kinshasa</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Lubumbashi</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Bangui</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Brazzaville</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Zürich</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Abidjan</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Rarotonga</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Húsvét-szigetek</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Santiago</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Douala</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Ürümqi</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Sanghaj</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Bogotá</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Costa Rica</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Havanna</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Zöld-Foki Szigetek</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Curacao</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Karácsony-sziget</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Nicosia</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Prága</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Büsingen</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Berlin</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Dzsibuti</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Koppenhága</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Dominika</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Santo Domingo</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Algír</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Galapagos-szigetek</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Guayaquil</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Tallin</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Kairó</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>El-Ajún</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Asmera</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Kanári-szigetek</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Ceuta</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Madrid</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Addisz-Abeba</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Helsinki</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Fidzsi</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Stanley</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Chuuk</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Ponape-szigetek</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Kosrae-szigetek</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Faroe</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>Párizs</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Libreville</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>London</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Grenada</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Tbiliszi</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Cayenne</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Guernsey</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Accra</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Gibraltár</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Thule</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Nuuk</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Ittoqqortoormiit</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Danmarkshavn</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Banjul</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Conakry</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Guadeloupe</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Malabó</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Athén</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Déli-Georgia</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Guatemala</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Guam</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Bissau</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Guyana</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Hongkong</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Tegucigalpa</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Zágráb</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Port-au-Prince</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Budapest</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Jakarta</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Pontianak</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Makasar</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Jayapura</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Dublin</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Jeruzsálem</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Man-sziget</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Kalkutta</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Chagos</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Bagdad</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Teherán</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Reykjavík</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Róma</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Jersey</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Jamaica</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Ammán</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Tokió</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Nairobi</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Biskek</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Phnom Penh</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Enderbury</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Kiritimati-sziget</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Tarawa</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Komoró</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>St. Kitts</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Phenjan</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Szöul</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Kuvait</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Kajmán-szigetek</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Aktau</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Oral</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Aktöbe</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Kizilorda</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Alma-Ata</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Vientián</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Bejrút</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>St. Lucia</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Vaduz</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Colombo</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Monrovia</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Maseru</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Vilnius</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Luxemburg</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Riga</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Tripoli</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Casablanca</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Monaco</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Chisinau</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Podgorica</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Marigot</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Antananarivo</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Kwajalein-zátony</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Majuro-zátony</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Skopje</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Bamako</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Rangoon</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Hovd</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Ulánbátor</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Csojbalszan</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Makaó</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Saipan</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Martinique</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Nouakchott</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Montserrat</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Málta</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Mauritius</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Maldív-szigetek</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Blantyre</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Tijuana</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Santa Isabel</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Hermosillo</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Mazatlán</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Chihuahua</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Bahia Banderas</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Ojinaga</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Monterrey</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Mexikóváros</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Matamoros</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Mérida</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Cancún</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Kuala Lumpur</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Kucseng</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Maputo</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Windhoek</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Noumea</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Niamey</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Norfolk</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Lagos</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Managua</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Amszterdam</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Oslo</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Katmandu</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Nauru</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Niue</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Chatham-szigetek</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Auckland</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Muscat</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Panama</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Lima</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Tahiti</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Marquesas-szigetek</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Gambier-szigetek</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Port Moresby</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>Bougainville</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Manila</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Karacsi</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Varsó</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Miquelon</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Pitcairn-szigetek</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Puerto Rico</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Gáza</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Hebron</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Azori-szigetek</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Madeira</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Lisszabon</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Palau</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Asunción</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Katar</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Réunion</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Bukarest</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Belgrád</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Kalinyingrád</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Szimferopol</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Moszkva</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Volgográd</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Szamara</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Jekatyerinburg</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Omszk</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Novoszibirszk</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Novokuznyeck</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Krasznojarszk</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Irkutszk</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>Csita</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Jakutszk</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Vlagyivosztok</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Handiga</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Szahalin</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Uszty-Nyera</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Magadán</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>Szrednekolimszk</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Kamcsatka</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Anadir</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Kigali</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Rijád</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Guadalcanal</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Mahe</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Kartúm</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Stockholm</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Szingapúr</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>Szent Ilona</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Ljubljana</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Longyearbyen</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Pozsony</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Freetown</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>San Marino</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Dakar</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Mogadishu</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Paramaribo</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Juba</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>São Tomé</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>Salvador</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Lower Prince’s Quarter</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Damaszkusz</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Mbabane</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Grand Turk</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>Ndjamena</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Kerguelen</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Lome</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Bangkok</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Dushanbe</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Fakaofo</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Dili</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Asgabat</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Tunisz</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Tongatapu</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Isztanbul</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Port of Spain</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Funafuti</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Tajpej</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Dar es-Salaam</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Ungvár</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Kijev</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Zaporozsje</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Kampala</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Midway-szigetek</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Johnston</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Wake-sziget</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Adak</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Nome</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Honolulu</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Anchorage</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Yakutat</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Sitka</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Juneau</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Metlakatla</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Los Angeles</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Boise</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Phoenix</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Denver</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Beulah, Észak-Dakota</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>New Salem, Észak-Dakota</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Középső, Észak-Dakota</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Chicago</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Menominee</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Vincennes, Indiana</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Petersburg, Indiana</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Tell City, Indiana</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Knox, Indiana</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Winamac, Indiana</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Marengo, Indiana</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Indianapolis</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Louisville</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Vevay, Indiana</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Monticello, Kentucky</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Detroit</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>New York</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Montevideo</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Szamarkand</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Taskent</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Vatikán</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>St. Vincent</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Caracas</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Tortola</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>St. Thomas</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Ho Si Minh-város</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Efate</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Wallis</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Apia</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Áden</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Mayotte</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Johannesburg</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Lusaka</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Harare</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.hy.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.hy.xlf
@@ -1,0 +1,1671 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="hy" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>Անհայտ քաղաք</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Անդորա</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Դուբայ</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Քաբուլ</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Անտիգուա</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Անգիլյա</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Տիրանա</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Երևան</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Լուանդա</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Ռոտերա</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Պալմեր</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Տրոլլ</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Սյովա</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Մոուսոն</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Դեյվիս</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Վոստոկ</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Քեյսի</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Դյումոն դ’Յուրվիլ</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>Մակ-Մերդո</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Ռիո Գալյեգոս</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Մենդոսա</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>Սան Խուան</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ուշուայա</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>Լա-Ռիոխա</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>Սան Լուիս</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Կատամարկա</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Սալտա</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Ժուժույ</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Տուկուման</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Կորդովա</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Բուենոս Այրես</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Պագո Պագո</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Վիեննա</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Պերթ</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Յուկլա</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Դարվին</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Ադելաիդա</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Բրոքեն Հիլ</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Քերի</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Մելբուրն</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Հոբարտ</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Լինդեման</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Սիդնեյ</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Բրիսբեն</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Մակկուորի կղզի</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Լորդ Հաու</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Արուբա</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Մարիեհամն</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Բաքու</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Սարաևո</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Բարբադոս</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Դաքքա</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Բրյուսել</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Ուագադուգու</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>Սոֆիա</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Բահրեյն</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Բուժումբուրա</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Պորտո Նովո</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>Սեն Բարտելմի</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Բերմուդյան կղզիներ</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Բրունեյ</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>Լա Պաս</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Կրալենդեյկ</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Էյրունեպե</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Ռիո Բրանկու</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Պորտու Վելյու</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Բոա-Վիստա</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Մանաուս</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Կույաբա</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Սանտարեմ</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Կամպո Գրանգե</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Բելեմ</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Արագուայնա</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>Սան Պաուլու</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Բայա</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Ֆորտալեզա</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Մասեյո</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Ռեսիֆի</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Նորոնխա</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Նասաու</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Թիմփու</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Գաբորոնե</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Մինսկ</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Բելիզ</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Դոուսոն</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Ուայթհորս</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Ինուվիկ</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Վանկուվեր</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Դոուսոն Կրիկ</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Քրեսթոն</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Յելոունայֆ</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Էդմոնտոն</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Սվիֆթ-Քարենտ</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Քեմբրիջ-Բեյ</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Ռեջայնա</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Վինիպեգ</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Ռեզոլյուտ</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Ռեյնի-Ռիվեր</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Ռանկին-Ինլետ</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Ատիկոկան</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Տանդեր-Բեյ</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Նիպիգոն</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Տորոնտո</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Իկալուիտ</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Պանգնիրտանգ</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Մոնկտոն</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Հալիֆաքս</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Գուս Բեյ</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Գլեյս Բեյ</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Բլան-Սաբլոն</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>Սենթ-Ջոնս</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Կոկոսյան կղզիներ</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Կինշասա</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Լուբումբաշի</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Բանգի</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Բրազավիլ</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Ցյուրիխ</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Աբիջան</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Ռառատոնգա</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Զատիկի կղզի</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Սանտյագո</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Դուալա</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Ուրումչի</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Շանհայ</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Բոգոտա</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Կոստա Ռիկա</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Հավանա</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Կաբո Վերդե</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Կյուրասաո</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Ծննդյան կղզի</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Նիկոսիա</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Պրահա</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Բյուզինգեն</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Բեռլին</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Ջիբութի</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Կոպենհագեն</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Դոմինիկա</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Սանտո Դոմինգո</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Ալժիր</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Գալապագոսյան կղզիներ</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Գուայակիլ</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Տալլին</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Կահիրե</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>Էլ Այուն</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Ասմարա</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Կանարյան կղզիներ</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Սեուտա</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Մադրիդ</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Ադիս Աբեբա</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Հելսինկի</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Ֆիջի</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Սթենլի</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Չուուկ</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Պոնպեի</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Կոսրաե</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Ֆարերյան կղզիներ</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>Փարիզ</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Լիբրևիլ</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>Լոնդոն</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Գրենադա</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Թբիլիսի</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Կայեն</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Գերնսի</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Ակրա</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Ջիբրալթար</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Տուլե</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Նուուկ</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Սկորսբիսուն</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Դենմարքսհավն</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Բանժուլ</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Կոնակրի</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Գվադելուպա</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Մալաբո</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Աթենք</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Հարավային Ջորջիա</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Գվատեմալա</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Գուամ</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Բիսաու</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Գայանա</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Հոնկոնգ</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Տեգուսիգալպա</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Զագրեբ</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Պորտ-օ-Պրենս</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Բուդապեշտ</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Ջակարտա</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Պոնտիանակ</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Մակասար</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Ջայպուրա</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Դուբլին</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Երուսաղեմ</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Մեն կղզի</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Կալկուտա</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Չագոս</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Բաղդադ</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Թեհրան</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Ռեյկյավիկ</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Հռոմ</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Ջերսի</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Ճամայկա</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Ամման</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Տոկիո</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Նայրոբի</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Բիշքեկ</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Պնոմպեն</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Էնդերբերի կղզի</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Կիրիտիմատի</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Տարավա</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Կոմորյան կղզիներ</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>Սենթ Քիթս</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Փխենյան</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Սեուլ</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Քուվեյթ</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Կայմանի կղզիներ</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Ակտաու</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Ուրալսկ</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Ակտոբե</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Կիզիլորդա</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Ալմաթի</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Վյենտյան</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Բեյրութ</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>Սենթ Լյուսիա</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Վադուց</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Կոլոմբո</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Մոնրովիա</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Մասերու</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Վիլնյուս</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Լյուքսեմբուրգ</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Ռիգա</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Տրիպոլի</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Կասաբլանկա</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Մոնակո</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Քիշնև</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Պոդգորիցա</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Մարիգո</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Անտանանարիվու</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Քվաջալեյն</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Մաջուրո</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Սկոպյե</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Բամակո</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Ռանգուն</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Հովդ</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Ուլան Բատոր</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Չոյբալսան</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Մակաո</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Սայպան</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Մարտինիկա</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Նուակշոտ</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Մոնտսեռատ</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Մալթա</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Մավրիկիոս</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Մալդիվյան կղզիներ</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Բլանթայր</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Տիխուանա</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Սանտա Իսաբել</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Էրմոսիլյո</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Մազաթլան</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Չիուաուա</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Բայա Բանդերաս</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Օխինագա</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Մոնտերեյ</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Մեխիկո</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Մատամորոս</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Մերիդա</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Կանկուն</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Կուալա Լումպուր</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Կուչինգ</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Մապուտու</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Վինդհուկ</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Նումեա</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Նիամեյ</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Նորֆոլկ</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Լագոս</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Մանագուա</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Ամստերդամ</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Օսլո</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Կատմանդու</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Նաուրու</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Նիուե</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Չաթեմ կղզի</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Օկլենդ</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Մուսկատ</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Պանամա</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Լիմա</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Թաիթի</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Մարկիզյան կղզիներ</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Գամբյե կղզիներ</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Պորտ Մորսբի</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Մանիլա</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Կարաչի</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Վարշավա</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Միքելոն</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Պիտկեռն</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Պուերտո Ռիկո</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Գազա</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Հեբրոն</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Ազորյան կղզիներ</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Մադեյրա</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Լիսաբոն</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Պալաու</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Ասունսյոն</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Կատար</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Ռեյունիոն</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Բուխարեստ</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Բելգրադ</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Կալինինգրադ</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Սիմֆերոպոլ</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Մոսկվա</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Վոլգոգրադ</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Սամարա</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Եկատերինբուրգ</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Օմսկ</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Նովոսիբիրսկ</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Նովոկուզնեցկ</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Կրասնոյարսկ</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Իրկուտսկ</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>Չիտա</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Յակուտսկ</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Վլադիվոստոկ</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Խանդիգա</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Սախալին</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Ուստ-Ներա</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Մագադան</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>Սրեդնեկոլիմսկ</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Կամչատկա</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Անադիր</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Կիգալի</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Էր Ռիադ</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Գուադալկանալ</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Մաէ</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Խարթում</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Ստոքհոլմ</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Սինգապուր</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>Սուրբ Հեղինեի կղզի</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Լյուբլյանա</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Լոնգյիր</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Բրատիսլավա</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Ֆրիթաուն</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>Սան Մարինո</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Դակար</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Մոգադիշո</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Պարամարիբո</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Ջուբա</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>Սան Տոմե</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>Սալվադոր</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Լոուեր Պրինսես Քվորթեր</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Դամասկոս</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Մբաբանե</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Գրանդ Տուրկ</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>Նջամենա</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Կերգելեն</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Լոմե</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Բանգկոկ</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Դուշանբե</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Ֆակաոֆո</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Դիլի</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Աշխաբադ</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Թունիս</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Տոնգատապու</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Ստամբուլ</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Պորտ-օֆ-Սփեյն</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Ֆունաֆուտի</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Թայպեյ</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Դար-Էս-Սալամ</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Ուժգորոդ</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Կիև</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Զապորոժյե</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Կամպալա</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Միդուեյ կղզի</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Ջոնսթոն</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Ուեյք կղզի</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Ադակ կղզի</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Նոմ</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Հոնոլուլու</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Անքորիջ</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Յակուտատ</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Սիտկա</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Ջունո</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Մետլակատլա</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Լոս Անջելես</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Բոյսե</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Ֆինիքս</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Դենվեր</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Բոյլա, Հյուսիսային Դակոտա</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>Նյու Սալեմ, Հյուսիսային Դակոտա</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Հյուսիսային Դակոտա - Կենտրոն</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Չիկագո</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Մենոմինի</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Վինսենս, Ինդիանա</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Պետերսբուրգ, Ինդիանա</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Թել-Սիթի, Ինդիանա</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Նոքս, Ինդիանա</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Վինամակ, Ինդիանա</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Մարենգո, Ինդիանա</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Ինդիանապոլիս</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Լուիսվիլ</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Վիվեյ, Ինդիանա</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Մոնտիսելո, Կենտուկի</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Դետրոյթ</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>Նյու Յորք</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Մոնտեվիդեո</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Սամարղանդ</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Տաշքենդ</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Վատիկան</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>Սենթ Վինսենթ</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Կարակաս</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Տորտոլա</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>Սենթ Թոմաս</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Հոշիմին</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Էֆատե</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Ուոլլիս</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Ապիա</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Ադեն</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Մայոտ</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Յոհանեսբուրգ</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Լուսակա</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Հարարե</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.id.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.id.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="id" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>Tidak Dikenal</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Andorra</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Dubai</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Kabul</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Antigua</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Anguila</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Tirane</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Yerevan</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Luanda</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Rothera</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Palmer</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Troll</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Syowa</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Mawson</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Davis</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Vostok</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Casey</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Dumont d’Urville</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>McMurdo</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Rio Gallegos</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Mendoza</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>San Juan</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ushuaia</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>La Rioja</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>San Luis</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Catamarca</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Salta</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Jujuy</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Tucuman</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Kordoba</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Buenos Aires</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Pago Pago</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Wina</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Perth</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Eucla</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Darwin</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Adelaide</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Broken Hill</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Currie</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Melbourne</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Hobart</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Lindeman</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Sydney</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Brisbane</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Macquarie</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Lord Howe</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Aruba</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Mariehamn</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Baku</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Sarajevo</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Barbados</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Dhaka</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Brussel</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Ouagadougou</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>Sofia</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Bahrain</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Bujumbura</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Porto-Novo</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>St. Barthelemy</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Bermuda</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Brunei</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>La Paz</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Kralendijk</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Eirunepe</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Rio Branco</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Porto Velho</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Boa Vista</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Manaus</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Cuiaba</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Santarem</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Campo Grande</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Belem</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Araguaina</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>Sao Paulo</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Bahia</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Fortaleza</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Maceio</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Recife</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Noronha</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Nassau</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Thimphu</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Gaborone</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Minsk</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Belize</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Dawson</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Whitehorse</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Inuvik</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Vancouver</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Dawson Creek</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Creston</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Yellowknife</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Edmonton</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Swift Current</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Cambridge Bay</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Regina</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Winnipeg</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Resolute</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Rainy River</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Rankin Inlet</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Atikokan</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Thunder Bay</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Nipigon</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Toronto</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Iqaluit</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Pangnirtung</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Moncton</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Halifax</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Goose Bay</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Glace Bay</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Blanc-Sablon</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>St. John’s</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Cocos</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Kinshasa</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Lubumbashi</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Bangui</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Brazzaville</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Zurich</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Abidjan</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Rarotonga</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Easter</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Santiago</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Douala</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Urumqi</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Shanghai</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Bogota</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Kosta Rika</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Havana</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Tanjung Verde</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Curacao</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Christmas</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Nikosia</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Praha</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Busingen</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Berlin</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Jibouti</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Kopenhagen</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Dominika</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Santo Domingo</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Aljir</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Galapagos</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Guayaquil</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Tallinn</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Kairo</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>El Aaiun</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Asmara</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Canary</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Ceuta</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Madrid</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Addis Ababa</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Helsinki</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Fiji</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Stanley</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Chuuk</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Pohnpei</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Kosrae</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Faroe</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>Paris</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Libreville</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>London</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Grenada</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Tbilisi</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Cayenne</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Guernsey</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Akra</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Gibraltar</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Thule</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Nuuk</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Ittoqqortoormiit</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Danmarkshavn</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Banjul</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Konakri</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Guadeloupe</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Malabo</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Athena</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Georgia Selatan</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Guatemala</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Guam</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Bissau</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Guyana</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Hong Kong</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Tegucigalpa</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Zagreb</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Port-au-Prince</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Budapest</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Jakarta</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Pontianak</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Makassar</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Jayapura</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Dublin</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Yerusalem</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Pulau Man</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Kolkata</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Chagos</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Bagdad</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Teheran</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Reykjavik</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Roma</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Jersey</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Jamaika</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Amman</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Tokyo</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Nairobi</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Bishkek</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Phnom Penh</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Enderbury</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Kiritimati</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Tarawa</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Komoro</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>St. Kitts</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Pyongyang</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Seoul</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Kuwait</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Cayman</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Aktau</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Oral</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Aktobe</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Qyzylorda</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Almaty</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Vientiane</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Beirut</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>St. Lucia</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Vaduz</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Kolombo</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Monrovia</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Maseru</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Vilnius</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Luksemburg</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Riga</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Tripoli</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Casablanca</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Monako</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Kishinev</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Podgorica</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Marigot</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Antananarivo</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Kwajalein</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Majuro</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Skopje</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Bamako</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Rangoon</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Hovd</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Ulaanbaatar</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Choibalsan</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Makau</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Saipan</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Martinik</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Nouakchott</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Montserrat</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Malta</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Mauritius</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Maladewa</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Blantyre</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Tijuana</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Santa Isabel</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Hermosillo</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Mazatlan</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Chihuahua</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Bahia Banderas</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Ojinaga</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Monterrey</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Mexico City</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Matamoros</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Merida</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Cancun</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Kuala Lumpur</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Kuching</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Maputo</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Windhoek</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Noumea</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Niamey</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Norfolk</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Lagos</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Managua</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Amsterdam</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Oslo</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Kathmandu</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Nauru</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Niue</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Chatham</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Auckland</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Muskat</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Panama</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Lima</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Tahiti</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Marquesas</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Gambier</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Port Moresby</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>Bougainville</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Manila</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Karachi</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Warsawa</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Miquelon</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Pitcairn</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Puerto Riko</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Gaza</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Hebron</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Azores</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Madeira</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Lisboa</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Palau</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Asuncion</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Qatar</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Reunion</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Bukares</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Beograd</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Kaliningrad</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Simferopol</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Moskwa</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Volgograd</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Samara</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Yekaterinburg</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Omsk</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Novosibirsk</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Novokuznetsk</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Krasnoyarsk</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Irkutsk</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>Chita</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Yakutsk</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Vladivostok</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Khandyga</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Sakhalin</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Ust-Nera</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Magadan</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>Srednekolymsk</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Kamchatka</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Anadyr</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Kigali</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Riyad</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Guadalkanal</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Mahe</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Khartum</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Stockholm</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Singapura</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>St. Helena</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Ljubljana</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Longyearbyen</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Bratislava</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Freetown</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>San Marino</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Dakar</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Mogadishu</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Paramaribo</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Juba</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>Sao Tome</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>El Salvador</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Lower Prince’s Quarter</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Damaskus</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Mbabane</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Grand Turk</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>Ndjamena</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Kerguelen</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Lome</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Bangkok</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Dushanbe</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Fakaofo</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Dili</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Ashgabat</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Tunis</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Tongatapu</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Istanbul</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Port of Spain</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Funafuti</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Taipei</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Dar es Salaam</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Uzhhorod</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Kiev</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Zaporizhia</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Kampala</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Midway</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Johnston</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Wake</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Adak</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Nome</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Honolulu</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Anchorage</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Yakutat</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Sitka</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Juneau</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Metlakatla</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Los Angeles</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Boise</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Phoenix</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Denver</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Beulah, Dakota Utara</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>New Salem, Dakota Utara</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Center, Dakota Utara</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Chicago</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Menominee</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Vincennes, Indiana</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Petersburg, Indiana</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Tell City, Indiana</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Knox, Indiana</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Winamac, Indiana</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Marengo, Indiana</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Indianapolis</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Louisville</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Vevay, Indiana</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Monticello, Kentucky</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Detroit</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>New York</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Montevideo</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Samarkand</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Tashkent</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Vatikan</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>St. Vincent</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Karakas</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Tortola</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>St. Thomas</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Kota Ho Chi Minh</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Efate</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Wallis</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Apia</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Aden</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Mayotte</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Johannesburg</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Lusaka</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Harare</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.it.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.it.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="it" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>Città sconosciuta</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Andorra</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Dubai</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Kabul</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Antigua</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Anguilla</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Tirana</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Yerevan</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Luanda</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Rothera</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Palmer</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Troll</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Syowa</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Mawson</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Davis</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Vostok</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Casey</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Dumont d’Urville</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>McMurdo</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Rio Gallegos</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Mendoza</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>San Juan</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ushuaia</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>La Rioja</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>San Luis</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Catamarca</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Salta</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Jujuy</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Tucumán</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Cordoba</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Buenos Aires</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Pago Pago</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Vienna</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Perth</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Eucla</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Darwin</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Adelaide</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Broken Hill</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Currie</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Melbourne</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Hobart</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Lindeman</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Sydney</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Brisbane</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Macquarie</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Lord Howe</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Aruba</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Mariehamn</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Baku</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Sarajevo</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Barbados</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Dacca</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Bruxelles</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Ouagadougou</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>Sofia</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Bahrein</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Bujumbura</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Porto-Novo</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>Saint-Barthélemy</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Bermuda</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Brunei</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>La Paz</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Kralendijk</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Eirunepe</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Rio Branco</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Porto Velho</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Boa Vista</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Manaus</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Cuiaba</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Santarém</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Campo Grande</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Belem</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Araguaina</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>San Paolo</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Bahia</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Fortaleza</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Maceio</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Recife</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Noronha</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Nassau</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Thimphu</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Gaborone</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Minsk</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Belize</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Dawson</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Whitehorse</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Inuvik</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Vancouver</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Dawson Creek</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Creston</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Yellowknife</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Edmonton</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Swift Current</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Cambridge Bay</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Regina</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Winnipeg</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Resolute</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Rainy River</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Rankin Inlet</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Atikokan</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Thunder Bay</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Nipigon</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Toronto</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Iqaluit</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Pangnirtung</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Moncton</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Halifax</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Goose Bay</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Glace Bay</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Blanc-Sablon</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>St. John’s</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Cocos</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Kinshasa</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Lubumbashi</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Bangui</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Brazzaville</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Zurigo</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Abidjan</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Rarotonga</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Pasqua</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Santiago</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Douala</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Urumqi</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Shanghai</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Bogotá</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Costa Rica</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>L’Avana</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Capo Verde</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Curaçao</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Natale</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Nicosia</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Praga</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Büsingen</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Berlino</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Gibuti</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Copenaghen</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Dominica</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Santo Domingo</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Algeri</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Galapagos</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Guayaquil</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Tallinn</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Il Cairo</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>El Ayun</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Asmara</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Canarie</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Ceuta</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Madrid</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Addis Abeba</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Helsinki</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Figi</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Stanley</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Chuuk</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Pohnpei</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Kosrae</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Isole Fær Øer</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>Parigi</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Libreville</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>Londra</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Grenada</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Tbilisi</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Caienna</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Guernsey</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Accra</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Gibilterra</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Thule</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Nuuk</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Ittoqqortoormiit</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Danmarkshavn</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Banjul</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Conakry</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Guadalupa</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Malabo</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Atene</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Georgia del Sud</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Guatemala</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Guam</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Bissau</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Guyana</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Hong Kong</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Tegucigalpa</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Zagabria</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Port-au-Prince</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Budapest</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Giacarta</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Pontianak</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Makassar</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Jayapura</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Dublino</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Gerusalemme</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Isola di Man</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Calcutta</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Chagos</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Baghdad</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Teheran</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Reykjavík</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Roma</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Jersey</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Giamaica</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Amman</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Tokyo</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Nairobi</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Bishkek</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Phnom Penh</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Enderbury</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Kiritimati</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Tarawa</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Comore</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>St. Kitts</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Pyongyang</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Seul</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Kuwait</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Cayman</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Aqtau</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Oral</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Aqtöbe</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Qyzylorda</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Almaty</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Vientiane</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Beirut</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>Santa Lucia</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Vaduz</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Colombo</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Monrovia</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Maseru</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Vilnius</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Lussemburgo</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Riga</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Tripoli</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Casablanca</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Monaco</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Chisinau</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Podgorica</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Marigot</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Antananarivo</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Kwajalein</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Majuro</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Skopje</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Bamako</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Rangoon</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Hovd</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Ulaanbaatar</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Choibalsan</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Macao</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Saipan</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Martinica</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Nouakchott</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Montserrat</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Malta</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Mauritius</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Maldive</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Blantyre</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Tijuana</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Santa Isabel</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Hermosillo</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Mazatlan</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Chihuahua</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Bahía de Banderas</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Ojinaga</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Monterrey</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Città del Messico</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Matamoros</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Mérida</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Cancún</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Kuala Lumpur</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Kuching</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Maputo</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Windhoek</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Noumea</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Niamey</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Norfolk</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Lagos</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Managua</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Amsterdam</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Oslo</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Kathmandu</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Nauru</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Niue</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Chatham</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Auckland</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Mascate</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Panamá</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Lima</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Tahiti</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Marchesi</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Gambier</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Port Moresby</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>Bougainville</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Manila</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Karachi</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Varsavia</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Miquelon</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Pitcairn</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Portorico</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Gaza</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Hebron</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Azzorre</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Madeira</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Lisbona</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Palau</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Asunción</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Qatar</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>La Riunione</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Bucarest</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Belgrado</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Kaliningrad</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Sinferopoli</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Mosca</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Volgograd</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Samara</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Ekaterinburg</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Omsk</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Novosibirsk</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Novokuzneck</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Krasnojarsk</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Irkutsk</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>Čita</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Jakutsk</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Vladivostok</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Chandyga</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Sachalin</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Ust’-Nera</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Magadan</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>Srednekolymsk</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Kamchatka</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Anadyr’</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Kigali</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Riyad</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Guadalcanal</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Mahe</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Khartum</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Stoccolma</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Singapore</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>Sant’Elena</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Lubiana</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Longyearbyen</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Bratislava</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Freetown</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>San Marino</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Dakar</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Mogadiscio</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Paramaribo</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Giuba</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>São Tomé</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>El Salvador</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Lower Prince’s Quarter</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Damasco</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Mbabane</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Grand Turk</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>N’Djamena</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Kerguelen</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Lomé</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Bangkok</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Dushanbe</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Fakaofo</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Dili</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Ashgabat</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Tunisi</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Tongatapu</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Istanbul</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Port of Spain</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Funafuti</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Taipei</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Dar es Salaam</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Užhorod</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Kiev</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Zaporozhye</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Kampala</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Midway</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Johnston</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Wake</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Adak</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Nome</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Honolulu</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Anchorage</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Yakutat</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Sitka</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Juneau</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Metlakatla</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Los Angeles</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Boise</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Phoenix</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Denver</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Beulah, Dakota del nord</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>New Salem, Dakota del nord</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Center, Dakota del nord</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Chicago</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Menominee</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Vincennes, Indiana</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Petersburg, Indiana</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Tell City, Indiana</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Knox, Indiana</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Winamac, Indiana</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Marengo, Indiana</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Indianapolis</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Louisville</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Vevay, Indiana</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Monticello, Kentucky</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Detroit</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>New York</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Montevideo</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Samarcanda</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Tashkent</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Città del Vaticano</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>Saint Vincent</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Caracas</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Tortola</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>Saint Thomas</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Ho Chi Minh</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Efate</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Wallis</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Apia</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Aden</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Mayotte</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Johannesburg</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Lusaka</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Harare</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.ja.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.ja.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="ja" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>地域不明</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>アンドラ</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>ドバイ</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>カブール</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>アンティグア</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>アンギラ</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>ティラナ</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>エレバン</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>ルアンダ</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>ロゼラ基地</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>パーマー基地</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>トロル基地</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>昭和基地</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>モーソン基地</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>デービス基地</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>ボストーク基地</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>ケーシー基地</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>デュモン・デュルヴィル基地</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>マクマード基地</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>リオガジェゴス</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>メンドーサ</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>サンファン</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>ウシュアイア</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>ラリオハ</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>サンルイス</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>カタマルカ</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>サルタ</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>フフイ</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>トゥクマン</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>コルドバ</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>ブエノスアイレス</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>パゴパゴ</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>ウィーン</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>パース</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>ユークラ</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>ダーウィン</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>アデレード</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>ブロークンヒル</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>カリー</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>メルボルン</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>ホバート</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>リンデマン</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>シドニー</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>ブリスベン</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>マッコリー</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>ロードハウ</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>アルバ</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>マリエハムン</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>バクー</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>サラエボ</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>バルバドス</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>ダッカ</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>ブリュッセル</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>ワガドゥグー</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>ソフィア</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>バーレーン</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>ブジュンブラ</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>ポルトノボ</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>サン・バルテルミー</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>バミューダ</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>ブルネイ</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>ラパス</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>クラレンダイク</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>エイルネペ</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>リオブランコ</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>ポルトベーリョ</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>ボアビスタ</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>マナウス</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>クイアバ</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>サンタレム</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>カンポグランデ</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>ベレン</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>アラグァイナ</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>サンパウロ</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>バイーア</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>フォルタレザ</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>マセイオ</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>レシフェ</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>ノローニャ</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>ナッソー</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>ティンプー</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>ハボローネ</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>ミンスク</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>ベリーズ</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>ドーソン</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>ホワイトホース</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>イヌヴィク</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>バンクーバー</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>ドーソンクリーク</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>クレストン</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>イエローナイフ</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>エドモントン</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>スウィフトカレント</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>ケンブリッジベイ</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>レジャイナ</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>ウィニペグ</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>レゾリュート</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>レイニーリバー</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>ランキンインレット</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>アティコカン</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>サンダーベイ</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>ニピゴン</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>トロント</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>イカルイット</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>パンナータング</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>モンクトン</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>ハリファクス</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>グースベイ</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>グレースベイ</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>ブラン・サブロン</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>セントジョンズ</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>ココス諸島</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>キンシャサ</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>ルブンバシ</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>バンギ</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>ブラザビル</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>チューリッヒ</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>アビジャン</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>ラロトンガ</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>イースター島</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>サンチアゴ</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>ドゥアラ</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>ウルムチ</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>上海</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>ボゴタ</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>コスタリカ</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>ハバナ</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>カーボベルデ</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>キュラソー</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>クリスマス島</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>ニコシア</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>プラハ</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>ビュージンゲン</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>ベルリン</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>ジブチ</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>コペンハーゲン</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>ドミニカ</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>サントドミンゴ</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>アルジェ</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>ガラパゴス</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>グアヤキル</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>タリン</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>カイロ</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>アイウン</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>アスマラ</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>カナリア</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>セウタ</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>マドリード</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>アジスアベバ</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>ヘルシンキ</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>フィジー</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>スタンレー</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>チューク</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>ポンペイ島</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>コスラエ</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>フェロー</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>パリ</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>リーブルヴィル</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>ロンドン</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>グレナダ</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>トビリシ</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>カイエンヌ</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>ガーンジー</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>アクラ</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>ジブラルタル</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>チューレ</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>ヌーク</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>イトコルトルミット</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>デンマークシャウン</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>バンジュール</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>コナクリ</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>グアダループ</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>マラボ</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>アテネ</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>サウスジョージア</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>グアテマラ</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>グアム</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>ビサウ</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>ガイアナ</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>香港</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>テグシガルパ</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>ザグレブ</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>ポルトープランス</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>ブダペスト</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>ジャカルタ</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>ポンティアナック</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>マカッサル</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>ジャヤプラ</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>ダブリン</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>エルサレム</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>マン島</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>コルカタ</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>チャゴス</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>バグダッド</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>テヘラン</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>レイキャビク</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>ローマ</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>ジャージー</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>ジャマイカ</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>アンマン</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>東京</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>ナイロビ</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>ビシュケク</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>プノンペン</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>エンダーベリー島</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>キリスィマスィ島</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>タラワ</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>コモロ</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>セントキッツ</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>平壌</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>ソウル</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>クウェート</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>ケイマン</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>アクタウ</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>オラル</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>アクトベ</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>クズロルダ</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>アルマトイ</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>ビエンチャン</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>ベイルート</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>セントルシア</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>ファドゥーツ</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>コロンボ</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>モンロビア</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>マセル</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>ヴィリニュス</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>ルクセンブルク</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>リガ</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>トリポリ</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>カサブランカ</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>モナコ</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>キシナウ</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>ポドゴリツァ</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>マリゴ</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>アンタナナリボ</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>クェゼリン</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>マジュロ</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>スコピエ</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>バマコ</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>ラングーン</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>ホブド</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>ウランバートル</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>チョイバルサン</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>マカオ</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>サイパン</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>マルティニーク</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>ヌアクショット</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>モントセラト</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>マルタ</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>モーリシャス</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>モルディブ</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>ブランタイヤ</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>ティフアナ</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>サンタイサベル</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>エルモシヨ</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>マサトラン</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>チワワ</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>バイアバンデラ</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>オヒナガ</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>モンテレイ</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>メキシコシティー</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>マタモロス</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>メリダ</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>カンクン</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>クアラルンプール</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>クチン</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>マプト</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>ウィントフック</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>ヌメア</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>ニアメ</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>ノーフォーク島</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>ラゴス</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>マナグア</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>アムステルダム</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>オスロ</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>カトマンズ</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>ナウル</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>ニウエ</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>チャタム</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>オークランド</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>マスカット</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>パナマ</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>リマ</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>タヒチ</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>マルキーズ</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>ガンビエ諸島</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>ポートモレスビー</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>ブーゲンビル</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>マニラ</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>カラチ</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>ワルシャワ</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>ミクロン島</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>ピトケアン諸島</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>プエルトリコ</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>ガザ</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>ヘブロン</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>アゾレス</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>マデイラ</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>リスボン</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>パラオ</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>アスンシオン</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>カタール</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>レユニオン</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>ブカレスト</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>ベオグラード</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>カリーニングラード</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>シンフェロポリ</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>モスクワ</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>ボルゴグラード</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>サマラ</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>エカテリンブルグ</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>オムスク</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>ノヴォシビルスク</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>ノヴォクズネツク</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>クラスノヤルスク</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>イルクーツク</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>チタ</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>ヤクーツク</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>ウラジオストク</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>ハンドゥイガ</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>サハリン</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>ウスチネラ</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>マガダン</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>スレドネコリムスク</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>カムチャッカ</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>アナディリ</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>キガリ</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>リヤド</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>ガダルカナル</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>マヘ</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>ハルツーム</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>ストックホルム</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>シンガポール</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>セントヘレナ</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>リュブリャナ</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>ロングイェールビーン</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>ブラチスラバ</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>フリータウン</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>サンマリノ</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>ダカール</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>モガディシオ</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>パラマリボ</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>ジュバ</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>サントメ</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>エルサルバドル</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>ローワー・プリンセズ・クウォーター</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>ダマスカス</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>ムババーネ</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>グランドターク</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>ンジャメナ</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>ケルゲレン諸島</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>ロメ</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>バンコク</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>ドゥシャンベ</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>ファカオフォ</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>ディリ</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>アシガバード</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>チュニス</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>トンガタプ</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>イスタンブール</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>ポートオブスペイン</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>フナフティ</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>台北</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>ダルエスサラーム</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>ウージュホロド</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>キエフ</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>ザポリージャ</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>カンパラ</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>ミッドウェー島</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>ジョンストン島</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>ウェーク島</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>アダック</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>ノーム</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>ホノルル</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>アンカレッジ</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>ヤクタット</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>シトカ</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>ジュノー</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>メトラカトラ</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>ロサンゼルス</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>ボイシ</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>フェニックス</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>デンバー</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>ノースダコタ州ビューラー</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>ノースダコタ州ニューセーラム</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>ノースダコタ州センター</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>シカゴ</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>メノミニー</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>インディアナ州ビンセンス</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>インディアナ州ピーターズバーグ</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>インディアナ州テルシティ</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>インディアナ州ノックス</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>インディアナ州ウィナマック</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>インディアナ州マレンゴ</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>インディアナポリス</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>ルイビル</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>インディアナ州ビベー</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>ケンタッキー州モンティチェロ</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>デトロイト</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>ニューヨーク</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>モンテビデオ</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>サマルカンド</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>タシケント</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>バチカン</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>セントビンセント</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>カラカス</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>トルトーラ</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>セントトーマス</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>ホーチミン</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>エフェテ島</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>ウォリス諸島</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>アピア</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>アデン</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>マヨット</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>ヨハネスブルグ</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>ルサカ</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>ハラレ</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.lb.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.lb.xlf
@@ -1,0 +1,443 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="lb" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>Onbekannt</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Tirana</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Erivan</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Wostok</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Dumont d’Urville</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Wien</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Bréissel</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Wagadugu</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>Saint-Barthélemy</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Bermudas</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Atikokan</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>St. John’s</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Zürech</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Ouschterinsel</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Havanna</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Kap Verde</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Curaçao</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Chrëschtdagsinsel</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Nikosia</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Prag</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Dschibuti</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Kopenhagen</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Alger</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Kairo</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>El Aaiún</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Asmara</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Kanaresch Inselen</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Addis Abeba</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Fidschi</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Chuuk</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Pohnpei</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Färöer</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Tiflis</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Accra</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Athen</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Südgeorgien</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Hong Kong</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Port Numbay</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Kalkutta</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Bagdad</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Teheran</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Roum</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Jamaika</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Tokio</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Bischkek</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Komoren</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>St. Kitts</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Pjöngjang</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Kaimaninselen</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Aqtöbe</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>St. Lucia</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Wilna</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Lëtzebuerg</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Tripoli</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Kischinau</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Macau</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Maldiven</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Mexiko-Stad</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Kathmandu</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Muskat</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Warschau</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Azoren</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Lissabon</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Asunción</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Katar</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Réunion</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Bukarest</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Belgrad</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Moskau</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Wolgograd</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Jekaterinbuerg</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Nowosibirsk</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Krasnojarsk</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Jakutsk</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Wladiwostok</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Sachalin</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Kamtschatka</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Riad</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Khartum</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Singapur</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>St. Helena</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Mogadischu</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>São Tomé</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>Salvador</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Lower Prince’s Quarter</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Damaskus</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Duschanbe</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Port-of-Spain</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Taipeh</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Dar es Salaam</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Uschgorod</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Kiew</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Saporischschja</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Beulah, North Dakota</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>New Salem, North Dakota</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Center, North Dakota</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Vincennes, Indiana</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Petersburg, Indiana</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Tell City, Indiana</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Knox, Indiana</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Winamac, Indiana</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Marengo, Indiana</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Vevay, Indiana</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Monticello, Kentucky</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Taschkent</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Vatikan</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>St. Vincent</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>St. Thomas</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Ho-Chi-Minh-Stad</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.lt.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.lt.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="lt" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>nežinomas miestas</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Andora</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Dubajus</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Kabulas</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Antigva</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Angilija</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Tirana</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Jerevanas</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Luanda</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Rotera</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Palmeris</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Trolis</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Siova</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Mosonas</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Deivisas</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Vostokas</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Keisis</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Diumonas d’Urvilis</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>Makmerdas</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Rio Galjegosas</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Mendosa</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>San Chuanas</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ušuaja</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>La Riocha</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>Sent Luisas</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Katamarka</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Saltas</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Chuchujus</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Tukumanas</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Kordoba</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Buenos Airės</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Pago Pagas</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Viena</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Pertas</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Jukla</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Darvinas</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Adelaidė</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Broken Hilis</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Karis</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Melburnas</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Hobartas</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Lindemanas</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Sidnėjus</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Brisbanas</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Makvoris</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Lordo Hau sala</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Aruba</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Marianhamina</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Baku</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Sarajevas</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Barbadosas</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Daka</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Briuselis</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Vagadugu</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>Sofija</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Bahreinas</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Bužumbūra</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Porto Novas</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>Sen Bartelemi</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Bermuda</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Brunėjus</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>La Pasas</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Kralendeikas</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Eirunepė</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Rio Brankas</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Porto Veljas</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Bua Vista</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Manausas</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Kujaba</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Santarenas</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Kampo Grandė</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Belenas</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Aragvajana</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>San Paulas</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Baija</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Fortaleza</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Masejo</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Resifė</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Noronja</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Nasau</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Timpu</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Gaboronas</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Minskas</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Belizas</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Dosonas</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Vaithorsas</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Inuvikas</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Vankuveris</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Doson Krikas</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Krestonas</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Jelounaifas</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Edmontonas</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Svift Karentas</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Keimbridž Bėjus</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Redžina</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Vinipegas</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Resolutas</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Reini Riveris</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Rankin Inletas</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Atikokanas</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Tander Bėjus</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Nipigonas</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Torontas</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Ikaluitas</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Pangnirtungas</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Monktonas</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Halifaksas</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Gus Bėjus</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Gleis Bėjus</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Blanč Sablonas</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>Sent Džonsas</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Kokosų sala</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Kinšasa</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Lubumbašis</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Bangis</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Brazavilis</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Ciurichas</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Abidžanas</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Rarotonga</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Velykų sala</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Santjagas</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Duala</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Urumči</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Šanchajus</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Bogota</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Kosta Rika</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Havana</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Žaliasis Kyšulys</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Kiurasao</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Kalėdų Sala</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Nikosija</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Praha</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Biusingenas</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Berlynas</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Džibutis</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Kopenhaga</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Dominika</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Santo Domingas</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Alžyras</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Galapagai</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Gvajakilis</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Talinas</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Kairas</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>al Ajūnas</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Asmara</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Kanarų salos</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Seuta</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Madridas</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Adis Abeba</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Helsinkis</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Fidžis</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Stenlis</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Čukas</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Ponapė</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Kosrajė</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Farerai</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>Paryžius</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Librevilis</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>Londonas</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Grenada</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Tbilisis</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Kajenas</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Gernsis</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Akra</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Gibraltaras</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Kanakas</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Nūkas</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Itokortormitas</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Danmarkshaunas</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Bandžulis</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Konakris</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Gvadalupė</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Malabas</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Atėnai</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Pietų Džordžija</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Gvatemala</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Guamas</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Bisau</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Gvajana</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Honkongas</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Tegusigalpa</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Zagrebas</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Port o Prensas</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Budapeštas</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Džakarta</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Pontianakas</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Makasaras</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Džajapura</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Dublinas</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Jeruzalė</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Meno sala</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Kolkata</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Čagosas</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Bagdadas</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Teheranas</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Reikjavikas</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Roma</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Džersis</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Jamaika</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Amanas</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Tokijas</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Nairobis</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Biškekas</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Pnompenis</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Enderburis</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Kiritimatis</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Tarava</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Komoras</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>Sent Kitsas</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Pchenjanas</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Seulas</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Kuveitas</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Kaimanas</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Aktau</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Uralskas</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Aktiubinskas</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Kzyl-Orda</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Alma Ata</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Vientianas</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Beirutas</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>Sent Lusija</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Vaducas</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Kolombas</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Monrovija</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Maseru</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Vilnius</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Liuksemburgas</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Ryga</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Tripolis</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Kasablanka</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Monakas</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Kišiniovas</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Podgorica</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Marigo</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Antananaryvas</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Kvadžaleinas</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Madžūras</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Skopjė</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Bamakas</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Rangūnas</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Hovdas</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Ulan Batoras</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Čoibalsanas</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Makao</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Saipanas</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Martinika</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Nuakšotas</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Montseratas</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Malta</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Mauricijus</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Maldyvai</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Blantairas</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Tichuana</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Santa Izabelė</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Hermosiljas</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Masatlanas</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Čihuahua</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Bahia Banderasas</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Ochinaga</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Monterėjus</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Meksikas</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Matamorosas</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Merida</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Kankūnas</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Kvala Lumpūras</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Kučingas</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Maputas</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Vindhukas</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Numėja</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Niamėjus</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Norfolkas</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Lagosas</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Managva</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Amsterdamas</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Oslas</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Katmandu</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Nauru</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Niujė</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Čatamas</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Oklandas</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Maskatas</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Panama</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Lima</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Taitis</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Markizo salos</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Gambyras</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Port Morsbis</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>Bugenvilis</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Manila</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Karačis</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Varšuva</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Mikelonas</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Pitkerno sala</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Puerto Rikas</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Gazos ruožas</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Hebronas</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Azorai</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Madeira</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Lisabona</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Palau</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Asunsjonas</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Kataras</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Reunjonas</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Bukareštas</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Belgradas</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Kaliningradas</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Simferopolis</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Maskva</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Volgogradas</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Samara</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Jekaterinburgas</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Omskas</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Novosibirskas</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Novokuzneckas</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Krasnojarskas</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Irkutskas</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>Čita</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Jakutskas</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Vladivostokas</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Chandyga</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Sachalinas</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Ust Nera</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Magadanas</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>Srednekolymskas</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Kamčiatka</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Anadyris</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Kigalis</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Rijadas</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Gvadalkanalis</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Mahė</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Chartumas</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Stokholmas</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Singapūras</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>Sent Helena</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Liubliana</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Longjyrbienas</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Bratislava</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Fritaunas</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>San Marinas</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Dakaras</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Mogadišas</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Paramaribas</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Džuba</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>San Tomė</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>Salvadoras</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Žemutinis Prinses Kvorteris</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Damaskas</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Mbabanė</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Grand Terkas</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>Ndžamena</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Kergelenas</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Lomė</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Bankokas</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Dušanbė</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Fakaofas</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Dilis</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Ašchabadas</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Tunisas</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Tongatapu</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Stambulas</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Port of Speinas</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Funafutis</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Taipėjus</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Dar es Salamas</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Užhorodas</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Kijevas</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Zaporožė</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Kampala</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Midvėjus</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Džonstonas</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Veiko sala</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Eidakas</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Nomas</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Honolulu</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Ankoridžas</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Jakutatas</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Sitka</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Džunas</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Metlakatla</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Los Andželas</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Boisis</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Finiksas</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Denveris</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Bjula, Šiaurės Dakota</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>Niu Seilemas, Šiaurės Dakota</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Senteris, Šiaurės Dakota</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Čikaga</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Menominis</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Vinsenas, Indiana</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Pitersbergas, Indiana</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Tel Sitis, Indiana</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Noksas, Indiana</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Vinamakas, Indiana</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Marengas, Indiana</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Indianapolis</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Luisvilis</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Vivis, Indiana</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Montiselas, Kentukis</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Detroitas</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>Niujorkas</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Montevidėjas</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Samarkandas</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Taškentas</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Vatikanas</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>Sent Vincentas</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Karakasas</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Tortola</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>Sent Tomasas</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Hošiminas</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Efatė</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Volisas</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Apija</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Adenas</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Majotas</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Johanesburgas</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Lusaka</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Hararė</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.lv.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.lv.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="lv" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>nezināma pilsēta</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Andora</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Dubaija</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Kabula</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Antigva</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Angilja</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Tirāna</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Erevāna</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Luanda</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Rotera</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Pālmera</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Trolla</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Šova</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Mosona</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Deivisa</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Vostoka</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Keisi</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Dimondirvila</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>Makmerdo</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Riogaljegosa</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Mendosa</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>Sanhuana</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ušuaja</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>Larjoha</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>Sanluisa</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Katamarka</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Salta</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Huhuja</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Tukumana</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Kordova</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Buenosairesa</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Pagopago</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Vīne</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Pērta</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Jukla</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Dārvina</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Adelaida</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Brokenhila</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Kari</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Melburna</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Hobārta</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Lindemana</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Sidneja</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Brisbena</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Makvori</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Lordhava</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Aruba</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Mariehamna</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Baku</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Sarajeva</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Barbadosa</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Daka</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Brisele</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Vagadugu</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>Sofija</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Bahreina</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Bužumbura</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Portonovo</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>Senbartelmī</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Bermuda</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Bruneja</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>Lapasa</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Krālendeika</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Eirunepe</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Riobranko</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Portuveļu</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Boavista</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Manausa</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Kujaba</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Santarena</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Kampugrandi</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Belena</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Aragvaina</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>Sanpaulu</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Baija</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Fortaleza</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Masejo</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Resifi</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Noroņa</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Naso</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Thimphu</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Gaborone</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Minska</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Beliza</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Dousona</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Vaithorsa</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Inuvika</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Vankūvera</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Dousonkrīka</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Krestona</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Jelounaifa</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Edmontona</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Sviftkarenta</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Keimbridžbeja</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Ridžaina</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Vinipega</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Rezolūta</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Reinirivera</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Rankininleta</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Atikokana</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Tanderbeja</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Nipigona</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Toronto</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Ikaluita</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Pannirtuna</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Monktona</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Helifeksa</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Gūsbeja</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Gleisbeja</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Blansablona</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>Sentdžonsa</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Kokosa sala</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Kinšasa</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Lubumbaši</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Bangi</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Brazavila</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Cīrihe</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Abidžana</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Rarotonga</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Lieldienu sala</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Santjago</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Duala</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Urumči</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Šanhaja</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Bogota</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Kostarika</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Havana</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Kaboverde</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Kirasao</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Ziemsvētku sala</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Nikosija</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Prāga</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Bīzingene</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Berlīne</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Džibutija</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Kopenhāgena</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Dominika</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Santodomingo</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Alžīra</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Galapagu salas</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Gvajakila</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Tallina</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Kaira</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>Ajūna</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Asmara</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Kanāriju salas</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Seuta</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Madride</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Adisabeba</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Helsinki</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Fidži</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Stenli</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Čūka</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Ponpeja</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Kosraja</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Fēru salas</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>Parīze</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Librevila</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>Londona</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Grenāda</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Tbilisi</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Kajenna</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Gērnsija</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Akra</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Gibraltārs</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Tule</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Nūka</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Itokortormita</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Denmārkšavna</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Bandžula</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Konakri</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Gvadelupa</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Malabo</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Atēnas</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Dienviddžordžija</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Gvatemala</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Guama</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Bisava</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Gajāna</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Honkonga</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Tegusigalpa</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Zagreba</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Portoprensa</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Budapešta</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Džakarta</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Pontianaka</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Makasara</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Džajapura</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Dublina</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Jeruzaleme</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Menas sala</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Kalkāta</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Čagosu arhipelāgs</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Bagdāde</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Teherāna</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Reikjavika</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Roma</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Džērsija</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Jamaika</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Ammāna</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Tokija</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Nairobi</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Biškeka</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Pnompeņa</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Enderberija</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Kirisimasi</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Tarava</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Komoras</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>Sentkitsa</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Phenjana</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Seula</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Kuveita</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Kaimanu salas</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Aktau</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Orala</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Aktebe</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Kizilorda</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Almati</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Vjenčana</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Beirūta</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>Sentlūsija</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Vaduca</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Kolombo</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Monrovija</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Maseru</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Viļņa</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Luksemburga</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Rīga</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Tripole</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Kasablanka</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Monako</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Kišiņeva</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Podgorica</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Merigota</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Antananarivu</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Kvadžaleina</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Madžuro</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Skopje</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Bamako</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Ranguna</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Hovda</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Ulanbatora</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Čoibalsana</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Makao</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Saipana</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Martinika</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Nuakšota</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Montserrata</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Malta</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Maurīcija</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Maldīvija</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Blantaira</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Tihuana</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Santaisabela</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Ermosiljo</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Masatlana</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Čivava</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Bajabanderasa</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Ohinaga</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Monterreja</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Mehiko</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Matamorosa</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Merida</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Kankuna</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Kualalumpura</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Kučina</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Maputu</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Vindhuka</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Numea</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Niameja</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Norfolka</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Lagosa</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Managva</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Amsterdama</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Oslo</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Katmandu</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Nauru</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Niue</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Četema</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Oklenda</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Maskata</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Panama</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Lima</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Taiti</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Marķīza salas</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Gambjē salas</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Portmorsbi</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>Bugeinvile</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Manila</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Karāči</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Varšava</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Mikelona</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Pitkērna</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Puertoriko</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Gaza</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Hebrona</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Azoru salas</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Madeira</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Lisabona</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Palau</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Asunsjona</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Katara</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Reinjona</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Bukareste</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Belgrada</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Kaļiņingrada</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Simferopole</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Maskava</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Volgograda</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Samara</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Jekaterinburga</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Omska</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Novosibirska</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Novokuzņecka</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Krasnojarska</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Irkutska</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>Čita</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Jakutska</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Vladivostoka</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Handiga</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Sahalīna</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Ustjņera</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Magadana</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>Sredņekolimska</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Kamčatka</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Anadira</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Kigali</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Rijāda</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Gvadalkanala</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Mae</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Hartūma</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Stokholma</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Singapūra</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>Sv.Helēnas sala</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Ļubļana</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Longjērbīene</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Bratislava</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Frītauna</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>Sanmarīno</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Dakara</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Mogadīšo</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Paramaribo</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Džūba</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>Santome</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>Salvadora</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Louerprinseskvotera</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Damaska</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Mbabane</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Grandtkērka</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>Ndžamena</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Kergelēna sala</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Lome</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Bangkoka</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Dušanbe</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Fakaofo</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Dili</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Ašgabata</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Tunisa</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Tongatapu</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Stambula</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Portofspeina</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Funafuti</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Taibei</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Dāresalāma</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Užhoroda</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Kijeva</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Zaporožje</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Kampala</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Midvejs</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Džonstona atols</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Veika sala</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Adaka</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Noma</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Honolulu</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Ankurāža</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Jakutata</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Sitka</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Džuno</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Metlakatla</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Losandželosa</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Boisisitija</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Fīniksa</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Denvera</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Bjula, Ziemeļdakota</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>Ņūseilema, Ziemeļdakota</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Sentera, Ziemeļdakota</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Čikāga</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Menominī</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Vinsensa, Indiāna</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Pītersbērga, Indiāna</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Telsitija, Indiāna</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Noksa, Indiāna</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Vinamaka, Indiāna</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Marengo, Indiāna</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Indianapolisa</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Lūivila</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Vīveja, Indiāna</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Montičelo, Kentuki</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Detroita</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>Ņujorka</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Montevideo</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Samarkanda</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Taškenta</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Vatikāns</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>Sentvinsenta</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Karakasa</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Tortola</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>Sentomasa</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Hošimina</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Efate</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Volisa</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Apija</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Adena</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Majota</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Johannesburga</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Lusaka</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Harare</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.mn.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.mn.xlf
@@ -1,0 +1,1663 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="mn" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>Тодорхойгүй хот</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Андорра</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Дубай</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Кабул</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Антигуа</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Ангилла</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Тирана</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Ереван</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Луанда</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Ротера</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Палмер</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Тролл</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Сьёва</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Моусон</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Дэвис</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Восток</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Кэсей</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Дюмон д’Юрвиль</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>Мак-Мёрдо</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Рио-Гальегос</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Мендоза</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>Сан-Хуан</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ушуайя</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>Ла-Риоха</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>Сан Луи</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Катамарка</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Салта</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Жужуй</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Тукуман</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Кордова</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Буэнос-Айрес</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Паго Паго</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Вена</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Перс</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Еукла</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Дарвин</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Аделэйд</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Брокен Хилл</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Кюрри</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Мельбурн</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Хобарт</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Линдемэн</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Сидней</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Брисбэн</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Маккуори</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Лорд Хау</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Аруба</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Мариехамн</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Баку</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Сараево</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Барбадос</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Дака</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Брюссель</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Уагадугу</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>София</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Бахрейн</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Бужумбура</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Порто-Ново</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>Сент Бартельми</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Бермуда</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Бруней</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>Ла Паз</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Кралендик</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Эйрунепе</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Рио-Бранко</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Порто-Велью</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Боа-Виста</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Манаус</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Куяба</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Сантарем</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Кампо-Гранде</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Белем</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Арагуана</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>Сан-Паулу</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Байя</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Форталеза</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Масейо</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Ресифи</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Норона</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Нассау</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Тхимпху</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Габороне</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Минск</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Белизе</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Доусон</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Уайтхорз</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Инувик</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Ванкувер</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Доусон Крик</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Крестон</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Йелоунайф</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Эдмонтон</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Свифт Каррент</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Кэмбриж бэй</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Регина</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Виннипег</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Резолют</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Рейни Ривер</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Рэнкин Инлет</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Атикокан</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Сандер Бэй</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Нипигон</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Торонто</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Икалуит</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Пангниртунг</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Монктон</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Халифакс</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Гуус бэй</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Глейс бэй</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Бланк-Саблон</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>Сент Жонс</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Кокос</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Киншаса</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Лубумбаши</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Бангуй</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Браззавиль</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Цюрих</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Абижан</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Раротонга</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Истер</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Сантьяго</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Дуала</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Үрүмчи</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Шанхай</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Богота</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Коста Рика</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Хавана</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Кейп Верде</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Куракао</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Крисмас</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Никосия</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Прага</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Бусинген</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Берлин</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Жибоути</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Копенгаген</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Доминика</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Санта Доминго</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Алжир</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Галапагос</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Гуаякиль</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Таллин</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Каир</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>Эль-Аюн</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Асмара</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Канари</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Сеута</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Мадрид</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Аддис-абеба</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Хельсинк</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Фижи</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Стэнлей</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Чүүк</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Понпей</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Косраэ</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Фароэ</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>Парис</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Либревиль</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>Лондон</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Гренада</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Тбилиси</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Кайенна</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Гернси</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Аккра</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Гибралтар</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Туле</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Нүүк</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Скорсбисунн</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Данмаркшавн</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Банжул</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Конакри</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Гваделуп</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Малабо</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Афин</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Өмнөд Жоржиа</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Гватемал</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Гуам</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Биссау</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Гуяана</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Хонг Конг</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Тегусигальпа</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Загреб</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Порт-о-Принс</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Будапешт</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Жакарта</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Понтианак</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Макассар</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Жайпур</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Дублин</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Ерусалем</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Мэн Арал</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Калькутта</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Чагос</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Багдад</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Тегеран</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Рекьявик</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Ром</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Жерси</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Ямайка</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Амман</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Токио</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Найроби</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Бишкек</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Пномпень</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Эндербери</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Киритимати</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Тарава</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Коморо</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>Сент-Киттс</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Пхеньян</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Сөүл</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Кувейт</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Кайман</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Актау</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Орал</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Актөбе</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Кызылорд</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Алматы</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Вьентьян</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Бейрут</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>Сент Люсиа</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Вадуз</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Коломбо</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Монрова</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Масеру</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Вильнюс</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Люксембург</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Рига</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Триполи</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Касабланка</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Монако</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Кишинёв</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Подгорица</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Маригот</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Антананариво</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Кважалейн</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Мажуро</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Скопье</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Бамако</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Рангун</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Ховд</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Улаанбаатар</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Чойбалсан</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Макао</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Сайпан</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Мартиник</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Нуакшот</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Монтсеррат</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Мальта</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Мавриту</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Мальдив</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Блантайр</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Тихуана</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Санта Изабель</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Хермосилло</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Мазатлан</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Чихуахуа</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Бахья Бандерас</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Ожинага</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Монтерей</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Мехико хот</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Матаморос</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Мерида</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Канкун</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Куала Лумпур</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Кучин</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Мапуто</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Виндхук</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Нумеа</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Ниамей</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Норфолк</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Лагос</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Манагуа</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Амстердам</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Осло</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Катманду</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Науру</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Ниуэ</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Чатем</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Оклэнд</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Мускат</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Панама</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Лима</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Таити</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Маркизас</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Гамбьер</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Порт-Морсби</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Манила</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Карачи</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Варшав</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Микелон</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Питкейрн</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Пуэрто-Рико</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Газа</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Хеброн</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Азор</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Мадейра</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Лисбон</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Палау</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Асунсьон</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Катар</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Реюньон</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Бухарест</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Белград</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Калининград</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Симферополь</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Москва</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Волгоград</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Самара</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Екатеринбург</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Омск</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Новосибирск</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Новокузнецк</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Красноярск</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Эрхүү</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Якутск</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Владивосток</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Кандяга</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Сахалин</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Уст-Нера</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Магадан</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Камчатка</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Анадыр</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Кигали</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Рияд</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Гуадалканал</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Махе</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Хартум</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Стокольм</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Сингапур</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>Сент Хелена</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Любляна</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Лонгирбюен</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Братислав</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Фритаун</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>Сан-Марино</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Дакар</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Могадишу</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Парамарибо</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Жуба</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>Сан-Том</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>Эль Сальвадор</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Ловер Принсес Квартер</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Дамаск</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Мбабане</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Гранд Турк</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>Нжамена</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Кергелен</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Ломе</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Бангкок</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Душанбе</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Факаофо</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Дили</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Ашхабад</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Тунис</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Тонгатапу</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Истанбул</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Порт-оф-Спейн</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Фунафути</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Тайпей</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Дар-эс-Салам</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Ужгород</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Киев</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Запорожье</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Кампала</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Мидвей</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Жонстон</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Уэйк</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Адак</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Ном</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Хонолулу</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Анкораж</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Якутат</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Ситка</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Жуно</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Метлакатла</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Лос-Анжелес</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Боисе</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Феникс</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Денвер</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Била, Хойд Дакота</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>Нью-Салем, Хойд Дакота</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Төв, Хойд Дакота</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Чикаго</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Меномини</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Винсенес, Индиана</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Питерсбург, Индиана</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Тел Сити, Индиана</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Нокс, Индиана</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Винамак, Индиана</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Маренго, Индиана</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Индианаполис</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Луисвилл</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Вивей, Индиана</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Монтичелло, Кентаки</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Детройт</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>Нью-Йорк</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Монтевидео</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Самарканд</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Ташкент</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Ватикан</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>Сент Винсент</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Каракас</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Тортола</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>Сент Томас</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Хо Ши Мин</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Эфате</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Уоллис</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Апиа</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Аден</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Майотта</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Йоханнесбург</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Лусака</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Хараре</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.nb.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.nb.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="nb" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>ukjent by</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Andorra</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Dubai</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Kabul</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Antigua</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Anguilla</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Tirana</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Jerevan</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Luanda</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Rothera</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Palmer</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Troll</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Syowa</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Mawson</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Davis</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Vostok</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Casey</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Dumont d’Urville</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>McMurdo</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Rio Gallegos</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Mendoza</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>San Juan</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ushuaia</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>La Rioja</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>San Luis</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Catamarca</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Salta</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Jujuy</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Tucumán</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Córdoba</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Buenos Aires</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Pago Pago</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Wien</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Perth</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Eucla</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Darwin</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Adelaide</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Broken Hill</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Currie</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Melbourne</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Hobart</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Lindeman</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Sydney</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Brisbane</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Macquarie</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Lord Howe</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Aruba</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Mariehamn</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Baku</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Sarajevo</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Barbados</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Dhaka</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Brussel</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Ouagadougou</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>Sofia</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Bahrain</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Bujumbura</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Porto-Novo</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>Saint-Barthélemy</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Bermuda</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Brunei</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>La Paz</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Kralendijk</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Eirunepe</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Rio Branco</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Porto Velho</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Boa Vista</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Manaus</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Cuiabá</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Santarém</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Campo Grande</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Belém</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Araguaína</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>São Paulo</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Bahia</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Fortaleza</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Maceió</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Recife</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Noronha</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Nassau</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Thimpu</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Gaborone</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Minsk</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Belize</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Dawson</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Whitehorse</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Inuvik</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Vancouver</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Dawson Creek</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Creston</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Yellowknife</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Edmonton</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Swift Current</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Cambridge Bay</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Regina</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Winnipeg</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Resolute</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Rainy River</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Rankin Inlet</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Atikokan</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Thunder Bay</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Nipigon</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Toronto</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Iqaluit</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Pangnirtung</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Moncton</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Halifax</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Goose Bay</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Glace Bay</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Blanc-Sablon</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>St. John’s</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Kokosøyene</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Kinshasa</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Lubumbashi</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Bangui</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Brazzaville</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Zürich</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Abidjan</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Rarotonga</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Påskeøya</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Santiago</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Douala</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Ürümqi</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Shanghai</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Bogotá</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Costa Rica</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Havana</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Kapp Verde</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Curaçao</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Christmasøya</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Nikosia</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Praha</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Büsingen</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Berlin</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Djibouti</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>København</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Dominica</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Santo Domingo</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Alger</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Galápagosøyene</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Guayaquil</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Tallinn</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Kairo</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>El Aaiún</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Asmara</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Kanariøyene</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Ceuta</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Madrid</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Addis Abeba</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Helsingfors</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Fiji</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Stanley</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Chuuk</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Pohnpei</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Kosrae</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Færøyene</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>Paris</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Libreville</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>London</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Grenada</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Tbilisi</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Cayenne</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Guernsey</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Accra</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Gibraltar</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Thule</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Godthåb</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Ittoqqortoormiit</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Danmarkshavn</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Banjul</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Conakry</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Guadeloupe</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Malabo</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Athen</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Sør-Georgia</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Guatemala</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Guam</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Bissau</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Guyana</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Hongkong</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Tegucigalpa</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Zagreb</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Port-au-Prince</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Budapest</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Jakarta</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Pontianak</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Makassar</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Jajapura</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Dublin</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Jerusalem</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Man</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Kolkata</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Chagos</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Bagdad</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Teheran</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Reykjavik</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Roma</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Jersey</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Jamaica</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Amman</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Tokyo</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Nairobi</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Bisjkek</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Phnom Penh</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Enderbury</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Kiritimati</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Tarawa</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Komorene</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>St. Kitts</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Pyongyang</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Seoul</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Kuwait</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Caymanøyene</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Aktau</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Uralsk</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Aqtöbe</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Kyzylorda</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Almaty</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Vientiane</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Beirut</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>St. Lucia</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Vaduz</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Colombo</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Monrovia</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Maseru</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Vilnius</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Luxemburg</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Riga</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Tripoli</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Casablanca</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Monaco</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Chișinău</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Podgorica</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Marigot</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Antananarivo</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Kwajalein</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Majuro</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Skopje</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Bamako</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Yangon</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Hovd</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Ulan Bator</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Choybalsan</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Macao</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Saipan</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Martinique</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Nouakchott</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Montserrat</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Malta</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Mauritius</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Maldivene</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Blantyre</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Tijuana</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Santa Isabel</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Hermosillo</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Mazatlan</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Chihuahua</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Bahía Banderas</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Ojinaga</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Monterrey</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Mexico by</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Matamoros</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Mérida</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Cancún</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Kuala Lumpur</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Kuching</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Maputo</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Windhoek</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Nouméa</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Niamey</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Norfolk</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Lagos</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Managua</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Amsterdam</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Oslo</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Katmandu</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Nauru</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Niue</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Chatham</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Auckland</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Muskat</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Panama</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Lima</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Tahiti</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Marquesas</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Gambier</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Port Moresby</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>Bougainville</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Manila</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Karachi</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Warszawa</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Miquelon</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Pitcairn</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Puerto Rico</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Gaza</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Hebron</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Azorene</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Madeira</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Lisboa</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Palau</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Asunción</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Qatar</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Réunion</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Bucuresti</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Beograd</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Kaliningrad</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Simferopol</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Moskva</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Volgograd</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Samara</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Jekaterinburg</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Omsk</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Novosibirsk</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Novokuznetsk</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Krasnojarsk</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Irkutsk</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>Chita</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Jakutsk</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Vladivostok</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Khandyga</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Sakhalin</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Ust-Nera</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Magadan</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>Srednekolymsk</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Kamtsjatka</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Anadyr</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Kigali</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Riyadh</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Guadalcanal</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Mahe</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Khartoum</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Stockholm</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Singapore</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>St. Helena</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Ljubljana</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Longyearbyen</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Bratislava</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Freetown</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>San Marino</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Dakar</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Mogadishu</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Paramaribo</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Juba</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>São Tomé</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>El Salvador</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Lower Prince’s Quarter</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Damaskus</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Mbabane</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Grand Turk</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>N’Djamena</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Kerguelen</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Lomé</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Bangkok</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Dusjanbe</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Fakaofo</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Dili</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Asjkhabad</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Tunis</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Tongatapu</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Istanbul</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Port of Spain</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Funafuti</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Taipei</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Dar-es-Salaam</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Uzjhorod</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Kiev</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Zaporozje</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Kampala</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Midway</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Johnston</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Wake</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Adak</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Nome</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Honolulu</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Anchorage</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Yakutat</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Sitka</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Juneau</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Metlakatla</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Los Angeles</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Boise</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Phoenix</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Denver</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Beulah, Nord-Dakota</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>New Salem, Nord-Dakota</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Center, Nord-Dakota</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Chicago</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Menominee</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Vincennes, Indiana</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Petersburg, Indiana</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Tell City, Indiana</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Knox, Indiana</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Winamac, Indiana</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Marengo, Indiana</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Indianapolis</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Louisville</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Vevay, Indiana</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Monticello, Kentucky</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Detroit</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>New York</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Montevideo</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Samarkand</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Tasjkent</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Vatikanstaten</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>St. Vincent</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Caracas</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Tortola</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>St. Thomas</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Ho Chi Minh-byen</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Efate</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Wallis</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Apia</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Aden</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Mayotte</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Johannesburg</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Lusaka</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Harare</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.nl.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.nl.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="nl" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>onbekende stad</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Andorra</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Dubai</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Kabul</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Antigua</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Anguilla</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Tirana</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Jerevan</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Luanda</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Rothera</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Palmer</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Troll</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Syowa</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Mawson</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Davis</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Vostok</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Casey</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Dumont d’Urville</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>McMurdo</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Río Gallegos</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Mendoza</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>San Juan</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ushuaia</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>La Rioja</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>San Luis</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Catamarca</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Salta</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Jujuy</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Tucumán</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Córdoba</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Buenos Aires</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Pago Pago</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Wenen</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Perth</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Eucla</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Darwin</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Adelaide</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Broken Hill</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Currie</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Melbourne</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Hobart</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Lindeman</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Sydney</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Brisbane</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Macquarie</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Lord Howe</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Aruba</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Mariehamn</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Bakoe</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Sarajevo</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Barbados</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Dhaka</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Brussel</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Ouagadougou</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>Sofia</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Bahrein</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Bujumbura</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Porto-Novo</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>Saint-Barthélemy</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Bermuda</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Brunei</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>La Paz</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Kralendijk</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Eirunepe</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Rio Branco</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Porto Velho</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Boa Vista</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Manaus</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Cuiabá</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Santarem</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Campo Grande</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Belém</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Araguaina</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>São Paulo</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Bahia</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Fortaleza</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Maceió</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Recife</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Noronha</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Nassau</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Thimphu</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Gaborone</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Minsk</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Belize</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Dawson</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Whitehorse</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Inuvik</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Vancouver</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Dawson Creek</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Creston</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Yellowknife</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Edmonton</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Swift Current</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Cambridge Bay</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Regina</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Winnipeg</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Resolute</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Rainy River</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Rankin Inlet</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Atikokan</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Thunder Bay</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Nipigon</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Toronto</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Iqaluit</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Pangnirtung</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Moncton</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Halifax</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Goose Bay</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Glace Bay</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Blanc-Sablon</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>St. John’s</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Cocoseilanden</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Kinshasa</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Lubumbashi</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Bangui</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Brazzaville</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Zürich</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Abidjan</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Rarotonga</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Paaseiland</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Santiago</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Douala</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Urumqi</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Sjanghai</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Bogota</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Costa Rica</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Havana</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Kaapverdië</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Curaçao</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Christmaseiland</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Nicosia</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Praag</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Busingen</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Berlijn</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Djibouti</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Kopenhagen</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Dominica</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Santo Domingo</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Algiers</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Galapagos</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Guayaquil</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Tallinn</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Caïro</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>El Aaiun</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Asmara</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Canarische Eilanden</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Ceuta</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Madrid</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Addis Abeba</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Helsinki</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Fiji</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Stanley</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Chuuk</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Pohnpei</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Kosrae</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Faeröer</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>Parijs</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Libreville</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>Londen</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Grenada</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Tbilisi</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Cayenne</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Guernsey</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Accra</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Gibraltar</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Thule</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Nuuk</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Ittoqqortoormiit</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Danmarkshavn</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Banjul</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Conakry</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Guadeloupe</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Malabo</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Athene</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Zuid-Georgia</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Guatemala</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Guam</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Bissau</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Guyana</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Hongkong</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Tegucigalpa</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Zagreb</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Port-au-Prince</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Boedapest</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Jakarta</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Pontianak</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Makassar</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Jayapura</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Dublin</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Jeruzalem</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Isle of Man</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Calcutta</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Chagosarchipel</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Bagdad</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Teheran</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Reykjavik</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Rome</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Jersey</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Jamaica</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Amman</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Tokio</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Nairobi</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Bisjkek</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Phnom-Penh</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Enderbury</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Kiritimati</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Tarawa</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Comoro</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>St. Kitts</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Pyongyang</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Seoul</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Koeweit</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Cayman</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Aqtau</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Oral</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Aqtöbe</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Qyzylorda</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Alma-Ata</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Vientiane</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Beiroet</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>St. Lucia</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Vaduz</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Colombo</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Monrovia</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Maseru</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Vilnius</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Luxemburg</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Riga</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Tripoli</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Casablanca</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Monaco</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Chisinau</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Podgorica</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Marigot</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Antananarivo</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Kwajalein</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Majuro</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Skopje</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Bamako</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Rangoon</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Hovd</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Ulaanbaatar</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Choibalsan</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Macau</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Saipan</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Martinique</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Nouakchott</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Montserrat</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Malta</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Mauritius</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Maldiven</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Blantyre</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Tijuana</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Santa Isabel</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Hermosillo</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Mazatlán</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Chihuahua</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Bahía de Banderas</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Ojinaga</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Monterrey</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Mexico-Stad</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Matamoros</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Mérida</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Cancun</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Kuala Lumpur</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Kuching</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Maputo</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Windhoek</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Nouméa</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Niamey</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Norfolk</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Lagos</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Managua</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Amsterdam</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Oslo</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Kathmandu</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Nauru</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Niue</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Chatham</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Auckland</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Muscat</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Panama</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Lima</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Tahiti</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Marquesaseilanden</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Îles Gambier</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Port Moresby</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>Bougainville</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Manilla</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Karachi</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Warschau</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Miquelon</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Pitcairn</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Puerto Rico</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Gaza</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Hebron</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Azoren</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Madeira</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Lissabon</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Palau</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Asunción</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Qatar</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Réunion</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Boekarest</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Belgrado</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Kaliningrad</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Simferopol</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Moskou</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Wolgograd</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Samara</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Jekaterinenburg</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Omsk</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Novosibirsk</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Novokuznetsk</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Krasnojarsk</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Irkoetsk</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>Chita</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Jakoetsk</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Vladivostok</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Khandyga</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Sachalin</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Ust-Nera</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Magadan</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>Srednekolymsk</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Kamtsjatka</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Anadyr</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Kigali</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Riyad</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Guadalcanal</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Mahé</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Khartoem</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Stockholm</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Singapore</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>Sint-Helena</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Ljubljana</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Longyearbyen</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Bratislava</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Freetown</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>San Marino</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Dakar</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Mogadishu</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Paramaribo</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Juba</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>Sao Tomé</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>El Salvador</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Beneden Prinsen Kwartier</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Damascus</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Mbabane</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Grand Turk</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>Ndjamena</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Kerguelen</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Lomé</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Bangkok</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Doesjanbe</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Fakaofo</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Dili</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Asjchabad</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Tunis</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Tongatapu</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Istanboel</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Port of Spain</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Funafuti</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Taipei</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Dar es Salaam</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Oezjhorod</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Kiev</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Zaporizja</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Kampala</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Midway</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Johnston</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Wake</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Adak</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Nome</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Honolulu</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Anchorage</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Yakutat</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Sitka</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Juneau</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Metlakatla</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Los Angeles</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Boise</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Phoenix</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Denver</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Beulah, Noord-Dakota</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>New Salem, Noord-Dakota</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Center, Noord-Dakota</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Chicago</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Menominee</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Vincennes, Indiana</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Petersburg, Indiana</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Tell City, Indiana</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Knox, Indiana</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Winamac, Indiana</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Marengo, Indiana</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Indianapolis</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Louisville</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Vevay, Indiana</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Monticello, Kentucky</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Detroit</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>New York</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Montevideo</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Samarkand</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Tasjkent</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Vaticaanstad</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>St. Vincent</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Caracas</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Tortola</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>St. Thomas</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Ho Chi Minhstad</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Efate</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Wallis</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Apia</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Aden</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Mayotte</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Johannesburg</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Lusaka</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Harare</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.pl.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.pl.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="pl" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>Nieznane</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Andora</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Dubaj</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Kabul</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Antigua</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Anguilla</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Tirana</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Erywań</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Luanda</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Stacja Naukowa Rothera</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Archipelag Palmera</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Troll</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Stacja Syowa</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Wybrzeże Mawsona</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Stacja Davis</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Stacja Wostok</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Stacja Casey</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Dumont d’Urville</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>Mc Murdo</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Rio Gallegos</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Mendoza</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>San Juan</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ushuaia</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>La Rioja</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>San Luis</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Catamarca</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Salta</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Jujuy</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Tucuman</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Kordoba</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Buenos Aires</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Pago Pago</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Wiedeń</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Perth</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Eucla</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Darwin</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Adelajda</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Broken Hill</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Currie</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Melbourne</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Hobart</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Lindeman</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Sydney</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Brisbane</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Macquarie</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Wyspa Lord Howe</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Aruba</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Maarianhamina</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Baku</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Sarajewo</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Barbados</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Dakka</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Bruksela</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Wagadugu</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>Sofia</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Bahrajn</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Bużumbura</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Porto Novo</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>Saint-Barthélemy</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Bermudy</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Brunei</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>La Paz</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Kralendijk</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Eirunepe</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Rio Branco</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Porto Velho</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Boa Vista</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Manaus</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Cuiabá</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Santarem</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Campo Grande</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Belém</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Araguaina</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>Sao Paulo</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Salvador</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Fortaleza</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Maceió</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Recife</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Noronha</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Nassau</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Thimphu</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Gaborone</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Mińsk</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Belize</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Dawson</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Whitehorse</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Inuvik</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Vancouver</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Dawson Creek</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Creston</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Yellowknife</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Edmonton</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Swift Current</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Cambridge Bay</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Regina</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Winnipeg</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Resolute</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Rainy River</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Rankin Inlet</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Atikokan</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Thunder Bay</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Nipigon</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Toronto</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Iqaluit</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Pangnirtung</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Moncton</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Halifax</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Goose Bay</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Glace Bay</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Blanc-Sablon</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>St. John’s</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Wyspy Kokosowe</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Kinszasa</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Lubumbashi</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Bangi</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Brazzaville</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Zurych</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Abidżan</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Rarotonga</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Wyspa Wielkanocna</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Santiago</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Duala</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Urumczi</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Szanghaj</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Bogota</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Kostaryka</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Hawana</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Zielony Przylądek</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Curaçao</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Wyspa Bożego Narodzenia</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Nikozja</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Praga</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Busingen</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Berlin</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Dżibuti</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Kopenhaga</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Dominika</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Santo Domingo</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Algier</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Galapagos</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Guayaquil</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Tallin</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Kair</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>Ujun</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Asmara</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Wyspy Kanaryjskie</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Ceuta</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Madryt</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Addis Abeba</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Helsinki</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Fidżi</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Stanley</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Chuuk</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Pohnpei</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Kosrae</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Wyspy Owcze</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>Paryż</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Libreville</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>Londyn</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Grenada</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Tbilisi</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Kajenna</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Guernsey</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Akra</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Gibraltar</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Qaanaaq</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Nuuk</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Ittoqqortoormiit</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Danmarkshavn</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Bandżul</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Konakri</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Gwadelupa</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Malabo</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Ateny</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Georgia Południowa</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Gwatemala</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Guam</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Bissau</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Gujana</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Hongkong</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Tegucigalpa</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Zagrzeb</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Port-au-Prince</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Budapeszt</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Dżakarta</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Pontianak</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Makassar</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Jayapura</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Dublin</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Jerozolima</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Wyspa Man</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Kalkuta</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Czagos</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Bagdad</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Teheran</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Rejkiawik</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Rzym</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Jersey</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Jamajka</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Amman</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Tokio</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Nairobi</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Biszkek</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Phnom Penh</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Enderbury</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Kiritimati</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Tarawa</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Komory</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>Saint Kitts</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Pjongjang</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Seul</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Kuwejt</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Kajmany</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Aktau</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Uralsk</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Aktiubińsk</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Kyzył Orda</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Ałma Ata</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Wientian</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Bejrut</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>Saint Lucia</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Vaduz</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Kolombo</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Monrovia</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Maseru</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Wilno</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Luksemburg</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Ryga</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Trypolis</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Casablanca</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Monako</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Kiszyniów</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Podgorica</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Marigot</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Antananarywa</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Kwajalein</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Majuro</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Skopje</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Bamako</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Rangun</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Howd</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Ułan Bator</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Czojbalsan</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Makau</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Saipan</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Martynika</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Nawakszut</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Montserrat</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Malta</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Mauritius</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Malediwy</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Blantyre</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Tijuana</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Santa Isabel</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Hermosillo</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Mazatlan</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Chihuahua</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Bahia Banderas</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Ojinaga</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Monterrey</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Meksyk (miasto)</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Matamoros</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Merida</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Cancún</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Kuala Lumpur</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Kuczing</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Maputo</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Windhuk</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Numea</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Niamej</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Norfolk</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Lagos</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Managua</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Amsterdam</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Oslo</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Katmandu</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Nauru</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Niue</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Chatham</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Auckland</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Maskat</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Panama</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Lima</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Tahiti</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Markizy</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Gambier</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Port Moresby</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>Bougainville</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Manila</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Karaczi</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Warszawa</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Miquelon</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Wyspy Pitcairn</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Portoryko</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Gaza</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Hebron</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Azory</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Madera</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Lizbona</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Palau</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Asunción</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Katar</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Réunion</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Bukareszt</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Belgrad</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Kaliningrad</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Symferopol</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Moskwa</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Wołgograd</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Samara</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Jekaterynburg</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Omsk</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Nowosybirsk</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Nowokuźnieck</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Krasnojarsk</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Irkuck</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>Chita</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Jakuck</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Władywostok</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Chandyga</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Sachalin</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Ust-Nera</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Magadan</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>Sriedniekołymsk</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Kamczatka</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Anadyr</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Kigali</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Rijad</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Guadalcanal</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Mahé</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Chartum</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Sztokholm</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Singapur</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>Święta Helena</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Lublana</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Longyearbyen</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Bratysława</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Freetown</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>San Marino</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Dakar</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Mogadiszu</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Paramaribo</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Juba</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>São Tomé</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>Salwador</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Lower Prince’s Quarter</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Damaszek</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Mbabane</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Grand Turk</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>Ndżamena</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Wyspy Kerguelena</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Lomé</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Bangkok</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Duszanbe</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Fakaofo</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Dili</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Aszchabad</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Tunis</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Tongatapu</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Stambuł</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Port-of-Spain</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Funafuti</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Tajpej</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Dar es-Salaam</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Użgorod</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Kijów</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Zaporoże</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Kampala</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Midway</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Johnston</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Wake</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Adak</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Nome</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Honolulu</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Anchorage</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Yakutat</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Sitka</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Juneau</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Metlakatla</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Los Angeles</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Boise</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Phoenix</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Denver</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Beulah, Dakota Północna</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>New Salem, Dakota Północna</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Center, Dakota Północna</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Chicago</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Menominee</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Vincennes</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Petersburg</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Tell City, Indiana</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Knox</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Winamac</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Marengo</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Indianapolis</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Louisville</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Vevay</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Monticello</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Detroit</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>Nowy Jork</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Montevideo</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Samarkanda</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Taszkient</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Watykan</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>Saint Vincent</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Caracas</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Tortola</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>Saint Thomas</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Ho Chi Minh (miasto)</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Efate</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Wallis</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Apia</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Aden</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Majotta</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Johannesburg</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Lusaka</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Harare</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.pt.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.pt.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="pt" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>Cidade desconhecida</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Andorra</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Dubai</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Kabul</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Antígua</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Anguilla</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Tirana</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Yerevan</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Luanda</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Rothera</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Palmer</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Troll</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Showa</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Mawson</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Davis</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Vostok</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Casey</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Dumont d’Urville</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>McMurdo</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Rio Gallegos</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Mendoza</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>San Juan</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ushuaia</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>La Rioja</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>San Luis</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Catamarca</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Salta</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Jujuy</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Tucumã</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Córdoba</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Buenos Aires</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Pago Pago</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Viena</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Perth</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Eucla</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Darwin</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Adelaide</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Broken Hill</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Currie</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Melbourne</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Hobart</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Lindeman</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Sydney</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Brisbane</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Macquarie</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Lord Howe</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Aruba</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Mariehamn</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Baku</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Sarajevo</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Barbados</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Dacca</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Bruxelas</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Ouagadougou</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>Sófia</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Barein</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Bujumbura</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Porto Novo</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>São Bartolomeu</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Bermudas</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Brunei</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>La Paz</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Kralendijk</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Eirunepé</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Rio Branco</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Porto Velho</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Boa Vista</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Manaus</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Cuiabá</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Santarém</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Campo Grande</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Belém</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Araguaína</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>São Paulo</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Bahia</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Fortaleza</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Maceió</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Recife</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Fernando de Noronha</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Nassau</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Timphu</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Gaborone</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Minsk</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Belize</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Dawson</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Whitehorse</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Inuvik</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Vancouver</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Dawson Creek</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Creston</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Yellowknife</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Edmonton</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Swift Current</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Cambridge Bay</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Regina</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Winnipeg</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Resolute</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Rainy River</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Rankin Inlet</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Atikokan</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Thunder Bay</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Nipigon</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Toronto</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Iqaluit</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Pangnirtung</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Moncton</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Halifax</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Goose Bay</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Glace Bay</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Blanc-Sablon</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>St. John’s</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Cocos</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Kinshasa</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Lubumbashi</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Bangui</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Brazzaville</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Zurique</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Abidjan</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Rarotonga</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Ilha de Páscoa</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Santiago</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Douala</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Urumqi</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Xangai</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Bogotá</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Costa Rica</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Havana</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Cabo Verde</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Curaçao</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Christmas</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Nicósia</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Praga</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Büsingen</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Berlim</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Djibuti</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Copenhague</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Dominica</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Santo Domingo</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Argel</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Galápagos</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Guaiaquil</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Tallinn</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Cairo</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>El Aaiún</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Asmara</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Canárias</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Ceuta</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Madri</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Adis-Abeba</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Helsinque</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Fiji</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Stanley</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Chuuk</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Pohnpei</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Kosrae</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Ilhas Faroe</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>Paris</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Libreville</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>Londres</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Granada</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Tbilisi</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Caiena</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Guernsey</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Acra</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Gibraltar</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Thule</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Nuuk</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Ittoqqortoormiit</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Danmarkshavn</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Banjul</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Conacri</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Guadalupe</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Malabo</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Atenas</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Geórgia do Sul</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Guatemala</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Guam</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Bissau</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Guiana</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Hong Kong</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Tegucigalpa</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Zagreb</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Porto Príncipe</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Budapeste</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Jacarta</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Pontianak</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Macassar</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Jayapura</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Dublin</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Jerusalém</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Ilha de Man</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Kolkata</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Chagos</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Bagdá</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Teerã</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Reykjavik</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Roma</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Jersey</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Jamaica</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Amã</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Tóquio</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Nairóbi</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Bishkek</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Phnom Penh</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Enderbury</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Kiritimati</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Taraua</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Comores</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>São Cristóvão</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Pyongyang</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Seul</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Kuwait</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Caimã</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Aqtau</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Oral</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Aqtöbe</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Qyzylorda</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Almaty</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Vientiane</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Beirute</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>Santa Lúcia</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Vaduz</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Colombo</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Monróvia</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Maseru</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Vilnius</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Luxemburgo</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Riga</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Trípoli</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Casablanca</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Mônaco</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Chisinau</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Podgóritza</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Marigot</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Antananarivo</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Kwajalein</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Majuro</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Skopje</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Bamaco</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Yangon</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Hovd</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Ulan Bator</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Choibalsan</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Macau</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Saipan</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Martinica</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Nouakchott</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Montserrat</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Malta</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Maurício</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Maldivas</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Blantyre</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Tijuana</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Santa Isabel</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Hermosillo</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Mazatlan</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Chihuahua</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Bahia Banderas</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Ojinaga</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Monterrei</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Cidade do México</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Matamoros</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Mérida</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Cancún</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Kuala Lampur</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Kuching</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Maputo</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Windhoek</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Nouméa</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Niamei</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Norfolk</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Lagos</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Manágua</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Amsterdã</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Oslo</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Catmandu</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Nauru</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Niue</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Chatham</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Auckland</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Mascate</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Panamá</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Lima</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Taiti</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Marquesas</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Gambier</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Port Moresby</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>Bougainville</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Manila</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Carachi</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Varsóvia</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Miquelon</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Pitcairn</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Porto Rico</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Gaza</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Hebron</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Açores</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Madeira</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Lisboa</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Palau</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Assunção</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Qatar</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Reunião</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Bucareste</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Belgrado</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Kaliningrado</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Simferopol</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Moscou</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Volgogrado</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Samara</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Ecaterimburgo</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Omsk</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Novosibirsk</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Novokuznetsk</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Krasnoyarsk</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Irkutsk</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>Chita</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Yakutsk</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Vladivostok</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Khandyga</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Sacalina</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Ust-Nera</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Magadan</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>Srednekolymsk</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Kamchatka</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Anadyr</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Kigali</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Riadi</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Guadalcanal</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Mahé</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Cartum</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Estocolmo</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Cingapura</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>Santa Helena</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Liubliana</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Longyearbyen</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Bratislava</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Freetown</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>San Marino</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Dacar</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Mogadíscio</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Paramaribo</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Juba</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>São Tomé</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>El Salvador</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Lower Prince’s Quarter</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Damasco</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Mbabane</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Grand Turk</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>Ndjamena</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Kerguelen</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Lomé</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Bangkok</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Duchambe</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Fakaofo</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Dili</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Asgabate</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Túnis</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Tongatapu</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Istambul</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Porto Espanha</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Funafuti</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Taipei</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Dar es Salaam</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Uzhgorod</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Kiev</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Zaporizhia</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Campala</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Midway</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Johnston</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Wake</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Adak</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Nome</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Honolulu</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Anchorage</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Yakutat</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Sitka</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Juneau</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Metlakatla</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Los Angeles</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Boise</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Phoenix</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Denver</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Beulah, Dakota do Norte</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>New Salen, Dakota do Norte</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Central, Dakota do Norte</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Chicago</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Menominee</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Vincennes, Indiana</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Petersburg, Indiana</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Tell City, Indiana</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Knox, Indiana</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Winamac, Indiana</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Marengo, Indiana</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Indianápolis</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Louisville</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Vevay, Indiana</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Monticello, Kentucky</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Detroit</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>Nova York</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Montevidéu</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Samarcanda</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Tashkent</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Vaticano</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>São Vicente</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Caracas</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Tortola</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>St. Thomas</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Ho Chi Minh</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Éfaté</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Wallis</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Ápia</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Adem</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Mayotte</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Johannesburgo</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Lusaca</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Harare</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.pt_BR.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.pt_BR.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="pt-BR" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>Cidade desconhecida</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Andorra</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Dubai</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Kabul</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Antígua</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Anguilla</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Tirana</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Yerevan</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Luanda</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Rothera</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Palmer</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Troll</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Showa</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Mawson</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Davis</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Vostok</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Casey</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Dumont d’Urville</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>McMurdo</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Rio Gallegos</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Mendoza</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>San Juan</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ushuaia</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>La Rioja</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>San Luis</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Catamarca</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Salta</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Jujuy</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Tucumã</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Córdoba</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Buenos Aires</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Pago Pago</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Viena</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Perth</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Eucla</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Darwin</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Adelaide</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Broken Hill</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Currie</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Melbourne</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Hobart</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Lindeman</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Sydney</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Brisbane</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Macquarie</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Lord Howe</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Aruba</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Mariehamn</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Baku</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Sarajevo</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Barbados</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Dacca</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Bruxelas</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Ouagadougou</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>Sófia</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Barein</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Bujumbura</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Porto Novo</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>São Bartolomeu</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Bermudas</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Brunei</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>La Paz</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Kralendijk</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Eirunepé</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Rio Branco</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Porto Velho</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Boa Vista</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Manaus</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Cuiabá</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Santarém</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Campo Grande</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Belém</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Araguaína</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>São Paulo</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Bahia</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Fortaleza</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Maceió</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Recife</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Fernando de Noronha</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Nassau</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Timphu</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Gaborone</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Minsk</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Belize</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Dawson</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Whitehorse</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Inuvik</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Vancouver</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Dawson Creek</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Creston</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Yellowknife</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Edmonton</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Swift Current</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Cambridge Bay</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Regina</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Winnipeg</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Resolute</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Rainy River</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Rankin Inlet</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Atikokan</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Thunder Bay</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Nipigon</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Toronto</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Iqaluit</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Pangnirtung</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Moncton</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Halifax</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Goose Bay</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Glace Bay</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Blanc-Sablon</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>St. John’s</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Cocos</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Kinshasa</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Lubumbashi</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Bangui</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Brazzaville</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Zurique</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Abidjan</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Rarotonga</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Ilha de Páscoa</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Santiago</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Douala</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Urumqi</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Xangai</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Bogotá</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Costa Rica</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Havana</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Cabo Verde</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Curaçao</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Christmas</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Nicósia</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Praga</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Büsingen</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Berlim</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Djibuti</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Copenhague</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Dominica</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Santo Domingo</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Argel</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Galápagos</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Guaiaquil</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Tallinn</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Cairo</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>El Aaiún</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Asmara</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Canárias</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Ceuta</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Madri</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Adis-Abeba</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Helsinque</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Fiji</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Stanley</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Chuuk</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Pohnpei</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Kosrae</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Ilhas Faroe</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>Paris</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Libreville</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>Londres</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Granada</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Tbilisi</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Caiena</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Guernsey</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Acra</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Gibraltar</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Thule</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Nuuk</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Ittoqqortoormiit</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Danmarkshavn</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Banjul</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Conacri</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Guadalupe</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Malabo</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Atenas</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Geórgia do Sul</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Guatemala</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Guam</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Bissau</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Guiana</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Hong Kong</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Tegucigalpa</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Zagreb</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Porto Príncipe</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Budapeste</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Jacarta</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Pontianak</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Macassar</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Jayapura</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Dublin</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Jerusalém</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Ilha de Man</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Kolkata</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Chagos</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Bagdá</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Teerã</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Reykjavik</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Roma</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Jersey</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Jamaica</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Amã</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Tóquio</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Nairóbi</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Bishkek</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Phnom Penh</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Enderbury</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Kiritimati</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Taraua</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Comores</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>São Cristóvão</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Pyongyang</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Seul</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Kuwait</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Caimã</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Aqtau</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Oral</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Aqtöbe</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Qyzylorda</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Almaty</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Vientiane</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Beirute</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>Santa Lúcia</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Vaduz</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Colombo</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Monróvia</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Maseru</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Vilnius</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Luxemburgo</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Riga</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Trípoli</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Casablanca</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Mônaco</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Chisinau</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Podgóritza</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Marigot</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Antananarivo</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Kwajalein</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Majuro</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Skopje</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Bamaco</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Yangon</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Hovd</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Ulan Bator</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Choibalsan</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Macau</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Saipan</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Martinica</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Nouakchott</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Montserrat</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Malta</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Maurício</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Maldivas</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Blantyre</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Tijuana</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Santa Isabel</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Hermosillo</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Mazatlan</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Chihuahua</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Bahia Banderas</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Ojinaga</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Monterrei</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Cidade do México</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Matamoros</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Mérida</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Cancún</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Kuala Lampur</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Kuching</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Maputo</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Windhoek</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Nouméa</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Niamei</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Norfolk</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Lagos</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Manágua</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Amsterdã</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Oslo</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Catmandu</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Nauru</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Niue</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Chatham</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Auckland</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Mascate</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Panamá</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Lima</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Taiti</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Marquesas</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Gambier</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Port Moresby</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>Bougainville</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Manila</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Carachi</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Varsóvia</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Miquelon</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Pitcairn</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Porto Rico</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Gaza</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Hebron</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Açores</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Madeira</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Lisboa</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Palau</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Assunção</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Qatar</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Reunião</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Bucareste</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Belgrado</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Kaliningrado</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Simferopol</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Moscou</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Volgogrado</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Samara</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Ecaterimburgo</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Omsk</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Novosibirsk</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Novokuznetsk</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Krasnoyarsk</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Irkutsk</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>Chita</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Yakutsk</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Vladivostok</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Khandyga</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Sacalina</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Ust-Nera</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Magadan</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>Srednekolymsk</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Kamchatka</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Anadyr</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Kigali</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Riadi</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Guadalcanal</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Mahé</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Cartum</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Estocolmo</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Cingapura</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>Santa Helena</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Liubliana</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Longyearbyen</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Bratislava</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Freetown</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>San Marino</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Dacar</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Mogadíscio</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Paramaribo</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Juba</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>São Tomé</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>El Salvador</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Lower Prince’s Quarter</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Damasco</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Mbabane</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Grand Turk</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>Ndjamena</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Kerguelen</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Lomé</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Bangkok</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Duchambe</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Fakaofo</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Dili</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Asgabate</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Túnis</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Tongatapu</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Istambul</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Porto Espanha</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Funafuti</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Taipei</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Dar es Salaam</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Uzhgorod</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Kiev</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Zaporizhia</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Campala</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Midway</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Johnston</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Wake</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Adak</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Nome</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Honolulu</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Anchorage</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Yakutat</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Sitka</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Juneau</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Metlakatla</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Los Angeles</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Boise</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Phoenix</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Denver</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Beulah, Dakota do Norte</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>New Salen, Dakota do Norte</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Central, Dakota do Norte</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Chicago</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Menominee</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Vincennes, Indiana</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Petersburg, Indiana</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Tell City, Indiana</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Knox, Indiana</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Winamac, Indiana</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Marengo, Indiana</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Indianápolis</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Louisville</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Vevay, Indiana</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Monticello, Kentucky</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Detroit</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>Nova York</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Montevidéu</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Samarcanda</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Tashkent</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Vaticano</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>São Vicente</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Caracas</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Tortola</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>St. Thomas</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Ho Chi Minh</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Éfaté</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Wallis</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Ápia</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Adem</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Mayotte</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Johannesburgo</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Lusaca</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Harare</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.ro.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.ro.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="ro" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>Oraș necunoscut</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Andorra</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Dubai</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Kabul</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Antigua</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Anguilla</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Tirana</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Erevan</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Luanda</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Rothera</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Palmer</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Troll</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Showa</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Mawson</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Davis</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Vostok</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Casey</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Dumont d’Urville</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>McMurdo</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Rio Gallegos</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Mendoza</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>San Juan</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ushuaia</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>La Rioja</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>San Luis</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Catamarca</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Salta</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Jujuy</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Tucuman</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Cordoba</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Buenos Aires</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Pago Pago</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Viena</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Perth</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Eucla</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Darwin</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Adelaide</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Broken Hill</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Currie</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Melbourne</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Hobart</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Lindeman</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Sydney</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Brisbane</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Macquarie</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Lord Howe</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Aruba</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Mariehamn</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Baku</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Sarajevo</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Barbados</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Dacca</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Bruxelles</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Ouagadougou</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>Sofia</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Bahrain</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Bujumbura</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Porto-Novo</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>Saint Barthélemy</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Bermuda</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Brunei</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>La Paz</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Kralendijk</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Eirunepe</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Rio Branco</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Porto Velho</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Boa Vista</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Manaus</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Cuiaba</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Santarem</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Campo Grande</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Belem</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Araguaina</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>Sao Paulo</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Bahia</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Fortaleza</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Maceio</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Recife</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Noronha</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Nassau</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Thimphu</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Gaborone</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Minsk</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Belize</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Dawson</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Whitehorse</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Inuvik</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Vancouver</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Dawson Creek</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Creston</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Yellowknife</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Edmonton</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Swift Current</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Cambridge Bay</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Regina</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Winnipeg</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Resolute</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Rainy River</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Rankin Inlet</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Atikokan</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Thunder Bay</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Nipigon</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Toronto</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Iqaluit</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Pangnirtung</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Moncton</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Halifax</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Goose Bay</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Glace Bay</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Blanc-Sablon</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>St. John’s</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Cocos</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Kinshasa</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Lubumbashi</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Bangui</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Brazzaville</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Zürich</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Abidjan</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Rarotonga</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Insula Paștelui</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Santiago</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Douala</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Urumqi</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Shanghai</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Bogota</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Costa Rica</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Havana</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Capul Verde</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Curaçao</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Insula Crăciunului</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Nicosia</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Praga</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Busingen</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Berlin</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Djibouti</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Copenhaga</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Dominica</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Santo Domingo</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Alger</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Galapagos</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Guayaquil</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Tallinn</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Cairo</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>El Aaiun</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Asmara</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Canare</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Ceuta</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Madrid</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Addis Abeba</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Helsinki</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Fiji</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Stanley</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Chuuk</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Pohnpei</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Kosrae</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Faroe</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>Paris</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Libreville</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>Londra</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Grenada</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Tbilisi</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Cayenne</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Guernsey</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Accra</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Gibraltar</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Thule</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Nuuk</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Ittoqqortoormiit</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Danmarkshavn</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Banjul</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Conakry</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Guadelupa</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Malabo</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Atena</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Georgia de Sud</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Guatemala</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Guam</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Bissau</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Guyana</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Hong Kong</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Tegucigalpa</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Zagreb</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Port-au-Prince</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Budapesta</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Jakarta</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Pontianak</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Makassar</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Jayapura</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Dublin</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Ierusalim</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Insula Man</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Calcutta</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Chagos</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Bagdad</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Teheran</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Reykjavik</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Roma</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Jersey</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Jamaica</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Amman</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Tokyo</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Nairobi</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Bișkek</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Phnom Penh</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Enderbury</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Kiritimati</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Tarawa</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Comore</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>St. Kitts</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Phenian</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Seul</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Kuweit</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Cayman</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Aktau</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Uralsk</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Aktobe</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Kyzylorda</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Almatî</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Vientiane</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Beirut</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>St. Lucia</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Vaduz</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Colombo</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Monrovia</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Maseru</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Vilnius</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Luxemburg</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Riga</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Tripoli</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Casablanca</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Monaco</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Chișinău</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Podgorica</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Marigot</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Antananarivo</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Kwajalein</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Majuro</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Skopje</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Bamako</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Yangon</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Hovd</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Ulan Bator</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Choibalsan</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Macao</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Saipan</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Martinica</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Nouakchott</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Montserrat</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Malta</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Mauritius</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Maldive</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Blantyre</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Tijuana</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Santa Isabel</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Hermosillo</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Mazatlan</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Chihuahua</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Bahia Banderas</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Ojinaga</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Monterrey</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Ciudad de Mexico</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Matamoros</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Merida</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Cancun</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Kuala Lumpur</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Kuching</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Maputo</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Windhoek</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Noumea</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Niamey</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Norfolk</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Lagos</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Managua</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Amsterdam</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Oslo</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Kathmandu</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Nauru</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Niue</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Chatham</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Auckland</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Muscat</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Panama</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Lima</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Tahiti</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Marchize</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Gambier</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Port Moresby</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>Bougainville</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Manila</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Karachi</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Varșovia</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Miquelon</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Insula Pitcairn</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Puerto Rico</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Gaza</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Hebron</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Azore</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Madeira</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Lisabona</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Palau</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Asunción</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Qatar</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Réunion</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>București</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Belgrad</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Kaliningrad</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Simferopol</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Moscova</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Volgograd</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Samara</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Ekaterinburg</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Omsk</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Novosibirsk</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Novokuznețk</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Krasnoiarsk</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Irkuțk</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>Cita</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Yakuțk</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Vladivostok</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Khandyga</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Sahalin</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Ust-Nera</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Magadan</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>Srednekolimsk</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Kamciatka</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Anadir</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Kigali</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Riad</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Guadalcanal</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Mahe</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Khartoum</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Stockholm</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Singapore</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>Sf. Elena</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Ljubljana</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Longyearbyen</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Bratislava</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Freetown</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>San Marino</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Dakar</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Mogadishu</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Paramaribo</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Juba</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>São Tomé</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>El Salvador</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Lower Prince’s Quarter</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Damasc</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Mbabane</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Grand Turk</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>N’Djamena</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Kerguelen</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Lome</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Bangkok</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Dușanbe</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Fakaofo</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Dili</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Așgabat</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Tunis</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Tongatapu</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Istanbul</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Port of Spain</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Funafuti</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Taipei</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Dar es Salaam</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Ujhorod</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Kiev</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Zaporoje</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Kampala</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Midway</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Johnston</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Wake</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Adak</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Nome</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Honolulu</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Anchorage</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Yakutat</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Sitka</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Juneau</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Metlakatla</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Los Angeles</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Boise</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Phoenix</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Denver</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Beulah, Dakota de Nord</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>New Salem, Dakota de Nord</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Centru, Dakota de Nord</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Chicago</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Menominee</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Vincennes, Indiana</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Petersburg, Indiana</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Tell City, Indiana</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Knox, Indiana</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Winamac, Indiana</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Marengo, Indiana</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Indianapolis</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Louisville</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Vevay, Indiana</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Monticello, Kentucky</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Detroit</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>New York</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Montevideo</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Samarkand</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Tașkent</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Vatican</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>St. Vincent</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Caracas</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Tortola</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>St. Thomas</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Ho Și Min</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Efate</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Wallis</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Apia</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Aden</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Mayotte</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Johannesburg</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Lusaka</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Harare</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.ru.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.ru.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="ru" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>Неизвестный город</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Андорра</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Дубай</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Кабул</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Антигуа</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Ангилья</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Тирана</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Ереван</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Луанда</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Ротера</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Палмер</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Тролль</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Сёва</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Моусон</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Дейвис</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Восток</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Кейси</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Дюмон-д’Юрвиль</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>Мак-Мердо</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Рио-Гальегос</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Мендоса</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>Сан-Хуан</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ушуая</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>Ла-Риоха</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>Сан-Луис</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Катамарка</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Сальта</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Жужуй</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Тукуман</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Кордова</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Буэнос-Айрес</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Паго-Паго</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Вена</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Перт</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Юкла</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Дарвин</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Аделаида</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Брокен-Хилл</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Керри</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Мельбурн</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Хобарт</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Линдеман</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Сидней</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Брисбен</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Маккуори</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Лорд-Хау, о-в</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Аруба</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Мариехамн</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Баку</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Сараево</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Барбадос</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Дакка</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Брюссель</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Уагадугу</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>София</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Бахрейн</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Бужумбура</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Порто-Ново</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>Сен-Бартельми</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Бермуды</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Бруней</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>Ла-Пас</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Кралендейк</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Эйрунепе</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Риу-Бранку</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Порту-Велью</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Боа-Виста</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Манаус</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Куяба</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Сантарен</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Кампу-Гранди</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Белен</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Арагуаина</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>Сан-Паулу</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Баия</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Форталеза</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Масейо</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Ресифи</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Норонха</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Нассау</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Тимпу</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Габороне</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Минск</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Белиз</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Доусон</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Уайтхорс</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Инувик</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Ванкувер</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Доусон-Крик</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Крестон</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Йеллоунайф</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Эдмонтон</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Свифт-Карент</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Кеймбридж-Бей</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Реджайна</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Виннипег</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Резолют</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Рейни-Ривер</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Ранкин-Инлет</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Корал-Харбор</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Тандер-Бей</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Нипигон</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Торонто</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Икалуит</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Пангниртанг</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Монктон</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Галифакс</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Гус-Бей</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Глейс-Бей</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Бланк-Саблон</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>Сент-Джонс</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Кокосовые о-ва</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Киншаса</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Лубумбаши</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Банги</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Браззавиль</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Цюрих</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Абиджан</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Раротонга</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Пасхи, о-в</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Сантьяго</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Дуала</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Урумчи</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Шанхай</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Богота</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Коста-Рика</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Гавана</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Острова Зеленого Мыса</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Кюрасао</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Рождества, о-в</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Никосия</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Прага</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Бюзинген-на-Верхнем-Рейне</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Берлин</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Джибути</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Копенгаген</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Доминика</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Санто-Доминго</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Алжир</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Галапагосские о-ва</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Гуаякиль</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Таллин</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Каир</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>Эль-Аюн</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Асмера</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Канарские о-ва</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Сеута</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Мадрид</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Аддис-Абеба</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Хельсинки</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Фиджи</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Стэнли</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Трук, о-ва</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Понапе, о-в</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Косрае</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Фарерские о-ва</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>Париж</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Либревиль</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>Лондон</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Гренада</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Тбилиси</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Кайенна</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Гернси</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Аккра</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Гибралтар</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Туле</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Готхоб</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Скорсбисунн</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Денмарксхавн</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Банжул</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Конакри</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Гваделупа</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Малабо</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Афины</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Юж. Георгия и Юж. Сэндвинчевы о-ва</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Гватемала</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Гуам</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Бисау</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Гайана</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Гонконг</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Тегусигальпа</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Загреб</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Порт-о-Пренс</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Будапешт</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Джакарта</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Понтианак</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Макасар</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Джайпур</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Дублин</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Иерусалим</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Мэн, о-в</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Калькутта</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Чагос</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Багдад</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Тегеран</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Рейкьявик</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Рим</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Джерси</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Ямайка</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Амман</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Токио</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Найроби</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Бишкек</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Пномпень</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Эндербери, о-в</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Киритимати</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Тарава</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Коморские о-ва</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>Сент-Китс</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Пхеньян</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Сеул</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Кувейт</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Каймановы о-ва</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Актау</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Орал (Уральск)</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Актобе (Актюбинск)</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Кызылорда</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Алматы</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Вьентьян</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Бейрут</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>Сент-Люсия</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Вадуц</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Коломбо</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Монровия</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Масеру</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Вильнюс</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Люксембург</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Рига</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Триполи</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Касабланка</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Монако</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Кишинев</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Подгорица</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Мариго</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Антананариву</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Кваджалейн</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Маджуро</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Скопье</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Бамако</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Рангун</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Ховд</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Улан-Батор</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Чойбалсан</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Макао</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Сайпан</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Мартиника</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Нуакшот</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Монсеррат</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Мальта</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Маврикий</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Мальдивы</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Блантайр</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Тихуана</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Санта-Изабел</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Эрмосильо</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Масатлан</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Чиуауа</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Баия-де-Бандерас</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Охинага</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Монтеррей</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Мехико</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Матаморос</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Мерида</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Канкун</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Куала-Лумпур</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Кучинг</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Мапуту</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Виндхук</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Нумеа</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Ниамей</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Норфолк</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Лагос</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Манагуа</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Амстердам</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Осло</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Катманду</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Науру</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Ниуэ</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Чатем, о-в</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Окленд</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Маскат</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Панама</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Лима</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Таити, о-в</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Маркизские о-ва</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Гамбье, о-ва</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Порт-Морсби</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>Бугенвиль</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Манила</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Карачи</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Варшава</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Микелон</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Питкерн</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Пуэрто-Рико</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Газа</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Хеврон</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Азорские о-ва</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Мадейра, о-в</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Лиссабон</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Палау</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Асунсьон</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Катар</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Реюньон</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Бухарест</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Белград</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Калининград</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Симферополь</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Москва</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Волгоград</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Самара</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Екатеринбург</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Омск</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Новосибирск</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Новокузнецк</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Красноярск</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Иркутск</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>Чита</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Якутск</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Владивосток</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Хандыга</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Сахалин, о-в</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Усть-Нера</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Магадан</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>Среднеколымск</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Петропавловск-Камчатский</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Анадырь</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Кигали</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Эр-Рияд</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Гвадалканал</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Маэ</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Хартум</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Стокгольм</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Сингапур</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>Св. Елены, о-в</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Любляна</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Лонгйир</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Братислава</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Фритаун</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>Сан-Марино</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Дакар</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Могадишо</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Парамарибо</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Джуба</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>Сан-Томе</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>Сальвадор</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Лоуэр-Принсес-Куортер</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Дамаск</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Мбабане</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Гранд Турк</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>Нджамена</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Кергелен</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Ломе</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Бангкок</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Душанбе</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Факаофо</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Дили</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Ашхабад</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Тунис</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Тонгатапу</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Стамбул</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Порт-оф-Спейн</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Фунафути</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Тайбэй</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Дар-эс-Салам</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Ужгород</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Киев</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Запорожье</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Кампала</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Мидуэй, о-ва</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Джонстон, ат.</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Уэйк, о-в</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Адак, о-в</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Ном</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Гонолулу</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Анкоридж</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Якутат</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Ситка</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Джуно</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Метлакатла</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Лос-Анджелес</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Бойсе</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Финикс</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Денвер</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Бойла, Северная Дакота</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>Нью-Салем</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Центр, Северная Дакота</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Чикаго</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Меномини</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Винсенс</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Петерсбург</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Телл-Сити</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Нокс</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Винамак</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Маренго</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Индианаполис</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Луисвилл</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Вивэй</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Монтиселло</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Детройт</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>Нью-Йорк</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Монтевидео</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Самарканд</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Ташкент</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Ватикан</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>Сент-Винсент</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Каракас</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Тортола</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>Сент-Томас</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Хошимин</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Эфате</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Уоллис</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Апия</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Аден</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Майорка</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Йоханнесбург</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Лусака</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Хараре</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.sk.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.sk.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="sk" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>neznáme mesto</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Andorra</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Dubaj</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Kábul</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Antigua</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Anguilla</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Tirana</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Jerevan</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Luanda</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Rothera</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Palmer</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Troll</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Šówa</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Mawson</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Davis</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Vostok</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Casey</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Dumont D’Urville</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>McMurdo</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Rio Gallegos</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Mendoza</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>San Juan</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ushuaia</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>La Rioja</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>San Luis</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Catamarca</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Salta</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Jujuy</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Tucuman</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Córdoba</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Buenos Aires</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Pago Pago</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Viedeň</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Perth</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Eucla</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Darwin</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Adelaide</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Broken Hill</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Currie</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Melbourne</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Hobart</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Lindeman</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Sydney</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Brisbane</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Macquarie</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Lord Howe</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Aruba</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Mariehamn</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Baku</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Sarajevo</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Barbados</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Dháka</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Brusel</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Ouagadougou</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>Sofia</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Bahrajn</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Bujumbura</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Porto-Novo</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>Svätý Bartolomej</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Bermudy</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Brunej</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>La Paz</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Kralendijk</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Eirunepé</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Rio Branco</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Porto Velho</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Boa Vista</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Manaus</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Cuiabá</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Santarém</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Campo Grande</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Belém</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Araguaina</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>São Paulo</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Bahia</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Fortaleza</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Maceió</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Recife</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Noronha</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Nassau</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Thimphu</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Gaborone</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Minsk</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Belize</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Dawson</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Whitehorse</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Inuvik</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Vancouver</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Dawson Creek</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Creston</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Yellowknife</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Edmonton</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Swift Current</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Cambridge Bay</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Regina</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Winnipeg</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Resolute</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Rainy River</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Rankin Inlet</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Atikokan</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Thunder Bay</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Nipigon</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Toronto</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Iqaluit</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Pangnirtung</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Moncton</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Halifax</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Goose Bay</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Glace Bay</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Blanc-Sablon</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>St. John’s</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Kokosové ostrovy</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Kinshasa</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Lubumbashi</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Bangui</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Brazzaville</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Zürich</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Abidjan</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Rarotonga</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Veľkonočný ostrov</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Santiago</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Douala</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Urumči</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Šanghaj</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Bogotá</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Kostarika</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Havana</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Kapverdy</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Curaçao</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Vianočný ostrov</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Nikózia</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Praha</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Büsingen</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Berlín</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Džibuti</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Kodaň</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Dominika</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Santo Domingo</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Alžír</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Galapágy</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Guayaquil</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Tallinn</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Káhira</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>El-Aaiún</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Asmara</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Kanárske ostrovy</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Ceuta</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Madrid</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Addis Abeba</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Helsinki</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Fidži</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Stanley</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Chuuk</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Pohnpei</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Kosrae</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Faerské ostrovy</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>Paríž</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Libreville</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>Londýn</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Grenada</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Tbilisi</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Cayenne</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Guernsey</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Accra</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Gibraltár</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Thule</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Nuuk</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Ittoqqortoormiit</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Danmarkshavn</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Banjul</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Conakry</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Guadeloupe</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Malabo</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Atény</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Južná Georgia</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Guatemala</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Guam</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Bissau</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Guyana</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Hongkong</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Tegucigalpa</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Záhreb</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Port-au-Prince</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Budapešť</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Jakarta</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Pontianak</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Makassar</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Jayapura</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Dublin</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Jeruzalem</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Ostrov Man</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Kalkata</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Chagos</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Bagdad</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Teherán</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Reykjavík</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Rím</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Jersey</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Jamajka</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Ammán</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Tokio</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Nairobi</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Biškek</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Phnom Pénh</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Enderbury</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Kiritimati</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Tarawa</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Komory</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>St. Kitts</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Pchjongjang</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Soul</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Kuvajt</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Kajmanie ostrovy</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Aktau</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Uraľsk</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Aktobe</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Kyzylorda</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Almaty</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Vientian</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Bejrút</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>Svätá Lucia</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Vaduz</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Kolombo</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Monrovia</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Maseru</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Vilnius</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Luxembursko</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Riga</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Tripolis</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Casablanca</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Monako</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Kišiňov</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Podgorica</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Marigot</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Antananarivo</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Kwajalein</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Majuro</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Skopje</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Bamako</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Rangún</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Chovd</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Ulanbátar</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Čojbalsan</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Macao</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Saipan</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Martinik</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Nouakchott</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Montserrat</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Malta</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Maurícius</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Maldivy</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Blantyre</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Tijuana</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Santa Isabel</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Hermosillo</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Mazatlán</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Chihuahua</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Bahia Banderas</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Ojinaga</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Monterrey</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>México</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Matamoros</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Mérida</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Cancún</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Kuala Lumpur</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Kučing</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Maputo</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Windhoek</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Nouméa</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Niamey</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Norfolk</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Lagos</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Managua</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Amsterdam</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Oslo</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Káthmandu</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Nauru</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Niue</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Chatham</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Auckland</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Maskat</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Panama</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Lima</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Tahiti</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Markézy</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Gambier</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Port Moresby</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>Bougainville</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Manila</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Karáči</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Varšava</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Miquelon</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Pitcairn</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Portoriko</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Gaza</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Hebron</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Azory</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Madeira</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Lisabon</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Palau</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Asunción</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Katar</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Réunion</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Bukurešť</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Belehrad</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Kaliningrad</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Simferopol</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Moskva</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Volgograd</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Samara</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Jekaterinburg</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Omsk</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Novosibirsk</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Novokuzneck</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Krasnojarsk</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Irkutsk</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>Čita</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Jakutsk</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Vladivostok</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Chandyga</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Sachalin</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Usť-Nera</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Magadan</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>Srednekolymsk</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Kamčatka</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Anadyr</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Kigali</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Rijád</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Guadalcanal</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Mahé</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Chartúm</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Štokholm</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Singapur</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>Svätá Helena</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Ľubľana</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Longyearbyen</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Bratislava</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Freetown</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>San Maríno</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Dakar</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Mogadišo</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Paramaribo</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Juba</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>Svätý Tomáš</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>Salvádor</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Lower Prince’s Quarter</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Damask</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Mbabane</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Grand Turk</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>N’Djamena</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Kergueleny</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Lomé</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Bangkok</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Dušanbe</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Fakaofo</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Dili</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Ašchabad</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Tunis</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Tongatapu</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Istanbul</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Port of Spain</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Funafuti</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Tchaj-pej</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Dar es Salaam</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Užhorod</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Kyjev</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Záporožie</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Kampala</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Midway</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Johnston</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Wake</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Adak</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Nome</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Honolulu</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Anchorage</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Yakutat</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Sitka</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Juneau</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Metlakatla</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Los Angeles</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Boise</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Phoenix</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Denver</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Beulah, Severná Dakota</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>New Salem, Severná Dakota</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Center, Severná Dakota</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Chicago</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Menominee</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Vincennes, Indiana</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Petersburg, Indiana</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Tell City, Indiana</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Knox, Indiana</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Winamac, Indiana</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Marengo, Indiana</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Indianapolis</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Louisville</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Vevay, Indiana</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Monticello, Kentucky</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Detroit</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>New York</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Montevideo</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Samarkand</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Taškent</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Vatikán</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>Sv. Vincent</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Caracas</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Tortola</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>Sv. Tomáš</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Hočiminovo Mesto</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Efate</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Wallis</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Apia</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Aden</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Mayotte</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Johannesburg</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Lusaka</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Harare</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.sl.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.sl.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="sl" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>neznano mesto</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Andora</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Dubaj</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Kabul</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Antigua</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Anguilla</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Tirana</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Erevan</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Luanda</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Rothera</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Palmer</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Troll</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Syowa</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Mawson</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Davis</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Vostok</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Casey</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Dumont d’Urville</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>McMurdo</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Rio Gallegos</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Mendoza</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>San Juan</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ushuaia</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>La Rioja</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>San Luis</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Catamarca</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Salta</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Jujuy</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Tucuman</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Kordova</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Buenos Aires</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Pago Pago</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Dunaj</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Perth</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Eucla</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Darwin</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Adelaide</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Broken Hill</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Currie</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Melbourne</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Hobart</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Lindeman</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Sydney</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Brisbane</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Macquarie</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Lord Howe</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Aruba</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Mariehamn</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Baku</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Sarajevo</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Barbados</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Daka</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Bruselj</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Ouagadougou</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>Sofija</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Bahrajn</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Bujumbura</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Porto-Novo</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>Saint Barthélemy</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Bermudi</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Brunej</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>La Paz</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Kralendijk</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Eirunepe</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Rio Branco</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Porto Velho</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Boa Vista</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Manaus</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Cuiaba</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Santarem</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Campo Grande</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Belem</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Araguaina</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>Sao Paulo</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Bahia</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Fortaleza</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Maceio</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Recife</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Noronha</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Nassau</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Thimphu</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Gaborone</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Minsk</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Belize</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Dawson</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Whitehorse</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Inuvik</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Vancouver</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Dawson Creek</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Creston</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Yellowknife</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Edmonton</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Swift Current</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Cambridge Bay</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Regina</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Winnipeg</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Resolute</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Rainy River</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Rankin Inlet</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Atikokan</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Thunder Bay</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Nipigon</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Toronto</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Iqaluit</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Pangnirtung</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Moncton</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Halifax</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Goose Bay</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Glace Bay</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Blanc-Sablon</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>St. John’s</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Kokosovi otoki</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Kinšasa</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Lubumbaši</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Bangui</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Brazzaville</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Zürich</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Abidžan</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Rarotonga</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Velikonočni otok</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Santiago</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Douala</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Urumči</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Šangaj</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Bogota</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Kostarika</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Havana</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Zelenortski otoki</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Curaçao</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Božični otok</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Nikozija</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Praga</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Busingen</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Berlin</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Džibuti</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Köbenhavn</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Dominika</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Santo Domingo</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Alžir</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Galapagos</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Guayaquil</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Talin</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Kairo</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>El Aaiun</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Asmara</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Kanarski otoki</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Ceuta</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Madrid</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Adis Abeba</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Helsinki</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Fidži</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Stanley</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Chuuk</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Pohnpei</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Kosrae</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Faroe</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>Pariz</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Libreville</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>London</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Grenada</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Tbilisi</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Cayenne</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Guernsey</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Akra</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Gibraltar</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Thule</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Nuuk</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Ittoqqortoormiit</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Danmarkshavn</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Banjul</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Conakry</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Gvadelup</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Malabo</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Atene</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Južna Georgia</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Gvatemala</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Guam</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Bissau</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Gvajana</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Hongkong</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Tegucigalpa</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Zagreb</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Port-au-Prince</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Budimpešta</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Džakarta</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Pontianak</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Makasar</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Jayapura</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Dublin</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Jeruzalem</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Otok Man</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Kolkata</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Chagos</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Bagdad</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Teheran</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Reykjavik</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Rim</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Jersey</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Jamajka</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Aman</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Tokio</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Nairobi</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Biškek</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Phnom Penh</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Enderbury</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Kiritimati</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Tarawa</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Komori</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>St. Kitts</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Pjongjang</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Seul</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Kuvajt</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Kajman</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Aktau</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Uralsk</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Aktobe</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Kizlorda</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Almati</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Vientiane</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Bejrut</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>St. Lucia</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Vaduz</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Colombo</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Monrovia</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Maseru</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Vilna</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Luksemburg</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Riga</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Tripoli</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Casablanca</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Monako</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Kišinjev</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Podgorica</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Marigot</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Antananarivo</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Kwajalein</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Majuro</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Skopje</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Bamako</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Rangun</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Hovd</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Ulan Bator</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Čojbalsan</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Macao</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Saipan</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Martinik</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Nouakchott</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Montserrat</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Malta</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Mauritius</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Maldivi</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Blantyre</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Tijuana</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Santa Isabel</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Hermosillo</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Mazatlan</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Chihuahua</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Bahia Banderas</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Ojinaga</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Monterrey</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Ciudad Mexico</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Matamoros</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Merida</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Cancun</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Kuala Lumpur</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Kuching</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Maputo</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Windhoek</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Noumea</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Niamey</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Norfolk</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Lagos</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Managua</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Amsterdam</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Oslo</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Katmandu</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Nauru</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Niue</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Chatham</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Auckland</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Muškat</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Panama</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Lima</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Tahiti</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Marquesas</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Gambier</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Port Moresby</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>Bougainville</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Manila</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Karači</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Varšava</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Miquelon</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Pitcairn</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Portoriko</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Gaza</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Hebron</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Azori</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Madeira</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Lizbona</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Palau</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Asunción</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Katar</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Reunion</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Bukarešta</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Beograd</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Kaliningrad</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Simferopol</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Moskva</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Volgograd</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Samara</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Jekaterinburg</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Omsk</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Novosibirsk</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Novokuznetsk</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Krasnojarsk</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Irkutsk</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>Chita</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Jakutsk</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Vladivostok</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Handiga</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Sahalin</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Ust-Nera</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Magadan</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>Srednekolymsk</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Kamčatka</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Anadir</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Kigali</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Rijad</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Guadalcanal</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Mahe</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Kartum</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Stockholm</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Singapur</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>St. Helena</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Ljubljana</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Longyearbyen</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Bratislava</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Freetown</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>San Marino</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Dakar</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Mogadišu</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Paramaribo</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Juba</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>São Tomé</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>Salvador</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Lower Prince’s Quarter</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Damask</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Mbabane</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Grand Turk</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>Ndjamena</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Kerguelen</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Lome</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Bangkok</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Dušanbe</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Fakaofo</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Dili</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Ašgabat</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Tunis</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Tongatapu</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Istanbul</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Port of Spain</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Funafuti</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Tajpej</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Dar es Salaam</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Užgorod</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Kijev</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Zaporožje</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Kampala</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Midway</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Johnston</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Wake</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Adak</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Nome</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Honolulu</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Anchorage</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Yakutat</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Sitka</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Juneau</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Metlakatla</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Los Angeles</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Boise</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Phoenix</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Denver</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Beulah, North Dakota</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>New Salem, Severna Dakota</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Center, Severna Dakota</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Chicago</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Menominee</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Vincennes, Indiana</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Petersburg, Indiana</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Tell City, Indiana</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Knox, Indiana</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Winamac, Indiana</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Marengo, Indiana</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Indianapolis</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Louisville</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Vevay, Indiana</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Monticello, Kentucky</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Detroit</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>New York</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Montevideo</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Samarkand</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Taškent</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Vatikan</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>St. Vincent</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Caracas</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Tortola</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>St. Thomas</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Hošiminh</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Efate</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Wallis</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Apia</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Aden</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Mayotte</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Johannesburg</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Lusaka</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Harare</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.sr_Cyrl.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.sr_Cyrl.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="sr-Cyrl" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>Непознат град</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Андора</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Дубаи</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Кабул</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Антигва</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Ангвила</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Тирана</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Јереван</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Луанда</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Ротера</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Палмер</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Трол</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Шова</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Мосон</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Дејвис</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Восток</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Кејси</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Димон д’Урвил</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>Макмурдо</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Рио Гелегос</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Мендоса</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>Сан Хуан</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ушуаија</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>Ла Риоха</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>Сан Луи</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Катамарка</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Салта</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Жужуи</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Тукуман</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Кордоба</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Буенос Ајрес</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Паго Паго</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Беч</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Перт</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Иукла</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Дарвин</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Аделејд</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Брокен Хил</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Кари</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Мелбурн</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Хобарт</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Линдеман</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Сиднеј</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Бризбејн</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Меквори</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Лорд Хау</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Аруба</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Марихамн</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Баку</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Сарајево</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Барбадос</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Дака</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Брисел</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Уагадугу</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>Софија</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Бахреин</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Буџумбура</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Порто Ново</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>Св. Бартоломeј</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Бермуда</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Брунеји</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>Ла Паз</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Кралендајк</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Еирунепе</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Рио Бранко</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Порто Вељо</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Боа Виста</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Манаус</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Куиаба</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Сантарем</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Кампо Гранде</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Белем</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Арагвајана</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>Сао Паоло</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Баија</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Форталеза</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Масејо</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Ресифе</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Нороња</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Насау</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Тимпу</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Габорон</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Минск</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Белизе</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Досон</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Вајтхорс</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Инувик</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Ванкувер</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Досон Крик</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Крестон</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Јелоунајф</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Едмонтон</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Свифт Курент</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Кембриџ Беј</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Регина</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Винипег</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Ресолут</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Рејни Ривер</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Ранкин Инлет</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Корал Харбур</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Тандер Беј</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Нипигон</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Торонто</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Иквалуит</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Пангниртунг</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Монктон</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Халифакс</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Гус Беј</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Глејс Беј</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Бланк-Сејблон</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>Св. Џон</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Кокос</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Киншаса</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Лубумбаши</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Бангуи</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Бразавил</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Цирих</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Абиџан</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Раротонга</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Ускршње острво</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Сантјаго</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Дуала</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Урумкви</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Шангај</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Богота</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Костарика</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Хавана</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Зеленортска Острва</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Кирасо</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Божић</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Никозија</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Праг</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Бисинген</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Берлин</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Џибути</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Копенхаген</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Доминика</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Санто Доминго</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Алжир</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Галапагос</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Гвајакил</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Талин</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Каиро</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>Ел Ајун</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Асмера</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Канарска острва</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Сеута</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Мадрид</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Адис Абеба</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Хелсинки</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Фиџи</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Стенли</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Трук</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Понапе</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Кошре</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Фарска Острва</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>Париз</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Либревил</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>Лондон</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Гренада</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Тбилиси</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Кајен</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Гернзи</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Акра</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Гибралтар</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Тул</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Готхаб</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Скорезбисунд</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Данмарксхаген</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Банжул</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Конакри</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Гвадалупе</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Малабо</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Атина</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Јужна Џорџија</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Гватемала</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Гуам</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Бисао</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Гвајана</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Хонг Конг</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Тегусигалпа</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Загреб</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Порт-о-Пренс</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Будимпешта</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Џакарта</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Понтијанак</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Макасар</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Џајапура</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Даблин</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Јерусалим</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Острво Ман</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Калкута</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Чагос</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Багдад</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Техеран</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Рејкјавик</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Рим</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Џерси</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Јамајка</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Аман</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Токио</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Најроби</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Бишкек</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Пном Пен</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Ендербери</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Киритимати</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Тарава</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Коморо</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>Сент Китс</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Пјонгјанг</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Сеул</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Кувајт</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Кајманска Острва</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Актау</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Орал</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Акутобе</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Кизилорда</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Алмати</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Вијентијан</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Бејрут</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>Св. Луција</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Вадуз</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Коломбо</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Монровија</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Масеру</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Вилњус</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Луксембург</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Рига</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Триполи</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Казабланка</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Монако</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Кишињев</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Подгорица</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Мариго</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Антананариво</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Кваџалејин</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Мајуро</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Скопље</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Бамако</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Рангун</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Ховд</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Улан Батор</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Чојбалсан</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Макао</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Сајпан</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Мартиник</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Нуакшот</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Монтсерат</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Малта</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Маурицијус</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Малдиви</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Блантир</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Тихуана</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Санта Изабел</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Хермосиљо</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Мазатлан</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Чихуахуа</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Баија Бандерас</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Охинага</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Монтереј</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Мексико Сити</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Матаморос</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Мерида</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Канкун</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Куала Лумпур</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Кучинг</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Мапуто</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Виндхук</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Нумеа</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Нијамеј</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Норфолк</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Лагос</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Манагва</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Амстердам</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Осло</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Катманду</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Науру</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Ниуе</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Чатам</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Окланд</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Мускат</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Панама</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Лима</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Тахити</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Маркиз</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Гамбије</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Порт Морзби</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>Буганвил</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Манила</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Карачи</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Варшава</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Микелон</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Питкерн</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Порто Рико</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Газа</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Хеброн</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Азори</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Мадеира</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Лисабон</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Палау</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Асунсион</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Катар</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Реунион</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Букурешт</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Београд</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Калињинград</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Симферопољ</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Москва</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Волгоград</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Самара</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Јекатеринбург</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Омск</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Новосибирск</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Новокузњецк</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Краснојарск</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Иркуцк</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>Чита</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Јакутск</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Владивосток</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Хандига</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Сахалин</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Уст-Нера</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Магадан</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>Средњеколимск</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Камчатка</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Анадир</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Кигали</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Ријад</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Гвадалканал</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Махе</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Картум</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Стокхолм</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Сингапур</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>Света Јелена</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Љубљана</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Лонгјербјен</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Братислава</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Фритаун</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>Сан Марино</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Дакар</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Могадиш</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Парамарибо</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Џуба</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>Сао Томе</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>Салвадор</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Лоуер Принсиз Квортер</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Дамаск</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Мбабане</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Гранд Турк</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>Нџамена</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Кергелен</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Ломе</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Банкок</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Душанбе</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Факаофо</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Дили</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Ашхабад</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Тунис</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Тонгатапу</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Истанбул</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Порт оф Спејн</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Фунафути</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Тајпеј</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Дар-ес-Салам</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Ужгород</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Кијев</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Запорожје</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Кампала</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Мидвеј</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Џонстон</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Вејк</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Адак</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Ном</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Хонолулу</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Енкориџ</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Јакутат</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Ситка</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Жуно</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Метлакатла</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Лос Анђелес</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Бојзи</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Финикс</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Денвер</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Бијула, Северна Дакота</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>Нови Салем, Северна Дакота</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Центар, Северна Дакота</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Чикаго</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Меномини</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Винценес, Индијана</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Питерсбург, Индијана</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Тел Сити</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Нокс, Индијана</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Винамак, Индијана</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Маренго, Индијана</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Индианаполис</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Луивиле</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Вевај, Индијана</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Монтичело, Кентаки</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Детроит</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>Њујорк</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Монтевидео</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Самарканд</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Ташкент</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Ватикан</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>Сент Винсент</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Каракас</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Тортола</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>Св. Тома</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Хо Ши Мин</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Ефат</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Валис</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Апија</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Аден</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Мајот</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Јоханесбург</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Лусака</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Хараре</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.sr_Latn.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.sr_Latn.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="sr-Latn" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>Nepoznat grad</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Andora</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Dubai</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Kabul</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Antigva</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Angvila</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Tirana</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Jerevan</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Luanda</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Rotera</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Palmer</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Trol</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Šova</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Moson</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Dejvis</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Vostok</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Kejsi</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Dimon d’Urvil</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>Makmurdo</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Rio Gelegos</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Mendosa</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>San Huan</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ušuaija</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>La Rioha</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>San Lui</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Katamarka</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Salta</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Žužui</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Tukuman</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Kordoba</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Buenos Ajres</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Pago Pago</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Beč</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Pert</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Iukla</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Darvin</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Adelejd</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Broken Hil</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Kari</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Melburn</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Hobart</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Lindeman</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Sidnej</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Brizbejn</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Mekvori</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Lord Hau</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Aruba</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Marihamn</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Baku</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Sarajevo</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Barbados</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Daka</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Brisel</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Uagadugu</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>Sofija</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Bahrein</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Budžumbura</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Porto Novo</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>Sv. Bartolomej</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Bermuda</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Bruneji</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>La Paz</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Kralendajk</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Eirunepe</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Rio Branko</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Porto Veljo</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Boa Vista</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Manaus</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Kuiaba</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Santarem</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Kampo Grande</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Belem</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Aragvajana</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>Sao Paolo</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Baija</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Fortaleza</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Masejo</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Resife</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Noronja</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Nasau</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Timpu</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Gaboron</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Minsk</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Belize</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Doson</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Vajthors</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Inuvik</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Vankuver</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Doson Krik</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Kreston</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Jelounajf</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Edmonton</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Svift Kurent</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Kembridž Bej</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Regina</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Vinipeg</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Resolut</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Rejni River</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Rankin Inlet</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Koral Harbur</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Tander Bej</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Nipigon</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Toronto</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Ikvaluit</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Pangnirtung</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Monkton</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Halifaks</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Gus Bej</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Glejs Bej</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Blank-Sejblon</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>Sv. Džon</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Kokos</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Kinšasa</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Lubumbaši</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Bangui</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Brazavil</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Cirih</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Abidžan</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Rarotonga</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Uskršnje ostrvo</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Santjago</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Duala</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Urumkvi</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Šangaj</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Bogota</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Kostarika</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Havana</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Zelenortska Ostrva</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Kiraso</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Božić</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Nikozija</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Prag</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Bisingen</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Berlin</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Džibuti</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Kopenhagen</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Dominika</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Santo Domingo</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Alžir</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Galapagos</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Gvajakil</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Talin</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Kairo</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>El Ajun</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Asmera</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Kanarska ostrva</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Seuta</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Madrid</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Adis Abeba</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Helsinki</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Fidži</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Stenli</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Truk</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Ponape</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Košre</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Farska Ostrva</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>Pariz</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Librevil</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>London</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Grenada</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Tbilisi</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Kajen</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Gernzi</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Akra</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Gibraltar</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Tul</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Gothab</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Skorezbisund</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Danmarkshagen</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Banžul</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Konakri</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Gvadalupe</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Malabo</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Atina</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Južna Džordžija</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Gvatemala</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Guam</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Bisao</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Gvajana</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Hong Kong</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Tegusigalpa</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Zagreb</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Port-o-Prens</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Budimpešta</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Džakarta</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Pontijanak</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Makasar</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Džajapura</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Dablin</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Jerusalim</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Ostrvo Man</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Kalkuta</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Čagos</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Bagdad</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Teheran</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Rejkjavik</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Rim</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Džersi</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Jamajka</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Aman</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Tokio</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Najrobi</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Biškek</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Pnom Pen</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Enderberi</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Kiritimati</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Tarava</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Komoro</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>Sent Kits</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Pjongjang</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Seul</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Kuvajt</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Kajmanska Ostrva</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Aktau</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Oral</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Akutobe</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Kizilorda</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Almati</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Vijentijan</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Bejrut</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>Sv. Lucija</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Vaduz</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Kolombo</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Monrovija</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Maseru</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Vilnjus</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Luksemburg</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Riga</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Tripoli</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Kazablanka</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Monako</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Kišinjev</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Podgorica</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Marigo</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Antananarivo</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Kvadžalejin</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Majuro</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Skoplje</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Bamako</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Rangun</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Hovd</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Ulan Bator</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Čojbalsan</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Makao</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Sajpan</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Martinik</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Nuakšot</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Montserat</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Malta</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Mauricijus</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Maldivi</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Blantir</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Tihuana</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Santa Izabel</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Hermosiljo</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Mazatlan</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Čihuahua</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Baija Banderas</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Ohinaga</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Monterej</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Meksiko Siti</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Matamoros</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Merida</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Kankun</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Kuala Lumpur</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Kučing</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Maputo</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Vindhuk</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Numea</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Nijamej</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Norfolk</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Lagos</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Managva</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Amsterdam</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Oslo</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Katmandu</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Nauru</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Niue</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Čatam</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Okland</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Muskat</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Panama</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Lima</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Tahiti</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Markiz</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Gambije</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Port Morzbi</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>Buganvil</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Manila</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Karači</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Varšava</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Mikelon</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Pitkern</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Porto Riko</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Gaza</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Hebron</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Azori</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Madeira</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Lisabon</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Palau</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Asunsion</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Katar</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Reunion</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Bukurešt</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Beograd</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Kalinjingrad</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Simferopolj</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Moskva</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Volgograd</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Samara</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Jekaterinburg</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Omsk</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Novosibirsk</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Novokuznjeck</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Krasnojarsk</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Irkuck</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>Čita</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Jakutsk</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Vladivostok</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Handiga</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Sahalin</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Ust-Nera</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Magadan</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>Srednjekolimsk</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Kamčatka</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Anadir</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Kigali</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Rijad</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Gvadalkanal</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Mahe</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Kartum</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Stokholm</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Singapur</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>Sveta Jelena</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Ljubljana</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Longjerbjen</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Bratislava</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Fritaun</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>San Marino</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Dakar</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Mogadiš</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Paramaribo</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Džuba</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>Sao Tome</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>Salvador</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Louer Prinsiz Kvorter</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Damask</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Mbabane</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Grand Turk</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>Ndžamena</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Kergelen</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Lome</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Bankok</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Dušanbe</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Fakaofo</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Dili</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Ašhabad</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Tunis</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Tongatapu</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Istanbul</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Port of Spejn</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Funafuti</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Tajpej</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Dar-es-Salam</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Užgorod</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Kijev</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Zaporožje</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Kampala</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Midvej</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Džonston</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Vejk</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Adak</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Nom</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Honolulu</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Enkoridž</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Jakutat</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Sitka</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Žuno</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Metlakatla</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Los Anđeles</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Bojzi</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Finiks</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Denver</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Bijula, Severna Dakota</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>Novi Salem, Severna Dakota</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Centar, Severna Dakota</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Čikago</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Menomini</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Vincenes, Indijana</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Pitersburg, Indijana</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Tel Siti</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Noks, Indijana</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Vinamak, Indijana</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Marengo, Indijana</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Indianapolis</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Luivile</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Vevaj, Indijana</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Montičelo, Kentaki</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Detroit</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>Njujork</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Montevideo</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Samarkand</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Taškent</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Vatikan</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>Sent Vinsent</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Karakas</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Tortola</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>Sv. Toma</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Ho Ši Min</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Efat</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Valis</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Apija</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Aden</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Majot</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Johanesburg</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Lusaka</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Harare</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.sv.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.sv.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="sv" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>okänd stad</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Andorra</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Dubai</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Kabul</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Antigua</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Anguilla</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Tirana</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Jerevan</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Luanda</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Rothera</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Palmer</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Troll</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Syowa</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Mawson</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Davis</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Vostok</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Casey</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Dumont d’Urville</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>McMurdo</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Río Gallegos</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Mendoza</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>San Juan</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ushuaia</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>La Rioja</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>San Luis</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Catamarca</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Salta</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>San Salvador de Jujuy</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Tucumán</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Córdoba</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Buenos Aires</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Pago Pago</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Wien</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Perth</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Eucla</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Darwin</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Adelaide</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Broken Hill</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Currie</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Melbourne</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Hobart</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Lindeman</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Sydney</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Brisbane</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Macquarie</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Lord Howe</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Aruba</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Mariehamn</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Baku</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Sarajevo</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Barbados</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Dhaka</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Bryssel</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Ouagadougou</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>Sofia</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Bahrain</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Bujumbura</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Porto-Novo</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>S:t Barthélemy</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Bermuda</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Brunei</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>La Paz</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Kralendijk</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Eirunepé</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Rio Branco</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Porto Velho</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Boa Vista</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Manaus</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Cuiabá</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Santarém</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Campo Grande</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Belém</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Araguaína</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>São Paulo</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Bahia</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Fortaleza</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Maceió</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Recife</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Fernando de Noronha</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Nassau</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Thimphu</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Gaborone</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Minsk</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Belize</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Dawson</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Whitehorse</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Inuvik</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Vancouver</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Dawson Creek</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Creston</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Yellowknife</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Edmonton</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Swift Current</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Cambridge Bay</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Regina</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Winnipeg</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Resolute</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Rainy River</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Rankin Inlet</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Atikokan</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Thunder Bay</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Nipigon</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Toronto</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Iqaluit</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Pangnirtung</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Moncton</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Halifax</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Goose Bay</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Glace Bay</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Blanc-Sablon</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>S:t Johns</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Kokosöarna</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Kinshasa</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Lubumbashi</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Bangui</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Brazzaville</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Zürich</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Abidjan</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Rarotonga</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Påskön</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Santiago</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Douala</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Ürümqi</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Shanghai</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Bogotá</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Costa Rica</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Havanna</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Kap Verde</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Curaçao</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Julön</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Nicosia</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Prag</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Büsingen am Hochrhein</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Berlin</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Djibouti</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Köpenhamn</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Dominica</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Santo Domingo</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Alger</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Galápagos</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Guayaquil</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Tallinn</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Kairo</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>El-Aaiún</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Asmara</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Kanarieöarna</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Ceuta</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Madrid</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Addis Abeba</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Helsingfors</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Fiji</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Stanley</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Chuuk</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Pohnpei</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Kosrae</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Torshamn</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>Paris</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Libreville</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>London</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Grenada</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Tbilisi</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Cayenne</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Guernsey</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Accra</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Gibraltar</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Qaanaaq</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Nuuk</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Ittoqqortoormiit</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Danmarkshavn</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Banjul</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Conakry</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Guadeloupe</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Malabo</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Aten</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Sydgeorgien</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Guatemala</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Guam</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Bissau</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Guyana</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Hongkong</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Tegucigalpa</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Zagreb</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Port-au-Prince</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Budapest</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Jakarta</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Pontianak</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Makassar</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Jayapura</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Dublin</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Jerusalem</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Isle of Man</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Kolkata</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Chagosöarna</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Bagdad</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Teheran</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Reykjavik</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Rom</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Jersey</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Jamaica</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Amman</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Tokyo</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Nairobi</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Bisjkek</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Phnom Penh</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Enderbury</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Kiritimati</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Tarawa</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Komorerna</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>S:t Kitts</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Pyongyang</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Söul</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Kuwait</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Caymanöarna</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Aktau</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Oral</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Aqtöbe</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Qyzylorda</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Alma-Ata</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>Vientiane</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Beirut</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>S:t Lucia</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Vaduz</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Colombo</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Monrovia</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Maseru</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Vilnius</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Luxemburg</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Riga</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Tripoli</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Casablanca</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Monaco</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Chișinău</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Podgorica</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Marigot</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Antananarivo</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Kwajalein</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Majuro</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Skopje</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Bamako</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Rangoon</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Chovd</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Ulaanbaatar</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Tjojbalsan</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Macao</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Saipan</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Martinique</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Nouakchott</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Montserrat</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Malta</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Mauritius</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Maldiverna</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Blantyre</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Tijuana</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Santa Isabel</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Hermosillo</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Mazatlán</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Chihuahua</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Bahía de Banderas</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Ojinaga</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Monterrey</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Mexico City</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Matamoros</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Mérida</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Cancún</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Kuala Lumpur</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Kuching</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Maputo</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Windhoek</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Nouméa</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Niamey</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Norfolk</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Lagos</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Managua</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Amsterdam</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Oslo</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Katmandu</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Nauru</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Niue</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Chatham</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Auckland</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Muskat</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Panama</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Lima</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Tahiti</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Marquesasöarna</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Gambieröarna</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Port Moresby</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>Bougainville</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Manilla</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Karachi</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Warszawa</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Miquelon</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Pitcairnöarna</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Puerto Rico</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Gaza</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Hebron</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Azorerna</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Madeira</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Lissabon</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Palau</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Asunción</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Qatar</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Réunion</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Bukarest</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Belgrad</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Kaliningrad</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Simferopol</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Moskva</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Volgograd</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Samara</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Jekaterinburg</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Omsk</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Novosibirsk</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Novokuznetsk</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Krasnojarsk</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Irkutsk</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>Tjita</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Jakutsk</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Vladivostok</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Chandyga</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Sachalin</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Ust-Nera</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Magadan</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>Srednekolymsk</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Kamtjatka</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Anadyr</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Kigali</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Riyadh</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Guadalcanal</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Mahé</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Khartoum</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Stockholm</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Singapore</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>S:t Helena</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Ljubljana</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Longyearbyen</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Bratislava</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Freetown</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>San Marino</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Dakar</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Mogadishu</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Paramaribo</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Juba</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>São Tomé</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>El Salvador</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Lower Prince’s Quarter</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Damaskus</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Mbabane</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Grand Turk</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>N’Djamena</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Kerguelenöarna</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Lomé</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Bangkok</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Dusjanbe</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Fakaofo</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Dili</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Asjchabad</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Tunis</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Tongatapu</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Istanbul</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Port of Spain</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Funafuti</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Taipei</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Dar es-Salaam</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Uzjhorod</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Kiev</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Zaporizjzja</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Kampala</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Midwayöarna</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Johnstonatollen</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Wake</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Adak</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Nome</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Honolulu</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Anchorage</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Yakutat</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Sitka</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Juneau</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Metlakatla</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Los Angeles</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Boise</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Phoenix</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Denver</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Beulah, North Dakota</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>New Salem, North Dakota</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Center, North Dakota</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Chicago</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Menominee</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Vincennes, Indiana</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Petersburg, Indiana</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Tell City, Indiana</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Knox, Indiana</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Winamac, Indiana</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Marengo, Indiana</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Indianapolis</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Louisville</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Vevay, Indiana</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Monticello, Kentucky</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Detroit</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>New York</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Montevideo</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Samarkand</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Tasjkent</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Vatikanen</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>S:t Vincent</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Caracas</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Tortola</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>S:t Thomas</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Ho Chi Minh-staden</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Efate</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Wallisön</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Apia</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Aden</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Mayotte</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Johannesburg</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Lusaka</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Harare</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.uk.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.uk.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="uk" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>Невідоме місто</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>Андорра</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>Дубаї</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>Кабул</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>Антигуа</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>Ангілья</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>Тирана</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>Єреван</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>Луанда</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>Ротера</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>Палмер</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>Тролл</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>Сьова</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>Моусон</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>Девіс</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>Восток</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>Кейсі</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>Дюмон-дʼЮрвіль</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>Мак-Мердо</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>Ріо-Гальєгос</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>Мендоса</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>Сан-Хуан</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>Ушуая</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>Ла-Ріоха</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>Сан-Луїс</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>Катамарка</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>Сальта</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>Жужуй</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>Тукуман</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>Кордоба</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>Буенос-Айрес</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>Паго-Паго</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>Відень</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>Перт</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>Евкла</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>Дарвін</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>Аделаїда</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>Брокен-Хілл</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>Каррі</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>Мельбурн</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>Гобарт</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>Ліндеман</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>Сідней</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>Брісбен</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>Маккуорі</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>Лорд-Хау</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>Аруба</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>Марієгамн</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>Баку</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>Сараєво</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>Барбадос</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>Дакка</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>Брюссель</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>Уагадугу</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>Софія</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>Бахрейн</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>Бужумбура</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>Порто-Ново</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>Сен-Бартельмі</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>Бермуди</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>Бруней</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>Ла-Пас</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>Кралендейк</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>Ейрунепе</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>Ріо-Бранко</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>Порту-Велью</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>Боа-Віста</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>Манаус</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>Куяба</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>Сантарен</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>Кампу-Гранді</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>Белен</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>Арагуайна</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>Сан-Паулу</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>Байя</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>Форталеза</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>Масейо</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>Ресіфі</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>Норонья</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>Насау</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>Тхімпху</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>Габороне</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>Мінськ</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>Беліз</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>Доусон</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>Вайтгорс</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>Інувік</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>Ванкувер</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>Доусон-Крік</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>Крестон</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>Єллоунайф</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>Едмонтон</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>Свіфт-Каррент</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>Кембридж-Бей</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>Реджайна</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>Вінніпег</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>Резолют</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>Рейні-Рівер</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>Ренкін-Інлет</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>Корал-Гарбор</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>Тандер-Бей</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>Ніпігон</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>Торонто</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>Ікалуїт</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>Пангніртанг</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>Монктон</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>Галіфакс</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>Гуз-Бей</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>Глейс-Бей</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>Бланк-Саблон</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>Сент-Джонс</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>Кокосові острови</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>Кіншаса</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>Лубумбаші</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>Бангі</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>Браззавіль</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>Цюрих</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>Абіджан</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>Раротонга</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>Острів Пасхи</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>Сантьяго</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>Дуала</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>Урумчі</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>Шанхай</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>Богота</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>Коста-Рика</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>Гавана</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>Кабо-Верде</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>Кюрасао</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>Острів Різдва</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>Нікосія</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>Прага</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>Бюзінген</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>Берлін</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>Джибуті</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>Копенгаген</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>Домініка</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>Санто-Домінго</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>Алжир</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>Галапагоські острови</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>Гуаякіль</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>Таллінн</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>Каїр</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>Ель-Аюн</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>Асмара</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>Канари</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>Сеута</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>Мадрид</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>Аддис-Абеба</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>Гельсінкі</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>Фіджі</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>Стенлі</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>Трук</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>Понапе</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>Косрае</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>Фарерські острови</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>Париж</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>Лібревіль</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>Лондон</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>Гренада</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>Тбілісі</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>Каєнна</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>Гернсі</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>Аккра</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>Гібралтар</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>Туле</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>Нуук</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>Іттоккортоорміут</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>Денмарксхавн</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>Банжул</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>Конакрі</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>Гваделупа</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>Малабо</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>Афіни</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>Південна Джорджія</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>Гватемала</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>Гуам</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>Бісау</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>Гаяна</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>Гонконг</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>Тегусігальпа</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>Загреб</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>Порт-о-Пренс</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>Будапешт</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>Джакарта</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>Понтіанак</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>Макассар</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>Джайпур</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>Дублін</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>Єрусалим</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>Острів Мен</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>Колката</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>Чагос</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>Багдад</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>Тегеран</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>Рейкʼявік</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>Рим</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>Джерсі</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>Ямайка</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>Амман</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>Токіо</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>Найробі</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>Бішкек</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>Пномпень</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>Ендербері</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>Кірітіматі</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>Тарава</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>Коморські острови</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>Сент-Кітс</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>Пхеньян</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>Сеул</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>Кувейт</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>Кайманові острови</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>Актау</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>Орал</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>Актобе</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>Кизилорда</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>Алмати</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>В’єнтьян</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>Бейрут</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>Сент-Люсія</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>Вадуц</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>Коломбо</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>Монровія</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>Масеру</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>Вільнюс</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>Люксембург</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>Рига</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>Триполі</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>Касабланка</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>Монако</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>Кишинів</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>Подгориця</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>Маріго</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>Антананаріву</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>Кваджалейн</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>Маджуро</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>Скоп’є</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>Бамако</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>Янгон</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>Ховд</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>Улан-Батор</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>Чойбалсан</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>Макао</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>Сайпан</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>Мартиніка</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>Нуакшот</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>Монсеррат</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>Мальта</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>Маврикій</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>Мальдіви</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>Блантир</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>Тіхуана</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>Санта-Ісабель</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>Ермосільйо</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>Масатлан</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>Чіуауа</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>Баїя Бандерас</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>Охінага</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>Монтерей</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>Мехіко</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>Матаморос</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>Меріда</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>Канкун</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>Куала-Лумпур</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>Кучінг</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>Мапуту</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>Віндгук</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>Нумеа</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>Ніамей</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>Норфолк</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>Лагос</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>Манагуа</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>Амстердам</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>Осло</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>Катманду</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>Науру</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>Ніуе</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>Чатем</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>Окленд</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>Маскат</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>Панама</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>Ліма</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>Таїті</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>Маркізькі острови</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>Гамбер</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>Порт-Морсбі</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>Бугенвіль</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>Маніла</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>Карачі</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>Варшава</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>Мікелон</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>Піткерн</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>Пуерто-Рико</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>Газа</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>Хеврон</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>Азорські острови</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>Мадейра</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>Лісабон</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>Палау</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>Асунсьйон</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>Катар</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>Реюньйон</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>Бухарест</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>Белград</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>Калінінград</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>Сімферополь</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>Москва</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>Волгоград</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>Самара</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>Єкатеринбург</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>Омськ</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>Новосибірськ</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>Новокузнецьк</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>Красноярськ</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>Іркутськ</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>Чита</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>Якутськ</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>Владивосток</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>Хандига</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>Сахалін</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>Усть-Нера</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>Магадан</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>Середньоколимськ</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>Камчатка</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>Анадир</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>Кігалі</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>Ер-Ріяд</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>Гвадалканал</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>Махе</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>Хартум</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>Стокгольм</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>Сінгапур</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>Острів Святої Єлени</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>Любляна</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>Лонг’їр</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>Братислава</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>Фрітаун</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>Сан-Марино</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>Дакар</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>Могадишо</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>Парамарибо</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>Джуба</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>Сан-Томе</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>Сальвадор</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>Лоуер-Принсес-Квотер</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>Дамаск</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>Мбабане</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>Гранд-Терк</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>Нджамена</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>Кергелен</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>Ломе</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>Бангкок</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>Душанбе</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>Факаофо</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>Ділі</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>Ашгабат</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>Туніс</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>Тонгатапу</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>Стамбул</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>Порт-оф-Спейн</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>Фунафуті</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>Тайбей</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>Дар-ес-Салам</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>Ужгород</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>Київ</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>Запоріжжя</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>Кампала</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>Мідвей</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>Джонстон</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>Вейк</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>Адак</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>Ном</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>Гонолулу</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>Анкоридж</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>Якутат</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>Сітка</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>Джуно</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>Метлакатла</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>Лос-Анджелес</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>Бойсе</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>Фінікс</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>Денвер</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>Б’юла, Північна Дакота</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>Нью-Салем, Північна Дакота</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>Центр, Північна Дакота</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>Чикаго</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>Меноміні</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>Вінсенс, Індіана</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>Пітерсберг, Індіана</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>Телл Сіті, Індіана</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>Нокс, Індіана</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>Вінамак, Індіана</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>Маренго, Індіана</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>Індіанаполіс</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>Луїсвілл</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>Вівей, Індіана</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>Монтічелло, Кентуккі</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>Детройт</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>Нью-Йорк</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>Монтевідео</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>Самарканд</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>Ташкент</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>Ватикан</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>Сент-Вінсент</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>Каракас</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>Тортола</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>Сент-Томас</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>Хошимін</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>Ефате</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>Волліс</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>Апіа</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>Аден</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>Майотта</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>Йоганнесбург</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>Лусака</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>Хараре</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/timezones.zh_CN.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/timezones.zh_CN.xlf
@@ -1,0 +1,1675 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="zh-CN" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="88183b946cc5f0e8c96b2e66e1c74a7e" resname="Unknown">
+        <source>Unknown</source>
+        <target>未知城市</target>
+      </trans-unit>
+      <trans-unit id="68746a7280b143cfc01f967610d3e86d" resname="Andorra">
+        <source>Andorra</source>
+        <target>安道尔</target>
+      </trans-unit>
+      <trans-unit id="23b998b19b5f60dbbc4eedc53328b0c7" resname="Dubai">
+        <source>Dubai</source>
+        <target>迪拜</target>
+      </trans-unit>
+      <trans-unit id="1e092a650984d90d9603620d4b36c255" resname="Kabul">
+        <source>Kabul</source>
+        <target>喀布尔</target>
+      </trans-unit>
+      <trans-unit id="96d833ae2c9a8a323465a459f1927f8b" resname="Antigua">
+        <source>Antigua</source>
+        <target>安提瓜</target>
+      </trans-unit>
+      <trans-unit id="cedfc05affe8143cc552076e77407863" resname="Anguilla">
+        <source>Anguilla</source>
+        <target>安圭拉</target>
+      </trans-unit>
+      <trans-unit id="d4db7bd1a57896923fda960f075a86ea" resname="Tirane">
+        <source>Tirane</source>
+        <target>地拉那</target>
+      </trans-unit>
+      <trans-unit id="06d3be641f6cc1104f650889d4047c67" resname="Yerevan">
+        <source>Yerevan</source>
+        <target>埃里温</target>
+      </trans-unit>
+      <trans-unit id="2d20c677063489ac1dd757cddfc62ed0" resname="Luanda">
+        <source>Luanda</source>
+        <target>罗安达</target>
+      </trans-unit>
+      <trans-unit id="cc1af030375640559b2875ad2122ca51" resname="Rothera">
+        <source>Rothera</source>
+        <target>罗瑟拉</target>
+      </trans-unit>
+      <trans-unit id="fb8c1806064c04593ecbcea0d561e900" resname="Palmer">
+        <source>Palmer</source>
+        <target>帕默尔</target>
+      </trans-unit>
+      <trans-unit id="922a511f02d148e4c9390526d85ca519" resname="Troll">
+        <source>Troll</source>
+        <target>特罗尔</target>
+      </trans-unit>
+      <trans-unit id="5aab3e11eefe4d9535556d5a6da8c8c1" resname="Syowa">
+        <source>Syowa</source>
+        <target>昭和</target>
+      </trans-unit>
+      <trans-unit id="38cfaed132b7d0bf89d4b9fdb2a3e043" resname="Mawson">
+        <source>Mawson</source>
+        <target>莫森</target>
+      </trans-unit>
+      <trans-unit id="8f2d58e32d065296e0ddcff5f6509a9f" resname="Davis">
+        <source>Davis</source>
+        <target>戴维斯</target>
+      </trans-unit>
+      <trans-unit id="31f04e8bfb6e05b3a41c47603eef5e33" resname="Vostok">
+        <source>Vostok</source>
+        <target>沃斯托克</target>
+      </trans-unit>
+      <trans-unit id="53cfbe4334e1550bd5201dfffb627317" resname="Casey">
+        <source>Casey</source>
+        <target>卡塞</target>
+      </trans-unit>
+      <trans-unit id="c21af64788307c2a625ddf063b16434c" resname="DumontDUrville">
+        <source>DumontDUrville</source>
+        <target>迪蒙迪尔维尔</target>
+      </trans-unit>
+      <trans-unit id="9d372f0a95f71e0c5e54449d14746df5" resname="McMurdo">
+        <source>McMurdo</source>
+        <target>麦克默多</target>
+      </trans-unit>
+      <trans-unit id="c45998477e748cf978e8bd35d26e5818" resname="Argentina - Rio Gallegos">
+        <source>Argentina - Rio Gallegos</source>
+        <target>里奥加耶戈斯</target>
+      </trans-unit>
+      <trans-unit id="1515960435c336515e9dca50c0f0df07" resname="Mendoza">
+        <source>Mendoza</source>
+        <target>门多萨</target>
+      </trans-unit>
+      <trans-unit id="c0f15fd3fae3f15e2c7042d1622e0ed1" resname="Argentina - San Juan">
+        <source>Argentina - San Juan</source>
+        <target>圣胡安</target>
+      </trans-unit>
+      <trans-unit id="0edaed5fac9762c1024015cfd2ba4535" resname="Argentina - Ushuaia">
+        <source>Argentina - Ushuaia</source>
+        <target>乌斯怀亚</target>
+      </trans-unit>
+      <trans-unit id="478429be15473e562c7dac2c4ea14bfa" resname="Argentina - La Rioja">
+        <source>Argentina - La Rioja</source>
+        <target>拉里奥哈</target>
+      </trans-unit>
+      <trans-unit id="1a3027ab539e36a122bf62bb929a6619" resname="Argentina - San Luis">
+        <source>Argentina - San Luis</source>
+        <target>圣路易斯</target>
+      </trans-unit>
+      <trans-unit id="0e0ad069acb8317acbb92223b8aea816" resname="Catamarca">
+        <source>Catamarca</source>
+        <target>卡塔马卡</target>
+      </trans-unit>
+      <trans-unit id="15ae618256506d0eb0130105cd23bae3" resname="Argentina - Salta">
+        <source>Argentina - Salta</source>
+        <target>萨尔塔</target>
+      </trans-unit>
+      <trans-unit id="23e65d0041b99b6709502af0b3e9dd53" resname="Jujuy">
+        <source>Jujuy</source>
+        <target>胡胡伊</target>
+      </trans-unit>
+      <trans-unit id="289140528d5b5147ed7be0fa818e82c1" resname="Argentina - Tucuman">
+        <source>Argentina - Tucuman</source>
+        <target>图库曼</target>
+      </trans-unit>
+      <trans-unit id="10c0f9ef36fc112872490e11a8c43a59" resname="Cordoba">
+        <source>Cordoba</source>
+        <target>科尔多瓦</target>
+      </trans-unit>
+      <trans-unit id="464f18360a31a99b8003db4c668244c0" resname="Buenos Aires">
+        <source>Buenos Aires</source>
+        <target>布宜诺斯艾利斯</target>
+      </trans-unit>
+      <trans-unit id="b2e5acba707d46f24d4720d3f93b2d86" resname="Pago Pago">
+        <source>Pago Pago</source>
+        <target>帕果帕果</target>
+      </trans-unit>
+      <trans-unit id="601f9226a92f0a314068aa4395f65528" resname="Vienna">
+        <source>Vienna</source>
+        <target>维也纳</target>
+      </trans-unit>
+      <trans-unit id="4bc44fa25c7afaf63618e6586084052e" resname="Perth">
+        <source>Perth</source>
+        <target>珀斯</target>
+      </trans-unit>
+      <trans-unit id="f091d4a02278c145746dc2e9b23560a3" resname="Eucla">
+        <source>Eucla</source>
+        <target>尤克拉</target>
+      </trans-unit>
+      <trans-unit id="a4bd01593487c956f68d360c18cb68b3" resname="Darwin">
+        <source>Darwin</source>
+        <target>达尔文</target>
+      </trans-unit>
+      <trans-unit id="a02f9768660497d370831df932feeeaf" resname="Adelaide">
+        <source>Adelaide</source>
+        <target>阿德莱德</target>
+      </trans-unit>
+      <trans-unit id="d79ed1dc3a91483e2ed57285db6a373e" resname="Broken Hill">
+        <source>Broken Hill</source>
+        <target>布罗肯希尔</target>
+      </trans-unit>
+      <trans-unit id="8387af48a68ebde0000b7acff8df82d5" resname="Currie">
+        <source>Currie</source>
+        <target>库利</target>
+      </trans-unit>
+      <trans-unit id="7c885b9c7c703a77befcabeea54944d5" resname="Melbourne">
+        <source>Melbourne</source>
+        <target>墨尔本</target>
+      </trans-unit>
+      <trans-unit id="9f610f074be03799cf1727a85127ab55" resname="Hobart">
+        <source>Hobart</source>
+        <target>霍巴特</target>
+      </trans-unit>
+      <trans-unit id="c5fc3ddf45caf05a2585677dca0aa850" resname="Lindeman">
+        <source>Lindeman</source>
+        <target>林德曼</target>
+      </trans-unit>
+      <trans-unit id="1fc91e86962825bb745de53d1657b3e4" resname="Sydney">
+        <source>Sydney</source>
+        <target>悉尼</target>
+      </trans-unit>
+      <trans-unit id="759302fb84c5f72078746e7358ba44a0" resname="Brisbane">
+        <source>Brisbane</source>
+        <target>布里斯班</target>
+      </trans-unit>
+      <trans-unit id="72ad64780fa067fcfa35ad4c7342cafb" resname="Macquarie">
+        <source>Macquarie</source>
+        <target>麦格理</target>
+      </trans-unit>
+      <trans-unit id="93f4d190e0f3df7a5183de12e70ec067" resname="Lord Howe">
+        <source>Lord Howe</source>
+        <target>豪勋爵</target>
+      </trans-unit>
+      <trans-unit id="4893b64051cf425047ddd8606dae25f4" resname="Aruba">
+        <source>Aruba</source>
+        <target>阿鲁巴</target>
+      </trans-unit>
+      <trans-unit id="b68111046d878713aeb8129f9312bcf5" resname="Mariehamn">
+        <source>Mariehamn</source>
+        <target>玛丽港</target>
+      </trans-unit>
+      <trans-unit id="e057658af9b30b9ca28c53ad80b96082" resname="Baku">
+        <source>Baku</source>
+        <target>巴库</target>
+      </trans-unit>
+      <trans-unit id="45cb61a48b985856d8bf1cb545661858" resname="Sarajevo">
+        <source>Sarajevo</source>
+        <target>萨拉热窝</target>
+      </trans-unit>
+      <trans-unit id="3214c0f21d200a1dae4eb83a53ec2730" resname="Barbados">
+        <source>Barbados</source>
+        <target>巴巴多斯</target>
+      </trans-unit>
+      <trans-unit id="1855ebb6505036646e82ea9b2533600d" resname="Dhaka">
+        <source>Dhaka</source>
+        <target>达卡</target>
+      </trans-unit>
+      <trans-unit id="068a0b5b2858dc3f1ac7b47464bc4b0a" resname="Brussels">
+        <source>Brussels</source>
+        <target>布鲁塞尔</target>
+      </trans-unit>
+      <trans-unit id="5f80d62bcbab66ccc64f4728691bfb84" resname="Ouagadougou">
+        <source>Ouagadougou</source>
+        <target>瓦加杜古</target>
+      </trans-unit>
+      <trans-unit id="654cd76590cebe0ba37e8d4cce8a96ee" resname="Sofia">
+        <source>Sofia</source>
+        <target>索非亚</target>
+      </trans-unit>
+      <trans-unit id="6ddecd8ccd9f648d19dc02c7a566cb4f" resname="Bahrain">
+        <source>Bahrain</source>
+        <target>巴林</target>
+      </trans-unit>
+      <trans-unit id="04071b0344fabee53a68866567c8b6c1" resname="Bujumbura">
+        <source>Bujumbura</source>
+        <target>布琼布拉</target>
+      </trans-unit>
+      <trans-unit id="e902b23e856a66be0230aae8bae3f723" resname="Porto-Novo">
+        <source>Porto-Novo</source>
+        <target>波多诺伏</target>
+      </trans-unit>
+      <trans-unit id="ac699d4b11782cfe863fe22ac5297811" resname="St Barthelemy">
+        <source>St Barthelemy</source>
+        <target>圣巴泰勒米岛</target>
+      </trans-unit>
+      <trans-unit id="6653bea16d7ac8a266d752e9a0176c4f" resname="Bermuda">
+        <source>Bermuda</source>
+        <target>百慕大</target>
+      </trans-unit>
+      <trans-unit id="d3f5841f04ba23bb90e1b9f4256cea70" resname="Brunei">
+        <source>Brunei</source>
+        <target>文莱</target>
+      </trans-unit>
+      <trans-unit id="acb1984e3b62f9178cf7d9cd5bf04764" resname="La Paz">
+        <source>La Paz</source>
+        <target>拉巴斯</target>
+      </trans-unit>
+      <trans-unit id="5f10de19683078cd0b3ef40f3d9aa0b0" resname="Kralendijk">
+        <source>Kralendijk</source>
+        <target>克拉伦代克</target>
+      </trans-unit>
+      <trans-unit id="3fc15b9bccc30eb7346b4fdd272fffa7" resname="Eirunepe">
+        <source>Eirunepe</source>
+        <target>依伦尼贝</target>
+      </trans-unit>
+      <trans-unit id="58b1cd5387b316d949c858c9e32e788d" resname="Rio Branco">
+        <source>Rio Branco</source>
+        <target>里奥布郎库</target>
+      </trans-unit>
+      <trans-unit id="b8d48386b4e372505c3c9ffbcdbb96e3" resname="Porto Velho">
+        <source>Porto Velho</source>
+        <target>波多韦柳</target>
+      </trans-unit>
+      <trans-unit id="8836280f8d85af8505071c6be8e7868c" resname="Boa Vista">
+        <source>Boa Vista</source>
+        <target>博阿维斯塔</target>
+      </trans-unit>
+      <trans-unit id="c76d102bdf98e28f21e83331d783063c" resname="Manaus">
+        <source>Manaus</source>
+        <target>马瑙斯</target>
+      </trans-unit>
+      <trans-unit id="d8daf906d575449cfdf8fe295734408f" resname="Cuiaba">
+        <source>Cuiaba</source>
+        <target>库亚巴</target>
+      </trans-unit>
+      <trans-unit id="43280a6033e59aff116cee3044b8cfdf" resname="Santarem">
+        <source>Santarem</source>
+        <target>圣塔伦</target>
+      </trans-unit>
+      <trans-unit id="955281b4c4be6b20e301e8a9d0efd4d8" resname="Campo Grande">
+        <source>Campo Grande</source>
+        <target>大坎普</target>
+      </trans-unit>
+      <trans-unit id="90b0f7b4d90733b04d2993884cd0cc59" resname="Belem">
+        <source>Belem</source>
+        <target>贝伦</target>
+      </trans-unit>
+      <trans-unit id="fdf973d5bf007aab31b11d142b8a25c3" resname="Araguaina">
+        <source>Araguaina</source>
+        <target>阿拉瓜伊纳</target>
+      </trans-unit>
+      <trans-unit id="9fe567255d6e1674b1a88a5433c2558d" resname="Sao Paulo">
+        <source>Sao Paulo</source>
+        <target>圣保罗</target>
+      </trans-unit>
+      <trans-unit id="4147fcba3b166ba39ab0d88afdbbb6b2" resname="Bahia">
+        <source>Bahia</source>
+        <target>巴伊亚</target>
+      </trans-unit>
+      <trans-unit id="f81fb1d5572fed4fecd111dec0fdb543" resname="Fortaleza">
+        <source>Fortaleza</source>
+        <target>福塔雷萨</target>
+      </trans-unit>
+      <trans-unit id="6b8cc4514dcb0b31f027832fb868cc35" resname="Maceio">
+        <source>Maceio</source>
+        <target>马塞约</target>
+      </trans-unit>
+      <trans-unit id="3333e0547576547b14326cddd9329671" resname="Recife">
+        <source>Recife</source>
+        <target>累西腓</target>
+      </trans-unit>
+      <trans-unit id="ad3e325d733ec65a198c2d33605a9431" resname="Noronha">
+        <source>Noronha</source>
+        <target>洛罗尼亚</target>
+      </trans-unit>
+      <trans-unit id="b3a3a0c6d2cb7b5adc8d3568f73ad8b2" resname="Nassau">
+        <source>Nassau</source>
+        <target>拿骚</target>
+      </trans-unit>
+      <trans-unit id="c7548e8a3eb9fa1f66b3d8012e5efded" resname="Thimphu">
+        <source>Thimphu</source>
+        <target>廷布</target>
+      </trans-unit>
+      <trans-unit id="822b8dd5ad9692b16c9348578224a71e" resname="Gaborone">
+        <source>Gaborone</source>
+        <target>哈博罗内</target>
+      </trans-unit>
+      <trans-unit id="8787a878258ef18bb38d9163f41b846c" resname="Minsk">
+        <source>Minsk</source>
+        <target>明斯克</target>
+      </trans-unit>
+      <trans-unit id="20bca6785240fa722edb5c85d055a93d" resname="Belize">
+        <source>Belize</source>
+        <target>伯利兹</target>
+      </trans-unit>
+      <trans-unit id="51ea0114e5e7ba6a6cad70f1cd33b1b4" resname="Dawson">
+        <source>Dawson</source>
+        <target>道森</target>
+      </trans-unit>
+      <trans-unit id="99707c417d6e80b2f9866d45fca2b17f" resname="Whitehorse">
+        <source>Whitehorse</source>
+        <target>怀特霍斯</target>
+      </trans-unit>
+      <trans-unit id="584ab3cf38643bf0ea98e0291c8ea353" resname="Inuvik">
+        <source>Inuvik</source>
+        <target>伊努维克</target>
+      </trans-unit>
+      <trans-unit id="38278119f2c41ca7aedcbc55eabf73cd" resname="Vancouver">
+        <source>Vancouver</source>
+        <target>温哥华</target>
+      </trans-unit>
+      <trans-unit id="8fce32b6532ce47976c04a1d5edd4a60" resname="Dawson Creek">
+        <source>Dawson Creek</source>
+        <target>道森克里克</target>
+      </trans-unit>
+      <trans-unit id="86027ec8d5ee8b1be366402b608ff8e9" resname="Creston">
+        <source>Creston</source>
+        <target>克雷斯顿</target>
+      </trans-unit>
+      <trans-unit id="ceb792ea2986a5233f84f38750526ba6" resname="Yellowknife">
+        <source>Yellowknife</source>
+        <target>耶洛奈夫</target>
+      </trans-unit>
+      <trans-unit id="25d43c379dc973b097d7d3ee052d7d2a" resname="Edmonton">
+        <source>Edmonton</source>
+        <target>埃德蒙顿</target>
+      </trans-unit>
+      <trans-unit id="1a84ad957db0945a05eae9c53655863e" resname="Swift Current">
+        <source>Swift Current</source>
+        <target>斯威夫特卡伦特</target>
+      </trans-unit>
+      <trans-unit id="9e806d139a947c7319e7a38426aaf3de" resname="Cambridge Bay">
+        <source>Cambridge Bay</source>
+        <target>剑桥湾</target>
+      </trans-unit>
+      <trans-unit id="cca17d86a631047538f816b2dd5306cc" resname="Regina">
+        <source>Regina</source>
+        <target>里贾纳</target>
+      </trans-unit>
+      <trans-unit id="9f52f29ade262903f15dc9455eb2ddac" resname="Winnipeg">
+        <source>Winnipeg</source>
+        <target>温尼伯</target>
+      </trans-unit>
+      <trans-unit id="f4a151e361182ca21dddc8de23c97cb5" resname="Resolute">
+        <source>Resolute</source>
+        <target>雷索卢特</target>
+      </trans-unit>
+      <trans-unit id="ace40369187336bfb9f5a06bad24aa6a" resname="Rainy River">
+        <source>Rainy River</source>
+        <target>雷尼河</target>
+      </trans-unit>
+      <trans-unit id="190cf98e55f4124f22aad52bf8e83d07" resname="Rankin Inlet">
+        <source>Rankin Inlet</source>
+        <target>兰今湾</target>
+      </trans-unit>
+      <trans-unit id="e0b3d3250559efeb30f10c713318889f" resname="Coral Harbour">
+        <source>Coral Harbour</source>
+        <target>阿蒂科肯</target>
+      </trans-unit>
+      <trans-unit id="a11a5405d5cf4d8e31bc1f03c5a93a15" resname="Thunder Bay">
+        <source>Thunder Bay</source>
+        <target>桑德贝</target>
+      </trans-unit>
+      <trans-unit id="95a858745dda2165e76b6ef61a9d56f8" resname="Nipigon">
+        <source>Nipigon</source>
+        <target>尼皮贡</target>
+      </trans-unit>
+      <trans-unit id="948ce72be6c871b84f6d0dab24f209ed" resname="Toronto">
+        <source>Toronto</source>
+        <target>多伦多</target>
+      </trans-unit>
+      <trans-unit id="eca762f4319b6210b961cf2eb19b8d66" resname="Iqaluit">
+        <source>Iqaluit</source>
+        <target>伊魁特</target>
+      </trans-unit>
+      <trans-unit id="2600f7cd7104218d4850d9a5554fbd56" resname="Pangnirtung">
+        <source>Pangnirtung</source>
+        <target>旁涅唐</target>
+      </trans-unit>
+      <trans-unit id="e4a8b18878ce4c1eafcd7799376ab615" resname="Moncton">
+        <source>Moncton</source>
+        <target>蒙克顿</target>
+      </trans-unit>
+      <trans-unit id="04d28aa7f993bd50749133f0128b5ca6" resname="Halifax">
+        <source>Halifax</source>
+        <target>哈利法克斯</target>
+      </trans-unit>
+      <trans-unit id="1ae358bf4d952d0c61693ec2506b3466" resname="Goose Bay">
+        <source>Goose Bay</source>
+        <target>古斯湾</target>
+      </trans-unit>
+      <trans-unit id="f55876239284c75c2cd35e8e5ed92197" resname="Glace Bay">
+        <source>Glace Bay</source>
+        <target>格莱斯贝</target>
+      </trans-unit>
+      <trans-unit id="8dcb8e25950a7a6ce98b64148b239539" resname="Blanc-Sablon">
+        <source>Blanc-Sablon</source>
+        <target>布兰克萨布隆</target>
+      </trans-unit>
+      <trans-unit id="435197f5ba12d1fa110763aff45a7bd2" resname="St Johns">
+        <source>St Johns</source>
+        <target>圣约翰斯</target>
+      </trans-unit>
+      <trans-unit id="6a4ec4e63df31c5d9eef72a024d5fd98" resname="Cocos">
+        <source>Cocos</source>
+        <target>可可斯</target>
+      </trans-unit>
+      <trans-unit id="99ca5c728926ae20d2e7ede113a67b11" resname="Kinshasa">
+        <source>Kinshasa</source>
+        <target>金沙萨</target>
+      </trans-unit>
+      <trans-unit id="67e6ed05e62cf5008647f5f0f4d7f025" resname="Lubumbashi">
+        <source>Lubumbashi</source>
+        <target>卢本巴希</target>
+      </trans-unit>
+      <trans-unit id="c183ebfa7247107256c5857d5b396cbd" resname="Bangui">
+        <source>Bangui</source>
+        <target>班吉</target>
+      </trans-unit>
+      <trans-unit id="6e6dd9a489c685c2ddd5ae639f4df14e" resname="Brazzaville">
+        <source>Brazzaville</source>
+        <target>布拉柴维尔</target>
+      </trans-unit>
+      <trans-unit id="2b29c5739ec4158573c66d2124e2c7e9" resname="Zurich">
+        <source>Zurich</source>
+        <target>苏黎世</target>
+      </trans-unit>
+      <trans-unit id="019de76eff70580b22de64a715456c31" resname="Abidjan">
+        <source>Abidjan</source>
+        <target>阿比让</target>
+      </trans-unit>
+      <trans-unit id="00c3554b0961ffecf272c8c7832ae06d" resname="Rarotonga">
+        <source>Rarotonga</source>
+        <target>拉罗汤加</target>
+      </trans-unit>
+      <trans-unit id="e82df739dd8c84c8ae105b514f4c10df" resname="Easter">
+        <source>Easter</source>
+        <target>复活节岛</target>
+      </trans-unit>
+      <trans-unit id="b402b481bc0dbd51687430c586c7909a" resname="Santiago">
+        <source>Santiago</source>
+        <target>圣地亚哥</target>
+      </trans-unit>
+      <trans-unit id="dfe1fe4e1b9f529489741369cca9d483" resname="Douala">
+        <source>Douala</source>
+        <target>杜阿拉</target>
+      </trans-unit>
+      <trans-unit id="c46e51c263ff26fbce724bc34c4c0cdd" resname="Urumqi">
+        <source>Urumqi</source>
+        <target>乌鲁木齐</target>
+      </trans-unit>
+      <trans-unit id="5466ee572bcbc75830d044e66ab429bc" resname="Shanghai">
+        <source>Shanghai</source>
+        <target>上海</target>
+      </trans-unit>
+      <trans-unit id="fd6317498ebab5f40e639003e3d863fc" resname="Bogota">
+        <source>Bogota</source>
+        <target>波哥大</target>
+      </trans-unit>
+      <trans-unit id="5882b568d8a010ef48a6896f53b6eddb" resname="Costa Rica">
+        <source>Costa Rica</source>
+        <target>哥斯达黎加</target>
+      </trans-unit>
+      <trans-unit id="8819692009314e64e3efb596442dbbb5" resname="Havana">
+        <source>Havana</source>
+        <target>哈瓦那</target>
+      </trans-unit>
+      <trans-unit id="81975d05c61d8de83f46487739fd77cf" resname="Cape Verde">
+        <source>Cape Verde</source>
+        <target>佛得角</target>
+      </trans-unit>
+      <trans-unit id="0d2268d462cd08b20b7508c3fc0fde5e" resname="Curacao">
+        <source>Curacao</source>
+        <target>库拉索</target>
+      </trans-unit>
+      <trans-unit id="81b616fbff55b8698d44852f45c08630" resname="Christmas">
+        <source>Christmas</source>
+        <target>圣诞岛</target>
+      </trans-unit>
+      <trans-unit id="bd558c0af9b32a3fcbd29e847d608f20" resname="Nicosia">
+        <source>Nicosia</source>
+        <target>尼科西亚</target>
+      </trans-unit>
+      <trans-unit id="a71105026dfe9155f7ac4d18e494a40b" resname="Prague">
+        <source>Prague</source>
+        <target>布拉格</target>
+      </trans-unit>
+      <trans-unit id="de052ce2496478a2009ce357a310095f" resname="Busingen">
+        <source>Busingen</source>
+        <target>布辛根</target>
+      </trans-unit>
+      <trans-unit id="ee1611b61f5688e70c12b40684dbb395" resname="Berlin">
+        <source>Berlin</source>
+        <target>柏林</target>
+      </trans-unit>
+      <trans-unit id="902f92c09660b797958acb27421fd9ac" resname="Djibouti">
+        <source>Djibouti</source>
+        <target>吉布提</target>
+      </trans-unit>
+      <trans-unit id="2da3c827ccabc4855cb9921b4f1addfa" resname="Copenhagen">
+        <source>Copenhagen</source>
+        <target>哥本哈根</target>
+      </trans-unit>
+      <trans-unit id="531c552093668f148d3c826fca6e3cc8" resname="Dominica">
+        <source>Dominica</source>
+        <target>多米尼加</target>
+      </trans-unit>
+      <trans-unit id="29cb8691e1843d307a8d831219167549" resname="Santo Domingo">
+        <source>Santo Domingo</source>
+        <target>圣多明各</target>
+      </trans-unit>
+      <trans-unit id="6a5f69fac89c795d9a842460b8f0ff02" resname="Algiers">
+        <source>Algiers</source>
+        <target>阿尔及尔</target>
+      </trans-unit>
+      <trans-unit id="b87bdcb10b2301092f9cc97a4f429a8b" resname="Galapagos">
+        <source>Galapagos</source>
+        <target>加拉帕戈斯</target>
+      </trans-unit>
+      <trans-unit id="739b1f90a4d8a4b01d5f64ba3a788857" resname="Guayaquil">
+        <source>Guayaquil</source>
+        <target>瓜亚基尔</target>
+      </trans-unit>
+      <trans-unit id="ea75099e3719bdc3deba58502baf3adb" resname="Tallinn">
+        <source>Tallinn</source>
+        <target>塔林</target>
+      </trans-unit>
+      <trans-unit id="b181c43993de481ea462a2bfe11f0a1b" resname="Cairo">
+        <source>Cairo</source>
+        <target>开罗</target>
+      </trans-unit>
+      <trans-unit id="6e4b4130e113f84a8fd0bc4a2040ec2c" resname="El Aaiun">
+        <source>El Aaiun</source>
+        <target>阿尤恩</target>
+      </trans-unit>
+      <trans-unit id="fd8c45bc580e2c930d4f855e5d4c3359" resname="Asmera">
+        <source>Asmera</source>
+        <target>阿斯马拉</target>
+      </trans-unit>
+      <trans-unit id="ecf715d6d79a2698b7fec0357f9d721f" resname="Canary">
+        <source>Canary</source>
+        <target>加那利</target>
+      </trans-unit>
+      <trans-unit id="b14c3890a187a7798035ac60d89b54f7" resname="Ceuta">
+        <source>Ceuta</source>
+        <target>休达</target>
+      </trans-unit>
+      <trans-unit id="6314044c3803213e9fd3f3ecf8c90d65" resname="Madrid">
+        <source>Madrid</source>
+        <target>马德里</target>
+      </trans-unit>
+      <trans-unit id="6c835e2e190196b7fe9d8255be6bbcb4" resname="Addis Ababa">
+        <source>Addis Ababa</source>
+        <target>亚的斯亚贝巴</target>
+      </trans-unit>
+      <trans-unit id="8449280a23f8c4fcfb13469f6dc19592" resname="Helsinki">
+        <source>Helsinki</source>
+        <target>赫尔辛基</target>
+      </trans-unit>
+      <trans-unit id="55b0c4d4efa00b59643b2e6a6e7c18c0" resname="Fiji">
+        <source>Fiji</source>
+        <target>斐济</target>
+      </trans-unit>
+      <trans-unit id="b34c7c6fbe78d3825bd9496c54e5eeeb" resname="Stanley">
+        <source>Stanley</source>
+        <target>斯坦利</target>
+      </trans-unit>
+      <trans-unit id="55958d4aa27d786c639498816d98d607" resname="Truk">
+        <source>Truk</source>
+        <target>特鲁克群岛</target>
+      </trans-unit>
+      <trans-unit id="dd09f8ad668676bd35710a9e5123151b" resname="Ponape">
+        <source>Ponape</source>
+        <target>波纳佩岛</target>
+      </trans-unit>
+      <trans-unit id="400d9146c5789a2c5b8412d7d0baeb5c" resname="Kosrae">
+        <source>Kosrae</source>
+        <target>库赛埃</target>
+      </trans-unit>
+      <trans-unit id="6ce2feac0a0962d43baacc6c95754a36" resname="Faeroe">
+        <source>Faeroe</source>
+        <target>法罗</target>
+      </trans-unit>
+      <trans-unit id="e20d37a5d7fcc4c35be6fc18a8e71bfa" resname="Paris">
+        <source>Paris</source>
+        <target>巴黎</target>
+      </trans-unit>
+      <trans-unit id="ebc240d7b6aada077f9b8365c46fbea4" resname="Libreville">
+        <source>Libreville</source>
+        <target>利伯维尔</target>
+      </trans-unit>
+      <trans-unit id="59ead8d1e124ccfb79f3ace06f43e703" resname="London">
+        <source>London</source>
+        <target>伦敦</target>
+      </trans-unit>
+      <trans-unit id="45b1cb9a558807139085c645d2f47f07" resname="Grenada">
+        <source>Grenada</source>
+        <target>格林纳达</target>
+      </trans-unit>
+      <trans-unit id="532531fe87971119dd0c1c2acbcbde56" resname="Tbilisi">
+        <source>Tbilisi</source>
+        <target>第比利斯</target>
+      </trans-unit>
+      <trans-unit id="2186db2ef123599822781fec32e3ac97" resname="Cayenne">
+        <source>Cayenne</source>
+        <target>卡宴</target>
+      </trans-unit>
+      <trans-unit id="a531abc58761191a634e3d485d0a199b" resname="Guernsey">
+        <source>Guernsey</source>
+        <target>根西岛</target>
+      </trans-unit>
+      <trans-unit id="74611b7301ba42555da48a38e252802c" resname="Accra">
+        <source>Accra</source>
+        <target>阿克拉</target>
+      </trans-unit>
+      <trans-unit id="672566a43483aa8212cb365658600b99" resname="Gibraltar">
+        <source>Gibraltar</source>
+        <target>直布罗陀</target>
+      </trans-unit>
+      <trans-unit id="6543b3db7c718190e572f23bfa8735c2" resname="Thule">
+        <source>Thule</source>
+        <target>图勒</target>
+      </trans-unit>
+      <trans-unit id="50c82a8293ab719513b412a74641f8b2" resname="Godthab">
+        <source>Godthab</source>
+        <target>戈特霍布</target>
+      </trans-unit>
+      <trans-unit id="ef10665ebf0dd8665912428e3d4979b6" resname="Scoresbysund">
+        <source>Scoresbysund</source>
+        <target>斯科列斯比桑德</target>
+      </trans-unit>
+      <trans-unit id="e7e7c3ca2fe165a4e6e2e540063d6f2a" resname="Danmarkshavn">
+        <source>Danmarkshavn</source>
+        <target>丹马沙文</target>
+      </trans-unit>
+      <trans-unit id="b2cda1914234d736f1b65df7a96f5244" resname="Banjul">
+        <source>Banjul</source>
+        <target>班珠尔</target>
+      </trans-unit>
+      <trans-unit id="8be2ff0a418d70660729851c3072d71c" resname="Conakry">
+        <source>Conakry</source>
+        <target>科纳克里</target>
+      </trans-unit>
+      <trans-unit id="0dc81c66d1c08d6ca64c7e8b60ae78fb" resname="Guadeloupe">
+        <source>Guadeloupe</source>
+        <target>瓜德罗普</target>
+      </trans-unit>
+      <trans-unit id="e05bccd56b9615e81e53c0d6a5f275fb" resname="Malabo">
+        <source>Malabo</source>
+        <target>马拉博</target>
+      </trans-unit>
+      <trans-unit id="e14045c6b4fe1e65d04aade91b1f8c1b" resname="Athens">
+        <source>Athens</source>
+        <target>雅典</target>
+      </trans-unit>
+      <trans-unit id="8c4dec4341eb6ce4274188438060ab3a" resname="South Georgia">
+        <source>South Georgia</source>
+        <target>南乔治亚</target>
+      </trans-unit>
+      <trans-unit id="948b13d5a3e11e21baadc349e199020e" resname="Guatemala">
+        <source>Guatemala</source>
+        <target>危地马拉</target>
+      </trans-unit>
+      <trans-unit id="2dc47f81fc4257e14c4d0fcd90d03b9a" resname="Guam">
+        <source>Guam</source>
+        <target>关岛</target>
+      </trans-unit>
+      <trans-unit id="d8a4801dc59c4cf7c13892540dd68c54" resname="Bissau">
+        <source>Bissau</source>
+        <target>比绍</target>
+      </trans-unit>
+      <trans-unit id="cf4c7e1169281886577940e361854a84" resname="Guyana">
+        <source>Guyana</source>
+        <target>圭亚那</target>
+      </trans-unit>
+      <trans-unit id="8b476ff778119b8d49588f3daadf69a1" resname="Hong Kong">
+        <source>Hong Kong</source>
+        <target>香港</target>
+      </trans-unit>
+      <trans-unit id="4af0091a7b7bb978ca7192b6a4d093ea" resname="Tegucigalpa">
+        <source>Tegucigalpa</source>
+        <target>特古西加尔巴</target>
+      </trans-unit>
+      <trans-unit id="b827d268b3e75abe3c4419d959d93998" resname="Zagreb">
+        <source>Zagreb</source>
+        <target>萨格勒布</target>
+      </trans-unit>
+      <trans-unit id="36447ecbdd29c73727b1b258321d253b" resname="Port-au-Prince">
+        <source>Port-au-Prince</source>
+        <target>太子港</target>
+      </trans-unit>
+      <trans-unit id="9fed5dae86e3030d9be3740efa198659" resname="Budapest">
+        <source>Budapest</source>
+        <target>布达佩斯</target>
+      </trans-unit>
+      <trans-unit id="f3a693cf1392030d179eaa94d226f0ea" resname="Jakarta">
+        <source>Jakarta</source>
+        <target>雅加达</target>
+      </trans-unit>
+      <trans-unit id="b6c9b6432c2e555dab016d7bdff217ab" resname="Pontianak">
+        <source>Pontianak</source>
+        <target>坤甸</target>
+      </trans-unit>
+      <trans-unit id="3de594abdcaa866aa0359fa4d66a9b3e" resname="Makassar">
+        <source>Makassar</source>
+        <target>望加锡</target>
+      </trans-unit>
+      <trans-unit id="005fd791c8f2834ec27482136e4c4870" resname="Jayapura">
+        <source>Jayapura</source>
+        <target>查亚普拉</target>
+      </trans-unit>
+      <trans-unit id="50fefb5efb085fd11b1a4fd2b6dda0aa" resname="Dublin">
+        <source>Dublin</source>
+        <target>都柏林</target>
+      </trans-unit>
+      <trans-unit id="0a5ed43ab1e290a2356aaa745e7d7196" resname="Jerusalem">
+        <source>Jerusalem</source>
+        <target>耶路撒冷</target>
+      </trans-unit>
+      <trans-unit id="9a3075ee78e707359751cecfffedc5b8" resname="Isle of Man">
+        <source>Isle of Man</source>
+        <target>曼岛</target>
+      </trans-unit>
+      <trans-unit id="3b84df2cb6339e5e6b02b82715d01817" resname="Calcutta">
+        <source>Calcutta</source>
+        <target>加尔各答</target>
+      </trans-unit>
+      <trans-unit id="4a90ae59e41168a559d502eabf488732" resname="Chagos">
+        <source>Chagos</source>
+        <target>查戈斯</target>
+      </trans-unit>
+      <trans-unit id="0c633450d0fa68db4da4e8ed6c7ed07c" resname="Baghdad">
+        <source>Baghdad</source>
+        <target>巴格达</target>
+      </trans-unit>
+      <trans-unit id="ed7b37ce943e144f5bd8bdbbb8d47062" resname="Tehran">
+        <source>Tehran</source>
+        <target>德黑兰</target>
+      </trans-unit>
+      <trans-unit id="83405408826823713d290a7a46aa65df" resname="Reykjavik">
+        <source>Reykjavik</source>
+        <target>雷克雅未克</target>
+      </trans-unit>
+      <trans-unit id="1f49f770adc6c84629f50ce3ca2a2109" resname="Rome">
+        <source>Rome</source>
+        <target>罗马</target>
+      </trans-unit>
+      <trans-unit id="3cda26e0c8aedbf662adb42f923ef3ec" resname="Jersey">
+        <source>Jersey</source>
+        <target>泽西岛</target>
+      </trans-unit>
+      <trans-unit id="1add2eb41fcae9b2a15b4a7d68571409" resname="Jamaica">
+        <source>Jamaica</source>
+        <target>牙买加</target>
+      </trans-unit>
+      <trans-unit id="65ca1960c302380349ee212d4d07e5c4" resname="Amman">
+        <source>Amman</source>
+        <target>安曼</target>
+      </trans-unit>
+      <trans-unit id="62413a57c5e3dc51177995fa175d3286" resname="Tokyo">
+        <source>Tokyo</source>
+        <target>东京</target>
+      </trans-unit>
+      <trans-unit id="fc9389801935ab6476b93373f658e705" resname="Nairobi">
+        <source>Nairobi</source>
+        <target>内罗毕</target>
+      </trans-unit>
+      <trans-unit id="f5a8e9ed5e2b823b00944a966c7111d9" resname="Bishkek">
+        <source>Bishkek</source>
+        <target>比什凯克</target>
+      </trans-unit>
+      <trans-unit id="0d021d5b6d6f7424119928cbb5ed257c" resname="Phnom Penh">
+        <source>Phnom Penh</source>
+        <target>金边</target>
+      </trans-unit>
+      <trans-unit id="d8bc05913d5fe8c175d96f8bd9e2ae9e" resname="Enderbury">
+        <source>Enderbury</source>
+        <target>恩德伯里</target>
+      </trans-unit>
+      <trans-unit id="05724f787b77de2d7287f2ad6cb7f4cb" resname="Kiritimati">
+        <source>Kiritimati</source>
+        <target>基里地马地岛</target>
+      </trans-unit>
+      <trans-unit id="d69d56a0498d291d0c18f2d8b1ab0ea4" resname="Tarawa">
+        <source>Tarawa</source>
+        <target>塔拉瓦</target>
+      </trans-unit>
+      <trans-unit id="8df35b117c42ac38d12c172cf609c2ee" resname="Comoro">
+        <source>Comoro</source>
+        <target>科摩罗</target>
+      </trans-unit>
+      <trans-unit id="b282c97f19d81e6d3a664b4684b016a8" resname="St Kitts">
+        <source>St Kitts</source>
+        <target>圣基茨</target>
+      </trans-unit>
+      <trans-unit id="959e827368022cb8f4cc5820767a44f0" resname="Pyongyang">
+        <source>Pyongyang</source>
+        <target>平壤</target>
+      </trans-unit>
+      <trans-unit id="fd38499c5c04df42d1d78807aa4b7d7d" resname="Seoul">
+        <source>Seoul</source>
+        <target>首尔</target>
+      </trans-unit>
+      <trans-unit id="05387f3ca38d7bd84ae35f31f2899ecf" resname="Kuwait">
+        <source>Kuwait</source>
+        <target>科威特</target>
+      </trans-unit>
+      <trans-unit id="8d5556b95994731c890a7e44d46f189e" resname="Cayman">
+        <source>Cayman</source>
+        <target>开曼</target>
+      </trans-unit>
+      <trans-unit id="91236dae43559c0f83ee7d55989f12e5" resname="Aqtau">
+        <source>Aqtau</source>
+        <target>阿克套</target>
+      </trans-unit>
+      <trans-unit id="1dfec3c050c45726e962e73fed647a8b" resname="Oral">
+        <source>Oral</source>
+        <target>乌拉尔</target>
+      </trans-unit>
+      <trans-unit id="54bc92b17b65cab4969327a201c7df12" resname="Aqtobe">
+        <source>Aqtobe</source>
+        <target>阿克托别</target>
+      </trans-unit>
+      <trans-unit id="1198d054a7f7e374aee9668f0da4accb" resname="Qyzylorda">
+        <source>Qyzylorda</source>
+        <target>克孜洛尔达</target>
+      </trans-unit>
+      <trans-unit id="6978afeae11d806acc9201337c0017b0" resname="Almaty">
+        <source>Almaty</source>
+        <target>阿拉木图</target>
+      </trans-unit>
+      <trans-unit id="5e0567589de4ecb8e7b2740e7260e7bf" resname="Vientiane">
+        <source>Vientiane</source>
+        <target>万象</target>
+      </trans-unit>
+      <trans-unit id="8567d06b436c06938d4d20225c9ea85c" resname="Beirut">
+        <source>Beirut</source>
+        <target>贝鲁特</target>
+      </trans-unit>
+      <trans-unit id="3c7c8ebce6da63ed8be4693f042b4bf7" resname="St Lucia">
+        <source>St Lucia</source>
+        <target>圣卢西亚</target>
+      </trans-unit>
+      <trans-unit id="1139cab61e63ffc39f0367d4e459e647" resname="Vaduz">
+        <source>Vaduz</source>
+        <target>瓦杜兹</target>
+      </trans-unit>
+      <trans-unit id="7bcd79e863547e9833b79aace39471b8" resname="Colombo">
+        <source>Colombo</source>
+        <target>科伦坡</target>
+      </trans-unit>
+      <trans-unit id="2a6d14355ea2edae611b49d8993bdac9" resname="Monrovia">
+        <source>Monrovia</source>
+        <target>蒙罗维亚</target>
+      </trans-unit>
+      <trans-unit id="4f9059639b967534ab194e2c44b6789e" resname="Maseru">
+        <source>Maseru</source>
+        <target>马塞卢</target>
+      </trans-unit>
+      <trans-unit id="674756b151c1a964546ad103f310fc5b" resname="Vilnius">
+        <source>Vilnius</source>
+        <target>维尔纽斯</target>
+      </trans-unit>
+      <trans-unit id="06630c890abadde9228ea818ce52b621" resname="Luxembourg">
+        <source>Luxembourg</source>
+        <target>卢森堡</target>
+      </trans-unit>
+      <trans-unit id="c16c50f34911d1f5d3924c8267409904" resname="Riga">
+        <source>Riga</source>
+        <target>里加</target>
+      </trans-unit>
+      <trans-unit id="9b3af1bb38b7114f349064f74ea83fa4" resname="Tripoli">
+        <source>Tripoli</source>
+        <target>的黎波里</target>
+      </trans-unit>
+      <trans-unit id="adf20488d00fb576b16546b1c93611b4" resname="Casablanca">
+        <source>Casablanca</source>
+        <target>卡萨布兰卡</target>
+      </trans-unit>
+      <trans-unit id="d6a297c6193fd59309453a0db7a51b90" resname="Monaco">
+        <source>Monaco</source>
+        <target>摩纳哥</target>
+      </trans-unit>
+      <trans-unit id="ec66590f905c5d01ae2f4a53fb33d2f6" resname="Chisinau">
+        <source>Chisinau</source>
+        <target>基希讷乌</target>
+      </trans-unit>
+      <trans-unit id="bc8ead33389619cc05222e0315e41216" resname="Podgorica">
+        <source>Podgorica</source>
+        <target>波德戈里察</target>
+      </trans-unit>
+      <trans-unit id="8d455f106480c517c4e99f7ebb89acaa" resname="Marigot">
+        <source>Marigot</source>
+        <target>马里戈特</target>
+      </trans-unit>
+      <trans-unit id="df4283d3aa6183cfcb74bffd1f545377" resname="Antananarivo">
+        <source>Antananarivo</source>
+        <target>安塔那那利佛</target>
+      </trans-unit>
+      <trans-unit id="9f8fc4aaedf19b807af50b6aad8fb855" resname="Kwajalein">
+        <source>Kwajalein</source>
+        <target>夸贾林</target>
+      </trans-unit>
+      <trans-unit id="c6703691b639f28585850248c340f2fb" resname="Majuro">
+        <source>Majuro</source>
+        <target>马朱罗</target>
+      </trans-unit>
+      <trans-unit id="a4d81f9796805c63e41f0bfdddff41ac" resname="Skopje">
+        <source>Skopje</source>
+        <target>斯科普里</target>
+      </trans-unit>
+      <trans-unit id="0df54a621a4e76c1683931b70d412f17" resname="Bamako">
+        <source>Bamako</source>
+        <target>巴马科</target>
+      </trans-unit>
+      <trans-unit id="39664ffbe787eeda57a1ce418c0bc740" resname="Rangoon">
+        <source>Rangoon</source>
+        <target>仰光</target>
+      </trans-unit>
+      <trans-unit id="806083e2567a6762ddf195ac18374eb6" resname="Hovd">
+        <source>Hovd</source>
+        <target>科布多</target>
+      </trans-unit>
+      <trans-unit id="ff4fc27f95d28622b1c18802fa908131" resname="Ulaanbaatar">
+        <source>Ulaanbaatar</source>
+        <target>乌兰巴托</target>
+      </trans-unit>
+      <trans-unit id="8866582f025850b1695785c99b90cf6e" resname="Choibalsan">
+        <source>Choibalsan</source>
+        <target>乔巴山</target>
+      </trans-unit>
+      <trans-unit id="9d6c9d893aa285a736aeabb2b66b316f" resname="Macau">
+        <source>Macau</source>
+        <target>澳门</target>
+      </trans-unit>
+      <trans-unit id="0f572236946c785fcd3dd3ff81303f62" resname="Saipan">
+        <source>Saipan</source>
+        <target>塞班</target>
+      </trans-unit>
+      <trans-unit id="899c4b2a0d41d5b86e2dbc3b2f5380cf" resname="Martinique">
+        <source>Martinique</source>
+        <target>马提尼克</target>
+      </trans-unit>
+      <trans-unit id="49a0c7aaede8ae2f47624661dd037fca" resname="Nouakchott">
+        <source>Nouakchott</source>
+        <target>努瓦克肖特</target>
+      </trans-unit>
+      <trans-unit id="3bac87d64d97e96d0e935628a9383379" resname="Montserrat">
+        <source>Montserrat</source>
+        <target>蒙特塞拉特</target>
+      </trans-unit>
+      <trans-unit id="92468e8a62373add2b9caefddbcf1303" resname="Malta">
+        <source>Malta</source>
+        <target>马耳他</target>
+      </trans-unit>
+      <trans-unit id="07f3ca235faaa1c9ad16facef5526d8b" resname="Mauritius">
+        <source>Mauritius</source>
+        <target>毛里求斯</target>
+      </trans-unit>
+      <trans-unit id="62235142f3fca96e1f2cd0ed4a7de48d" resname="Maldives">
+        <source>Maldives</source>
+        <target>马尔代夫</target>
+      </trans-unit>
+      <trans-unit id="be865914e58d6c1e69c1923efa083ffa" resname="Blantyre">
+        <source>Blantyre</source>
+        <target>布兰太尔</target>
+      </trans-unit>
+      <trans-unit id="f8abf41bf5d4f0064441e43046f7010f" resname="Tijuana">
+        <source>Tijuana</source>
+        <target>蒂华纳</target>
+      </trans-unit>
+      <trans-unit id="f9de9282c2d8dafe3df6dc7c6fe79dd8" resname="Santa Isabel">
+        <source>Santa Isabel</source>
+        <target>圣伊萨贝尔</target>
+      </trans-unit>
+      <trans-unit id="00641d7f43bebff5001c4030979470a7" resname="Hermosillo">
+        <source>Hermosillo</source>
+        <target>埃莫西约</target>
+      </trans-unit>
+      <trans-unit id="2d5533901246a77a16da08db674f76d6" resname="Mazatlan">
+        <source>Mazatlan</source>
+        <target>马萨特兰</target>
+      </trans-unit>
+      <trans-unit id="4ab02eb42d91b8e97216863c820a553b" resname="Chihuahua">
+        <source>Chihuahua</source>
+        <target>奇瓦瓦</target>
+      </trans-unit>
+      <trans-unit id="8db193cc90167f2db583c736f55ecc11" resname="Bahia Banderas">
+        <source>Bahia Banderas</source>
+        <target>巴伊亚班德拉斯</target>
+      </trans-unit>
+      <trans-unit id="951c4265d398fe0b2b6bbb7bbd074f42" resname="Ojinaga">
+        <source>Ojinaga</source>
+        <target>奥希纳加</target>
+      </trans-unit>
+      <trans-unit id="520b719ffeaafb7246f8e5da26d5c0a4" resname="Monterrey">
+        <source>Monterrey</source>
+        <target>蒙特雷</target>
+      </trans-unit>
+      <trans-unit id="0b4596f8efe110dc55bbe564213dfb33" resname="Mexico City">
+        <source>Mexico City</source>
+        <target>墨西哥城</target>
+      </trans-unit>
+      <trans-unit id="6c851b965778e56409a4963807c11122" resname="Matamoros">
+        <source>Matamoros</source>
+        <target>马塔莫罗斯</target>
+      </trans-unit>
+      <trans-unit id="1399d043315471d4177e9ec91671e87e" resname="Merida">
+        <source>Merida</source>
+        <target>梅里达</target>
+      </trans-unit>
+      <trans-unit id="fd5a6f048c89ada0ec63459c7d4467dc" resname="Cancun">
+        <source>Cancun</source>
+        <target>坎昆</target>
+      </trans-unit>
+      <trans-unit id="dc5df51ea7e4a83d5663ca4ced03a1aa" resname="Kuala Lumpur">
+        <source>Kuala Lumpur</source>
+        <target>吉隆坡</target>
+      </trans-unit>
+      <trans-unit id="d2ab9576e1acdedebd70f54d03d5e77c" resname="Kuching">
+        <source>Kuching</source>
+        <target>古晋</target>
+      </trans-unit>
+      <trans-unit id="0218a77ed79362a40e5f018feeebaba2" resname="Maputo">
+        <source>Maputo</source>
+        <target>马普托</target>
+      </trans-unit>
+      <trans-unit id="9b1c3a79a84cc0ee72dcc5218b20e426" resname="Windhoek">
+        <source>Windhoek</source>
+        <target>温得和克</target>
+      </trans-unit>
+      <trans-unit id="40149e9553be6e5888ad73c1792f74ef" resname="Noumea">
+        <source>Noumea</source>
+        <target>努美阿</target>
+      </trans-unit>
+      <trans-unit id="39ef60154960c66c93d8b584450edc06" resname="Niamey">
+        <source>Niamey</source>
+        <target>尼亚美</target>
+      </trans-unit>
+      <trans-unit id="c394bf9a4d43b977e11610b5b5f85843" resname="Norfolk">
+        <source>Norfolk</source>
+        <target>诺福克</target>
+      </trans-unit>
+      <trans-unit id="8db95c71eae98cf838c50d8916379eef" resname="Lagos">
+        <source>Lagos</source>
+        <target>拉各斯</target>
+      </trans-unit>
+      <trans-unit id="d98bf2a51283482a9283735e2324a1f2" resname="Managua">
+        <source>Managua</source>
+        <target>马那瓜</target>
+      </trans-unit>
+      <trans-unit id="3eb8670d999ac077dd0e2c345cb7c905" resname="Amsterdam">
+        <source>Amsterdam</source>
+        <target>阿姆斯特丹</target>
+      </trans-unit>
+      <trans-unit id="f4830432874f86d2e2a1a5f2dbebbc80" resname="Oslo">
+        <source>Oslo</source>
+        <target>奥斯陆</target>
+      </trans-unit>
+      <trans-unit id="93fc44650edaa1f5609fd87fa22f0787" resname="Katmandu">
+        <source>Katmandu</source>
+        <target>加德满都</target>
+      </trans-unit>
+      <trans-unit id="d0c5ab6bebe308a495693e990a2947bc" resname="Nauru">
+        <source>Nauru</source>
+        <target>瑙鲁</target>
+      </trans-unit>
+      <trans-unit id="de48fee9c7511bf7158b1e28b3d0baec" resname="Niue">
+        <source>Niue</source>
+        <target>纽埃</target>
+      </trans-unit>
+      <trans-unit id="32ce3f1410510651a5f862f64e137868" resname="Chatham">
+        <source>Chatham</source>
+        <target>查塔姆</target>
+      </trans-unit>
+      <trans-unit id="146159057df3f8947f820d9fc184c6cd" resname="Auckland">
+        <source>Auckland</source>
+        <target>奥克兰</target>
+      </trans-unit>
+      <trans-unit id="ac6a6d52cb1827030753631c1285e1ec" resname="Muscat">
+        <source>Muscat</source>
+        <target>马斯喀特</target>
+      </trans-unit>
+      <trans-unit id="6bec347f256837d3539ad619bd489de7" resname="Panama">
+        <source>Panama</source>
+        <target>巴拿马</target>
+      </trans-unit>
+      <trans-unit id="0cb9cde516c38ed84dc1f3f2b5556ed3" resname="Lima">
+        <source>Lima</source>
+        <target>利马</target>
+      </trans-unit>
+      <trans-unit id="1e257d79cd2dd7a09657597cee33bbe5" resname="Tahiti">
+        <source>Tahiti</source>
+        <target>塔希提</target>
+      </trans-unit>
+      <trans-unit id="cafeb784052c0cb87d4ccaf32ba55eb4" resname="Marquesas">
+        <source>Marquesas</source>
+        <target>马克萨斯</target>
+      </trans-unit>
+      <trans-unit id="4ef4530ac1d56e51694e88d4f7a356ff" resname="Gambier">
+        <source>Gambier</source>
+        <target>甘比尔</target>
+      </trans-unit>
+      <trans-unit id="8c12211143d722e1400a95ae20b7266b" resname="Port Moresby">
+        <source>Port Moresby</source>
+        <target>莫尔兹比港</target>
+      </trans-unit>
+      <trans-unit id="d99b6ddbaaee083560f47ee12ef57113" resname="Bougainville">
+        <source>Bougainville</source>
+        <target>布干维尔</target>
+      </trans-unit>
+      <trans-unit id="b07c844628c2a9ec3593f4ff4b4f1ec1" resname="Manila">
+        <source>Manila</source>
+        <target>马尼拉</target>
+      </trans-unit>
+      <trans-unit id="896efdfbc7675d56197f2bc7dc4f3ffc" resname="Karachi">
+        <source>Karachi</source>
+        <target>卡拉奇</target>
+      </trans-unit>
+      <trans-unit id="ab014f5797b79c42d078976b9d1a413c" resname="Warsaw">
+        <source>Warsaw</source>
+        <target>华沙</target>
+      </trans-unit>
+      <trans-unit id="c42d3a4442b1247b852e2f1ccb3f8d79" resname="Miquelon">
+        <source>Miquelon</source>
+        <target>密克隆</target>
+      </trans-unit>
+      <trans-unit id="7fad9908f71e4ba29eeff3847d7ccc10" resname="Pitcairn">
+        <source>Pitcairn</source>
+        <target>皮特凯恩</target>
+      </trans-unit>
+      <trans-unit id="f76257271129c703d6c0442c8ac00dae" resname="Puerto Rico">
+        <source>Puerto Rico</source>
+        <target>波多黎各</target>
+      </trans-unit>
+      <trans-unit id="667af97a2cc4afa3b1d21d954e14744d" resname="Gaza">
+        <source>Gaza</source>
+        <target>加沙</target>
+      </trans-unit>
+      <trans-unit id="9b61c6e44adca2da616c13c8419a8f3c" resname="Hebron">
+        <source>Hebron</source>
+        <target>希伯伦</target>
+      </trans-unit>
+      <trans-unit id="7e4f720b22dacae27dfef80e243596c3" resname="Azores">
+        <source>Azores</source>
+        <target>亚速尔群岛</target>
+      </trans-unit>
+      <trans-unit id="419b15d7a08e509c228471308ab72939" resname="Madeira">
+        <source>Madeira</source>
+        <target>马德拉</target>
+      </trans-unit>
+      <trans-unit id="260b4e591e03de9750f965a30087ed5f" resname="Lisbon">
+        <source>Lisbon</source>
+        <target>里斯本</target>
+      </trans-unit>
+      <trans-unit id="46096bb96824852d15ce4fa5ba4bf58e" resname="Palau">
+        <source>Palau</source>
+        <target>帕劳</target>
+      </trans-unit>
+      <trans-unit id="8410f16f69626640a58f6c75509b068b" resname="Asuncion">
+        <source>Asuncion</source>
+        <target>亚松森</target>
+      </trans-unit>
+      <trans-unit id="7cc7ef17c45527cf90fcf27516794d21" resname="Qatar">
+        <source>Qatar</source>
+        <target>卡塔尔</target>
+      </trans-unit>
+      <trans-unit id="939c3c13a3d058c4c53109d7f804b631" resname="Reunion">
+        <source>Reunion</source>
+        <target>留尼汪</target>
+      </trans-unit>
+      <trans-unit id="26ba3224ef491b44fad2bb9545bf84d5" resname="Bucharest">
+        <source>Bucharest</source>
+        <target>布加勒斯特</target>
+      </trans-unit>
+      <trans-unit id="c87f42a2ab4a24074411dfd55ca71450" resname="Belgrade">
+        <source>Belgrade</source>
+        <target>贝尔格莱德</target>
+      </trans-unit>
+      <trans-unit id="1c1b8f5f242fe55c82138b8935e847f7" resname="Kaliningrad">
+        <source>Kaliningrad</source>
+        <target>加里宁格勒</target>
+      </trans-unit>
+      <trans-unit id="8dbeff9871dc83a2ffa1edb23f38c1aa" resname="Simferopol">
+        <source>Simferopol</source>
+        <target>辛菲罗波尔</target>
+      </trans-unit>
+      <trans-unit id="7e35e74e610188414ad24235dd787c78" resname="Moscow">
+        <source>Moscow</source>
+        <target>莫斯科</target>
+      </trans-unit>
+      <trans-unit id="1b76b0d2b1c0131465044a89285260a8" resname="Volgograd">
+        <source>Volgograd</source>
+        <target>伏尔加格勒</target>
+      </trans-unit>
+      <trans-unit id="ae6d06b333642fea786d801e95e0b8d0" resname="Samara">
+        <source>Samara</source>
+        <target>萨马拉</target>
+      </trans-unit>
+      <trans-unit id="f4e6a69a8ad28a7626085d92488fb2c0" resname="Yekaterinburg">
+        <source>Yekaterinburg</source>
+        <target>叶卡捷琳堡</target>
+      </trans-unit>
+      <trans-unit id="0d9b5c7faf5c1ce7d0728391ac51b538" resname="Omsk">
+        <source>Omsk</source>
+        <target>鄂木斯克</target>
+      </trans-unit>
+      <trans-unit id="f38c039e89b151ba91c0ca6a990ae9ba" resname="Novosibirsk">
+        <source>Novosibirsk</source>
+        <target>诺沃西比尔斯克</target>
+      </trans-unit>
+      <trans-unit id="376b27caaada5274b2b208bf11dff8e0" resname="Novokuznetsk">
+        <source>Novokuznetsk</source>
+        <target>新库兹涅茨克</target>
+      </trans-unit>
+      <trans-unit id="862d60f5be96b7f4cfbd82cc5e4f0892" resname="Krasnoyarsk">
+        <source>Krasnoyarsk</source>
+        <target>克拉斯诺亚尔斯克</target>
+      </trans-unit>
+      <trans-unit id="91096d8fb26e22feebbb050667f4cdf5" resname="Irkutsk">
+        <source>Irkutsk</source>
+        <target>伊尔库茨克</target>
+      </trans-unit>
+      <trans-unit id="ef937327b5563c0003e9e24cb8b418d7" resname="Chita">
+        <source>Chita</source>
+        <target>赤塔</target>
+      </trans-unit>
+      <trans-unit id="53e900778331887011cd918a45bc1d34" resname="Yakutsk">
+        <source>Yakutsk</source>
+        <target>雅库茨克</target>
+      </trans-unit>
+      <trans-unit id="e5aa23b540ec1892cc88127073613ec0" resname="Vladivostok">
+        <source>Vladivostok</source>
+        <target>符拉迪沃斯托克</target>
+      </trans-unit>
+      <trans-unit id="8a41bb92aa5f0cf446eeed27acc73ec1" resname="Khandyga">
+        <source>Khandyga</source>
+        <target>汉德加</target>
+      </trans-unit>
+      <trans-unit id="eedfc25c7412e7860273f001307332a1" resname="Sakhalin">
+        <source>Sakhalin</source>
+        <target>萨哈林</target>
+      </trans-unit>
+      <trans-unit id="7601fb3981fa705669018768c2833532" resname="Ust-Nera">
+        <source>Ust-Nera</source>
+        <target>乌斯内拉</target>
+      </trans-unit>
+      <trans-unit id="bb94646e8dc57ee333222f76296e9f3c" resname="Magadan">
+        <source>Magadan</source>
+        <target>马加丹</target>
+      </trans-unit>
+      <trans-unit id="9796152b9a3725311b3a03291859f45e" resname="Srednekolymsk">
+        <source>Srednekolymsk</source>
+        <target>中科雷姆斯克</target>
+      </trans-unit>
+      <trans-unit id="9ca589c66e1d35dec0efb2f0ac5f3059" resname="Kamchatka">
+        <source>Kamchatka</source>
+        <target>堪察加</target>
+      </trans-unit>
+      <trans-unit id="141610764096e0253c6d388242e6c51d" resname="Anadyr">
+        <source>Anadyr</source>
+        <target>阿纳德尔</target>
+      </trans-unit>
+      <trans-unit id="0de15f9adc749698be030c64cd8c4d6c" resname="Kigali">
+        <source>Kigali</source>
+        <target>基加利</target>
+      </trans-unit>
+      <trans-unit id="1abf78bf4a6d3cbfff7a0b66a203c755" resname="Riyadh">
+        <source>Riyadh</source>
+        <target>利雅得</target>
+      </trans-unit>
+      <trans-unit id="f55ca8d05bcb054815a26e955d47b078" resname="Guadalcanal">
+        <source>Guadalcanal</source>
+        <target>瓜达尔卡纳尔</target>
+      </trans-unit>
+      <trans-unit id="5215723c74c40c5a72021819bad24abb" resname="Mahe">
+        <source>Mahe</source>
+        <target>马埃岛</target>
+      </trans-unit>
+      <trans-unit id="260bbc70aae21dad4eefd307b690e2e5" resname="Khartoum">
+        <source>Khartoum</source>
+        <target>喀土穆</target>
+      </trans-unit>
+      <trans-unit id="fcfff492e00727b63cf5dff9f59bc2a4" resname="Stockholm">
+        <source>Stockholm</source>
+        <target>斯德哥尔摩</target>
+      </trans-unit>
+      <trans-unit id="458e4cbc78201c1aec5fc53a31c59378" resname="Singapore">
+        <source>Singapore</source>
+        <target>新加坡</target>
+      </trans-unit>
+      <trans-unit id="ff6655718a257f3aa50ec89cbd7691c4" resname="St Helena">
+        <source>St Helena</source>
+        <target>圣赫勒拿</target>
+      </trans-unit>
+      <trans-unit id="a606fe014370d8c520a07f30df46ef10" resname="Ljubljana">
+        <source>Ljubljana</source>
+        <target>卢布尔雅那</target>
+      </trans-unit>
+      <trans-unit id="a3b22d6f93e68b9d306fc912e9d1a92c" resname="Longyearbyen">
+        <source>Longyearbyen</source>
+        <target>朗伊尔城</target>
+      </trans-unit>
+      <trans-unit id="c114af7c3a3c9bbbbe2875e03aa486f7" resname="Bratislava">
+        <source>Bratislava</source>
+        <target>布拉迪斯拉发</target>
+      </trans-unit>
+      <trans-unit id="a3fc5ecf4be63b4b184658caec8d6756" resname="Freetown">
+        <source>Freetown</source>
+        <target>弗里敦</target>
+      </trans-unit>
+      <trans-unit id="a7db85742c67a70f8764c4d9c53bdb36" resname="San Marino">
+        <source>San Marino</source>
+        <target>圣马力诺</target>
+      </trans-unit>
+      <trans-unit id="08ec2b465e90b2a8de19b62a7315fc69" resname="Dakar">
+        <source>Dakar</source>
+        <target>达喀尔</target>
+      </trans-unit>
+      <trans-unit id="45b08e61d1324dbd318896c8c66b3a57" resname="Mogadishu">
+        <source>Mogadishu</source>
+        <target>摩加迪沙</target>
+      </trans-unit>
+      <trans-unit id="579caf0030a1314651d363a4052f37b6" resname="Paramaribo">
+        <source>Paramaribo</source>
+        <target>帕拉马里博</target>
+      </trans-unit>
+      <trans-unit id="2fa76c446c14896d647ceef6dd6803e9" resname="Juba">
+        <source>Juba</source>
+        <target>朱巴</target>
+      </trans-unit>
+      <trans-unit id="ff8d0d21141bd958cb19055812caa5a5" resname="Sao Tome">
+        <source>Sao Tome</source>
+        <target>圣多美</target>
+      </trans-unit>
+      <trans-unit id="e96d24bdfc024e04f49f1f0cc011ca20" resname="El Salvador">
+        <source>El Salvador</source>
+        <target>萨尔瓦多</target>
+      </trans-unit>
+      <trans-unit id="ac94871b4108eb33fe617eb28c560a2b" resname="Lower Princes">
+        <source>Lower Princes</source>
+        <target>下太子区</target>
+      </trans-unit>
+      <trans-unit id="f9087af03968b9a75a67376447f88bcf" resname="Damascus">
+        <source>Damascus</source>
+        <target>大马士革</target>
+      </trans-unit>
+      <trans-unit id="137c9977a8657a7c637d25c029ba81d2" resname="Mbabane">
+        <source>Mbabane</source>
+        <target>姆巴巴纳</target>
+      </trans-unit>
+      <trans-unit id="f59ecdc0701cbbedde3b1da2c6b7f66c" resname="Grand Turk">
+        <source>Grand Turk</source>
+        <target>大特克</target>
+      </trans-unit>
+      <trans-unit id="9f9fc7efaea5af65f558c2c04efc4052" resname="Ndjamena">
+        <source>Ndjamena</source>
+        <target>恩贾梅纳</target>
+      </trans-unit>
+      <trans-unit id="3f177e23ab98cd2de7ea313d3cc41e24" resname="Kerguelen">
+        <source>Kerguelen</source>
+        <target>凯尔盖朗</target>
+      </trans-unit>
+      <trans-unit id="107d58b900283b8113ce75f16c46abf7" resname="Lome">
+        <source>Lome</source>
+        <target>洛美</target>
+      </trans-unit>
+      <trans-unit id="3d147c6ba113929f5a004a5e9dcc832e" resname="Bangkok">
+        <source>Bangkok</source>
+        <target>曼谷</target>
+      </trans-unit>
+      <trans-unit id="598b379b1cd6ddb572482fb064024b26" resname="Dushanbe">
+        <source>Dushanbe</source>
+        <target>杜尚别</target>
+      </trans-unit>
+      <trans-unit id="7996d0f88b56815d3ea0423d2de3ab3c" resname="Fakaofo">
+        <source>Fakaofo</source>
+        <target>法考福</target>
+      </trans-unit>
+      <trans-unit id="db6ee1314441d918407bae9b1cabb4c5" resname="Dili">
+        <source>Dili</source>
+        <target>帝力</target>
+      </trans-unit>
+      <trans-unit id="1cb67632535fc726ef7986ccc6744fd3" resname="Ashgabat">
+        <source>Ashgabat</source>
+        <target>阿什哈巴德</target>
+      </trans-unit>
+      <trans-unit id="044c0f755d7e410a0da4c7d2b1a52263" resname="Tunis">
+        <source>Tunis</source>
+        <target>突尼斯</target>
+      </trans-unit>
+      <trans-unit id="7916ea90dc494215e95c0ea58ba20186" resname="Tongatapu">
+        <source>Tongatapu</source>
+        <target>东加塔布</target>
+      </trans-unit>
+      <trans-unit id="0ef8f876d62a45352e28410454e3634b" resname="Istanbul">
+        <source>Istanbul</source>
+        <target>伊斯坦布尔</target>
+      </trans-unit>
+      <trans-unit id="28d6c36330dc199939bfdcb9321719a3" resname="Port of Spain">
+        <source>Port of Spain</source>
+        <target>西班牙港</target>
+      </trans-unit>
+      <trans-unit id="73e8d007c01762e16d0e8dd1d4d5335f" resname="Funafuti">
+        <source>Funafuti</source>
+        <target>富纳富提</target>
+      </trans-unit>
+      <trans-unit id="7a4e1add2047d025b98f55dbb33382b5" resname="Taipei">
+        <source>Taipei</source>
+        <target>台北</target>
+      </trans-unit>
+      <trans-unit id="cde2d5e4d7c441ee80fcd3d7b328bebf" resname="Dar es Salaam">
+        <source>Dar es Salaam</source>
+        <target>达累斯萨拉姆</target>
+      </trans-unit>
+      <trans-unit id="bde8acaf5b357c3ab4410292428a22a7" resname="Uzhgorod">
+        <source>Uzhgorod</source>
+        <target>乌日哥罗德</target>
+      </trans-unit>
+      <trans-unit id="c5c12fffd30a23e3468076da2e046b90" resname="Kiev">
+        <source>Kiev</source>
+        <target>基辅</target>
+      </trans-unit>
+      <trans-unit id="a6afe2aa8f2b2df7a5308ffb0a83a4a9" resname="Zaporozhye">
+        <source>Zaporozhye</source>
+        <target>扎波罗热</target>
+      </trans-unit>
+      <trans-unit id="a006156c20b3fbbbbec28e9fac9a1d02" resname="Kampala">
+        <source>Kampala</source>
+        <target>坎帕拉</target>
+      </trans-unit>
+      <trans-unit id="1e3a8048bc6b7cadc1d967e198cf8584" resname="Midway">
+        <source>Midway</source>
+        <target>中途岛</target>
+      </trans-unit>
+      <trans-unit id="2a6707b6b439cbb234bd95047cc34a3b" resname="Johnston">
+        <source>Johnston</source>
+        <target>约翰斯顿</target>
+      </trans-unit>
+      <trans-unit id="688761c83ec62d30ec1fe269849d42ad" resname="Wake">
+        <source>Wake</source>
+        <target>威克</target>
+      </trans-unit>
+      <trans-unit id="7e731a704dbabd7d67b40fad4003923d" resname="Adak">
+        <source>Adak</source>
+        <target>埃达克</target>
+      </trans-unit>
+      <trans-unit id="c0289e98897ab58f231c168b19a67b2e" resname="Nome">
+        <source>Nome</source>
+        <target>诺姆</target>
+      </trans-unit>
+      <trans-unit id="904b6f7e29f77065ee9977b30660617c" resname="Honolulu">
+        <source>Honolulu</source>
+        <target>檀香山</target>
+      </trans-unit>
+      <trans-unit id="b19ebe22fcdcb7a220932846969bddcc" resname="Anchorage">
+        <source>Anchorage</source>
+        <target>安克雷奇</target>
+      </trans-unit>
+      <trans-unit id="d2b15f8810bd0653f14ebf7891ac08ba" resname="Yakutat">
+        <source>Yakutat</source>
+        <target>亚库塔特</target>
+      </trans-unit>
+      <trans-unit id="96ff1548c1e57274b2cce7eb082b5519" resname="Sitka">
+        <source>Sitka</source>
+        <target>锡特卡</target>
+      </trans-unit>
+      <trans-unit id="8115ce7fd7de25169acc9247e1d5c7f2" resname="Juneau">
+        <source>Juneau</source>
+        <target>朱诺</target>
+      </trans-unit>
+      <trans-unit id="18e8b82696d9009a4a59d861c98f9eaf" resname="Metlakatla">
+        <source>Metlakatla</source>
+        <target>梅特拉卡特拉</target>
+      </trans-unit>
+      <trans-unit id="d0aa2dffa0da83f1f34681308d04db5d" resname="Los Angeles">
+        <source>Los Angeles</source>
+        <target>洛杉矶</target>
+      </trans-unit>
+      <trans-unit id="daf1f64af9cb2ac00c1175a98e51ea42" resname="Boise">
+        <source>Boise</source>
+        <target>博伊西</target>
+      </trans-unit>
+      <trans-unit id="5047bc596a4bab2dc7f7c120bb22dec5" resname="Phoenix">
+        <source>Phoenix</source>
+        <target>凤凰城</target>
+      </trans-unit>
+      <trans-unit id="67100af8b08e073c3ba7f4de2707584b" resname="Denver">
+        <source>Denver</source>
+        <target>丹佛</target>
+      </trans-unit>
+      <trans-unit id="e765087f4627124b29b372489e576d19" resname="North Dakota - Beulah">
+        <source>North Dakota - Beulah</source>
+        <target>北达科他州比尤拉</target>
+      </trans-unit>
+      <trans-unit id="3f1cf993e47aa2210a7f6a9d0a13e991" resname="North Dakota - New Salem">
+        <source>North Dakota - New Salem</source>
+        <target>北达科他州新塞勒姆</target>
+      </trans-unit>
+      <trans-unit id="0f299c008b55c3c563b07378ac1229be" resname="North Dakota - Center">
+        <source>North Dakota - Center</source>
+        <target>北达科他州申特</target>
+      </trans-unit>
+      <trans-unit id="9cfa1e69f507d007a516eb3e9f5074e2" resname="Chicago">
+        <source>Chicago</source>
+        <target>芝加哥</target>
+      </trans-unit>
+      <trans-unit id="8439cdbd38144568408796094d5effd9" resname="Menominee">
+        <source>Menominee</source>
+        <target>梅诺米尼</target>
+      </trans-unit>
+      <trans-unit id="c03879329cd20c2704501542b8b790ea" resname="Indiana - Vincennes">
+        <source>Indiana - Vincennes</source>
+        <target>印第安纳州温森斯</target>
+      </trans-unit>
+      <trans-unit id="93ac4a2ce9a6db6e39ef1c28a4001715" resname="Indiana - Petersburg">
+        <source>Indiana - Petersburg</source>
+        <target>印第安纳州彼得斯堡</target>
+      </trans-unit>
+      <trans-unit id="7267f6aa0545f987cb1fe36f2837c482" resname="Indiana - Tell City">
+        <source>Indiana - Tell City</source>
+        <target>印第安纳州特尔城</target>
+      </trans-unit>
+      <trans-unit id="ef34be0af16cd7777b6c88174f8b0697" resname="Indiana - Knox">
+        <source>Indiana - Knox</source>
+        <target>印第安纳州诺克斯</target>
+      </trans-unit>
+      <trans-unit id="f6753419422d5d5bc02d5e3fbe343979" resname="Indiana - Winamac">
+        <source>Indiana - Winamac</source>
+        <target>印第安纳州威纳马克</target>
+      </trans-unit>
+      <trans-unit id="76284e0e67220a5304cb72d658fbe877" resname="Indiana - Marengo">
+        <source>Indiana - Marengo</source>
+        <target>印第安纳州马伦戈</target>
+      </trans-unit>
+      <trans-unit id="8b9c1179fe8a1c342a1950be99ac9c90" resname="Indianapolis">
+        <source>Indianapolis</source>
+        <target>印第安纳波利斯</target>
+      </trans-unit>
+      <trans-unit id="4fba925a7279f52a42d0f614b063e707" resname="Louisville">
+        <source>Louisville</source>
+        <target>路易斯维尔</target>
+      </trans-unit>
+      <trans-unit id="283666bd69be41c2ffdedc8a48c9d0ef" resname="Indiana - Vevay">
+        <source>Indiana - Vevay</source>
+        <target>印第安纳州维维市</target>
+      </trans-unit>
+      <trans-unit id="2d6bf5704647640c51c4e0de84075176" resname="Kentucky - Monticello">
+        <source>Kentucky - Monticello</source>
+        <target>肯塔基州蒙蒂塞洛</target>
+      </trans-unit>
+      <trans-unit id="1206c1cb107044f291a52d53fc9ec748" resname="Detroit">
+        <source>Detroit</source>
+        <target>底特律</target>
+      </trans-unit>
+      <trans-unit id="87809c954948d8a20507bee3648281b3" resname="New York">
+        <source>New York</source>
+        <target>纽约</target>
+      </trans-unit>
+      <trans-unit id="f01ac1a04a0343a4b0d4ec3976fc7b83" resname="Montevideo">
+        <source>Montevideo</source>
+        <target>蒙得维的亚</target>
+      </trans-unit>
+      <trans-unit id="ddd001de81e887225bc2c7a8519a072f" resname="Samarkand">
+        <source>Samarkand</source>
+        <target>撒马尔罕</target>
+      </trans-unit>
+      <trans-unit id="1e37948858daa7aed71fcb3f2e95e3e6" resname="Tashkent">
+        <source>Tashkent</source>
+        <target>塔什干</target>
+      </trans-unit>
+      <trans-unit id="a8571795df5a56146cfde039bd9c1a5a" resname="Vatican">
+        <source>Vatican</source>
+        <target>梵蒂冈</target>
+      </trans-unit>
+      <trans-unit id="580075e0252774484dee979d540badc6" resname="St Vincent">
+        <source>St Vincent</source>
+        <target>圣文森特</target>
+      </trans-unit>
+      <trans-unit id="c9fa5b8cb3b197ae5ce4baf8415a375b" resname="Caracas">
+        <source>Caracas</source>
+        <target>加拉加斯</target>
+      </trans-unit>
+      <trans-unit id="b66a1e094aa3558566a205f4066bf6fb" resname="Tortola">
+        <source>Tortola</source>
+        <target>托尔托拉</target>
+      </trans-unit>
+      <trans-unit id="cc3d62a8e96816948963ffa218ec0a93" resname="St Thomas">
+        <source>St Thomas</source>
+        <target>圣托马斯</target>
+      </trans-unit>
+      <trans-unit id="40d76e9f62624ae13d97fabdf6e201ca" resname="Saigon">
+        <source>Saigon</source>
+        <target>胡志明市</target>
+      </trans-unit>
+      <trans-unit id="32cdb3ff826949bb66dcaee94f1e6b5c" resname="Efate">
+        <source>Efate</source>
+        <target>埃法特</target>
+      </trans-unit>
+      <trans-unit id="3c807ca34dcea18fe702966da369e296" resname="Wallis">
+        <source>Wallis</source>
+        <target>瓦利斯</target>
+      </trans-unit>
+      <trans-unit id="d1834f40446a6347852a69c5a6e272b7" resname="Apia">
+        <source>Apia</source>
+        <target>阿皮亚</target>
+      </trans-unit>
+      <trans-unit id="4ec8d822dd82f63af55d4c01eeb93eff" resname="Aden">
+        <source>Aden</source>
+        <target>亚丁</target>
+      </trans-unit>
+      <trans-unit id="9c05c40b81fd906b1585e231c0d896f1" resname="Mayotte">
+        <source>Mayotte</source>
+        <target>马约特</target>
+      </trans-unit>
+      <trans-unit id="33416c1d32d3c19771d09bf215c7b514" resname="Johannesburg">
+        <source>Johannesburg</source>
+        <target>约翰内斯堡</target>
+      </trans-unit>
+      <trans-unit id="c9e26aa604ddee6234c920e6d006ca8b" resname="Lusaka">
+        <source>Lusaka</source>
+        <target>卢萨卡</target>
+      </trans-unit>
+      <trans-unit id="b430d27fbf2eb1c3dda104005c96fa05" resname="Harare">
+        <source>Harare</source>
+        <target>哈拉雷</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #13662 |
| License | MIT |
| Doc PR | - |

This patch adds translation files for time zone names based on Unicode CLDR data (see e.g. http://www.unicode.org/cldr/charts/27/by_type/timezones.north_america.html).

The translations are generated using a simple PHP script that must be run when there are changes to the CLDR data. The files must then be regenerated and committed to Git.

The generator only generates translations for locales already supported by the Form component (the CLDR contains a lot more).

The CLDR repository does not contain translations of the continent names. This must be done using the override files in translations-source. I have added the file for the da locale (Danish).

The patch is against the 2.7 branch. This is when the `choice_translation_domain` option was added.

A patch for 2.3 will be based on the assumption that the default `messages` domain is used for the form control. I will provide a separate PR for that.
