### PR TITLE
[DomCrawler] Clarify the value returned by getPhpFiles()

### DIFF
--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -157,8 +157,12 @@ class Form extends Link implements \ArrayAccess
      *
      * This method converts fields with the array notation
      * (like foo[bar] to arrays) like PHP does.
+     * The returned array is consistent with the array for field values
+     * (@see getPhpValues), rather than uploaded files found in $_FILES.
+     * For a compound file field foo[bar] it will create foo[bar][name],
+     * instead of foo[name][bar] which would be found in $_FILES.
      *
-     * @return array An array of field values.
+     * @return array An array of file field values.
      */
     public function getPhpFiles()
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14021 |
| License | MIT |
| Doc PR | - |

The comment was previously suggesting the returned value is similar to the one stored in $_FILES, while it is more similar to the way PHP stores submitted form values. It is actually more convenient to have it this way, so rather then changing the returned value (which would break BC), it is better to clarify the comment.
