### PR TITLE
[Console] Add non-auto column width functionality

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * added truncate method to FormatterHelper
+ * added setColumnWidth(s) method to Table 
 
 2.8.3
 -----

--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -207,15 +207,12 @@ class Table
 
         if ('auto' !== $width) {
             $width = intval($width);
+
+            if (-1 > $width) {
+                throw new InvalidArgumentException(sprintf('Width "%d" is not a valid column width for column %d. Expected width > 0 or "auto".',$width,$columnIndex));
+            }
         }
 
-        if ('auto' !== $width && 0 >= $width) {
-            throw new InvalidArgumentException(sprintf(
-                'Width "%d" is not a valid column width for column %d. Expected width > 0 or \'auto\'.',
-                $width,
-                $columnIndex
-            ));
-        }
 
         $this->columnWidths[$columnIndex] = $width;
 
@@ -237,20 +234,6 @@ class Table
         }
 
         return $this;
-    }
-
-    /**
-     * Gets the column's declared width.
-     *
-     * If no width was set, it returns the default 'auto'.
-     *
-     * @param int $columnIndex
-     *
-     * @return int|string
-     */
-    public function getColumnWidth($columnIndex)
-    {
-        return isset($this->columnWidths[$columnIndex]) ? $this->columnWidths[$columnIndex] : 'auto';
     }
 
     public function setHeaders(array $headers)
@@ -674,7 +657,9 @@ class Table
             }
         }
 
-        return max($cellWidth, $this->getColumnWidth($column));
+        $columnWidth = isset($this->columnWidths[$column]) ? $this->columnWidths[$column] : 0;
+
+        return max($cellWidth, $columnWidth);
     }
 
     /**

--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -194,25 +194,17 @@ class Table
     }
 
     /**
-     * Sets the width for a column.
+     * Sets the minimum width of a column.
      *
-     * @param int        $columnIndex Column index.
-     * @param int|string $width       Column with in characters. Set to 'auto' to auto-fit the content.
+     * @param int $columnIndex Column index.
+     * @param int $width       Column minimum with in characters.
      *
      * @return Table
      */
     public function setColumnWidth($columnIndex, $width)
     {
         $columnIndex = intval($columnIndex);
-
-        if ('auto' !== $width) {
-            $width = intval($width);
-
-            if (-1 > $width) {
-                throw new InvalidArgumentException(sprintf('Width "%d" is not a valid column width for column %d. Expected width > 0 or "auto".',$width,$columnIndex));
-            }
-        }
-
+        $width = intval($width);
 
         $this->columnWidths[$columnIndex] = $width;
 
@@ -220,7 +212,7 @@ class Table
     }
 
     /**
-     * Set all column widths. Use 'auto' to auto-fit the content.
+     * Set the minimum width of all columns.
      *
      * @param array $widths
      *

--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -196,8 +196,8 @@ class Table
     /**
      * Sets the minimum width of a column.
      *
-     * @param int $columnIndex Column index.
-     * @param int $width       Column minimum with in characters.
+     * @param int $columnIndex Column index
+     * @param int $width       Minimum column width in characters
      *
      * @return Table
      */
@@ -209,7 +209,7 @@ class Table
     }
 
     /**
-     * Set the minimum width of all columns.
+     * Sets the minimum width of all columns.
      *
      * @param array $widths
      *

--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -203,10 +203,7 @@ class Table
      */
     public function setColumnWidth($columnIndex, $width)
     {
-        $columnIndex = intval($columnIndex);
-        $width = intval($width);
-
-        $this->columnWidths[$columnIndex] = $width;
+        $this->columnWidths[intval($columnIndex)] = intval($width);
 
         return $this;
     }

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -666,7 +666,7 @@ TABLE;
                 array('99921-58-10-7', 'Divine Comedy', 'Dante Alighieri', '9.95'),
                 array('9971-5-0210-0', 'A Tale of Two Cities', 'Charles Dickens', '139.25'),
             ))
-            ->setColumnWidths(array(15, 'auto', -1, 10));
+            ->setColumnWidths(array(15, 0, -1, 10));
 
         $style = new TableStyle();
         $style->setPadType(STR_PAD_LEFT);

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -625,6 +625,38 @@ TABLE;
         $this->assertEquals($expected, $this->getOutputContent($output));
     }
 
+    public function testColumnFixedWith()
+    {
+        $table = new Table($output = $this->getOutputStream());
+        $table
+            ->setHeaders(array('ISBN', 'Title', 'Author', 'Price'))
+            ->setRows(array(
+                array('99921-58-10-7', 'Divine Comedy', 'Dante Alighieri', '9.95'),
+                array('9971-5-0210-0', 'A Tale of Two Cities', 'Charles Dickens', '139.25'),
+            ))
+            ->setColumnFixedWidth(0, 15)
+            ->setColumnFixedWidth(3, 10);
+
+        $style = new TableStyle();
+        $style->setPadType(STR_PAD_LEFT);
+        $table->setColumnStyle(3, $style);
+
+        $table->render();
+
+        $expected =
+            <<<TABLE
++-----------------+----------------------+-----------------+------------+
+| ISBN            | Title                | Author          |      Price |
++-----------------+----------------------+-----------------+------------+
+| 99921-58-10-7   | Divine Comedy        | Dante Alighieri |       9.95 |
+| 9971-5-0210-0   | A Tale of Two Cities | Charles Dickens |     139.25 |
++-----------------+----------------------+-----------------+------------+
+
+TABLE;
+
+        $this->assertEquals($expected, $this->getOutputContent($output));
+    }
+
     protected function getOutputStream()
     {
         return new StreamOutput($this->stream, StreamOutput::VERBOSITY_NORMAL, false);

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -666,7 +666,7 @@ TABLE;
                 array('99921-58-10-7', 'Divine Comedy', 'Dante Alighieri', '9.95'),
                 array('9971-5-0210-0', 'A Tale of Two Cities', 'Charles Dickens', '139.25'),
             ))
-            ->setColumnWidths(array(15, 'auto', 'auto', 10));
+            ->setColumnWidths(array(15, 'auto', -1, 10));
 
         $style = new TableStyle();
         $style->setPadType(STR_PAD_LEFT);

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -625,7 +625,7 @@ TABLE;
         $this->assertEquals($expected, $this->getOutputContent($output));
     }
 
-    public function testColumnFixedWith()
+    public function testColumnWith()
     {
         $table = new Table($output = $this->getOutputStream());
         $table
@@ -634,8 +634,39 @@ TABLE;
                 array('99921-58-10-7', 'Divine Comedy', 'Dante Alighieri', '9.95'),
                 array('9971-5-0210-0', 'A Tale of Two Cities', 'Charles Dickens', '139.25'),
             ))
-            ->setColumnFixedWidth(0, 15)
-            ->setColumnFixedWidth(3, 10);
+            ->setColumnWidth(0, 15)
+            ->setColumnWidth(3, 10);
+
+        $style = new TableStyle();
+        $style->setPadType(STR_PAD_LEFT);
+        $table->setColumnStyle(3, $style);
+
+        $table->render();
+
+        $expected =
+            <<<TABLE
++-----------------+----------------------+-----------------+------------+
+| ISBN            | Title                | Author          |      Price |
++-----------------+----------------------+-----------------+------------+
+| 99921-58-10-7   | Divine Comedy        | Dante Alighieri |       9.95 |
+| 9971-5-0210-0   | A Tale of Two Cities | Charles Dickens |     139.25 |
++-----------------+----------------------+-----------------+------------+
+
+TABLE;
+
+        $this->assertEquals($expected, $this->getOutputContent($output));
+    }
+
+    public function testColumnWiths()
+    {
+        $table = new Table($output = $this->getOutputStream());
+        $table
+            ->setHeaders(array('ISBN', 'Title', 'Author', 'Price'))
+            ->setRows(array(
+                array('99921-58-10-7', 'Divine Comedy', 'Dante Alighieri', '9.95'),
+                array('9971-5-0210-0', 'A Tale of Two Cities', 'Charles Dickens', '139.25'),
+            ))
+            ->setColumnWidths(array(15, 'auto', 'auto', 10));
 
         $style = new TableStyle();
         $style->setPadType(STR_PAD_LEFT);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | [#6296](https://github.com/symfony/symfony-docs/pull/6296) |

Be able to fix a columns width in a console table (i.e. set a columns width beforehand).
When a column's contents exceed the given column width, it will stretch.

Very useful, for instance, when one wants to display multiple tables that are separated from each other, but still want to align their columns.
