### PR TITLE
[Form] set unique block prefix with any namespace

### DIFF
--- a/src/Symfony/Component/Form/AbstractRendererEngine.php
+++ b/src/Symfony/Component/Form/AbstractRendererEngine.php
@@ -171,7 +171,7 @@ abstract class AbstractRendererEngine implements FormRendererEngineInterface
             // The next two if statements contain slightly duplicated code. This is by intention
             // and tries to avoid execution of unnecessary checks in order to increase performance.
 
-            if (isset($this->resources[$cacheKey][$parentBlockName])) {
+            if (isset($this->resources[$cacheKey][$parentBlockName]) && $this->resources[$cacheKey][$parentBlockName] !== false) {
                 // It may happen that the parent block is already loaded, but its level is not.
                 // In this case, the parent block must have been loaded by loadResourceForBlock(),
                 // which does not check the hierarchy of the block. Subsequently the block must have

--- a/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
@@ -77,7 +77,10 @@ abstract class BaseType extends AbstractType
 
         $blockPrefixes = array();
         for ($type = $form->getConfig()->getType(); null !== $type; $type = $type->getParent()) {
-            array_unshift($blockPrefixes, $type->getBlockPrefix());
+            $blockPrefix = $type->getBlockPrefix();
+            if (!in_array($blockPrefix, $blockPrefixes)) {
+                array_unshift($blockPrefixes, $blockPrefix);
+            }
         }
         $blockPrefixes[] = $uniqueBlockPrefix;
 

--- a/src/Symfony/Component/Form/Tests/FixtureTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/FixtureTypeTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests;
+
+class FixtureTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
+{
+    /**
+     * @dataProvider provideTypeClassBlockPrefix
+     */
+    public function testUniqueBlockPrefixes($typeClass, $blockPrefixes)
+    {
+        $form = $this->factory->create($typeClass);
+        $view = $form->createView();
+        $this->assertEquals($view->vars['block_prefixes'], $blockPrefixes);
+    }
+
+    /**
+     * @return array
+     */
+    public function provideTypeClassBlockPrefix()
+    {
+        return array(
+            array(__NAMESPACE__.'\Fixtures\Foo', ['form','foo','_foo']),
+            array(__NAMESPACE__.'\Fixtures\Type', ['form', 'type', '_type']),
+            array(__NAMESPACE__.'\Fixtures\FooBarHTMLType',['form', 'foo_bar_html', '_foo_bar_html']),
+            array(__NAMESPACE__.'\Fixtures\Foo1Bar2Type', ['form', 'foo1_bar2', '_foo1_bar2']),
+            array(__NAMESPACE__.'\Fixtures\OtherType\Foo1Bar2Type', ['form', 'foo1_bar2', '_foo1_bar2']),
+            array(__NAMESPACE__.'\Fixtures\FBooType', ['form', 'f_boo', '_f_boo']),
+        );
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/OtherType/Foo1Bar2Type.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/OtherType/Foo1Bar2Type.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures\OtherType;
+
+use Symfony\Component\Form\AbstractType;
+
+class Foo1Bar2Type extends AbstractType
+{
+    public function getParent()
+    {
+        return 'Symfony\Component\Form\Tests\Fixtures\Foo1Bar2Type';
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

if there is no block `hidden_locale_row` when error

```
An exception has been thrown during the rendering of a template ("Unable to
render the form as none of the following blocks exist: "_form_texts_0_row",
"hidden_locale_row", "hidden_locale_row", "form_row", "form_row".") in
form_div_layout.html.twig at line 312.
```
