### PR TITLE
[TwigBridge] fix default argument value

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/YamlExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/YamlExtension.php
@@ -31,7 +31,7 @@ class YamlExtension extends \Twig_Extension
         );
     }
 
-    public function encode($input, $inline = 0, $dumpObjects = false)
+    public function encode($input, $inline = 0, $dumpObjects = 0)
     {
         static $dumper;
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17705 |
| License | MIT |
| Doc PR |  |

When deprecating boolean argument values, the default value must not be
`false`.
