### PR TITLE
[Ldap] Added environment-based Ldap server configuration for tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,6 +13,8 @@
         <ini name="memory_limit" value="-1" />
         <env name="DUMP_LIGHT_ARRAY" value="" />
         <env name="DUMP_STRING_LENGTH" value="" />
+        <env name="LDAP_HOST" value="127.0.0.1" />
+        <env name="LDAP_PORT" value="3389" />
     </php>
 
     <testsuites>

--- a/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Ldap\LdapInterface;
 /**
  * @requires extension ldap
  */
-class AdapterTest extends \PHPUnit_Framework_TestCase
+class AdapterTest extends LdapTestCase
 {
     public function testLdapEscape()
     {
@@ -33,7 +33,7 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
      */
     public function testLdapQuery()
     {
-        $ldap = new Adapter(array('host' => 'localhost', 'port' => 3389));
+        $ldap = new Adapter($this->getLdapConfig());
 
         $ldap->getConnection()->bind('cn=admin,dc=symfony,dc=com', 'symfony');
         $query = $ldap->createQuery('dc=symfony,dc=com', '(&(objectclass=person)(ou=Maintainers))', array());

--- a/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/LdapManagerTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/LdapManagerTest.php
@@ -19,14 +19,14 @@ use Symfony\Component\Ldap\Exception\LdapException;
 /**
  * @requires extension ldap
  */
-class LdapManagerTest extends \PHPUnit_Framework_TestCase
+class LdapManagerTest extends LdapTestCase
 {
     /** @var Adapter */
     private $adapter;
 
     protected function setUp()
     {
-        $this->adapter = new Adapter(array('host' => 'localhost', 'port' => 3389));
+        $this->adapter = new Adapter($this->getLdapConfig());
         $this->adapter->getConnection()->bind('cn=admin,dc=symfony,dc=com', 'symfony');
     }
 

--- a/src/Symfony/Component/Ldap/Tests/LdapTestCase.php
+++ b/src/Symfony/Component/Ldap/Tests/LdapTestCase.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\Ldap\Tests;
+
+class LdapTestCase extends \PHPUnit_Framework_TestCase
+{
+    protected function getLdapConfig()
+    {
+        return array(
+            'host' => getenv('LDAP_HOST'),
+            'port' => getenv('LDAP_PORT'),
+        );
+    }
+}

--- a/src/Symfony/Component/Ldap/phpunit.xml.dist
+++ b/src/Symfony/Component/Ldap/phpunit.xml.dist
@@ -8,6 +8,8 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
+        <env name="LDAP_HOST" value="127.0.0.1" />
+        <env name="LDAP_PORT" value="3389" />
     </php>
 
     <testsuites>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This PR makes Ldap server host and port configurable by using environment variables. This enables a developer to test the Ldap component locally, or on a vagrant virtual machine, depending on the use case.

If one wishes to run the tests against his own Ldap server, one simply needs to use the `LDAP_HOST` and `LDAP_PORT` environment variables when running the `phpunit` command.
