### PR TITLE
[VarDumper] fix PHP 7 tests

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/HtmlDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/HtmlDumperTest.php
@@ -56,6 +56,36 @@ class HtmlDumperTest extends \PHPUnit_Framework_TestCase
 EOTXT;
         }
 
+        if (PHP_VERSION_ID >= 70000) {
+            $resource = <<<EOTXT
+  "<span class=sf-dump-key>res</span>" => <span class=sf-dump-note>stream resource</span> <a class=sf-dump-ref>@{$res}</a><samp>
+    <span class=sf-dump-meta>timed_out</span>: <span class=sf-dump-const>false</span>
+    <span class=sf-dump-meta>blocked</span>: <span class=sf-dump-const>true</span>
+    <span class=sf-dump-meta>eof</span>: <span class=sf-dump-const>false</span>
+    <span class=sf-dump-meta>wrapper_type</span>: "<span class=sf-dump-str title="9 characters">plainfile</span>"
+    <span class=sf-dump-meta>stream_type</span>: "<span class=sf-dump-str title="5 characters">STDIO</span>"
+    <span class=sf-dump-meta>mode</span>: "<span class=sf-dump-str>r</span>"
+    <span class=sf-dump-meta>unread_bytes</span>: <span class=sf-dump-num>0</span>
+    <span class=sf-dump-meta>seekable</span>: <span class=sf-dump-const>true</span>
+    <span class=sf-dump-meta>options</span>: []
+  </samp>}
+EOTXT;
+        } else {
+            $resource = <<<EOTXT
+  "<span class=sf-dump-key>res</span>" => <span class=sf-dump-note>stream resource</span> <a class=sf-dump-ref>@{$res}</a><samp>
+    <span class=sf-dump-meta>wrapper_type</span>: "<span class=sf-dump-str title="9 characters">plainfile</span>"
+    <span class=sf-dump-meta>stream_type</span>: "<span class=sf-dump-str title="5 characters">STDIO</span>"
+    <span class=sf-dump-meta>mode</span>: "<span class=sf-dump-str>r</span>"
+    <span class=sf-dump-meta>unread_bytes</span>: <span class=sf-dump-num>0</span>
+    <span class=sf-dump-meta>seekable</span>: <span class=sf-dump-const>true</span>
+    <span class=sf-dump-meta>timed_out</span>: <span class=sf-dump-const>false</span>
+    <span class=sf-dump-meta>blocked</span>: <span class=sf-dump-const>true</span>
+    <span class=sf-dump-meta>eof</span>: <span class=sf-dump-const>false</span>
+    <span class=sf-dump-meta>options</span>: []
+  </samp>}
+EOTXT;
+        }
+
         $this->assertStringMatchesFormat(
             <<<EOTXT
 <foo></foo><bar><span class=sf-dump-note>array:24</span> [<samp>
@@ -71,17 +101,7 @@ EOTXT;
   "<span class=sf-dump-key>str</span>" => "<span class=sf-dump-str title="5 characters">d&#233;j&#224;</span>\\n"
   <span class=sf-dump-key>7</span> => b"<span class=sf-dump-str title="2 binary or non-UTF-8 characters">&#233;</span>\\x00"
   "<span class=sf-dump-key>[]</span>" => []
-  "<span class=sf-dump-key>res</span>" => <span class=sf-dump-note>stream resource</span> <a class=sf-dump-ref>@{$res}</a><samp>
-    <span class=sf-dump-meta>wrapper_type</span>: "<span class=sf-dump-str title="9 characters">plainfile</span>"
-    <span class=sf-dump-meta>stream_type</span>: "<span class=sf-dump-str title="5 characters">STDIO</span>"
-    <span class=sf-dump-meta>mode</span>: "<span class=sf-dump-str>r</span>"
-    <span class=sf-dump-meta>unread_bytes</span>: <span class=sf-dump-num>0</span>
-    <span class=sf-dump-meta>seekable</span>: <span class=sf-dump-const>true</span>
-    <span class=sf-dump-meta>timed_out</span>: <span class=sf-dump-const>false</span>
-    <span class=sf-dump-meta>blocked</span>: <span class=sf-dump-const>true</span>
-    <span class=sf-dump-meta>eof</span>: <span class=sf-dump-const>false</span>
-    <span class=sf-dump-meta>options</span>: []
-  </samp>}
+{$resource}
   "<span class=sf-dump-key>obj</span>" => <abbr title="Symfony\Component\VarDumper\Tests\Fixture\DumbFoo" class=sf-dump-note>DumbFoo</abbr> {<a class=sf-dump-ref href=#{$dumpId}-ref2%d title="2 occurrences">#%d</a><samp id={$dumpId}-ref2%d>
     +<span class=sf-dump-public title="Public property">foo</span>: "<span class=sf-dump-str title="3 characters">foo</span>"
     +"<span class=sf-dump-public title="Runtime added dynamic property">bar</span>": "<span class=sf-dump-str title="3 characters">bar</span>"


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

I think this is only a short term solution. We should rather find a way to have the tests not rely on the order of the dumped properties or ensure in the component that the order does not change. But this at least makes our test suite reliable again.
