### PR TITLE
	[Serializer] Integrate the PropertyInfo Component (recursive denormalization and hardening)

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG
  * added support for serializing objects that implement `DateTimeInterface`
  * added `AbstractObjectNormalizer` as a base class for normalizers that deal
    with objects
+ * added support to relation deserialization
 
 2.7.0
 -----

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\Normalizer;
 
+use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
 use Symfony\Component\Serializer\Exception\CircularReferenceException;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\RuntimeException;
@@ -69,15 +70,21 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
     protected $camelizedAttributes = array();
 
     /**
+     * @var PropertyInfoExtractorInterface
+     */
+    protected $propertyInfoExtractor;
+
+    /**
      * Sets the {@link ClassMetadataFactoryInterface} to use.
      *
      * @param ClassMetadataFactoryInterface|null $classMetadataFactory
      * @param NameConverterInterface|null        $nameConverter
      */
-    public function __construct(ClassMetadataFactoryInterface $classMetadataFactory = null, NameConverterInterface $nameConverter = null)
+    public function __construct(ClassMetadataFactoryInterface $classMetadataFactory = null, NameConverterInterface $nameConverter = null, PropertyInfoExtractorInterface $propertyInfoExtractor = null)
     {
         $this->classMetadataFactory = $classMetadataFactory;
         $this->nameConverter = $nameConverter;
+        $this->propertyInfoExtractor = $propertyInfoExtractor;
     }
 
     /**
@@ -285,6 +292,11 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
             return $object;
         }
 
+        $format = null;
+        if (isset($context['format'])) {
+            $format = $context['format'];
+        }
+
         $constructor = $reflectionClass->getConstructor();
         if ($constructor) {
             $constructorParameters = $constructor->getParameters();
@@ -305,6 +317,23 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
                         $params = array_merge($params, $data[$paramName]);
                     }
                 } elseif ($allowed && !$ignored && (isset($data[$key]) || array_key_exists($key, $data))) {
+                    if ($this->propertyInfoExtractor) {
+                        $types = $this->propertyInfoExtractor->getTypes($class, $key);
+
+                        foreach ($types as $type) {
+                            if ($type && $type->getClassName() && (!empty($data[$key]) || !$type->isNullable())) {
+                                if (!$this->serializer instanceof DenormalizerInterface) {
+                                    throw new RuntimeException(sprintf('Cannot denormalize attribute "%s" because injected serializer is not a denormalizer', $key));
+                                }
+
+                                $value = $data[$paramName];
+                                $data[$paramName] = $this->serializer->denormalize($value, $type->getClassName(), $format, $context);
+
+                                break;
+                            }
+                        }
+                    }
+
                     $params[] = $data[$key];
                     // don't run set for a parameter passed to the constructor
                     unset($data[$key]);

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Serializer\Normalizer;
 
-use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
 use Symfony\Component\Serializer\Exception\CircularReferenceException;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\RuntimeException;
@@ -70,21 +69,15 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
     protected $camelizedAttributes = array();
 
     /**
-     * @var PropertyInfoExtractorInterface
-     */
-    protected $propertyInfoExtractor;
-
-    /**
      * Sets the {@link ClassMetadataFactoryInterface} to use.
      *
      * @param ClassMetadataFactoryInterface|null $classMetadataFactory
      * @param NameConverterInterface|null        $nameConverter
      */
-    public function __construct(ClassMetadataFactoryInterface $classMetadataFactory = null, NameConverterInterface $nameConverter = null, PropertyInfoExtractorInterface $propertyInfoExtractor = null)
+    public function __construct(ClassMetadataFactoryInterface $classMetadataFactory = null, NameConverterInterface $nameConverter = null)
     {
         $this->classMetadataFactory = $classMetadataFactory;
         $this->nameConverter = $nameConverter;
-        $this->propertyInfoExtractor = $propertyInfoExtractor;
     }
 
     /**
@@ -292,11 +285,6 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
             return $object;
         }
 
-        $format = null;
-        if (isset($context['format'])) {
-            $format = $context['format'];
-        }
-
         $constructor = $reflectionClass->getConstructor();
         if ($constructor) {
             $constructorParameters = $constructor->getParameters();
@@ -317,23 +305,6 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
                         $params = array_merge($params, $data[$paramName]);
                     }
                 } elseif ($allowed && !$ignored && (isset($data[$key]) || array_key_exists($key, $data))) {
-                    if ($this->propertyInfoExtractor) {
-                        $types = $this->propertyInfoExtractor->getTypes($class, $key);
-
-                        foreach ($types as $type) {
-                            if ($type && $type->getClassName() && (!empty($data[$key]) || !$type->isNullable())) {
-                                if (!$this->serializer instanceof DenormalizerInterface) {
-                                    throw new RuntimeException(sprintf('Cannot denormalize attribute "%s" because injected serializer is not a denormalizer', $key));
-                                }
-
-                                $value = $data[$paramName];
-                                $data[$paramName] = $this->serializer->denormalize($value, $type->getClassName(), $format, $context);
-
-                                break;
-                            }
-                        }
-                    }
-
                     $params[] = $data[$key];
                     // don't run set for a parameter passed to the constructor
                     unset($data[$key]);

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -47,8 +47,7 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
         $normalizedData = $this->prepareForDenormalization($data);
 
         $reflectionClass = new \ReflectionClass($class);
-        $subcontext = array_merge($context, array('format' => $format));
-        $object = $this->instantiateObject($normalizedData, $class, $subcontext, $reflectionClass, $allowedAttributes);
+        $object = $this->instantiateObject($normalizedData, $class, $context, $reflectionClass, $allowedAttributes);
 
         $classMethods = get_class_methods($object);
         foreach ($normalizedData as $attribute => $value) {
@@ -61,33 +60,8 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
 
             if ($allowed && !$ignored) {
                 $setter = 'set'.ucfirst($attribute);
+
                 if (in_array($setter, $classMethods) && !$reflectionClass->getMethod($setter)->isStatic()) {
-                    if ($this->propertyInfoExtractor) {
-                        $types = (array) $this->propertyInfoExtractor->getTypes($class, $attribute);
-
-                        foreach ($types as $type) {
-                            if ($type && (!empty($value) || !$type->isNullable())) {
-                                if (!$this->serializer instanceof DenormalizerInterface) {
-                                    throw new RuntimeException(
-                                        sprintf(
-                                            'Cannot denormalize attribute "%s" because injected serializer is not a denormalizer',
-                                            $attribute
-                                        )
-                                    );
-                                }
-
-                                $value = $this->serializer->denormalize(
-                                    $value,
-                                    $type->getClassName(),
-                                    $format,
-                                    $context
-                                );
-
-                                break;
-                            }
-                        }
-                    }
-
                     $object->$setter($value);
                 }
             }

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Serializer\Normalizer;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 
@@ -29,9 +30,9 @@ class ObjectNormalizer extends AbstractObjectNormalizer
      */
     protected $propertyAccessor;
 
-    public function __construct(ClassMetadataFactoryInterface $classMetadataFactory = null, NameConverterInterface $nameConverter = null, PropertyAccessorInterface $propertyAccessor = null)
+    public function __construct(ClassMetadataFactoryInterface $classMetadataFactory = null, NameConverterInterface $nameConverter = null, PropertyAccessorInterface $propertyAccessor = null, PropertyTypeExtractorInterface $propertyTypeExtractor = null)
     {
-        parent::__construct($classMetadataFactory, $nameConverter);
+        parent::__construct($classMetadataFactory, $nameConverter, $propertyTypeExtractor);
 
         $this->propertyAccessor = $propertyAccessor ?: PropertyAccess::createPropertyAccessor();
     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -12,8 +12,6 @@
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use Doctrine\Common\Annotations\AnnotationReader;
-use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
-use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
 use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
 use Symfony\Component\Serializer\Serializer;
@@ -392,7 +390,7 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Symfony\Component\Serializer\Exception\LogicException
-     * @expectedExceptionMessage Cannot normalize attribute "object" because injected serializer is not a normalizer
+     * @expectedExceptionMessage Cannot normalize attribute "object" because the injected serializer is not a normalizer
      */
     public function testUnableToNormalizeObjectAttribute()
     {
@@ -490,24 +488,6 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
     public function testNoStaticGetSetSupport()
     {
         $this->assertFalse($this->normalizer->supportsNormalization(new ObjectWithJustStaticSetterDummy()));
-    }
-
-    public function testDenormalizeWithTypehint()
-    {
-        /* need a serializer that can recurse denormalization $normalizer */
-        $normalizer = new GetSetMethodNormalizer(null, null, new PropertyInfoExtractor(array(), array(new ReflectionExtractor())));
-        $serializer = new Serializer(array($normalizer));
-        $normalizer->setSerializer($serializer);
-
-        $obj = $normalizer->denormalize(
-            array(
-                'object' => array('foo' => 'foo', 'bar' => 'bar'),
-            ),
-            __NAMESPACE__.'\GetTypehintedDummy',
-            'any'
-        );
-        $this->assertEquals('foo', $obj->getObject()->getFoo());
-        $this->assertEquals('bar', $obj->getObject()->getBar());
     }
 
     public function testPrivateSetter()
@@ -775,59 +755,6 @@ class GetCamelizedDummy
     public function getBar_foo()
     {
         return $this->bar_foo;
-    }
-}
-
-class GetTypehintedDummy
-{
-    protected $object;
-
-    public function getObject()
-    {
-        return $this->object;
-    }
-
-    public function setObject(GetTypehintDummy $object)
-    {
-        $this->object = $object;
-    }
-}
-
-class GetTypehintDummy
-{
-    protected $foo;
-    protected $bar;
-
-    /**
-     * @return mixed
-     */
-    public function getFoo()
-    {
-        return $this->foo;
-    }
-
-    /**
-     * @param mixed $foo
-     */
-    public function setFoo($foo)
-    {
-        $this->foo = $foo;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getBar()
-    {
-        return $this->bar;
-    }
-
-    /**
-     * @param mixed $bar
-     */
-    public function setBar($bar)
-    {
-        $this->bar = $bar;
     }
 }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use Doctrine\Common\Annotations\AnnotationReader;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
 use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
 use Symfony\Component\Serializer\Serializer;
@@ -490,6 +492,24 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->normalizer->supportsNormalization(new ObjectWithJustStaticSetterDummy()));
     }
 
+    public function testDenormalizeWithTypehint()
+    {
+        /* need a serializer that can recurse denormalization $normalizer */
+        $normalizer = new GetSetMethodNormalizer(null, null, new PropertyInfoExtractor(array(), array(new ReflectionExtractor())));
+        $serializer = new Serializer(array($normalizer));
+        $normalizer->setSerializer($serializer);
+
+        $obj = $normalizer->denormalize(
+            array(
+                'object' => array('foo' => 'foo', 'bar' => 'bar'),
+            ),
+            __NAMESPACE__.'\GetTypehintedDummy',
+            'any'
+        );
+        $this->assertEquals('foo', $obj->getObject()->getFoo());
+        $this->assertEquals('bar', $obj->getObject()->getBar());
+    }
+
     public function testPrivateSetter()
     {
         $obj = $this->normalizer->denormalize(array('foo' => 'foobar'), __NAMESPACE__.'\ObjectWithPrivateSetterDummy');
@@ -755,6 +775,59 @@ class GetCamelizedDummy
     public function getBar_foo()
     {
         return $this->bar_foo;
+    }
+}
+
+class GetTypehintedDummy
+{
+    protected $object;
+
+    public function getObject()
+    {
+        return $this->object;
+    }
+
+    public function setObject(GetTypehintDummy $object)
+    {
+        $this->object = $object;
+    }
+}
+
+class GetTypehintDummy
+{
+    protected $foo;
+    protected $bar;
+
+    /**
+     * @return mixed
+     */
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+
+    /**
+     * @param mixed $foo
+     */
+    public function setFoo($foo)
+    {
+        $this->foo = $foo;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getBar()
+    {
+        return $this->bar;
+    }
+
+    /**
+     * @param mixed $bar
+     */
+    public function setBar($bar)
+    {
+        $this->bar = $bar;
     }
 }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -349,7 +349,7 @@ class PropertyNormalizerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Symfony\Component\Serializer\Exception\LogicException
-     * @expectedExceptionMessage Cannot normalize attribute "bar" because injected serializer is not a normalizer
+     * @expectedExceptionMessage Cannot normalize attribute "bar" because the injected serializer is not a normalizer
      */
     public function testUnableToNormalizeObjectAttribute()
     {

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -33,7 +33,7 @@
     },
     "suggest": {
         "psr/cache-implementation": "For using the metadata cache.",
-        "symfony/property-info": "To harden the component and deserialize relations.",
+        "symfony/property-info": "To deserialize relations.",
         "symfony/yaml": "For using the default YAML mapping loader.",
         "symfony/config": "For using the XML mapping loader.",
         "symfony/property-access": "For using the ObjectNormalizer.",

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -24,6 +24,7 @@
         "symfony/property-access": "~2.8|~3.0",
         "symfony/http-foundation": "~2.8|~3.0",
         "symfony/cache": "~3.1",
+        "symfony/property-info": "~2.8|~3.0",
         "doctrine/annotations": "~1.0",
         "doctrine/cache": "~1.0"
     },
@@ -32,6 +33,7 @@
     },
     "suggest": {
         "psr/cache-implementation": "For using the metadata cache.",
+        "symfony/property-info": "To harden the component and deserialize relations.",
         "symfony/yaml": "For using the default YAML mapping loader.",
         "symfony/config": "For using the XML mapping loader.",
         "symfony/property-access": "For using the ObjectNormalizer.",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16143, #17193, #14844 |
| License | MIT |
| Doc PR | todo |

Integrates the PropertyInfo Component in order to:
- denormalize a graph of objects recursively (see tests)
- harden the hydratation logic

The hardening part is interesting. Considering the following example:

``` php
class Foo
{
    public function setDate(\DateTimeInterface $date)
    {
    }
}

// initialize $normalizer
$normalizer->denormalize(['date' => 1234], Foo::class);
```

Previously, a PHP error was thrown because the type passed to the setter (an int) doesn't match the one checked with the typehint. With the PropertyInfo integration, an `UnexpectedValueExcption` is throw instead.
It's especially interesting for web APIs dealing with JSON documents. For instance in API Platform, previously a 500 error was thrown, but thanks to this fix a 400 HTTP code with a descriptive error message will be returned. (/cc @csarrazi @mRoca @blazarecki, it's an alternative to https://github.com/dunglas/php-to-json-schema for protecting an API).

/cc @mihai-stancu 
