### PR TITLE
[HttpFoundation] Add accessor for uploaded file test mode.

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -290,4 +290,14 @@ class UploadedFile extends File
 
         return sprintf($message, $this->getClientOriginalName(), $maxFilesize);
     }
+
+    /**
+     * Checks if the file is using test mode.
+     *
+     * @return bool
+     */
+    public function isForTesting()
+    {
+        return $this->test;
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

Currently it is impossible to determine if a given `UploadedFile` instance has the `$test` flag set to `true` or not, which in turns makes it impossible to duplicate the UploadedFile instance for customization purposes.

This PR simply adds an accessor for that flag so I can create an extended `UploadedFile` instance by doing:

``` php
$file = new MyUploadedFile(....., $original->isForTesting());
```
