### PR TITLE
[Translation][transChoice] allows escaping the pipe character.

### DIFF
--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.2.0
+-----
+
+ * Added support for escaping `|` in plural translations with double pipe.
+
 3.1.0
 -----
 

--- a/src/Symfony/Component/Translation/MessageSelector.php
+++ b/src/Symfony/Component/Translation/MessageSelector.php
@@ -47,11 +47,11 @@ class MessageSelector
      */
     public function choose($message, $number, $locale)
     {
-        $parts = explode('|', $message);
+        preg_match_all('/(?:\|\||[^\|])++/', $message, $parts);
         $explicitRules = array();
         $standardRules = array();
-        foreach ($parts as $part) {
-            $part = trim($part);
+        foreach ($parts[0] as $part) {
+            $part = trim(str_replace('||', '|', $part));
 
             if (preg_match('/^(?P<interval>'.Interval::getIntervalRegexp().')\s*(?P<message>.*?)$/xs', $part, $matches)) {
                 $explicitRules[$matches['interval']] = $matches['message'];
@@ -74,7 +74,7 @@ class MessageSelector
         if (!isset($standardRules[$position])) {
             // when there's exactly one rule given, and that rule is a standard
             // rule, use this rule
-            if (1 === count($parts) && isset($standardRules[0])) {
+            if (1 === count($parts[0]) && isset($standardRules[0])) {
                 return $standardRules[0];
             }
 

--- a/src/Symfony/Component/Translation/Tests/MessageSelectorTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageSelectorTest.php
@@ -125,6 +125,8 @@ class MessageSelectorTest extends \PHPUnit_Framework_TestCase
             array('This is a text with a\nnew-line in it. Selector = 0.', '{0}This is a text with a\nnew-line in it. Selector = 0.|{1}This is a text with a\nnew-line in it. Selector = 1.|[1,Inf]This is a text with a\nnew-line in it. Selector > 1.', 0),
             // with double-quotes and id split accros lines
             array("This is a text with a\nnew-line in it. Selector = 1.", "{0}This is a text with a\nnew-line in it. Selector = 0.|{1}This is a text with a\nnew-line in it. Selector = 1.|[1,Inf]This is a text with a\nnew-line in it. Selector > 1.", 1),
+            // esacape pipe
+            array('This is a text with | in it. Selector = 0.', '{0}This is a text with || in it. Selector = 0.|{1}This is a text with || in it. Selector = 1.', 0),
         );
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | #15195 |
| Tests pass? | yes |
| License | MIT |
