### PR TITLE
[WIP] [3.0] [Form] fix tests added by #17760 by removing `choices_as_values`

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -148,7 +148,7 @@ class ChoiceType extends AbstractType
                 // with the string value so it can be matched in
                 // {@link \Symfony\Component\Form\Extension\Core\DataMapper\RadioListMapper::mapDataToForms()}
                 $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
-                    $choiceList = $event->getForm()->getConfig()->getOption('choice_list');
+                    $choiceList = $event->getForm()->getConfig()->getAttribute('choice_list');
                     $value = current($choiceList->getValuesForChoices(array($event->getData())));
                     $event->setData((string) $value);
                 });

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -29,7 +29,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         'No' => false,
         'n/a' => '',
     );
-	
+
     private $objectChoices;
 
     protected $groupedChoices = array(
@@ -104,7 +104,6 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     {
         $view = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'choices' => $this->scalarChoices,
-            'choices_as_values' => true,
         ))->createView();
 
         $this->assertSame('1', $view->vars['choices'][0]->value);
@@ -119,7 +118,6 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     {
         $view = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', false, array(
             'choices' => $this->scalarChoices,
-            'choices_as_values' => true,
         ))->createView();
 
         $this->assertTrue($view->vars['is_selected']($view->vars['choices'][1]->value, $view->vars['value']), 'False value should be pre selected');
@@ -129,7 +127,6 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     {
         $view = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'choices' => $this->scalarChoices,
-            'choices_as_values' => true,
             'expanded' => true,
         ))->createView();
 
@@ -142,7 +139,6 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     {
         $view = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', false, array(
             'choices' => $this->scalarChoices,
-            'choices_as_values' => true,
             'expanded' => true,
         ))->createView();
 
@@ -218,7 +214,6 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
                 'No' => false,
             ),
             'placeholder' => 'Select an option',
-            'choices_as_values' => true,
         ));
 
         $view = $form->createView();
@@ -240,7 +235,6 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
                 'No' => false,
             ),
             'placeholder' => 'Select an option',
-            'choices_as_values' => true,
         ));
 
         $view = $form->createView();
@@ -262,7 +256,6 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
                 'No' => false,
             ),
             'placeholder' => 'Select an option',
-            'choices_as_values' => true,
         ));
 
         $this->assertTrue(isset($form['placeholder']), 'Placeholder should be set');
@@ -287,7 +280,6 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
                 'No' => false,
             ),
             'placeholder' => 'Select an option',
-            'choices_as_values' => true,
         ));
 
         $this->assertTrue(isset($form['placeholder']), 'Placeholder should be set');

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -29,15 +29,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         'No' => false,
         'n/a' => '',
     );
-
-    private $numericChoicesFlipped = array(
-        0 => 'Bernhard',
-        1 => 'Fabien',
-        2 => 'Kris',
-        3 => 'Jon',
-        4 => 'Roman',
-    );
-
+	
     private $objectChoices;
 
     protected $groupedChoices = array(

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -102,7 +102,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testChoiceListWithScalarValues()
     {
-        $view = $this->factory->create('choice', null, array(
+        $view = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'choices' => $this->scalarChoices,
             'choices_as_values' => true,
         ))->createView();
@@ -117,7 +117,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testChoiceListWithScalarValuesAndFalseAsPreSetData()
     {
-        $view = $this->factory->create('choice', false, array(
+        $view = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', false, array(
             'choices' => $this->scalarChoices,
             'choices_as_values' => true,
         ))->createView();
@@ -127,7 +127,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testExpandedChoiceListWithScalarValues()
     {
-        $view = $this->factory->create('choice', null, array(
+        $view = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'choices' => $this->scalarChoices,
             'choices_as_values' => true,
             'expanded' => true,
@@ -140,7 +140,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testExpandedChoiceListWithScalarValuesAndFalseAsPreSetData()
     {
-        $view = $this->factory->create('choice', false, array(
+        $view = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', false, array(
             'choices' => $this->scalarChoices,
             'choices_as_values' => true,
             'expanded' => true,
@@ -209,7 +209,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPlaceholderWithBooleanChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => false,
             'required' => false,
@@ -231,7 +231,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPlaceholderWithBooleanChoicesWithFalseAsPreSetData()
     {
-        $form = $this->factory->create('choice', false, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', false, array(
             'multiple' => false,
             'expanded' => false,
             'required' => false,
@@ -253,7 +253,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPlaceholderWithExpandedBooleanChoices()
     {
-        $form = $this->factory->create('choice', null, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -278,7 +278,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
     public function testPlaceholderWithExpandedBooleanChoicesAndWithFalseAsPreSetData()
     {
-        $form = $this->factory->create('choice', false, array(
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ChoiceType', false, array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | not yet |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | - |
- [x] Wait for #17760 being merged in 3.0
