### PR TITLE
[Yaml] deprecate starting plain scalars with % characters

### DIFF
--- a/UPGRADE-3.1.md
+++ b/UPGRADE-3.1.md
@@ -33,6 +33,8 @@ Serializer
 Yaml
 ----
 
+ * Deprecated usage of `%` at the beginning of an unquoted string.
+
  * The `Dumper::setIndentation()` method is deprecated and will be removed in
    Symfony 4.0. Pass the indentation level to the constructor instead.
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -30,6 +30,8 @@ Serializer
 Yaml
 ----
 
+ * Starting an unquoted string with `%` leads to a `ParseException`.
+
  * The `Dumper::setIndentation()` method was removed. Pass the indentation
    level to the constructor instead.
 

--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 3.1.0
 -----
 
+ * Deprecated usage of `%` at the beginning of an unquoted string.
+
  * Added support for customizing the YAML parser behavior through an optional bit field:
 
    ```php

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -289,6 +289,10 @@ class Inline
                 throw new ParseException(sprintf('The reserved indicator "%s" cannot start a plain scalar; you need to quote the scalar.', $output[0]));
             }
 
+            if ($output && '%' === $output[0]) {
+                @trigger_error('Not quoting a scalar starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0.', E_USER_DEPRECATED);
+            }
+
             if ($evaluate) {
                 $output = self::evaluateScalar($output, $references);
             }

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -252,6 +252,27 @@ class InlineTest extends \PHPUnit_Framework_TestCase
         return array(array('|'), array('>'));
     }
 
+    /**
+     * @group legacy
+     * throws \Symfony\Component\Yaml\Exception\ParseException in 4.0
+     */
+    public function testParseUnquotedScalarStartingWithPercentCharacter()
+    {
+        $deprecations = array();
+        set_error_handler(function ($type, $msg) use (&$deprecations) {
+            if (E_USER_DEPRECATED === $type) {
+                $deprecations[] = $msg;
+            }
+        });
+
+        Inline::parse('{ foo: %foo }');
+
+        restore_error_handler();
+
+        $this->assertCount(1, $deprecations);
+        $this->assertContains('Not quoting a scalar starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0.', $deprecations[0]);
+    }
+
     public function getTestsForParse()
     {
         return array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | symfony/symfony-docs#6269, symfony/symfony-standard#426 |
| License | MIT |
| Doc PR |  |
