### PR TITLE
Fix decoration of private services

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
@@ -48,16 +48,14 @@ class DecoratorServicePass implements CompilerPassInterface
             // to be able to reference it in the new one
             if ($container->hasAlias($inner)) {
                 $alias = $container->getAlias($inner);
-                $public = $alias->isPublic();
                 $container->setAlias($renamedId, new Alias((string) $alias, false));
             } else {
                 $definition = $container->getDefinition($inner);
-                $public = $definition->isPublic();
                 $definition->setPublic(false);
                 $container->setDefinition($renamedId, $definition);
             }
 
-            $container->setAlias($inner, new Alias($id, $public));
+            $container->setAlias($inner, new Alias($id));
         }
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/DecoratorServicePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/DecoratorServicePassTest.php
@@ -42,7 +42,7 @@ class DecoratorServicePassTest extends \PHPUnit_Framework_TestCase
         $this->process($container);
 
         $this->assertEquals('foo.extended', $container->getAlias('foo'));
-        $this->assertFalse($container->getAlias('foo')->isPublic());
+        $this->assertTrue($container->getAlias('foo')->isPublic());
 
         $this->assertEquals('bar.extended', $container->getAlias('bar'));
         $this->assertTrue($container->getAlias('bar')->isPublic());
@@ -74,7 +74,7 @@ class DecoratorServicePassTest extends \PHPUnit_Framework_TestCase
         $this->process($container);
 
         $this->assertEquals('foo.extended', $container->getAlias('foo.alias'));
-        $this->assertFalse($container->getAlias('foo.alias')->isPublic());
+        $this->assertTrue($container->getAlias('foo.alias')->isPublic());
 
         $this->assertEquals('foo', $container->getAlias('foo.extended.inner'));
         $this->assertFalse($container->getAlias('foo.extended.inner')->isPublic());
@@ -108,7 +108,7 @@ class DecoratorServicePassTest extends \PHPUnit_Framework_TestCase
         $this->process($container);
 
         $this->assertEquals('bar', $container->getAlias('foo'));
-        $this->assertFalse($container->getAlias('foo')->isPublic());
+        $this->assertTrue($container->getAlias('foo')->isPublic());
 
         $this->assertSame($fooDefinition, $container->getDefinition('baz.inner'));
         $this->assertFalse($container->getDefinition('baz.inner')->isPublic());

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 
 /**
  * This class tests the integration of the different compiler passes.
@@ -112,5 +113,25 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($container->hasDefinition('a'));
         $this->assertFalse($container->hasDefinition('b'));
         $this->assertFalse($container->hasDefinition('c'), 'Service C was not inlined.');
+    }
+
+    public function testDecoratePrivateServiceDontThrowException()
+    {
+        $container = new ContainerBuilder();
+        $container->setResourceTracking(false);
+
+        $foo = $container->register('foo', '\stdClass');
+        $foo->setPublic(false);
+
+        $bar = $container->register('bar', '\stdClass');
+        $bar->setDecoratedService('foo');
+
+        $container->compile();
+
+        try {
+            $container->get('foo');
+        } catch (InvalidArgumentException $e) {
+            $this->fail('The service foo should exists, but it doesn\'t.');
+        }
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | no |
| License | MIT |
| Doc PR | no |

This PR allow to decorate private service.
The alternative is to not remove private aliases which are not use elsewhere.

What do you think ?
