### PR TITLE
[DependencyInjection] Fix #16461 Container::set() replace aliases

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -169,6 +169,10 @@ class Container implements ResettableContainerInterface
             throw new InvalidArgumentException('You cannot set service "service_container".');
         }
 
+        if (isset($this->aliases[$id])) {
+            unset($this->aliases[$id]);
+        }
+
         $this->services[$id] = $service;
 
         if (null === $service) {

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -231,6 +231,16 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(isset($aliases['foobar']));
     }
 
+    public function testSetReplacesAlias()
+    {
+        $builder = new ContainerBuilder();
+        $builder->setAlias('alias', 'aliased');
+        $builder->set('aliased', new \stdClass());
+
+        $builder->set('alias', $foo = new \stdClass());
+        $this->assertSame($foo, $builder->get('alias'), '->set() replaces an existing alias');
+    }
+
     public function testAddGetCompilerPass()
     {
         $builder = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -142,6 +142,14 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($sc->has('foo'), '->set() with null service resets the service');
     }
 
+    public function testSetReplacesAlias()
+    {
+        $c = new ProjectServiceContainer();
+
+        $c->set('alias', $foo = new \stdClass());
+        $this->assertSame($foo, $c->get('alias'), '->set() replaces an existing alias');
+    }
+
     public function testGet()
     {
         $sc = new ProjectServiceContainer();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16461 |
| License | MIT |
| Doc PR | - |

`Container::set()` now overrides any previously alias defined with the same name. Please see #16461 for the background.

Example:
- given `event_dispatcher` is an alias to `debug.event_dispatcher`
- when I run: `$container->set('event_dispatcher', new FakeEventDispatcher)`
- _before this patch_: nothing happens
- _after this patch_: the `event_dispatcher` is now my fake event dispatcher
