### PR TITLE
[Form] BooleanToStringTransformer - return false on falsy values

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/BooleanToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/BooleanToStringTransformer.php
@@ -80,6 +80,6 @@ class BooleanToStringTransformer implements DataTransformerInterface
             throw new TransformationFailedException('Expected a string.');
         }
 
-        return true;
+        return '' === $value || false !== filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/BooleanToStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/BooleanToStringTransformerTest.php
@@ -67,4 +67,30 @@ class BooleanToStringTransformerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->transformer->reverseTransform(''));
         $this->assertFalse($this->transformer->reverseTransform(null));
     }
+
+    /**
+     * @return array
+     */
+    public function falsyValues()
+    {
+        return array(
+            array(false, 'false'),
+            array(false, 'no'),
+            array(false, '0'),
+            array(false, 'off'),
+
+            array(true, 'true'),
+            array(true, 'on'),
+            array(true, ''), // must be true for BC
+            array(true, 'symfony'),
+        );
+    }
+
+    /**
+     * @dataProvider falsyValues
+     */
+    public function testReverseTransformOnFalsyValues($expected, $value)
+    {
+        $this->assertEquals($expected, $this->transformer->reverseTransform($value));
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | maybe |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17026 |
| License | MIT |
| Doc PR | - |

it should return false on falsy values. But there is an [assertion](https://github.com/symfony/symfony/blob/582f4753a343f230fbe18b4e9a0747d48351ddfb/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/BooleanToStringTransformerTest.php#L67) for the empty string must be return true, so i added an exception for that. 

Now its return false only; `"0"`, `"false"`, `"off"`, `"no"`; true otherwise.
