### PR TITLE
[DependencyInjection] don't rely on deprecated YAML parser feature

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
@@ -28,14 +28,14 @@ class YamlDumperTest extends \PHPUnit_Framework_TestCase
     {
         $dumper = new YamlDumper($container = new ContainerBuilder());
 
-        $this->assertEqualYamlStructure(self::$fixturesPath.'/yaml/services1.yml', $dumper->dump(), '->dump() dumps an empty container as an empty YAML file');
+        $this->assertEqualYamlStructure(file_get_contents(self::$fixturesPath.'/yaml/services1.yml'), $dumper->dump(), '->dump() dumps an empty container as an empty YAML file');
     }
 
     public function testAddParameters()
     {
         $container = include self::$fixturesPath.'/containers/container8.php';
         $dumper = new YamlDumper($container);
-        $this->assertEqualYamlStructure(self::$fixturesPath.'/yaml/services8.yml', $dumper->dump(), '->dump() dumps parameters');
+        $this->assertEqualYamlStructure(file_get_contents(self::$fixturesPath.'/yaml/services8.yml'), $dumper->dump(), '->dump() dumps parameters');
     }
 
     public function testAddService()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17814 |
| License | MIT |
| Doc PR |  |

see [failing tests for the 2.7 branch](https://travis-ci.org/symfony/symfony/jobs/109537695#L2238)
