### PR TITLE
[ci] clone with depth=1 to kill push-forced PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: php
 
 sudo: false
 
+git:
+    depth: 1
+
 addons:
     apt_packages:
         - parallel

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 build: false
-shallow_clone: true
-platform: x86
+clone_depth: 1
 clone_folder: c:\projects\symfony
 
 cache:


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

As documented in https://github.com/travis-ci/travis-ci/issues/4575#issuecomment-125200308, setting a clone depth of 1 will make push-forced PRs to fail quickly so that our CI won't spend too much time on them.
