### PR TITLE
Fixed the antialiasing of the toolbar text

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -47,6 +47,10 @@
     text-align: left;
     text-transform: none;
     z-index: 99999;
+
+    /* neutralize the aliasing defined by external CSS styles */
+    -webkit-font-smoothing: subpixel-antialiased;
+    -moz-osx-font-smoothing: auto;
 }
 .sf-toolbarreset abbr {
     border: dashed #777;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
### Problem

The Symfony toolbar looks ugly in some situations (the text is too thin and unreadable); for example inside a SonataAdmin backend:

(top: toolbar in a normal page; bottom: toolbar in Sonata backend; if you don't see any difference, click on the image to zoom it)
#### Chrome

![before_chrome](https://cloud.githubusercontent.com/assets/73419/13181902/8836e586-d72f-11e5-9394-490f81978606.png)
#### Firefox

![before_firefox](https://cloud.githubusercontent.com/assets/73419/13181905/8cca5eac-d72f-11e5-9905-b85cb5249a45.png)
### Solution

The cause of this problem are the styles applied by the popular AdminLTE template used by Sonata and other admin bundles. The proposed changes neutralize any aliasing set by external CSS styles, so the toolbar is always displayed the same way:
#### Chrome

![after_chrome](https://cloud.githubusercontent.com/assets/73419/13182022/0e15fade-d730-11e5-8e0b-d5a712c7158e.png)
#### Firefox

![after_firefox](https://cloud.githubusercontent.com/assets/73419/13182024/104e3cb2-d730-11e5-83d8-86cb52b87358.png)
