### PR TITLE
[HttpKernel] Prevent a fatal error when DebugHandlersListener is used with a kernel with no terminateWithException() method

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
@@ -93,7 +93,9 @@ class DebugHandlersListener implements EventSubscriberInterface
         }
         if (!$this->exceptionHandler) {
             if ($event instanceof KernelEvent) {
-                $this->exceptionHandler = array($event->getKernel(), 'terminateWithException');
+                if (method_exists($event->getKernel(), 'terminateWithException')) {
+                    $this->exceptionHandler = array($event->getKernel(), 'terminateWithException');
+                }
             } elseif ($event instanceof ConsoleEvent && $app = $event->getCommand()->getApplication()) {
                 $output = $event->getOutput();
                 if ($output instanceof ConsoleOutputInterface) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

I just suffered from this bug on a project that used HttpKernelInterface implementation with no `terminateWithException() method (which is not part of the interface).
