### PR TITLE
Simplify markdown for PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,10 @@
 | Q             | A
 | ------------- | ---
-| Bug fix?      | [yes|no]
-| New feature?  | [yes|no]
-| BC breaks?    | [yes|no]
-| Deprecations? | [yes|no]
-| Tests pass?   | [yes|no]
-| Fixed tickets | [comma-separated list of tickets fixed by the PR, if any]
+| Bug fix?      | yes/no
+| New feature?  | yes/no
+| BC breaks?    | yes/no
+| Deprecations? | yes/no
+| Tests pass?   | yes/no
+| Fixed tickets | comma-separated list of tickets fixed by the PR, if any
 | License       | MIT
-| Doc PR        | [reference to the documentation PR, if any]
+| Doc PR        | reference to the documentation PR, if any


### PR DESCRIPTION
I know it's all about rendering in the issue, but actually putting `[` in markdown can create some issues.

Here, having raw informations looks better IMO and does not cause any rendering issue when not used. And double-click-selection does not force to remove the brackets manually.

What do you think?
