### PR TITLE
[Yaml] deprecate the Dumper::setIndentation() method

### DIFF
--- a/UPGRADE-3.1.md
+++ b/UPGRADE-3.1.md
@@ -33,6 +33,9 @@ Serializer
 Yaml
 ----
 
+ * The `Dumper::setIndentation()` method is deprecated and will be removed in
+   Symfony 4.0. Pass the indentation level to the constructor instead.
+
  * Deprecated support for passing `true`/`false` as the second argument to the
    `parse()` method to trigger exceptions when an invalid type was passed.
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -24,6 +24,9 @@ Serializer
 Yaml
 ----
 
+ * The `Dumper::setIndentation()` method was removed. Pass the indentation
+   level to the constructor instead.
+
  * Removed support for passing `true`/`false` as the second argument to the
    `parse()` method to trigger exceptions when an invalid type was passed.
 

--- a/src/Symfony/Component/Yaml/Dumper.php
+++ b/src/Symfony/Component/Yaml/Dumper.php
@@ -23,7 +23,15 @@ class Dumper
      *
      * @var int
      */
-    protected $indentation = 4;
+    protected $indentation;
+
+    /**
+     * @param int $indentation
+     */
+    public function __construct($indentation = 4)
+    {
+        $this->indentation = $indentation;
+    }
 
     /**
      * Sets the indentation.
@@ -32,6 +40,8 @@ class Dumper
      */
     public function setIndentation($num)
     {
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 3.1 and will be removed in 4.0. Pass the indentation to the constructor instead.', E_USER_DEPRECATED);
+
         $this->indentation = (int) $num;
     }
 

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -51,6 +51,34 @@ class DumperTest extends \PHPUnit_Framework_TestCase
         $this->array = null;
     }
 
+    public function testIndentationInConstructor()
+    {
+        $dumper = new Dumper(7);
+        $expected = <<<'EOF'
+'': bar
+foo: '#bar'
+'foo''bar': {  }
+bar:
+       - 1
+       - foo
+foobar:
+       foo: bar
+       bar:
+              - 1
+              - foo
+       foobar:
+              foo: bar
+              bar:
+                     - 1
+                     - foo
+
+EOF;
+        $this->assertEquals($expected, $dumper->dump($this->array, 4, 0));
+    }
+
+    /**
+     * @group legacy
+     */
     public function testSetIndentation()
     {
         $this->dumper->setIndentation(7);

--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -96,8 +96,7 @@ class Yaml
             $flags = (int) $flags;
         }
 
-        $yaml = new Dumper();
-        $yaml->setIndentation($indent);
+        $yaml = new Dumper($indent);
 
         return $yaml->dump($array, $inline, 0, $exceptionOnInvalidType, $flags);
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
