### PR TITLE
[Console] InvalidArgumentException is thrown under wrong condition

### DIFF
--- a/src/Symfony/Component/Console/Question/Question.php
+++ b/src/Symfony/Component/Console/Question/Question.php
@@ -143,7 +143,7 @@ class Question
         }
 
         if (null !== $values && !is_array($values)) {
-            if (!$values instanceof \Traversable || $values instanceof \Countable) {
+            if (!$values instanceof \Traversable || !$values instanceof \Countable) {
                 throw new InvalidArgumentException('Autocompleter values can be either an array, `null` or an object implementing both `Countable` and `Traversable` interfaces.');
             }
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | no |

When an object is passed to `setAutocompleterValues` that implements `\Countable` and `\Traversable`, an `InvalidArgumentException` is thrown, even though its message says that the argument should implement both of those interfaces.

Instead, the exception should be thrown if the parameter fails to implement either `\Countable` or `\Traversable`, like the exception message says.

_Disclaimer: I've been looking at this line for 10min, and I've become convinced it should be changed according to my PR, but I could be wrong._
