### PR TITLE
Fixed (string) catchable fatal error for PHP Incomplete Class instances

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
@@ -45,6 +45,10 @@ abstract class DataCollector implements DataCollectorInterface, \Serializable
             return sprintf('Object(%s)', get_class($var));
         }
 
+        if ($var instanceof \__PHP_Incomplete_Class) {
+            return sprintf('__PHP_Incomplete_Class(%s)', $this->getClassNameFromIncomplete($var));
+        }
+
         if (is_array($var)) {
             $a = array();
             foreach ($var as $k => $v) {
@@ -71,5 +75,12 @@ abstract class DataCollector implements DataCollectorInterface, \Serializable
         }
 
         return (string) $var;
+    }
+
+    private function getClassNameFromIncomplete(\__PHP_Incomplete_Class $var)
+    {
+        $array = new \ArrayObject($var);
+
+        return $array['__PHP_Incomplete_Class_Name'];
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17586 |
| License | MIT |
| Doc PR | - |

Fixing for 2.3 branch.
