### PR TITLE
[PropertyAccess] Throw an InvalidArgumentException when the type do not match

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -589,6 +589,8 @@ class PropertyAccessor implements PropertyAccessorInterface
             } catch (\TypeError $e) {
                 throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
             }
+
+            return;
         }
 
         // PHP 5

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\PropertyAccess;
 
 use Symfony\Component\PropertyAccess\Exception\AccessException;
+use Symfony\Component\PropertyAccess\Exception\InvalidArgumentException;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\Exception\NoSuchIndexException;
 use Symfony\Component\PropertyAccess\Exception\UnexpectedTypeException;
@@ -553,7 +554,7 @@ class PropertyAccessor implements PropertyAccessorInterface
         $access = $this->getWriteAccessInfo($object, $property, $value);
 
         if (self::ACCESS_TYPE_METHOD === $access[self::ACCESS_TYPE]) {
-            $object->{$access[self::ACCESS_NAME]}($value);
+            $this->callMethod($object, $access[self::ACCESS_NAME], $value);
         } elseif (self::ACCESS_TYPE_PROPERTY === $access[self::ACCESS_TYPE]) {
             $object->{$access[self::ACCESS_NAME]} = $value;
         } elseif (self::ACCESS_TYPE_ADDER_AND_REMOVER === $access[self::ACCESS_TYPE]) {
@@ -567,9 +568,38 @@ class PropertyAccessor implements PropertyAccessorInterface
 
             $object->$property = $value;
         } elseif (self::ACCESS_TYPE_MAGIC === $access[self::ACCESS_TYPE]) {
-            $object->{$access[self::ACCESS_NAME]}($value);
+            $this->callMethod($object, $access[self::ACCESS_NAME], $value);
         } else {
             throw new NoSuchPropertyException($access[self::ACCESS_NAME]);
+        }
+    }
+
+    /**
+     * Call a method and convert {@see \TypeError} to {@see InvalidArgumentException}.
+     *
+     * @param object $object
+     * @param string $method
+     * @param mixed  $value
+     */
+    private function callMethod($object, $method, $value) {
+        if (class_exists('TypeError')) {
+            // PHP 7
+            try {
+                $object->{$method}($value);
+            } catch (\TypeError $e) {
+                throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
+            }
+        }
+
+        // PHP 5
+        set_error_handler(function ($errno, $errstr) {
+            throw new InvalidArgumentException($errstr);
+        });
+
+        try {
+            $object->{$method}($value);
+        } finally {
+            restore_error_handler();
         }
     }
 
@@ -613,11 +643,11 @@ class PropertyAccessor implements PropertyAccessorInterface
         }
 
         foreach ($itemToRemove as $item) {
-            $object->{$removeMethod}($item);
+            $this->callMethod($object, $removeMethod, $item);
         }
 
         foreach ($itemsToAdd as $item) {
-            $object->{$addMethod}($item);
+            $this->callMethod($object, $addMethod, $item);
         }
     }
 

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -541,8 +541,8 @@ class PropertyAccessor implements PropertyAccessorInterface
      * @param string $property The property to write
      * @param mixed  $value    The value to write
      *
-     * @throws NoSuchPropertyException  If the property does not exist or is not
-     *                                  public.
+     * @throws NoSuchPropertyException If the property does not exist or is not
+     *                                 public.
      * @throws \TypeError
      */
     private function writeProperty(&$object, $property, $value)
@@ -575,7 +575,7 @@ class PropertyAccessor implements PropertyAccessorInterface
     }
 
     /**
-     * Emulates PHP 7 behavior in PHP 5.
+     * Throws a {@see \TypeError} as in PHP 7 when using PHP 5.
      *
      * @param object $object
      * @param string $method
@@ -591,7 +591,6 @@ class PropertyAccessor implements PropertyAccessorInterface
             return;
         }
 
-        // Emulates PHP 7 behavior
         set_error_handler(function ($errno, $errstr) use ($object, $method) {
             if (E_RECOVERABLE_ERROR === $errno && false !== strpos($errstr, sprintf('passed to %s::%s() must', get_class($object), $method))) {
                 throw new \TypeError($errstr);

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -600,7 +600,11 @@ class PropertyAccessor implements PropertyAccessorInterface
 
         // PHP 5
         set_error_handler(function ($errno, $errstr) {
-            throw new InvalidArgumentException($errstr);
+            if (E_RECOVERABLE_ERROR === $errno) {
+                throw new InvalidArgumentException($errstr);
+            }
+
+            return false;
         });
 
         try {

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\PropertyAccess;
 
 use Symfony\Component\PropertyAccess\Exception\AccessException;
-use Symfony\Component\PropertyAccess\Exception\InvalidArgumentException;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\Exception\NoSuchIndexException;
 use Symfony\Component\PropertyAccess\Exception\UnexpectedTypeException;
@@ -588,6 +587,7 @@ class PropertyAccessor implements PropertyAccessorInterface
     private function callMethod($object, $method, $value) {
         if (PHP_MAJOR_VERSION >= 7) {
             $object->{$method}($value);
+
             return;
         }
 

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -543,7 +543,7 @@ class PropertyAccessor implements PropertyAccessorInterface
      *
      * @throws NoSuchPropertyException  If the property does not exist or is not
      *                                  public.
-     * @throws InvalidArgumentException
+     * @throws \TypeError
      */
     private function writeProperty(&$object, $property, $value)
     {
@@ -575,13 +575,13 @@ class PropertyAccessor implements PropertyAccessorInterface
     }
 
     /**
-     * Call a method and convert {@see \TypeError} to {@see InvalidArgumentException}.
+     * Emulates PHP 7 behavior in PHP 5.
      *
      * @param object $object
      * @param string $method
      * @param mixed  $value
      *
-     * @throws InvalidArgumentException
+     * @throws \TypeError
      * @throws \Exception
      */
     private function callMethod($object, $method, $value) {
@@ -621,7 +621,7 @@ class PropertyAccessor implements PropertyAccessorInterface
      * @param string             $addMethod    The add*() method
      * @param string             $removeMethod The remove*() method
      *
-     * @throws InvalidArgumentException
+     * @throws \TypeError
      */
     private function writeCollection($object, $property, $collection, $addMethod, $removeMethod)
     {

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessorInterface.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessorInterface.php
@@ -43,10 +43,12 @@ interface PropertyAccessorInterface
      * @param string|PropertyPathInterface $propertyPath  The property path to modify
      * @param mixed                        $value         The value to set at the end of the property path
      *
-     * @throws Exception\InvalidArgumentException If the property path is invalid or the value type does not match with the setter type hint
+     * @throws Exception\InvalidArgumentException If the property path is invalid
      * @throws Exception\AccessException          If a property/index does not exist or is not public
      * @throws Exception\UnexpectedTypeException  If a value within the path is neither object
      *                                            nor array
+     * @throws \TypeError                         If a the type of the value does not match the type
+     *                                            of the parameter of the mutator method
      */
     public function setValue(&$objectOrArray, $propertyPath, $value);
 

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessorInterface.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessorInterface.php
@@ -43,7 +43,7 @@ interface PropertyAccessorInterface
      * @param string|PropertyPathInterface $propertyPath  The property path to modify
      * @param mixed                        $value         The value to set at the end of the property path
      *
-     * @throws Exception\InvalidArgumentException If the property path is invalid
+     * @throws Exception\InvalidArgumentException If the property path is invalid or the value type do not match with the setter type hint
      * @throws Exception\AccessException          If a property/index does not exist or is not public
      * @throws Exception\UnexpectedTypeException  If a value within the path is neither object
      *                                            nor array

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessorInterface.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessorInterface.php
@@ -43,7 +43,7 @@ interface PropertyAccessorInterface
      * @param string|PropertyPathInterface $propertyPath  The property path to modify
      * @param mixed                        $value         The value to set at the end of the property path
      *
-     * @throws Exception\InvalidArgumentException If the property path is invalid or the value type do not match with the setter type hint
+     * @throws Exception\InvalidArgumentException If the property path is invalid or the value type does not match with the setter type hint
      * @throws Exception\AccessException          If a property/index does not exist or is not public
      * @throws Exception\UnexpectedTypeException  If a value within the path is neither object
      *                                            nor array

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestClass.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestClass.php
@@ -26,6 +26,7 @@ class TestClass
     private $publicIsAccessor;
     private $publicHasAccessor;
     private $publicGetter;
+    private $date;
 
     public function __construct($value)
     {
@@ -172,5 +173,15 @@ class TestClass
     public function getPublicGetter()
     {
         return $this->publicGetter;
+    }
+
+    public function setDate(\DateTimeInterface $date)
+    {
+        $this->date = $date;
+    }
+
+    public function getDate()
+    {
+        return $this->date;
     }
 }

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\PropertyAccess\Tests;
 
+use Symfony\Component\PropertyAccess\Exception\InvalidArgumentException;
 use Symfony\Component\PropertyAccess\Exception\NoSuchIndexException;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClass;
@@ -509,5 +510,22 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
     public function testIsWritableForReferenceChainIssue($object, $path, $value)
     {
         $this->assertEquals($value, $this->propertyAccessor->isWritable($object, $path));
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testConvertTypeErrorToInvalidArgumentException()
+    {
+        $this->propertyAccessor->setValue(new TestClass('Kévin'), 'date', 'This is a string, \DateTime excepted.');
+    }
+
+    public function testSetTypeHint()
+    {
+        $date = new \DateTimeImmutable();
+        $object = new TestClass('Kévin');
+
+        $this->propertyAccessor->setValue($object, 'date', $date);
+        $this->assertSame($date, $object->getDate());
     }
 }

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -513,7 +513,7 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \TypeError
      */
     public function testConvertTypeErrorToInvalidArgumentException()
     {

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\PropertyAccess\Tests;
 
-use Symfony\Component\PropertyAccess\Exception\InvalidArgumentException;
 use Symfony\Component\PropertyAccess\Exception\NoSuchIndexException;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClass;
@@ -515,7 +514,7 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \TypeError
      */
-    public function testConvertTypeErrorToInvalidArgumentException()
+    public function testThrowTypeError()
     {
         $this->propertyAccessor->setValue(new TestClass('Kévin'), 'date', 'This is a string, \DateTime excepted.');
     }

--- a/src/Symfony/Component/PropertyAccess/composer.json
+++ b/src/Symfony/Component/PropertyAccess/composer.json
@@ -16,7 +16,8 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9"
+        "php": ">=5.5.9",
+        "symfony/polyfill-php70": "~1.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\PropertyAccess\\": "" },


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no (?) |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Currently, when the Property Access Component call a setter with a value not matching its typehint, a `\TypeError` is thrown with PHP 7 and a `PHP Catchable fatal error` with PHP 5.

This PR make the component returning an `InvalidArgumentException` with both version. It's a (better) alternative to #17660 (the hardening part) to make the Symfony Serializer (and probably many other pieces of code) more robust when types do not match.

/cc @csarrazi @mRoca @blazarecki
