### PR TITLE
[Cache] Don't clone, serialize

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
@@ -276,13 +276,6 @@ abstract class AbstractAdapter implements CacheItemPoolInterface, LoggerAwareInt
         if (!$item instanceof CacheItem) {
             return false;
         }
-        try {
-            $item = clone $item;
-        } catch (\Exception $e) {
-            $value = $item->get();
-            $type = is_object($value) ? get_class($value) : gettype($value);
-            CacheItem::log($this->logger, 'Failed to clone key "{key}" ({type})', array('key' => $key, 'type' => $type, 'exception' => $e));
-        }
         $this->deferred[$item->getKey()] = $item;
 
         return true;

--- a/src/Symfony/Component/Cache/CacheItem.php
+++ b/src/Symfony/Component/Cache/CacheItem.php
@@ -31,13 +31,6 @@ final class CacheItem implements CacheItemInterface
     private $lifetime;
     private $defaultLifetime;
 
-    public function __clone()
-    {
-        if (is_object($this->value)) {
-            $this->value = clone $this->value;
-        }
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -112,7 +105,7 @@ final class CacheItem implements CacheItemInterface
      *
      * @internal
      */
-    public function log(LoggerInterface $logger = null, $message, $context = array())
+    public static function log(LoggerInterface $logger = null, $message, $context = array())
     {
         if ($logger) {
             $logger->warning($message, $context);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Cloning is not required by PSR-6, adds overhead and doesn't prevent any mistake for nested objects. Let's simplify.
ArrayCache in turn should store serialized by default, so that data is deep-cloned. But since this can cause a perf issue for some, I propose to add a constructor flag to disable serializing. WDYT?
