### PR TITLE
Improve error reporting in router panel of web profiler

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
@@ -76,8 +76,8 @@ class RouterController
     /**
      * Returns the routing traces associated to the given request.
      *
-     * @param  RequestDataCollector $request
-     * @param  string               $method
+     * @param RequestDataCollector $request
+     * @param string               $method
      *
      * @return array
      */

--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
@@ -88,7 +88,7 @@ class RouterController
             $request->getRequestServer()->get('REQUEST_METHOD'),
             $request->getRequestAttributes()->all(),
             $request->getRequestCookies()->all(),
-            [],
+            array(),
             $request->getRequestServer()->all()
         );
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
@@ -96,6 +96,6 @@ class RouterController
         $context->setMethod($method);
         $matcher = new TraceableUrlMatcher($this->routes, $context);
 
-        return $matcher->getTracesFromRequest($traceRequest);
+        return $matcher->getTracesForRequest($traceRequest);
     }
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
@@ -18,6 +18,7 @@ use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
+use Symfony\Component\HttpKernel\DataCollector\RequestDataCollector;
 
 /**
  * RouterController.
@@ -62,16 +63,39 @@ class RouterController
 
         $profile = $this->profiler->loadProfile($token);
 
-        $context = $this->matcher->getContext();
-        $context->setMethod($profile->getMethod());
-        $matcher = new TraceableUrlMatcher($this->routes, $context);
-
+        /** @var RequestDataCollector $request */
         $request = $profile->getCollector('request');
 
         return new Response($this->twig->render('@WebProfiler/Router/panel.html.twig', array(
             'request' => $request,
             'router' => $profile->getCollector('router'),
-            'traces' => $matcher->getTraces($request->getPathInfo()),
+            'traces' => $this->getTraces($request, $profile->getMethod()),
         )), 200, array('Content-Type' => 'text/html'));
+    }
+
+    /**
+     * Returns the routing traces associated to the given request.
+     *
+     * @param  RequestDataCollector $request
+     * @param  string               $method
+     *
+     * @return array
+     */
+    private function getTraces(RequestDataCollector $request, $method)
+    {
+        $traceRequest = Request::create(
+            $request->getPathInfo(),
+            $request->getRequestServer()->get('REQUEST_METHOD'),
+            $request->getRequestAttributes()->all(),
+            $request->getRequestCookies()->all(),
+            [],
+            $request->getRequestServer()->all()
+        );
+
+        $context = $this->matcher->getContext();
+        $context->setMethod($method);
+        $matcher = new TraceableUrlMatcher($this->routes, $context);
+
+        return $matcher->getTracesFromRequest($traceRequest);
     }
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Router/panel.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Router/panel.html.twig
@@ -31,14 +31,23 @@
                 <th>Log</th>
             </tr>
             {% for trace in traces %}
-                <tr class="{{ 1 == trace.level ? 'almost' : 2 == trace.level ? 'matches' : '' }}">
-                    <td>{{ trace.name }}</td>
-                    <td>{{ trace.path }}</td>
-                    <td>{{ trace.log }}</td>
-                </tr>
+                {% if trace.level == -1 %}
+                    <tr class="status-error">
+                        <td colspan="3">
+                            {{ trace.name }}
+                        </td>
+                    </tr>
+                {% else %}
+                    <tr class="{{ 1 == trace.level ? 'almost' : 2 == trace.level ? 'matches' : '' }}">
+                        <td>{{ trace.name }}</td>
+                        <td>{{ trace.path }}</td>
+                        <td>{{ trace.log }}</td>
+                    </tr>
+                {% endif %}
             {% endfor %}
         </table>
         <em><small>Note: The above matching is based on the configuration for the current router which might differ from
-        the configuration used while routing this request.</small></em>
+        the configuration used while routing this request.
+        Logs are not available for routes that define conditions using the "request" object.</small></em>
     </li>
 </ul>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Router/panel.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Router/panel.html.twig
@@ -31,23 +31,14 @@
                 <th>Log</th>
             </tr>
             {% for trace in traces %}
-                {% if trace.level == -1 %}
-                    <tr class="status-error">
-                        <td colspan="3">
-                            {{ trace.log }}
-                        </td>
-                    </tr>
-                {% else %}
-                    <tr class="{{ 1 == trace.level ? 'almost' : 2 == trace.level ? 'matches' : '' }}">
-                        <td>{{ trace.name }}</td>
-                        <td>{{ trace.path }}</td>
-                        <td>{{ trace.log }}</td>
-                    </tr>
-                {% endif %}
+                <tr class="{{ 1 == trace.level ? 'almost' : 2 == trace.level ? 'matches' : '' }}">
+                    <td>{{ trace.name }}</td>
+                    <td>{{ trace.path }}</td>
+                    <td>{{ trace.log }}</td>
+                </tr>
             {% endfor %}
         </table>
         <em><small>Note: The above matching is based on the configuration for the current router which might differ from
-        the configuration used while routing this request.
-        Logs are not available for routes that define conditions using the "request" object.</small></em>
+        the configuration used while routing this request.</small></em>
     </li>
 </ul>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Router/panel.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Router/panel.html.twig
@@ -34,7 +34,7 @@
                 {% if trace.level == -1 %}
                     <tr class="status-error">
                         <td colspan="3">
-                            {{ trace.name }}
+                            {{ trace.log }}
                         </td>
                     </tr>
                 {% else %}

--- a/src/Symfony/Component/Routing/Matcher/TraceableUrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/TraceableUrlMatcher.php
@@ -41,7 +41,7 @@ class TraceableUrlMatcher extends UrlMatcher
         return $this->traces;
     }
 
-    public function getTracesFromRequest(Request $request)
+    public function getTracesForRequest(Request $request)
     {
         $this->request = $request;
         $traces = $this->getTraces($request->getPathInfo());

--- a/src/Symfony/Component/Routing/Matcher/TraceableUrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/TraceableUrlMatcher.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Routing\Matcher;
 
+use Symfony\Component\Routing\Exception\ExceptionInterface;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
@@ -33,11 +34,12 @@ class TraceableUrlMatcher extends UrlMatcher
 
         try {
             $this->match($pathinfo);
+        } catch (ExceptionInterface $e) {
         } catch (\Exception $e) {
             $this->traces = array(array(
-                'name' => sprintf('[ERROR] The following exception prevented the route to be matched against application routes: "%s" (in %s line %d)', $e->getMessage(), $e->getFile(), $e->getLine()),
-                'log' => '-',
                 'level' => -1,
+                'log' => sprintf('[ERROR] The following exception prevented the route to be matched against application routes: "%s" (in %s line %d)', $e->getMessage(), $e->getFile(), $e->getLine()),
+                'name' => '-',
                 'path' => '-',
             ));
         }

--- a/src/Symfony/Component/Routing/Matcher/TraceableUrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/TraceableUrlMatcher.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Routing\Matcher;
 
-use Symfony\Component\Routing\Exception\ExceptionInterface;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
@@ -39,7 +38,7 @@ class TraceableUrlMatcher extends UrlMatcher
                 'name' => sprintf('[ERROR] The following exception prevented the route to be matched against application routes: "%s" (in %s line %d)', $e->getMessage(), $e->getFile(), $e->getLine()),
                 'log' => '-',
                 'level' => -1,
-                'path' => '-'
+                'path' => '-',
             ));
         }
 

--- a/src/Symfony/Component/Routing/Matcher/TraceableUrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/TraceableUrlMatcher.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Routing\Matcher;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Exception\ExceptionInterface;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
@@ -35,16 +36,18 @@ class TraceableUrlMatcher extends UrlMatcher
         try {
             $this->match($pathinfo);
         } catch (ExceptionInterface $e) {
-        } catch (\Exception $e) {
-            $this->traces = array(array(
-                'level' => -1,
-                'log' => sprintf('[ERROR] The following exception prevented the route to be matched against application routes: "%s" (in %s line %d)', $e->getMessage(), $e->getFile(), $e->getLine()),
-                'name' => '-',
-                'path' => '-',
-            ));
         }
 
         return $this->traces;
+    }
+
+    public function getTracesFromRequest(Request $request)
+    {
+        $this->request = $request;
+        $traces = $this->getTraces($request->getPathInfo());
+        $this->request = null;
+
+        return $traces;
     }
 
     protected function matchCollection($pathinfo, RouteCollection $routes)

--- a/src/Symfony/Component/Routing/Matcher/TraceableUrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/TraceableUrlMatcher.php
@@ -34,7 +34,13 @@ class TraceableUrlMatcher extends UrlMatcher
 
         try {
             $this->match($pathinfo);
-        } catch (ExceptionInterface $e) {
+        } catch (\Exception $e) {
+            $this->traces = array(array(
+                'name' => sprintf('[ERROR] The following exception prevented the route to be matched against application routes: "%s" (in %s line %d)', $e->getMessage(), $e->getFile(), $e->getLine()),
+                'log' => '-',
+                'level' => -1,
+                'path' => '-'
+            ));
         }
 
         return $this->traces;

--- a/src/Symfony/Component/Routing/Tests/Matcher/TraceableUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/TraceableUrlMatcherTest.php
@@ -116,6 +116,6 @@ class TraceableUrlMatcherTest extends \PHPUnit_Framework_TestCase
 
         $matchingRequest = Request::create('/foo', 'GET', array(), array(), array(), array('HTTP_USER_AGENT' => 'Firefox'));
         $traces = $matcher->getTracesFromRequest($matchingRequest);
-        $this->assertEquals("Route matches!", $traces[0]['log']);
+        $this->assertEquals('Route matches!', $traces[0]['log']);
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Matcher/TraceableUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/TraceableUrlMatcherTest.php
@@ -111,11 +111,11 @@ class TraceableUrlMatcherTest extends \PHPUnit_Framework_TestCase
         $matcher = new TraceableUrlMatcher($routes, $context);
 
         $notMatchingRequest = Request::create('/foo', 'GET');
-        $traces = $matcher->getTracesFromRequest($notMatchingRequest);
+        $traces = $matcher->getTracesForRequest($notMatchingRequest);
         $this->assertEquals("Condition \"request.headers.get('User-Agent') matches '/firefox/i'\" does not evaluate to \"true\"", $traces[0]['log']);
 
         $matchingRequest = Request::create('/foo', 'GET', array(), array(), array(), array('HTTP_USER_AGENT' => 'Firefox'));
-        $traces = $matcher->getTracesFromRequest($matchingRequest);
+        $traces = $matcher->getTracesForRequest($matchingRequest);
         $this->assertEquals('Route matches!', $traces[0]['log']);
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Matcher/TraceableUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/TraceableUrlMatcherTest.php
@@ -98,4 +98,19 @@ class TraceableUrlMatcherTest extends \PHPUnit_Framework_TestCase
 
         return $levels;
     }
+
+    public function testExceptionOnRouteCondition()
+    {
+        $coll = new RouteCollection();
+        $coll->add('foo', new Route('/foo', array(), array(), array(), 'baz', array(), array(), "request.headers.get('User-Agent') matches '/firefox/i'"));
+
+        $context = new RequestContext();
+        $context->setHost('baz');
+
+        $matcher = new TraceableUrlMatcher($coll, $context);
+        $traces = $matcher->getTraces('/foo');
+
+        $this->assertEquals(-1, $traces[0]['level']);
+        $this->assertRegExp('/\[ERROR\] The following exception prevented the route to be matched against application routes: "Unable to get a property on a non-object\." \(in .* line \d+\)/', $traces[0]['log']);
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17342 |
| License | MIT |
| Doc PR | - |
### Problem

If you define a route condition like this:

``` yaml
app:
    resource: '@AppBundle/Controller/'
    type:     annotation
    condition: "request.server.get('HTTP_HOST') matches '/.*\.dev/'"
```

When browsing the Routing panel in the web profiler, you see an exception:

![problem](https://cloud.githubusercontent.com/assets/73419/12930027/553eeb08-cf76-11e5-90b1-ab0de6175d4e.png)
#### Why?

Because the route condition uses the `request` object, but the special `TraceableUrlMatcher` class doesn't get access to the real `request` object but to the special object obtained via:

``` php
$request = $profile->getCollector('request');
```

These are the contents of this pseudo-request:

![cause](https://cloud.githubusercontent.com/assets/73419/12930052/804ea248-cf76-11e5-9c38-2e43e1654065.png)

`request.server.get(...)` condition fails because `request.server` is `null`. The full exception message shows this:

![exception](https://cloud.githubusercontent.com/assets/73419/12930079/9c7d6058-cf76-11e5-8eeb-45f5059c824c.png)
### Solution

I propose to catch all exceptions in `TraceableUrlMatcher` and display an error message with some details of the exception:

![error_message](https://cloud.githubusercontent.com/assets/73419/12930106/b29e31d2-cf76-11e5-868c-98d8b0cc4e5b.png)
