### PR TITLE
Validate XLIFF translation files

### DIFF
--- a/src/Symfony/Component/Form/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Form/Tests/Resources/TranslationFilesTest.php
@@ -16,13 +16,9 @@ class TranslationFilesTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider provideTranslationFiles
      */
-    public function testTranslationFilesAreValid($filePath)
+    public function testTranslationFileIsValid($filePath)
     {
-        try {
-            \PHPUnit_Util_XML::loadfile($filePath, false, false, true);
-        } catch (\PHPUnit_Framework_Exception $e) {
-            $this->fail($e->getMessage());
-        }
+        \PHPUnit_Util_XML::loadfile($filePath, false, false, true);
     }
 
     public function provideTranslationFiles()

--- a/src/Symfony/Component/Form/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Form/Tests/Resources/TranslationFilesTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Validator\Tests\Resources;
+namespace Symfony\Component\Form\Tests\Resources;
 
 class TranslationFilesTest extends \PHPUnit_Framework_TestCase
 {

--- a/src/Symfony/Component/Form/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Form/Tests/Resources/TranslationFilesTest.php
@@ -25,7 +25,7 @@ class TranslationFilesTest extends \PHPUnit_Framework_TestCase
     {
         return array_map(
             function ($filePath) { return (array) $filePath; },
-            glob(__DIR__.'/../../Resources/translations/*.xlf')
+            glob(dirname(dirname(__DIR__)).'/Resources/translations/*.xlf')
         );
     }
 }

--- a/src/Symfony/Component/Security/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Security/Tests/Resources/TranslationFilesTest.php
@@ -16,13 +16,9 @@ class TranslationFilesTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider provideTranslationFiles
      */
-    public function testTranslationFilesAreValid($filePath)
+    public function testTranslationFileIsValid($filePath)
     {
-        try {
-            \PHPUnit_Util_XML::loadfile($filePath, false, false, true);
-        } catch (\PHPUnit_Framework_Exception $e) {
-            $this->fail($e->getMessage());
-        }
+        \PHPUnit_Util_XML::loadfile($filePath, false, false, true);
     }
 
     public function provideTranslationFiles()

--- a/src/Symfony/Component/Security/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Security/Tests/Resources/TranslationFilesTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Validator\Tests\Resources;
+namespace Symfony\Component\Form\Tests\Resources;
 
 class TranslationFilesTest extends \PHPUnit_Framework_TestCase
 {

--- a/src/Symfony/Component/Security/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Security/Tests/Resources/TranslationFilesTest.php
@@ -25,7 +25,7 @@ class TranslationFilesTest extends \PHPUnit_Framework_TestCase
     {
         return array_map(
             function ($filePath) { return (array) $filePath; },
-            glob(__DIR__.'/../../Resources/translations/*.xlf')
+            glob(dirname(dirname(__DIR__)).'/Resources/translations/*.xlf')
         );
     }
 }

--- a/src/Symfony/Component/Security/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Security/Tests/Resources/TranslationFilesTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Form\Tests\Resources;
+namespace Symfony\Component\Security\Tests\Resources;
 
 class TranslationFilesTest extends \PHPUnit_Framework_TestCase
 {

--- a/src/Symfony/Component/Validator/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Validator/Tests/Resources/TranslationFilesTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Resources;
+
+class ConstraintTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        libxml_use_internal_errors(true);
+        libxml_clear_errors();
+    }
+
+    public function testXlfFilesAreValid()
+    {
+        $translationFiles = glob(__DIR__.'/../../Resources/translations/*.xlf');
+        foreach ($translationFiles as $filePath) {
+            $xlfFile = simplexml_load_file($filePath);
+            $errors = libxml_get_errors();
+
+            if (!empty($errors)) {
+                $this->renderErrors($errors);
+            }
+
+            $this->assertEmpty($errors, sprintf('The "%s" file is not a valid XML file.', realpath($filePath)));
+        }
+    }
+
+    private function renderErrors(array $errors)
+    {
+        $firstError = $errors[0];
+
+        echo sprintf("\nErrors found in '%s' file\n", basename($firstError->file));
+        echo sprintf("(path: %s)\n\n", realpath($firstError->file));
+
+        foreach ($errors as $error) {
+            echo sprintf("  Line %d, Column %d\n", $error->line, $error->column);
+            echo sprintf("  %s\n", $error->message);
+        }
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Validator/Tests/Resources/TranslationFilesTest.php
@@ -16,13 +16,9 @@ class TranslationFilesTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider provideTranslationFiles
      */
-    public function testTranslationFilesAreValid($filePath)
+    public function testTranslationFileIsValid($filePath)
     {
-        try {
-            \PHPUnit_Util_XML::loadfile($filePath, false, false, true);
-        } catch (\PHPUnit_Framework_Exception $e) {
-            $this->fail($e->getMessage());
-        }
+        \PHPUnit_Util_XML::loadfile($filePath, false, false, true);
     }
 
     public function provideTranslationFiles()

--- a/src/Symfony/Component/Validator/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Validator/Tests/Resources/TranslationFilesTest.php
@@ -13,17 +13,13 @@ namespace Symfony\Component\Validator\Tests\Resources;
 
 class TranslationFilesTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
-    {
-        libxml_use_internal_errors(true);
-        libxml_clear_errors();
-    }
-
     public function testXlfFilesAreValid()
     {
         $translationFiles = glob(__DIR__.'/../../Resources/translations/*.xlf');
         foreach ($translationFiles as $filePath) {
-            $xlfFile = simplexml_load_file($filePath);
+            libxml_use_internal_errors(true);
+            libxml_clear_errors();
+            simplexml_load_file($filePath);
             $errors = libxml_get_errors();
 
             if (!empty($errors)) {

--- a/src/Symfony/Component/Validator/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Validator/Tests/Resources/TranslationFilesTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Resources;
 
-class ConstraintTest extends \PHPUnit_Framework_TestCase
+class TranslationFilesTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {

--- a/src/Symfony/Component/Validator/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Validator/Tests/Resources/TranslationFilesTest.php
@@ -25,7 +25,7 @@ class TranslationFilesTest extends \PHPUnit_Framework_TestCase
     {
         return array_map(
             function ($filePath) { return (array) $filePath; },
-            glob(__DIR__.'/../../Resources/translations/*.xlf')
+            glob(dirname(dirname(__DIR__)).'/Resources/translations/*.xlf')
         );
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Validator/Tests/Resources/TranslationFilesTest.php
@@ -13,34 +13,23 @@ namespace Symfony\Component\Validator\Tests\Resources;
 
 class TranslationFilesTest extends \PHPUnit_Framework_TestCase
 {
-    public function testXlfFilesAreValid()
+    /**
+     * @dataProvider provideTranslationFiles
+     */
+    public function testTranslationFilesAreValid($filePath)
     {
         libxml_use_internal_errors(true);
+        libxml_clear_errors();
+        simplexml_load_file($filePath);
 
-        $translationFiles = glob(__DIR__.'/../../Resources/translations/*.xlf');
-        foreach ($translationFiles as $filePath) {
-            libxml_clear_errors();
-            simplexml_load_file($filePath);
-            $errors = libxml_get_errors();
-
-            if (!empty($errors)) {
-                $this->renderErrors($errors);
-            }
-
-            $this->assertEmpty($errors, sprintf('The "%s" file is not a valid XML file.', realpath($filePath)));
-        }
+        $this->assertSame(array(), libxml_get_errors());
     }
 
-    private function renderErrors(array $errors)
+    public function provideTranslationFiles()
     {
-        $firstError = $errors[0];
-
-        echo sprintf("\nErrors found in '%s' file\n", basename($firstError->file));
-        echo sprintf("(path: %s)\n\n", realpath($firstError->file));
-
-        foreach ($errors as $error) {
-            echo sprintf("  Line %d, Column %d\n", $error->line, $error->column);
-            echo sprintf("  %s\n", $error->message);
-        }
+        return array_map(
+            function ($filePath) { return (array) $filePath; },
+            glob(__DIR__.'/../../Resources/translations/*.xlf')
+        );
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Validator/Tests/Resources/TranslationFilesTest.php
@@ -15,9 +15,10 @@ class TranslationFilesTest extends \PHPUnit_Framework_TestCase
 {
     public function testXlfFilesAreValid()
     {
+        libxml_use_internal_errors(true);
+
         $translationFiles = glob(__DIR__.'/../../Resources/translations/*.xlf');
         foreach ($translationFiles as $filePath) {
-            libxml_use_internal_errors(true);
             libxml_clear_errors();
             simplexml_load_file($filePath);
             $errors = libxml_get_errors();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

In #17902 @stof proposed to add a simple test to validate `.xlf` files (to avoid issues like #17893).

This is a proposal for that test. My questions:

**1)** Do you agree displaying detailed error messages when the XML is not valid. Example output for the #17893 error:

![error_log](https://cloud.githubusercontent.com/assets/73419/13250664/932d2f14-da2b-11e5-8ea0-ecb43f58feea.png)

Or is it enough displaying just the PHPUnit error message and let the user figure out the details?

![simple_error](https://cloud.githubusercontent.com/assets/73419/13250671/a3b4bfd2-da2b-11e5-9277-454d0dd160b2.png)

**2)** How do I validate the translation files of the Security and Form components? Do I just copy+paste this test in those components?
