### PR TITLE
[DomCrawler] Remove the overridden getHash() method to prevent problems when cloning the crawler

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -951,16 +951,6 @@ class Crawler extends \SplObjectStorage
     }
 
     /**
-     * @deprecated Using the SplObjectStorage API on the Crawler is deprecated as of 2.8 and will be removed in 3.0.
-     */
-    public function getHash($object)
-    {
-        $this->triggerDeprecation(__METHOD__, true);
-
-        return parent::getHash($object);
-    }
-
-    /**
      * Filters the list of nodes with an XPath expression.
      *
      * The XPath expression should already be processed to apply it in the context of each node.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16421 |
| License | MIT |
| Doc PR | - |

Overriding the `SplObjectStorage::getHash()` is affected by a [PHP bug](https://bugs.php.net/bug.php?id=67582), which makes the Crawler unusable in Symfony 2.8 for anyone who relied on `SplObjectStorage` methods.

Removing the `getHash()` method means we will no longer trigger the deprecation error. Given this method is unlikely to be used directly and other `SplObjectStorage` methods will trigger the error, it is the simplest thing we can do to maintain BC.
