### PR TITLE
[HttpFoundation] Add test for non-string request attribute matching

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/RequestMatcherTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestMatcherTest.php
@@ -127,4 +127,17 @@ class RequestMatcherTest extends \PHPUnit_Framework_TestCase
         $matcher->matchAttribute('foo', 'babar');
         $this->assertFalse($matcher->matches($request));
     }
+
+    function testAttributeWithNonStringValue()
+    {
+        $matcher = new RequestMatcher();
+
+        $request = Request::create('/admin/foo');
+        $request->attributes->set('_foo', function () {
+            return 'bar';
+        });
+
+        $matcher->matchAttribute('_foo', 'bar');
+        $this->assertFalse($matcher->matches($request));
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | related #16529 |
| License | MIT |
| Doc PR | N/A |
