### PR TITLE
[Config] Fix EnumNodeDefinition to allow building enum nodes with one element

### DIFF
--- a/src/Symfony/Component/Config/Definition/Builder/EnumNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/EnumNodeDefinition.php
@@ -31,8 +31,8 @@ class EnumNodeDefinition extends ScalarNodeDefinition
     {
         $values = array_unique($values);
 
-        if (count($values) <= 1) {
-            throw new \InvalidArgumentException('->values() must be called with at least two distinct values.');
+        if (empty($values)) {
+            throw new \InvalidArgumentException('->values() must be called with at least one value.');
         }
 
         $this->values = $values;

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/EnumNodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/EnumNodeDefinitionTest.php
@@ -15,14 +15,22 @@ use Symfony\Component\Config\Definition\Builder\EnumNodeDefinition;
 
 class EnumNodeDefinitionTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage ->values() must be called with at least two distinct values.
-     */
-    public function testNoDistinctValues()
+    public function testWithOneValue()
+    {
+        $def = new EnumNodeDefinition('foo');
+        $def->values(array('foo'));
+
+        $node = $def->getNode();
+        $this->assertEquals(array('foo'), $node->getValues());
+    }
+
+    public function testWithOneDistinctValue()
     {
         $def = new EnumNodeDefinition('foo');
         $def->values(array('foo', 'foo'));
+
+        $node = $def->getNode();
+        $this->assertEquals(array('foo'), $node->getValues());
     }
 
     /**
@@ -33,6 +41,16 @@ class EnumNodeDefinitionTest extends \PHPUnit_Framework_TestCase
     {
         $def = new EnumNodeDefinition('foo');
         $def->getNode();
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage ->values() must be called with at least one value.
+     */
+    public function testWithNoValues()
+    {
+        $def = new EnumNodeDefinition('foo');
+        $def->values(array());
     }
 
     public function testGetNode()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15433, #17774 |
| License | MIT |
| Doc PR | - |
