### PR TITLE
Support autowiring for Doctrine\Common\Annotations\Reader

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\DependencyInjection;
 
+use Doctrine\Common\Annotations\Reader;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
@@ -844,6 +845,7 @@ class FrameworkExtension extends Extension
                 ->getDefinition('annotations.cached_reader')
                 ->replaceArgument(1, new Reference('file' !== $config['cache'] ? $config['cache'] : 'annotations.filesystem_cache'))
                 ->replaceArgument(2, $config['debug'])
+                ->addAutowiringType(Reader::class)
             ;
             $container->setAlias('annotation_reader', 'annotations.cached_reader');
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
@@ -5,7 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="annotations.reader" class="Doctrine\Common\Annotations\AnnotationReader" public="false" />
+        <service id="annotations.reader" class="Doctrine\Common\Annotations\AnnotationReader" public="false">
+            <autowiring-type>Doctrine\Common\Annotations\Reader</autowiring-type>
+        </service>
 
         <service id="annotations.cached_reader" class="Doctrine\Common\Annotations\CachedReader" public="false">
             <argument type="service" id="annotations.reader" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AutowiringTypesTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AutowiringTypesTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\CachedReader;
+
+class AutowiringTypesTest extends WebTestCase
+{
+    public function testAnnotationReaderAutowiring()
+    {
+        static::bootKernel(array('root_config' => 'no_annotations_cache.yml', 'environment' => 'no_annotations_cache'));
+        $container = static::$kernel->getContainer();
+
+        $annotationReader = $container->get('test.autowiring_types.autowired_services')->getAnnotationReader();
+        $this->assertInstanceOf(AnnotationReader::class, $annotationReader);
+    }
+
+    public function testCachedAnnotationReaderAutowiring()
+    {
+        static::bootKernel();
+        $container = static::$kernel->getContainer();
+
+        $annotationReader = $container->get('test.autowiring_types.autowired_services')->getAnnotationReader();
+        $this->assertInstanceOf(CachedReader::class, $annotationReader);
+    }
+
+    protected static function createKernel(array $options = array())
+    {
+        return parent::createKernel(array('test_case' => 'AutowiringTypes') + $options);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/AutowiringTypes/AutowiredServices.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/AutowiringTypes/AutowiredServices.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\AutowiringTypes;
+
+use Doctrine\Common\Annotations\Reader;
+
+class AutowiredServices
+{
+    private $annotationReader;
+
+    public function __construct(Reader $annotationReader = null)
+    {
+        $this->annotationReader = $annotationReader;
+    }
+
+    public function getAnnotationReader()
+    {
+        return $this->annotationReader;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AutowiringTypes/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AutowiringTypes/bundles.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+
+return array(
+    new FrameworkBundle(),
+    new TestBundle(),
+);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AutowiringTypes/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AutowiringTypes/config.yml
@@ -1,0 +1,7 @@
+imports:
+    - { resource: ../config/default.yml }
+
+services:
+    test.autowiring_types.autowired_services:
+        class: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\AutowiringTypes\AutowiredServices
+        autowire: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AutowiringTypes/no_annotations_cache.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AutowiringTypes/no_annotations_cache.yml
@@ -1,0 +1,6 @@
+imports:
+    - { resource: config.yml }
+
+framework:
+    annotations:
+        cache: none


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

I've added support for autowiring based on `Doctrine\Common\Annotations\Reader` interface simmilar to https://github.com/symfony/symfony/pull/17703/files

The `annotations.cached_reader` service is injected when cache is enabled.
