### PR TITLE
[Form] Fix submitting checkboxes and radios with PATCH method

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
@@ -64,7 +64,7 @@ class CheckboxType extends AbstractType
 
         $resolver->setNormalizer('force_submit', function (Options $options) {
             // If pre set data is true, we need to ensure that $emptyData will be submitted
-            return (bool) $options['data'];
+            return isset($options['data']) && (bool) $options['data'];
         });
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\Extension\Core\DataTransformer\BooleanToStringTransformer;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class CheckboxType extends AbstractType
@@ -51,13 +52,18 @@ class CheckboxType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $forceSubmit = function (FormInterface $form, $viewData) {
+        $emptyData = function (FormInterface $form, $viewData) {
             return $viewData;
+        };
+
+        $forceSubmit = function (Options $options) {
+            return $options['data'];
         };
 
         $resolver->setDefaults(array(
             'value' => '1',
             'compound' => false,
+            'empty_data' => $emptyData,
             'force_submit' => $forceSubmit, // internal
         ));
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
@@ -56,16 +56,16 @@ class CheckboxType extends AbstractType
             return $viewData;
         };
 
-        $forceSubmit = function (Options $options) {
-            return $options['data'];
-        };
-
         $resolver->setDefaults(array(
             'value' => '1',
             'compound' => false,
             'empty_data' => $emptyData,
-            'force_submit' => $forceSubmit, // internal
         ));
+
+        $resolver->setNormalizer('force_submit', function (Options $options) {
+            // If pre set data is true, we need to ensure that $emptyData will be submitted
+            return (bool) $options['data'];
+        });
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
@@ -51,14 +51,14 @@ class CheckboxType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $emptyData = function (FormInterface $form, $viewData) {
+        $forceSubmit = function (FormInterface $form, $viewData) {
             return $viewData;
         };
 
         $resolver->setDefaults(array(
             'value' => '1',
-            'empty_data' => $emptyData,
             'compound' => false,
+            'force_submit' => $forceSubmit, // internal
         ));
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -215,6 +215,7 @@ class FormType extends BaseType
             'attr' => $defaultAttr,
             'post_max_size_message' => 'The uploaded file was too large. Please try to upload a smaller file.',
             'upload_max_size_message' => $uploadMaxSizeMessage, // internal
+            'force_submit' => false, // internal
         ));
 
         $resolver->setAllowedTypes('label_attr', 'array');

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -562,8 +562,11 @@ class Form implements \IteratorAggregate, FormInterface
 
                 foreach ($this->children as $name => $child) {
                     $isSubmitted = array_key_exists($name, $submittedData);
+                    // Some form types like {@link \Symfony\Component\Form\Extension\Core\Type\CheckboxType}
+                    // need to force submission of null, so the form is properly updated.
+                    $forceSubmit = $child->getConfig()->getOption('force_submit', false);
 
-                    if ($isSubmitted || $clearMissing) {
+                    if ($isSubmitted || $clearMissing || $forceSubmit) {
                         $child->submit($isSubmitted ? $submittedData[$name] : null, $clearMissing);
                         unset($submittedData[$name]);
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
@@ -136,6 +136,49 @@ class CheckboxTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertSame('', $form->getViewData());
     }
 
+    public function testSubmitNestedCheckBoxWithEmptyValueAndFalseUnchecked()
+    {
+        $form = $this->factory->create('form', array(
+                'check' => true,
+            ))
+            ->add('check', 'checkbox', array(
+                'value' => '',
+            ))
+        ;
+
+        $form->submit(null);
+
+        $this->assertFalse($form->get('check')->getData());
+        $this->assertNull($form->get('check')->getViewData());
+    }
+
+    public function testSubmitNestedCheckBoxWithEmptyValueAndFalseUncheckedWithClearMissingFalse()
+    {
+        $form = $this->factory->create('form', array(
+                'check' => true,
+            ))
+            ->add('check', 'checkbox', array(
+                'value' => '',
+            ))
+        ;
+
+        $form->submit(null, false);
+
+        $this->assertFalse($form->get('check')->getData());
+        $this->assertNull($form->get('check')->getViewData());
+    }
+
+    public function testSubmitNestedCheckboxWithEmptyValueAndTrueCheckedWithClearMissingFalse()
+    {
+        $form = $this->factory->create('checkbox', null, array(
+            'value' => '',
+        ));
+        $form->submit(true, false);
+
+        $this->assertTrue($form->getData());
+        $this->assertSame('', $form->getViewData());
+    }
+
     /**
      * @dataProvider provideCustomModelTransformerData
      */

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -2283,4 +2283,43 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         // In this case the 'choice_label' closure returns null and not the closure from the first choice type.
         $this->assertNull($form->get('subChoice')->getConfig()->getOption('choice_label'));
     }
+
+    public function testSubmitDoesMapChoiceDataIfNotClearMissingWhenExpanded()
+    {
+        $builder = $this->factory->createBuilder('form', array('foo' => 'bar'));
+
+        $form = $builder->add('foo', 'choice', array(
+            'choices' => array(
+                'bar' => 'BAR',
+                'baz' => 'BAZ',
+            ),
+            'expanded' => true,
+        ))
+            ->getForm();
+
+        $this->assertSame(array('foo' => 'bar'), $form->getData());
+
+        $form->submit(array('foo' => 'baz'), false);
+
+        $this->assertSame(array('foo' => 'baz'), $form->getData());
+    }
+
+    public function testSubmitDoesMapChoiceDataIfNotClearMissingWhenCollapsed()
+    {
+        $builder = $this->factory->createBuilder('form', array('foo' => 'bar'));
+
+        $form = $builder->add('foo', 'choice', array(
+            'choices' => array(
+                'bar' => 'BAR',
+                'baz' => 'BAZ',
+            ),
+        ))
+            ->getForm();
+
+        $this->assertSame(array('foo' => 'bar'), $form->getData());
+
+        $form->submit(array('foo' => 'baz'), false);
+
+        $this->assertSame(array('foo' => 'baz'), $form->getData());
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16802, #17799, #17899, #20179 |
| License | MIT |
| Doc PR | - |
- [x] Confirm this is the right fix
- [ ] Update tests for 2.8 with FQCN
- [ ] Update tests for 3.0 by flipping choice keys and values

The bug seems to make it impossible to submit an expanded `ChoiceType` with a PATCH method, see #17799.