### PR TITLE
fixed codeblock in UPGRADE-3.1.md

### DIFF
--- a/UPGRADE-3.1.md
+++ b/UPGRADE-3.1.md
@@ -45,6 +45,7 @@ Yaml
 
    ```php
    Yaml::dump(array('foo' => new A(), 'bar' => 1), 0, 0, false, Yaml::DUMP_OBJECT);
+   ```
 
  * The `!!php/object` tag to indicate dumped PHP objects has been deprecated
    and will be removed in Symfony 4.0. Use the `!php/object` tag instead.


### PR DESCRIPTION
Missing backticks break upgrade notes for 3.1. 

| Q | A |
| --- | --- |
| Bug fix? | - |
| New feature? | - |
| BC breaks? | - |
| Deprecations? | - |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
