### PR TITLE
[CS] Remove useless else statements. (2.3)

### DIFF
--- a/src/Symfony/Bridge/Twig/NodeVisitor/TranslationDefaultDomainNodeVisitor.php
+++ b/src/Symfony/Bridge/Twig/NodeVisitor/TranslationDefaultDomainNodeVisitor.php
@@ -48,13 +48,13 @@ class TranslationDefaultDomainNodeVisitor extends \Twig_BaseNodeVisitor
                 $this->scope->set('domain', $node->getNode('expr'));
 
                 return $node;
-            } else {
+            }  
                 $var = $env->getParser()->getVarName();
                 $name = new \Twig_Node_Expression_AssignName($var, $node->getLine());
                 $this->scope->set('domain', new \Twig_Node_Expression_Name($var, $node->getLine()));
 
                 return new \Twig_Node_Set(false, new \Twig_Node(array($name)), new \Twig_Node(array($node->getNode('expr'))), $node->getLine());
-            }
+            
         }
 
         if (!$this->scope->has('domain')) {

--- a/src/Symfony/Bridge/Twig/NodeVisitor/TranslationDefaultDomainNodeVisitor.php
+++ b/src/Symfony/Bridge/Twig/NodeVisitor/TranslationDefaultDomainNodeVisitor.php
@@ -48,13 +48,13 @@ class TranslationDefaultDomainNodeVisitor extends \Twig_BaseNodeVisitor
                 $this->scope->set('domain', $node->getNode('expr'));
 
                 return $node;
-            }  
-                $var = $env->getParser()->getVarName();
-                $name = new \Twig_Node_Expression_AssignName($var, $node->getLine());
-                $this->scope->set('domain', new \Twig_Node_Expression_Name($var, $node->getLine()));
+            }
 
-                return new \Twig_Node_Set(false, new \Twig_Node(array($name)), new \Twig_Node(array($node->getNode('expr'))), $node->getLine());
-            
+            $var = $env->getParser()->getVarName();
+            $name = new \Twig_Node_Expression_AssignName($var, $node->getLine());
+            $this->scope->set('domain', new \Twig_Node_Expression_Name($var, $node->getLine()));
+
+            return new \Twig_Node_Set(false, new \Twig_Node(array($name)), new \Twig_Node(array($node->getNode('expr'))), $node->getLine());
         }
 
         if (!$this->scope->has('domain')) {

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/PhpExtractor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/PhpExtractor.php
@@ -167,9 +167,9 @@ class PhpExtractor implements ExtractorInterface
                     } elseif (self::MESSAGE_TOKEN == $item) {
                         $message = $this->getMessage($tokenIterator);
                         break;
-                    } else {
+                    }  
                         break;
-                    }
+                    
                 }
 
                 if ($message) {

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/PhpExtractor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/PhpExtractor.php
@@ -167,9 +167,9 @@ class PhpExtractor implements ExtractorInterface
                     } elseif (self::MESSAGE_TOKEN == $item) {
                         $message = $this->getMessage($tokenIterator);
                         break;
-                    }  
-                        break;
-                    
+                    }
+
+                    break;
                 }
 
                 if ($message) {

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/PhpStringTokenParser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/PhpStringTokenParser.php
@@ -80,9 +80,9 @@ class PhpStringTokenParser
                 array('\\', '\''),
                 substr($str, $bLength + 1, -1)
             );
-        } else {
+        }  
             return self::parseEscapeSequences(substr($str, $bLength + 1, -1), '"');
-        }
+        
     }
 
     /**
@@ -114,9 +114,9 @@ class PhpStringTokenParser
             return self::$replacements[$str];
         } elseif ('x' === $str[0] || 'X' === $str[0]) {
             return chr(hexdec($str));
-        } else {
+        }  
             return chr(octdec($str));
-        }
+        
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/PhpStringTokenParser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/PhpStringTokenParser.php
@@ -80,9 +80,9 @@ class PhpStringTokenParser
                 array('\\', '\''),
                 substr($str, $bLength + 1, -1)
             );
-        }  
-            return self::parseEscapeSequences(substr($str, $bLength + 1, -1), '"');
-        
+        }
+
+        return self::parseEscapeSequences(substr($str, $bLength + 1, -1), '"');
     }
 
     /**
@@ -114,9 +114,9 @@ class PhpStringTokenParser
             return self::$replacements[$str];
         } elseif ('x' === $str[0] || 'X' === $str[0]) {
             return chr(hexdec($str));
-        }  
-            return chr(octdec($str));
-        
+        }
+
+        return chr(octdec($str));
     }
 
     /**

--- a/src/Symfony/Component/Console/Helper/ProgressHelper.php
+++ b/src/Symfony/Component/Console/Helper/ProgressHelper.php
@@ -413,10 +413,10 @@ class ProgressHelper extends Helper
                 if (count($format) == 2) {
                     $text = $format[1];
                     break;
-                } else {
+                }  
                     $text = ceil($secs / $format[2]).' '.$format[1];
                     break;
-                }
+                
             }
         }
 

--- a/src/Symfony/Component/Console/Helper/ProgressHelper.php
+++ b/src/Symfony/Component/Console/Helper/ProgressHelper.php
@@ -413,10 +413,10 @@ class ProgressHelper extends Helper
                 if (count($format) == 2) {
                     $text = $format[1];
                     break;
-                }  
-                    $text = ceil($secs / $format[2]).' '.$format[1];
-                    break;
-                
+                }
+
+                $text = ceil($secs / $format[2]).' '.$format[1];
+                break;
             }
         }
 

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -129,9 +129,9 @@ class ArgvInput extends Input
                 $this->addLongOption($option->getName(), $i === $len - 1 ? null : substr($name, $i + 1));
 
                 break;
-            } else {
+            }  
                 $this->addLongOption($option->getName(), null);
-            }
+            
         }
     }
 

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -129,9 +129,9 @@ class ArgvInput extends Input
                 $this->addLongOption($option->getName(), $i === $len - 1 ? null : substr($name, $i + 1));
 
                 break;
-            }  
-                $this->addLongOption($option->getName(), null);
-            
+            }
+
+            $this->addLongOption($option->getName(), null);
         }
     }
 

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -891,9 +891,9 @@ EOF;
         if (!$aliases = $this->container->getAliases()) {
             if ($this->container->isFrozen()) {
                 return "\n        \$this->aliases = array();\n";
-            }  
-                return '';
-            
+            }
+
+            return '';
         }
 
         $code = "        \$this->aliases = array(\n";
@@ -1218,9 +1218,9 @@ EOF;
                     $service = $this->dumpValue($value->getFactoryService());
 
                     return sprintf('%s->%s(%s)', 0 === strpos($service, '$') ? sprintf('$this->get(%s)', $service) : $this->getServiceCall($value->getFactoryService()), $value->getFactoryMethod(), implode(', ', $arguments));
-                }  
-                    throw new RuntimeException('Cannot dump definitions which have factory method without factory service or factory class.');
-                
+                }
+
+                throw new RuntimeException('Cannot dump definitions which have factory method without factory service or factory class.');
             }
 
             $class = $value->getClass();
@@ -1248,21 +1248,21 @@ EOF;
                 // we do this to deal with non string values (Boolean, integer, ...)
                 // the preg_replace_callback converts them to strings
                 return $this->dumpParameter(strtolower($match[1]));
-            }  
-                $that = $this;
-                $replaceParameters = function ($match) use ($that) {
-                    return "'.".$that->dumpParameter(strtolower($match[2])).".'";
-                };
+            }
 
-                $code = str_replace('%%', '%', preg_replace_callback('/(?<!%)(%)([^%]+)\1/', $replaceParameters, $this->export($value)));
+            $that = $this;
+            $replaceParameters = function ($match) use ($that) {
+                return "'.".$that->dumpParameter(strtolower($match[2])).".'";
+            };
 
-                return $code;
-            
+            $code = str_replace('%%', '%', preg_replace_callback('/(?<!%)(%)([^%]+)\1/', $replaceParameters, $this->export($value)));
+
+            return $code;
         } elseif (is_object($value) || is_resource($value)) {
             throw new RuntimeException('Unable to dump a service container if a parameter is an object or a resource.');
-        }  
-            return $this->export($value);
-        
+        }
+
+        return $this->export($value);
     }
 
     /**
@@ -1297,13 +1297,13 @@ EOF;
 
         if (null !== $reference && ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE !== $reference->getInvalidBehavior()) {
             return sprintf('$this->get(\'%s\', ContainerInterface::NULL_ON_INVALID_REFERENCE)', $id);
-        }  
-            if ($this->container->hasAlias($id)) {
-                $id = (string) $this->container->getAlias($id);
-            }
+        }
 
-            return sprintf('$this->get(\'%s\')', $id);
-        
+        if ($this->container->hasAlias($id)) {
+            $id = (string) $this->container->getAlias($id);
+        }
+
+        return sprintf('$this->get(\'%s\')', $id);
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -891,9 +891,9 @@ EOF;
         if (!$aliases = $this->container->getAliases()) {
             if ($this->container->isFrozen()) {
                 return "\n        \$this->aliases = array();\n";
-            } else {
+            }  
                 return '';
-            }
+            
         }
 
         $code = "        \$this->aliases = array(\n";
@@ -1218,9 +1218,9 @@ EOF;
                     $service = $this->dumpValue($value->getFactoryService());
 
                     return sprintf('%s->%s(%s)', 0 === strpos($service, '$') ? sprintf('$this->get(%s)', $service) : $this->getServiceCall($value->getFactoryService()), $value->getFactoryMethod(), implode(', ', $arguments));
-                } else {
+                }  
                     throw new RuntimeException('Cannot dump definitions which have factory method without factory service or factory class.');
-                }
+                
             }
 
             $class = $value->getClass();
@@ -1248,7 +1248,7 @@ EOF;
                 // we do this to deal with non string values (Boolean, integer, ...)
                 // the preg_replace_callback converts them to strings
                 return $this->dumpParameter(strtolower($match[1]));
-            } else {
+            }  
                 $that = $this;
                 $replaceParameters = function ($match) use ($that) {
                     return "'.".$that->dumpParameter(strtolower($match[2])).".'";
@@ -1257,12 +1257,12 @@ EOF;
                 $code = str_replace('%%', '%', preg_replace_callback('/(?<!%)(%)([^%]+)\1/', $replaceParameters, $this->export($value)));
 
                 return $code;
-            }
+            
         } elseif (is_object($value) || is_resource($value)) {
             throw new RuntimeException('Unable to dump a service container if a parameter is an object or a resource.');
-        } else {
+        }  
             return $this->export($value);
-        }
+        
     }
 
     /**
@@ -1297,13 +1297,13 @@ EOF;
 
         if (null !== $reference && ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE !== $reference->getInvalidBehavior()) {
             return sprintf('$this->get(\'%s\', ContainerInterface::NULL_ON_INVALID_REFERENCE)', $id);
-        } else {
+        }  
             if ($this->container->hasAlias($id)) {
                 $id = (string) $this->container->getAlias($id);
             }
 
             return sprintf('$this->get(\'%s\')', $id);
-        }
+        
     }
 
     /**

--- a/src/Symfony/Component/Finder/Iterator/RecursiveDirectoryIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/RecursiveDirectoryIterator.php
@@ -103,9 +103,9 @@ class RecursiveDirectoryIterator extends \RecursiveDirectoryIterator
             if ($this->ignoreUnreadableDirs) {
                 // If directory is unreadable and finder is set to ignore it, a fake empty content is returned.
                 return new \RecursiveArrayIterator(array());
-            } else {
+            }  
                 throw new AccessDeniedException($e->getMessage(), $e->getCode(), $e);
-            }
+            
         }
     }
 

--- a/src/Symfony/Component/Finder/Iterator/RecursiveDirectoryIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/RecursiveDirectoryIterator.php
@@ -103,9 +103,9 @@ class RecursiveDirectoryIterator extends \RecursiveDirectoryIterator
             if ($this->ignoreUnreadableDirs) {
                 // If directory is unreadable and finder is set to ignore it, a fake empty content is returned.
                 return new \RecursiveArrayIterator(array());
-            }  
-                throw new AccessDeniedException($e->getMessage(), $e->getCode(), $e);
-            
+            }
+
+            throw new AccessDeniedException($e->getMessage(), $e->getCode(), $e);
         }
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToBooleanArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToBooleanArrayTransformer.php
@@ -107,9 +107,9 @@ class ChoiceToBooleanArrayTransformer implements DataTransformerInterface
                     return $choices[$i] === '' ? null : $choices[$i];
                 } elseif ($this->placeholderPresent && 'placeholder' === $i) {
                     return;
-                } else {
+                }  
                     throw new TransformationFailedException(sprintf('The choice "%s" does not exist', $i));
-                }
+                
             }
         }
     }

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToBooleanArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToBooleanArrayTransformer.php
@@ -107,9 +107,9 @@ class ChoiceToBooleanArrayTransformer implements DataTransformerInterface
                     return $choices[$i] === '' ? null : $choices[$i];
                 } elseif ($this->placeholderPresent && 'placeholder' === $i) {
                     return;
-                }  
-                    throw new TransformationFailedException(sprintf('The choice "%s" does not exist', $i));
-                
+                }
+
+                throw new TransformationFailedException(sprintf('The choice "%s" does not exist', $i));
             }
         }
     }

--- a/src/Symfony/Component/Routing/Matcher/ApacheUrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/ApacheUrlMatcher.php
@@ -87,9 +87,9 @@ class ApacheUrlMatcher extends UrlMatcher
             return $this->mergeDefaults($parameters, $defaults);
         } elseif (0 < count($allow)) {
             throw new MethodNotAllowedException($allow);
-        } else {
+        }  
             return parent::match($pathinfo);
-        }
+        
     }
 
     /**

--- a/src/Symfony/Component/Routing/Matcher/ApacheUrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/ApacheUrlMatcher.php
@@ -87,9 +87,9 @@ class ApacheUrlMatcher extends UrlMatcher
             return $this->mergeDefaults($parameters, $defaults);
         } elseif (0 < count($allow)) {
             throw new MethodNotAllowedException($allow);
-        }  
-            return parent::match($pathinfo);
-        
+        }
+
+        return parent::match($pathinfo);
     }
 
     /**

--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -203,12 +203,12 @@ class RouteCompiler implements RouteCompilerInterface
         if ('text' === $token[0]) {
             // Text tokens
             return preg_quote($token[1], self::REGEX_DELIMITER);
-        } else {
+        }  
             // Variable tokens
             if (0 === $index && 0 === $firstOptional) {
                 // When the only token is an optional variable token, the separator is required
                 return sprintf('%s(?P<%s>%s)?', preg_quote($token[1], self::REGEX_DELIMITER), $token[3], $token[2]);
-            } else {
+            }  
                 $regexp = sprintf('%s(?P<%s>%s)', preg_quote($token[1], self::REGEX_DELIMITER), $token[3], $token[2]);
                 if ($index >= $firstOptional) {
                     // Enclose each optional token in a subpattern to make it optional.
@@ -223,7 +223,7 @@ class RouteCompiler implements RouteCompilerInterface
                 }
 
                 return $regexp;
-            }
-        }
+            
+        
     }
 }

--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -203,27 +203,27 @@ class RouteCompiler implements RouteCompilerInterface
         if ('text' === $token[0]) {
             // Text tokens
             return preg_quote($token[1], self::REGEX_DELIMITER);
-        }  
-            // Variable tokens
-            if (0 === $index && 0 === $firstOptional) {
-                // When the only token is an optional variable token, the separator is required
-                return sprintf('%s(?P<%s>%s)?', preg_quote($token[1], self::REGEX_DELIMITER), $token[3], $token[2]);
-            }  
-                $regexp = sprintf('%s(?P<%s>%s)', preg_quote($token[1], self::REGEX_DELIMITER), $token[3], $token[2]);
-                if ($index >= $firstOptional) {
-                    // Enclose each optional token in a subpattern to make it optional.
-                    // "?:" means it is non-capturing, i.e. the portion of the subject string that
-                    // matched the optional subpattern is not passed back.
-                    $regexp = "(?:$regexp";
-                    $nbTokens = count($tokens);
-                    if ($nbTokens - 1 == $index) {
-                        // Close the optional subpatterns
-                        $regexp .= str_repeat(')?', $nbTokens - $firstOptional - (0 === $firstOptional ? 1 : 0));
-                    }
-                }
+        }
 
-                return $regexp;
-            
-        
+        // Variable tokens
+        if (0 === $index && 0 === $firstOptional) {
+            // When the only token is an optional variable token, the separator is required
+            return sprintf('%s(?P<%s>%s)?', preg_quote($token[1], self::REGEX_DELIMITER), $token[3], $token[2]);
+        }
+
+        $regexp = sprintf('%s(?P<%s>%s)', preg_quote($token[1], self::REGEX_DELIMITER), $token[3], $token[2]);
+        if ($index >= $firstOptional) {
+            // Enclose each optional token in a subpattern to make it optional.
+            // "?:" means it is non-capturing, i.e. the portion of the subject string that
+            // matched the optional subpattern is not passed back.
+            $regexp = "(?:$regexp";
+            $nbTokens = count($tokens);
+            if ($nbTokens - 1 == $index) {
+                // Close the optional subpatterns
+                $regexp .= str_repeat(')?', $nbTokens - $firstOptional - (0 === $firstOptional ? 1 : 0));
+            }
+        }
+
+        return $regexp;
     }
 }

--- a/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
@@ -124,10 +124,10 @@ class AclProvider implements AclProviderInterface
                     //        reached by the default implementation, since we do not
                     //        filter by SID
                     throw new \RuntimeException('This is not supported by the default implementation.');
-                } else {
+                }  
                     $result->attach($oid, $acl);
                     $aclFound = true;
-                }
+                
             }
 
             // check if we can locate the ACL in the cache
@@ -145,10 +145,10 @@ class AclProvider implements AclProviderInterface
                             if (isset($this->loadedAcls[$parentOid->getType()][$parentOid->getIdentifier()])) {
                                 $acl->setParentAcl($this->loadedAcls[$parentOid->getType()][$parentOid->getIdentifier()]);
                                 break;
-                            } else {
+                            }  
                                 $this->loadedAcls[$parentOid->getType()][$parentOid->getIdentifier()] = $parentAcl;
                                 $this->updateAceIdentityMap($parentAcl);
-                            }
+                            
 
                             $parentAcl = $parentAcl->getParentAcl();
                         }
@@ -182,9 +182,9 @@ class AclProvider implements AclProviderInterface
                         $partialResultException = new NotAllAclsFoundException('The provider could not find ACLs for all object identities.');
                         $partialResultException->setPartialResult($result);
                         throw $partialResultException;
-                    } else {
+                    }  
                         throw $e;
-                    }
+                    
                 }
                 foreach ($loadedBatch as $loadedOid) {
                     $loadedAcl = $loadedBatch->offsetGet($loadedOid);

--- a/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
@@ -124,10 +124,10 @@ class AclProvider implements AclProviderInterface
                     //        reached by the default implementation, since we do not
                     //        filter by SID
                     throw new \RuntimeException('This is not supported by the default implementation.');
-                }  
-                    $result->attach($oid, $acl);
-                    $aclFound = true;
-                
+                }
+
+                $result->attach($oid, $acl);
+                $aclFound = true;
             }
 
             // check if we can locate the ACL in the cache
@@ -145,11 +145,10 @@ class AclProvider implements AclProviderInterface
                             if (isset($this->loadedAcls[$parentOid->getType()][$parentOid->getIdentifier()])) {
                                 $acl->setParentAcl($this->loadedAcls[$parentOid->getType()][$parentOid->getIdentifier()]);
                                 break;
-                            }  
-                                $this->loadedAcls[$parentOid->getType()][$parentOid->getIdentifier()] = $parentAcl;
-                                $this->updateAceIdentityMap($parentAcl);
-                            
+                            }
 
+                            $this->loadedAcls[$parentOid->getType()][$parentOid->getIdentifier()] = $parentAcl;
+                            $this->updateAceIdentityMap($parentAcl);
                             $parentAcl = $parentAcl->getParentAcl();
                         }
 
@@ -182,10 +181,11 @@ class AclProvider implements AclProviderInterface
                         $partialResultException = new NotAllAclsFoundException('The provider could not find ACLs for all object identities.');
                         $partialResultException->setPartialResult($result);
                         throw $partialResultException;
-                    }  
-                        throw $e;
-                    
+                    }
+
+                    throw $e;
                 }
+
                 foreach ($loadedBatch as $loadedOid) {
                     $loadedAcl = $loadedBatch->offsetGet($loadedOid);
 

--- a/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
@@ -79,9 +79,9 @@ class ChainUserProvider implements UserProviderInterface
             $e = new UsernameNotFoundException(sprintf('There is no user with name "%s".', $user->getUsername()));
             $e->setUsername($user->getUsername());
             throw $e;
-        } else {
+        }  
             throw new UnsupportedUserException(sprintf('The account "%s" is not supported.', get_class($user)));
-        }
+        
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
@@ -79,9 +79,9 @@ class ChainUserProvider implements UserProviderInterface
             $e = new UsernameNotFoundException(sprintf('There is no user with name "%s".', $user->getUsername()));
             $e->setUsername($user->getUsername());
             throw $e;
-        }  
-            throw new UnsupportedUserException(sprintf('The account "%s" is not supported.', get_class($user)));
-        
+        }
+
+        throw new UnsupportedUserException(sprintf('The account "%s" is not supported.', get_class($user)));
     }
 
     /**

--- a/src/Symfony/Component/Security/Tests/Acl/Dbal/AclProviderBenchmarkTest.php
+++ b/src/Symfony/Component/Security/Tests/Acl/Dbal/AclProviderBenchmarkTest.php
@@ -125,9 +125,9 @@ class AclProviderBenchmarkTest extends \PHPUnit_Framework_TestCase
             ++$id;
 
             return $id - 1;
-        } else {
+        }  
             return rand(1000, $id - 1);
-        }
+        
     }
 
     protected function generateAcl($classId, $parentId, $ancestors)
@@ -166,9 +166,9 @@ class AclProviderBenchmarkTest extends \PHPUnit_Framework_TestCase
             ++$id;
 
             return $id - 1;
-        } else {
+        }  
             return rand(1000, $id - 1);
-        }
+        
     }
 
     protected function generateAces($classId, $objectId)

--- a/src/Symfony/Component/Security/Tests/Acl/Dbal/AclProviderBenchmarkTest.php
+++ b/src/Symfony/Component/Security/Tests/Acl/Dbal/AclProviderBenchmarkTest.php
@@ -125,9 +125,9 @@ class AclProviderBenchmarkTest extends \PHPUnit_Framework_TestCase
             ++$id;
 
             return $id - 1;
-        }  
-            return rand(1000, $id - 1);
-        
+        }
+
+        return rand(1000, $id - 1);
     }
 
     protected function generateAcl($classId, $parentId, $ancestors)
@@ -166,9 +166,9 @@ class AclProviderBenchmarkTest extends \PHPUnit_Framework_TestCase
             ++$id;
 
             return $id - 1;
-        }  
-            return rand(1000, $id - 1);
-        
+        }
+
+        return rand(1000, $id - 1);
     }
 
     protected function generateAces($classId, $objectId)

--- a/src/Symfony/Component/Security/Tests/Core/Authorization/Voter/AuthenticatedVoterTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Authorization/Voter/AuthenticatedVoterTest.php
@@ -71,8 +71,8 @@ class AuthenticatedVoterTest extends \PHPUnit_Framework_TestCase
             return $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
         } elseif ('remembered' === $authenticated) {
             return $this->getMock('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken', array('setPersistent'), array(), '', false);
-        } else {
+        }  
             return $this->getMock('Symfony\Component\Security\Core\Authentication\Token\AnonymousToken', null, array('', ''));
-        }
+        
     }
 }

--- a/src/Symfony/Component/Security/Tests/Core/Authorization/Voter/AuthenticatedVoterTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Authorization/Voter/AuthenticatedVoterTest.php
@@ -71,8 +71,8 @@ class AuthenticatedVoterTest extends \PHPUnit_Framework_TestCase
             return $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
         } elseif ('remembered' === $authenticated) {
             return $this->getMock('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken', array('setPersistent'), array(), '', false);
-        }  
-            return $this->getMock('Symfony\Component\Security\Core\Authentication\Token\AnonymousToken', null, array('', ''));
-        
+        }
+
+        return $this->getMock('Symfony\Component\Security\Core\Authentication\Token\AnonymousToken', null, array('', ''));
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

This PR is to see if a new fixer @ PHP-CS-Fixer should be added to the set of default fixers of Symfony.
The fixer removes `else`-case when those are overcomplete.

For ref:
https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/1773
