### PR TITLE
[Crawler] Remove a mention of an interface removed before a merge

### DIFF
--- a/src/Symfony/Component/DomCrawler/CHANGELOG.md
+++ b/src/Symfony/Component/DomCrawler/CHANGELOG.md
@@ -4,8 +4,10 @@ CHANGELOG
 3.1.0
 -----
 
-* All the URI parsing logic have been abstracted in the `AbstractUriElement` class. The `Link` class is now a child of `AbstractUriElement` which implements the new `UriElementInterface`, describing the common `getNode`, `getMethod` and `getUri` methods.
-* Added an `Image` class to crawl images and parse their `src` attribute, and `selectImage`, `image`, `images` methods in `Crawler`, the image version of the equivalent `link` methods.
+* All the URI parsing logic have been abstracted in the `AbstractUriElement` class.
+  The `Link` class is now a child of `AbstractUriElement`.
+* Added an `Image` class to crawl images and parse their `src` attribute,
+  and `selectImage`, `image`, `images` methods in the `Crawler` (the image version of the equivalent `link` methods).
 
 2.5.0
 -----


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Missed it while merging #17585.
