### PR TITLE
Added pipe for multiline string (correctly indented), which makes them much more readable

### DIFF
--- a/src/Symfony/Component/Yaml/Dumper.php
+++ b/src/Symfony/Component/Yaml/Dumper.php
@@ -55,7 +55,7 @@ class Dumper
      *
      * @return string The YAML representation of the PHP value
      */
-    public function dump($input, $inline = 0, $indent = 0, $flags = 0)
+    public function dump($input, $inline = 0, $indent = 0, $absIndent = 0, $flags = 0)
     {
         if (is_bool($flags)) {
             @trigger_error('Passing a boolean flag to toggle exception handling is deprecated since version 3.1 and will be removed in 4.0. Use the Yaml::DUMP_EXCEPTION_ON_INVALID_TYPE flag instead.', E_USER_DEPRECATED);
@@ -79,7 +79,7 @@ class Dumper
         $prefix = $indent ? str_repeat(' ', $indent) : '';
 
         if ($inline <= 0 || !is_array($input) || empty($input)) {
-            $output .= $prefix.Inline::dump($input, $flags);
+            $output .= $prefix.Inline::dump($input, $flags, $absIndent);
         } else {
             $isAHash = array_keys($input) !== range(0, count($input) - 1);
 
@@ -88,9 +88,10 @@ class Dumper
 
                 $output .= sprintf('%s%s%s%s',
                     $prefix,
-                    $isAHash ? Inline::dump($key, $flags).':' : '-',
+                    $isAHash ? Inline::dump($key, $flags, $absIndent).':' : '-',
                     $willBeInlined ? ' ' : "\n",
-                    $this->dump($value, $inline - 1, $willBeInlined ? 0 : $indent + $this->indentation, $flags)
+                    $this->dump($value, $inline - 1, $willBeInlined ? 0 : $indent + $this->indentation, $inline - 1 <= 0 ? 0 : $absIndent + $this->indentation, $flags)
+
                 ).($willBeInlined ? "\n" : '');
             }
         }

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -201,6 +201,7 @@ class Inline
               if (Yaml::DUMP_MULTI_LINE_AS_BLOCK & $flags) {
                 if ($indent) {
                   $prefix = $indent ? str_repeat(' ', $indent) : '';
+
                   return "|\n$prefix".preg_replace( '/\n/',"\n$prefix", str_replace( "\r", '', $value ) );
               }
             }

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -125,7 +125,7 @@ class Inline
      *
      * @throws DumpException When trying to dump PHP resource
      */
-    public static function dump($value, $flags = 0)
+    public static function dump($value, $flags = 0, $indent = 0)
     {
         if (is_bool($flags)) {
             @trigger_error('Passing a boolean flag to toggle exception handling is deprecated since version 3.1 and will be removed in 4.0. Use the Yaml::DUMP_EXCEPTION_ON_INVALID_TYPE flag instead.', E_USER_DEPRECATED);
@@ -165,7 +165,7 @@ class Inline
 
                 return 'null';
             case is_array($value):
-                return self::dumpArray($value, $flags);
+                return self::dumpArray($value, $flags, $indent);
             case null === $value:
                 return 'null';
             case true === $value:
@@ -197,6 +197,15 @@ class Inline
                 return $repr;
             case '' == $value:
                 return "''";
+            case strstr($value, "\n"):
+              if (Yaml::DUMP_MULTI_LINE_AS_BLOCK & $flags) {
+                if ($indent) {
+                  $prefix = $indent ? str_repeat(' ', $indent) : '';
+                  return "|\n$prefix". preg_replace( '/\n/',"\n$prefix", str_replace( "\r", '', $value ) );
+              }
+            }
+
+
             case Escaper::requiresDoubleQuoting($value):
                 return Escaper::escapeWithDoubleQuotes($value);
             case Escaper::requiresSingleQuoting($value):
@@ -216,7 +225,7 @@ class Inline
      *
      * @return string The YAML string representing the PHP array
      */
-    private static function dumpArray($value, $flags)
+    private static function dumpArray($value, $flags, $indent)
     {
         // array
         $keys = array_keys($value);
@@ -226,7 +235,7 @@ class Inline
         ) {
             $output = array();
             foreach ($value as $val) {
-                $output[] = self::dump($val, $flags);
+                $output[] = self::dump($val, $flags, $indent);
             }
 
             return sprintf('[%s]', implode(', ', $output));
@@ -235,7 +244,7 @@ class Inline
         // mapping
         $output = array();
         foreach ($value as $key => $val) {
-            $output[] = sprintf('%s: %s', self::dump($key, $flags), self::dump($val, $flags));
+            $output[] = sprintf('%s: %s', self::dump($key, $flags, $indent), self::dump($val, $flags, $indent));
         }
 
         return sprintf('{ %s }', implode(', ', $output));

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -201,10 +201,9 @@ class Inline
               if (Yaml::DUMP_MULTI_LINE_AS_BLOCK & $flags) {
                 if ($indent) {
                   $prefix = $indent ? str_repeat(' ', $indent) : '';
-                  return "|\n$prefix". preg_replace( '/\n/',"\n$prefix", str_replace( "\r", '', $value ) );
+                  return "|\n$prefix".preg_replace( '/\n/',"\n$prefix", str_replace( "\r", '', $value ) );
               }
             }
-
 
             case Escaper::requiresDoubleQuoting($value):
                 return Escaper::escapeWithDoubleQuotes($value);

--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -26,6 +26,7 @@ class Yaml
     const PARSE_OBJECT_FOR_MAP = 8;
     const DUMP_EXCEPTION_ON_INVALID_TYPE = 16;
     const PARSE_DATETIME = 32;
+    const DUMP_MULTI_LINE_AS_BLOCK = 64;
 
     /**
      * Parses YAML into a PHP value.
@@ -89,7 +90,7 @@ class Yaml
      *
      * @return string A YAML string representing the original PHP array
      */
-    public static function dump($array, $inline = 2, $indent = 4, $flags = 0)
+    public static function dump($array, $inline = 2, $indent = 4, $absInden = 0,$flags = 0)
     {
         if (is_bool($flags)) {
             @trigger_error('Passing a boolean flag to toggle exception handling is deprecated since version 3.1 and will be removed in 4.0. Use the DUMP_EXCEPTION_ON_INVALID_TYPE flag instead.', E_USER_DEPRECATED);
@@ -111,6 +112,6 @@ class Yaml
 
         $yaml = new Dumper($indent);
 
-        return $yaml->dump($array, $inline, 0, $flags);
+        return $yaml->dump($array, $inline, 0, 0, $flags);
     }
 }

--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -90,7 +90,7 @@ class Yaml
      *
      * @return string A YAML string representing the original PHP array
      */
-    public static function dump($array, $inline = 2, $indent = 4, $absInden = 0,$flags = 0)
+    public static function dump($array, $inline = 2, $indent = 4, $absIndent = 0,$flags = 0)
     {
         if (is_bool($flags)) {
             @trigger_error('Passing a boolean flag to toggle exception handling is deprecated since version 3.1 and will be removed in 4.0. Use the DUMP_EXCEPTION_ON_INVALID_TYPE flag instead.', E_USER_DEPRECATED);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | ? |
| Deprecations? | no |
| Tests pass? | Nod tone |
| Fixed tickets | #17391 |
| License | MIT |
| Doc PR | - |

The PR to actually implement #17391. 
Text:

I nearly gave up on this -- twice. Actually, three times.
Once I got to a point where I was happy with where I was... I realised that I had a version of Symfony that was too old! Having done all that work, I went ahead and re-applied the changes I had made.

NOTE: You absolutely have to document that multiline strings are NOT compatible with inline ones. So, if the parser is being used like this:

$yaml = Yaml::dump ( $user, 0, 4, 0, Yaml::DUMP_MULTI_LINE_AS_BLOCK );

Then the flag will basically be ignored, since everything will be inlined (and you cannot use multilne `|` pipe in inline fields.

About the PR...  I tried the path of returning an array. However, it got messy very quickly. The main issue I had with that approach is that while the `Dumper::dump` is the "data preparator", the "Inline:dump" is the part that always does the formatting. Forcing `Dumper` to do data formatting quickly showed that the approach was not ideal.

The approach I took in the end was to add a parameter to `Dumper::dump()`:

```
   public function dump($input, $inline = 0, $indent = 0, $absIndent = 0, $flags = 0)
   {
```

The key point of this is:

```
           $willBeInlined = $inline - 1 <= 0 || !is_array($value) || empty($value);

            $output .= sprintf('%s%s%s%s',
                $prefix,
                $isAHash ? Inline::dump($key, $flags, $absIndent).':' : '-',
                $willBeInlined ? ' ' : "\n",
                $this->dump($value, $inline - 1, $willBeInlined ? 0 : $indent + $this->indentation, $inline - 1 <= 0 ? 0 : $absIndent + $this->indentation, $flags)
```

Basically the problem I was having is that whenever a non-array was found, the field was going to be inlined -- and therefore, the tab was zeroed. I needed _another_ tab indicator, something that would _always_ be current and correct. So, I added one.

As I said, I am not a PHP person. So I had to do this without any debugging tools -- and without any real current knowledge of PHP.

I did my best to follow the coding styles... hopefully it will work!

Also, I didn't do any unit-tests. Since I don't know anything about unit testing with PHP, and I have already spent 3.5 hours on something I will never, ever use nor need... I was hoping you could :dancer: 

Thank you!

Addendum: I couldn't actually work out when the function `Inline::dumpArray()` would ever, ever get called. I added the extra parameter to it. However, I do wonder...

Added pipe for multiline string, which makes them much more readabl 
