### PR TITLE
[Form] add test for ArrayChoiceList handling null

### DIFF
--- a/src/Symfony/Component/Form/Tests/ChoiceList/AbstractChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/AbstractChoiceListTest.php
@@ -209,6 +209,13 @@ abstract class AbstractChoiceListTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(array(), $this->list->getValuesForChoices(array()));
     }
 
+    public function testGetChoicesForValuesWithNull()
+    {
+        $values = $this->list->getValuesForChoices(array(null));
+
+        $this->assertNotEmpty($this->list->getChoicesForValues($values));
+    }
+
     /**
      * @return \Symfony\Component\Form\ChoiceList\ChoiceListInterface
      */

--- a/src/Symfony/Component/Form/Tests/ChoiceList/ArrayChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/ArrayChoiceListTest.php
@@ -22,9 +22,9 @@ class ArrayChoiceListTest extends AbstractChoiceListTest
 
     protected function setUp()
     {
-        parent::setUp();
-
         $this->object = new \stdClass();
+
+        parent::setUp();
     }
 
     protected function createChoiceList()
@@ -34,12 +34,12 @@ class ArrayChoiceListTest extends AbstractChoiceListTest
 
     protected function getChoices()
     {
-        return array(0, 1, '1', 'a', false, true, $this->object);
+        return array(0, 1, '1', 'a', false, true, $this->object, null);
     }
 
     protected function getValues()
     {
-        return array('0', '1', '2', '3', '4', '5', '6');
+        return array('0', '1', '2', '3', '4', '5', '6', '7');
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

I found this bug but then realised that it was already fixed in #17511.
So this just adds a test.
