### PR TITLE
[HttpFoundation] Fix incompatibility with php-memcache from Debian

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcacheSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcacheSessionHandler.php
@@ -79,7 +79,10 @@ class MemcacheSessionHandler implements \SessionHandlerInterface
      */
     public function read($sessionId)
     {
-        return $this->memcache->get($this->prefix.$sessionId) ?: '';
+        $flags = null;
+        $cas = null;
+
+        return $this->memcache->get($this->prefix.$sessionId, $flags, $cas) ?: '';
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The version of php-memcache (3.0.9~20151130.fdbd46b-1) in Debian makes
the test MemcacheSessionHandlerTest::testReadSession fail with the following
error message:

```
There was 1 error:

1) Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler\MemcacheSessionHandlerTest::testReadSession
Missing argument 2 for Mock_Memcache_ddacd7a0::get(), called in /tmp/buildd/symfony/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcacheSessionHandler.php on line 82 and defined

/tmp/buildd/symfony/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcacheSessionHandler.php:82
/tmp/buildd/symfony/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcacheSessionHandlerTest.php:75
```

This PR solves the issue reported here.
