### PR TITLE
[Routing] add files used in FileResource objects

### DIFF
--- a/src/Symfony/Component/Routing/Loader/ObjectRouteLoader.php
+++ b/src/Symfony/Component/Routing/Loader/ObjectRouteLoader.php
@@ -87,7 +87,9 @@ abstract class ObjectRouteLoader extends Loader
     private function addClassResource(\ReflectionClass $class, RouteCollection $collection)
     {
         do {
-            $collection->addResource(new FileResource($class->getFileName()));
+            if (is_file($class->getFileName())) {
+                $collection->addResource(new FileResource($class->getFileName()));
+            }
         } while ($class = $class->getParentClass());
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Loader/ObjectRouteLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/ObjectRouteLoaderTest.php
@@ -25,17 +25,8 @@ class ObjectRouteLoaderTest extends \PHPUnit_Framework_TestCase
         $collection = new RouteCollection();
         $collection->add('foo', new Route('/foo'));
 
-        // create some callable object
-        $service = $this->getMockBuilder('stdClass')
-            ->setMethods(array('loadRoutes'))
-            ->getMock();
-        $service->expects($this->once())
-            ->method('loadRoutes')
-            ->with($loader)
-            ->will($this->returnValue($collection));
-
         $loader->loaderMap = array(
-            'my_route_provider_service' => $service,
+            'my_route_provider_service' => new RouteService($collection),
         );
 
         $actualRoutes = $loader->load(
@@ -112,5 +103,20 @@ class ObjectRouteLoaderForTest extends ObjectRouteLoader
     protected function getServiceObject($id)
     {
         return isset($this->loaderMap[$id]) ? $this->loaderMap[$id] : null;
+    }
+}
+
+class RouteService
+{
+    private $collection;
+
+    public function __construct($collection)
+    {
+        $this->collection = $collection;
+    }
+
+    public function loadRoutes()
+    {
+        return $this->collection;
     }
 }

--- a/src/Symfony/Component/Routing/Tests/RouteCollectionBuilderTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCollectionBuilderTest.php
@@ -30,7 +30,7 @@ class RouteCollectionBuilderTest extends \PHPUnit_Framework_TestCase
         $originalRoute = new Route('/foo/path');
         $expectedCollection = new RouteCollection();
         $expectedCollection->add('one_test_route', $originalRoute);
-        $expectedCollection->addResource(new FileResource('file_resource.yml'));
+        $expectedCollection->addResource(new FileResource(__DIR__.'/Fixtures/file_resource.yml'));
 
         $resolvedLoader
             ->expects($this->once())


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/pull/17598#discussion_r51756307 |
| License | MIT |
| Doc PR |  |

Starting with Symfony 3.1, the constructor of the `FileResource` class
will throw an exception when the passed file does not exist.
