### PR TITLE
[FrameworkBundle] [DX] Add `Controller::json` method to make it easy to send json

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.1.0
+-----
+
+ * Added `Controller::json` to simplify creating JSON responses when using the Serializer component
+
 3.0.0
 -----
 

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Controller;
 
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -95,6 +96,29 @@ abstract class Controller implements ContainerAwareInterface
     protected function redirectToRoute($route, array $parameters = array(), $status = 302)
     {
         return $this->redirect($this->generateUrl($route, $parameters), $status);
+    }
+
+    /**
+     * Returns a JsonResponse that uses the serializer component if enabled, or json_encode.
+     *
+     * @param mixed $data    The response data
+     * @param int   $status  The status code to use for the Response
+     * @param array $headers Array of extra headers to add
+     * @param array $context Context to pass to serializer when using serializer component
+     *
+     * @return JsonResponse
+     */
+    protected function json($data, $status = 200, $headers = array(), $context = array())
+    {
+        if ($this->container->has('serializer')) {
+            $json = $this->container->get('serializer')->serialize($data, 'json', array_merge(array(
+                'json_encode_options' => JsonResponse::DEFAULT_ENCODING_OPTIONS,
+            ), $context));
+
+            return new JsonResponse($json, $status, $headers, true);
+        }
+
+        return new JsonResponse($data, $status, $headers);
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -22,7 +22,7 @@
         "symfony/dependency-injection": "~2.8|~3.0",
         "symfony/config": "~2.8|~3.0",
         "symfony/event-dispatcher": "~2.8|~3.0",
-        "symfony/http-foundation": "~2.8|~3.0",
+        "symfony/http-foundation": "~3.1",
         "symfony/http-kernel": "~2.8|~3.0",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/filesystem": "~2.8|~3.0",

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.1.0
+-----
+
+ * Added support for creating `JsonResponse` with a string of JSON data
+
 3.0.0
 -----
 

--- a/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
@@ -75,6 +75,18 @@ class JsonResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('application/vnd.acme.blog-v1+json', $response->headers->get('Content-Type'));
     }
 
+    public function testConstructorWithPreEncoded()
+    {
+        $response = new JsonResponse('1', 200, array(), true);
+        $this->assertEquals('1', $response->getContent());
+
+        $response = new JsonResponse('[1]', 200, array(), true);
+        $this->assertEquals('[1]', $response->getContent());
+
+        $response = new JsonResponse('true', 200, array(), true);
+        $this->assertEquals('true', $response->getContent());
+    }
+
     public function testCreate()
     {
         $response = JsonResponse::create(array('foo' => 'bar'), 204);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Its currently a awkward to use Serializer component to send a `JsonResponse`.

I have tried two approaches
1. use `Serializer::normalize` and `JsonResponse`
2. use `Serializer::serialize` and a plain `Response`, and set the `content-type`

In either cases there is need for a custom `json` function so as not to repeat yourself and there are disadvantages.
1. In the first case you are only partly using `Serializer` and any custom `Encoder` would be skipped
2. In the second you are not making use of `JsonResponse`, particular disadvantage if you want to support JSONP. 

This new `json` method uses the serializer component is enabled it is used to generate the json data, and falls back to normal `JsonResponse` when its not.
