### PR TITLE
[Yaml] Fix wrong line number when comments are inserted in the middle of a block.

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -448,7 +448,7 @@ class Parser
             }
 
             // we ignore "comment" lines only when we are not inside a scalar block
-            if (empty($blockScalarIndentations) && $this->isCurrentLineComment()) {
+            if (empty($blockScalarIndentations) && $this->isCurrentLineComment() && false === $this->isPreviousNonCommentLineIsCollectionItem()) {
                 continue;
             }
 

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -816,7 +816,7 @@ class Parser
     /**
      * Returns true if the current line is a collection item.
      *
-     * @return bool Returns true if the current line is a collection item line, false otherwise.
+     * @return bool
      */
     private function isCurrentLineCollectionItem()
     {
@@ -834,7 +834,7 @@ class Parser
     {
         $isCollectionItem = false;
         $moves = 0;
-        while($this->moveToPreviousLine()) {
+        while ($this->moveToPreviousLine()) {
             ++$moves;
             // If previous line is a comment, move back again.
             if ($this->isCurrentLineComment()) {
@@ -845,7 +845,7 @@ class Parser
         }
 
         // Move parser back to previous line.
-        while($moves > 0) {
+        while ($moves > 0) {
             $this->moveToNextLine();
             --$moves;
         }

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -28,6 +28,7 @@ class Parser
     private $currentLineNb = -1;
     private $currentLine = '';
     private $refs = array();
+    private $skippedCommentLines = 0;
 
     /**
      * Constructor.
@@ -154,7 +155,7 @@ class Parser
                 try {
                     $key = Inline::parseScalar($values['key']);
                 } catch (ParseException $e) {
-                    $e->setParsedLine($this->getRealCurrentLineNb() + 1);
+                    $e->setParsedLine($this->getRealCurrentLineNb() + $this->skippedCommentLines + 1);
                     $e->setSnippet($this->currentLine);
 
                     throw $e;

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -822,7 +822,7 @@ class Parser
     {
         $ltrimmedLine = ltrim($this->currentLine, ' ');
 
-        return '' !== $ltrimmedLine && $ltrimmedLine[0] === '-';
+        return '' !== $ltrimmedLine && '-' === $ltrimmedLine[0];
     }
 
     /**

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -448,7 +448,7 @@ class Parser
             }
 
             // we ignore "comment" lines only when we are not inside a scalar block
-            if (empty($blockScalarIndentations) && $this->isCurrentLineComment() && false === $this->isPreviousNonCommentLineIsCollectionItem()) {
+            if (empty($blockScalarIndentations) && $this->isCurrentLineComment() && false === $this->checkIfPreviousNonCommentLineIsCollectionItem()) {
                 continue;
             }
 
@@ -826,11 +826,11 @@ class Parser
     }
 
     /**
-     * Tests whether or not the current comment line is in a collection.
+     * Tests whether the current comment line is in a collection.
      *
      * @return bool
      */
-    private function isPreviousNonCommentLineIsCollectionItem()
+    private function checkIfPreviousNonCommentLineIsCollectionItem()
     {
         $isCollectionItem = false;
         $moves = 0;

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -1239,6 +1239,19 @@ foo:
         bar: "123",
 YAML
             ),
+            array(
+                8,
+                <<<YAML
+foo:
+    -
+        # foobar
+        baz: 123
+bar:
+    -
+        # bar
+        bar: "123",
+YAML
+            ),
         );
     }
 }

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -1201,6 +1201,46 @@ EOT
             ),
         );
     }
+
+    /**
+     * @param $lineNumber
+     * @param $yaml
+     * @dataProvider parserThrowsExceptionWithCorrectLineNumberProvider
+     */
+    public function testParserThrowsExceptionWithCorrectLineNumber($lineNumber, $yaml)
+    {
+        $this->setExpectedException(
+            '\Symfony\Component\Yaml\Exception\ParseException',
+            sprintf('Unexpected characters near "," at line %d (near "bar: "123",").', $lineNumber)
+        );
+
+        $this->parser->parse($yaml);
+    }
+
+    public function parserThrowsExceptionWithCorrectLineNumberProvider()
+    {
+        return array(
+            array(
+                4,
+                <<<YAML
+foo:
+    -
+        # bar
+        bar: "123",
+YAML
+            ),
+            array(
+                5,
+                <<<YAML
+foo:
+    -
+        # bar
+        # bar
+        bar: "123",
+YAML
+            ),
+        );
+    }
 }
 
 class B

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -1252,6 +1252,21 @@ bar:
         bar: "123",
 YAML
             ),
+            array(
+                10,
+                <<<YAML
+foo:
+    -
+        # foobar
+        # foobar
+        baz: 123
+bar:
+    -
+        # bar
+        # bar
+        bar: "123",
+YAML
+            ),
         );
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15437 |
| License | MIT |
| Doc PR | - |

@xabbuh what is your opinion a solution like this? (counting the skipped comment lines and when exception occurs add them to the current line count.)
