### PR TITLE
[Cache] Count cache hits/misses in ProxyAdapter

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/ProxyAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ProxyAdapterTest.php
@@ -29,4 +29,21 @@ class ProxyAdapterTest extends CachePoolTest
     {
         return new ProxyAdapter(new ArrayAdapter());
     }
+
+    public function testGetHitsMisses()
+    {
+        $pool = $this->createCachePool();
+
+        $this->assertSame(0, $pool->getHits());
+        $this->assertSame(0, $pool->getMisses());
+
+        $bar = $pool->getItem('bar');
+        $this->assertSame(0, $pool->getHits());
+        $this->assertSame(1, $pool->getMisses());
+
+        $pool->save($bar->set('baz'));
+        $bar = $pool->getItem('bar');
+        $this->assertSame(1, $pool->getHits());
+        $this->assertSame(1, $pool->getMisses());
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17537 partially |
| License | MIT |
| Doc PR | - |

I propose to add this subset of the `Doctrine\Common\Cache\Cache` interface so that we can build data collectors on top and show these stats in the web profiler.
ping @javiereguiluz 
