### PR TITLE
[Yaml] always restore the error handler in tests

### DIFF
--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -896,10 +896,10 @@ EOF;
 
         $this->parser->parse($yaml);
 
+        restore_error_handler();
+
         $this->assertCount(1, $deprecations);
         $this->assertContains('Using a colon in the unquoted mapping value "bar: baz" in line 1 is deprecated since Symfony 2.8 and will throw a ParseException in 3.0.', $deprecations[0]);
-
-        restore_error_handler();
     }
 
     public function testColonInMappingValueExceptionNotTriggeredByColonInComment()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/pull/17809#discussion_r52928131 |
| License | MIT |
| Doc PR |  |

The error handler must be restored even when assertions failed.
