### PR TITLE
Remove InputOption::VALUE_REQUIRED mode from $default parameter description

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -383,7 +383,7 @@ class Command
      * @param string $shortcut    The shortcut (can be null)
      * @param int    $mode        The option mode: One of the InputOption::VALUE_* constants
      * @param string $description A description text
-     * @param mixed  $default     The default value (must be null for InputOption::VALUE_REQUIRED or InputOption::VALUE_NONE)
+     * @param mixed  $default     The default value (must be null for InputOption::VALUE_NONE)
      *
      * @return Command The current instance
      */

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -39,7 +39,7 @@ class InputOption
      * @param string|array $shortcut    The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
      * @param int          $mode        The option mode: One of the VALUE_* constants
      * @param string       $description A description text
-     * @param mixed        $default     The default value (must be null for self::VALUE_REQUIRED or self::VALUE_NONE)
+     * @param mixed        $default     The default value (must be null for self::VALUE_NONE)
      *
      * @throws InvalidArgumentException If option mode is invalid or incompatible
      */


### PR DESCRIPTION
Reopening previous PR, providing more information

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Remove InputOption::VALUE_REQUIRED mode from $default parameter description as InputOption::setDefault() throws an exception only when called with InputOption::VALUE_NONE mode.
In practice the $default not null value could be still used in VALUE_REQUIRED mode in case InputOption was never set but accessed from InputDefinition::getOption() method.

There is an important difference between 2 concepts. Not required Option AND not required option Value. When the not required Option is not provided the default value still could be taken from required option Value instance.

Relevant (correct) test case:
https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php#L136
