### PR TITLE
[FrameworkBundle] Remove unused private method.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -429,17 +429,6 @@ class TextDescriptor extends Descriptor
     }
 
     /**
-     * @param string $section
-     * @param string $message
-     *
-     * @return string
-     */
-    private function formatSection($section, $message)
-    {
-        return sprintf('<info>[%s]</info> %s', $section, $message);
-    }
-
-    /**
      * @param callable $callable
      *
      * @return string


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Since 2.8, this method is not used in `TextDescriptor`.
