### PR TITLE
[HttpKernel] Caching HttpKernel instance in Kernel

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -58,7 +58,6 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $name;
     protected $startTime;
     protected $loadClassCache;
-    protected $httpKernel;
 
     const VERSION = '3.1.0-DEV';
     const VERSION_ID = 30100;
@@ -123,7 +122,6 @@ abstract class Kernel implements KernelInterface, TerminableInterface
         }
 
         $this->booted = true;
-        $this->httpKernel = $this->getHttpKernel();
     }
 
     /**
@@ -135,8 +133,9 @@ abstract class Kernel implements KernelInterface, TerminableInterface
             return;
         }
 
-        if ($this->httpKernel instanceof TerminableInterface) {
-            $this->httpKernel->terminate($request, $response);
+        $httpKernel = $this->getHttpKernel();
+        if ($httpKernel instanceof TerminableInterface) {
+            $thttpKernel->terminate($request, $response);
         }
     }
 
@@ -168,7 +167,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
             $this->boot();
         }
 
-        return $this->httpKernel->handle($request, $type, $catch);
+        return $this->getHttpKernel()->handle($request, $type, $catch);
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -58,7 +58,6 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $name;
     protected $startTime;
     protected $loadClassCache;
-    
     protected $httpKernel;
 
     const VERSION = '3.1.0-DEV';
@@ -169,7 +168,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
             $this->boot();
         }
 
-        return $this->httpKernel>handle($request, $type, $catch);
+        return $this->httpKernel->handle($request, $type, $catch);
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\HttpKernel;
 
 use Symfony\Bridge\ProxyManager\LazyProxy\Instantiator\RuntimeInstantiator;
 use Symfony\Bridge\ProxyManager\LazyProxy\PhpDumper\ProxyDumper;
-use Symfony\Component\DependencyInjection\ContainerInterface;t
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\HttpKernel;
 
 use Symfony\Bridge\ProxyManager\LazyProxy\Instantiator\RuntimeInstantiator;
 use Symfony\Bridge\ProxyManager\LazyProxy\PhpDumper\ProxyDumper;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;t
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
@@ -135,7 +135,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
 
         $httpKernel = $this->getHttpKernel();
         if ($httpKernel instanceof TerminableInterface) {
-            $thttpKernel->terminate($request, $response);
+            $httpKernel->terminate($request, $response);
         }
     }
 

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -58,6 +58,8 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $name;
     protected $startTime;
     protected $loadClassCache;
+    
+    protected $httpKernel;
 
     const VERSION = '3.1.0-DEV';
     const VERSION_ID = 30100;
@@ -122,6 +124,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
         }
 
         $this->booted = true;
+        $this->httpKernel = $this->getHttpKernel();
     }
 
     /**
@@ -133,8 +136,8 @@ abstract class Kernel implements KernelInterface, TerminableInterface
             return;
         }
 
-        if ($this->getHttpKernel() instanceof TerminableInterface) {
-            $this->getHttpKernel()->terminate($request, $response);
+        if ($this->httpKernel instanceof TerminableInterface) {
+            $this->httpKernel->terminate($request, $response);
         }
     }
 
@@ -166,7 +169,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
             $this->boot();
         }
 
-        return $this->getHttpKernel()->handle($request, $type, $catch);
+        return $this->httpKernel>handle($request, $type, $catch);
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -695,11 +695,6 @@ EOF;
             ->expects($this->never())
             ->method('terminate');
 
-        $kernel = $this->getKernel(array('getHttpKernel'));
-        $kernel->expects($this->once())
-            ->method('getHttpKernel')
-            ->will($this->returnValue($httpKernelMock));
-
         $kernel->boot();
         $kernel->terminate(Request::create('/'), new Response());
 
@@ -712,11 +707,6 @@ EOF;
         $httpKernelMock
             ->expects($this->once())
             ->method('terminate');
-
-        $kernel = $this->getKernel(array('getHttpKernel'));
-        $kernel->expects($this->exactly(2))
-            ->method('getHttpKernel')
-            ->will($this->returnValue($httpKernelMock));
 
         $kernel->boot();
         $kernel->terminate(Request::create('/'), new Response());


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

After some profiling I've spotted that `Kernel` was calling `$container->get('http_kernel')` 3 times when using:

``` php
<?php

use Symfony\Component\HttpFoundation\Request;

require_once __DIR__.'/vendor/autoload.php';

$kernel = new AppKernel('prod', true);
$kernel->loadClassCache();
Request::enableHttpMethodParameterOverride();
$request = Request::createFromGlobals();
$response = $kernel->handle($request); // calling `$container->get('http_kernel')` 1 time 
$response->send();
$kernel->terminate($request, $response); // calling `$container->get('http_kernel')` 2 times 
```

It's mostly fine because `http_kernel` is a shared service (so `HttpKernel` is instantiated only once), but maybe we could still reduce those calls to 1 by saving the instance in a class property?
There's actually many ways to do this (remove `getHttpKernel()`, or add the property initialization in `getHttpKernel()`, etc), so here's a first patch.

[See profiling comparison](https://blackfire.io/profiles/compare/7f6b2e9f-d0ac-48bd-ae61-9270e1e18773/graph)
