### PR TITLE
[FrameworkBundle] Improve debug:container command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -192,7 +192,9 @@ EOF
             throw new \InvalidArgumentException(sprintf('No services found that match "%s".', $name));
         }
 
-        return $io->choice('Select one of the following services to display its information', $matchingServices);
+        $default = 1 === count($matchingServices) ? $matchingServices[0] : null;
+
+        return $io->choice('Select one of the following services to display its information', $matchingServices, $default);
     }
 
     private function findServiceIdsContaining(ContainerBuilder $builder, $name)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

When the only one service found we could set it as a default value, so user have to just press enter to see it's definition. 
