### PR TITLE
[Form] fix problems when the field values are Boolean

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -344,7 +344,7 @@ class Form implements \IteratorAggregate, FormInterface
         }
 
         // Treat data as strings unless a value transformer exists
-        if (!$this->config->getViewTransformers() && !$this->config->getModelTransformers() && is_scalar($modelData)) {
+        if (!$this->config->getViewTransformers() && !$this->config->getModelTransformers() && !is_bool($modelData) && is_scalar($modelData)) {
             $modelData = (string) $modelData;
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
# Problem

When the field values are Boolean as below, false value is not shown.
class RadioYesNoType extends AbstractType

```
{
    public function setDefaultOptions(OptionsResolverInterface $resolver)
    {
        $resolver->setDefaults(array(
            'choices' => array(
                false => 'Yes',
                true => 'No',
            ),
            'multiple'  => false,
            'expanded'  => true,
        ));
    }

    public function getParent()
    {
        return 'choice';
    }

    public function getName()
    {
        return 'Radio_Yes_No';
    }
}
```
