### PR TITLE
[Form] fix violation mapper tests

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
@@ -1552,12 +1552,14 @@ class ViolationMapperTest extends \PHPUnit_Framework_TestCase
         $parent->add($child2);
         $child2->add($grandChild);
 
+        $parent->submit(array());
+
         $this->mapper->mapViolation($violation, $parent);
 
         // The error occurred on the child of the second form with the same path
         $this->assertCount(0, $parent->getErrors(), $parent->getName().' should not have an error, but has one');
         $this->assertCount(0, $child1->getErrors(), $child1->getName().' should not have an error, but has one');
         $this->assertCount(0, $child2->getErrors(), $child2->getName().' should not have an error, but has one');
-        $this->assertEquals(array($this->getFormError()), $grandChild->getErrors(), $grandChild->getName().' should have an error, but has none');
+        $this->assertEquals(array($this->getFormError($violation, $grandChild)), iterator_to_array($grandChild->getErrors()), $grandChild->getName().' should have an error, but has none');
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17099 |
| License | MIT |
| Doc PR |  |

This takes into account the changes to the `getErrors()` in Symfony 2.5
(the method rturns a `FormErrorIterator` instead of an array) as well as
the fact that non-submitted forms do not accept errors since #10567
anymore.
