### PR TITLE
[WIP] [Form] Fix submitting data to ChoiceType with `clearMissing` false

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -580,6 +580,8 @@ class Form implements \IteratorAggregate, FormInterface
                         if (method_exists($child, 'getClickedButton') && null !== $child->getClickedButton()) {
                             $this->clickedButton = $child->getClickedButton();
                         }
+                    } elseif (!$isSubmitted && !$clearMissing && !empty($submittedData)) {
+                        $child->submit($submittedData, $clearMissing);
                     }
                 }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -1914,4 +1914,24 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         // In this case the 'choice_label' closure returns null and not the closure from the first choice type.
         $this->assertNull($form->get('subChoice')->getConfig()->getOption('choice_label'));
     }
+
+    public function testSubmitDoesMapChoiceDataIfNotClearMissingWhenExpanded()
+    {
+        $builder = $this->factory->createBuilder('form', array('foo' => 'bar'));
+
+        $form = $builder->add('foo', 'choice', array(
+            'choices' => array(
+                'bar' => 'BAR',
+                'baz' => 'BAZ',
+            ),
+            'expanded' => true,
+        ))
+            ->getForm();
+
+        $this->assertSame(array('foo' => 'bar'), $form->getData());
+
+        $form->submit(array('foo' => 'baz'), false);
+
+        $this->assertSame(array('foo' => 'baz'), $form->getData());
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16802 |
| License | MIT |
| Doc PR | - |
- [ ] Confirm that this is the right fix

Not sure about this one, but tests are passing though.
