### PR TITLE
#17676 - making the proxy instantiation compatible with ProxyManager 2.x by detecting proxy features

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,6 +82,7 @@
         "doctrine/orm": "~2.4,>=2.4.5",
         "doctrine/doctrine-bundle": "~1.4",
         "monolog/monolog": "~1.11",
+        "ocramius/proxy-manager": "~0.4|~1.0|~2.0",
         "egulias/email-validator": "~1.2",
         "symfony/polyfill-apcu": "~1.1",
         "symfony/security-acl": "~2.8|~3.0",

--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,6 @@
         "doctrine/orm": "~2.4,>=2.4.5",
         "doctrine/doctrine-bundle": "~1.4",
         "monolog/monolog": "~1.11",
-        "ocramius/proxy-manager": "~0.4|~1.0",
         "egulias/email-validator": "~1.2",
         "symfony/polyfill-apcu": "~1.1",
         "symfony/security-acl": "~2.8|~3.0",

--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
@@ -74,10 +74,16 @@ class ProxyDumper implements DumperInterface
         $methodName = 'get'.Container::camelize($id).'Service';
         $proxyClass = $this->getProxyClassName($definition);
 
+        $generatedClass = $this->generateProxyClass($definition);
+
+        $constructorCall = $generatedClass->hasMethod('staticProxyConstructor')
+            ? $proxyClass . '::staticProxyConstructor'
+            : 'new ' . $proxyClass;
+
         return <<<EOF
         if (\$lazyLoad) {
 
-            $instantiation new $proxyClass(
+            $instantiation $constructorCall(
                 function (&\$wrappedInstance, \ProxyManager\Proxy\LazyLoadingInterface \$proxy) {
                     \$wrappedInstance = \$this->$methodName(false);
 
@@ -97,11 +103,7 @@ EOF;
      */
     public function getProxyCode(Definition $definition)
     {
-        $generatedClass = new ClassGenerator($this->getProxyClassName($definition));
-
-        $this->proxyGenerator->generate(new \ReflectionClass($definition->getClass()), $generatedClass);
-
-        return $this->classGenerator->generate($generatedClass);
+        return $this->classGenerator->generate($this->generateProxyClass($definition));
     }
 
     /**
@@ -114,5 +116,17 @@ EOF;
     private function getProxyClassName(Definition $definition)
     {
         return str_replace('\\', '', $definition->getClass()).'_'.spl_object_hash($definition).$this->salt;
+    }
+
+    /**
+     * @return ClassGenerator
+     */
+    private function generateProxyClass(Definition $definition)
+    {
+        $generatedClass = new ClassGenerator($this->getProxyClassName($definition));
+
+        $this->proxyGenerator->generate(new \ReflectionClass($definition->getClass()), $generatedClass);
+
+        return $generatedClass;
     }
 }

--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
@@ -77,8 +77,8 @@ class ProxyDumper implements DumperInterface
         $generatedClass = $this->generateProxyClass($definition);
 
         $constructorCall = $generatedClass->hasMethod('staticProxyConstructor')
-            ? $proxyClass . '::staticProxyConstructor'
-            : 'new ' . $proxyClass;
+            ? $proxyClass.'::staticProxyConstructor'
+            : 'new '.$proxyClass;
 
         return <<<EOF
         if (\$lazyLoad) {

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Dumper/PhpDumperTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\ProxyManager\Tests\LazyProxy\Dumper;
 
+use ProxyManager\ProxyGenerator\LazyLoading\MethodGenerator\StaticProxyConstructor;
 use Symfony\Bridge\ProxyManager\LazyProxy\PhpDumper\ProxyDumper;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
@@ -49,7 +50,11 @@ class PhpDumperTest extends \PHPUnit_Framework_TestCase
      */
     public function testDumpContainerWithProxyServiceWillShareProxies()
     {
-        require_once __DIR__.'/../Fixtures/php/lazy_service.php';
+        if (class_exists(StaticProxyConstructor::class)) { // detecting ProxyManager v2
+            require_once __DIR__ . '/../Fixtures/php/lazy_service_with_hints.php';
+        } else {
+            require_once __DIR__ . '/../Fixtures/php/lazy_service.php';
+        }
 
         $container = new \LazyServiceProjectServiceContainer();
 

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Dumper/PhpDumperTest.php
@@ -51,9 +51,9 @@ class PhpDumperTest extends \PHPUnit_Framework_TestCase
     public function testDumpContainerWithProxyServiceWillShareProxies()
     {
         if (class_exists(StaticProxyConstructor::class)) { // detecting ProxyManager v2
-            require_once __DIR__ . '/../Fixtures/php/lazy_service_with_hints.php';
+            require_once __DIR__.'/../Fixtures/php/lazy_service_with_hints.php';
         } else {
-            require_once __DIR__ . '/../Fixtures/php/lazy_service.php';
+            require_once __DIR__.'/../Fixtures/php/lazy_service.php';
         }
 
         $container = new \LazyServiceProjectServiceContainer();

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Fixtures/php/lazy_service_structure.txt
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Fixtures/php/lazy_service_structure.txt
@@ -7,7 +7,7 @@ class ProjectServiceContainer extends Container
     {
         if ($lazyLoad) {
 
-            return $this->services['foo'] = new stdClass_%s(
+            return $this->services['foo'] =%sstdClass_%s(
                 function (&$wrappedInstance, \ProxyManager\Proxy\LazyLoadingInterface $proxy) {
                     $wrappedInstance = $this->getFooService(false);
 

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Fixtures/php/lazy_service_with_hints.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Fixtures/php/lazy_service_with_hints.php
@@ -1,0 +1,187 @@
+<?php
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Parameter;
+use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
+
+/**
+ * ProjectServiceContainer.
+ *
+ * This class has been auto-generated
+ * by the Symfony Dependency Injection Component.
+ */
+class LazyServiceProjectServiceContainer extends Container
+{
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->services = array();
+    }
+
+    /**
+     * Gets the 'foo' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @param bool $lazyLoad whether to try lazy-loading the service with a proxy
+     *
+     * @return stdClass A stdClass instance.
+     */
+    public function getFooService($lazyLoad = true)
+    {
+        if ($lazyLoad) {
+            return $this->services['foo'] = new stdClass_c1d194250ee2e2b7d2eab8b8212368a8(
+                function (&$wrappedInstance, \ProxyManager\Proxy\LazyLoadingInterface $proxy) {
+                    $wrappedInstance = $this->getFooService(false);
+
+                    $proxy->setProxyInitializer(null);
+
+                    return true;
+                }
+            );
+        }
+
+        return new \stdClass();
+    }
+}
+
+class stdClass_c1d194250ee2e2b7d2eab8b8212368a8 extends \stdClass implements \ProxyManager\Proxy\LazyLoadingInterface, \ProxyManager\Proxy\ValueHolderInterface
+{
+    /**
+     * @var \Closure|null initializer responsible for generating the wrapped object
+     */
+    private $valueHolder5157dd96e88c0 = null;
+
+    /**
+     * @var \Closure|null initializer responsible for generating the wrapped object
+     */
+    private $initializer5157dd96e8924 = null;
+
+    /**
+     * @override constructor for lazy initialization
+     *
+     * @param \Closure|null $initializer
+     */
+    public function __construct($initializer)
+    {
+        $this->initializer5157dd96e8924 = $initializer;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function __get($name)
+    {
+        $this->initializer5157dd96e8924 && $this->initializer5157dd96e8924->__invoke($this->valueHolder5157dd96e88c0, $this, '__get', array('name' => $name));
+
+        return $this->valueHolder5157dd96e88c0->$name;
+    }
+
+    /**
+     * @param string $name
+     * @param mixed  $value
+     */
+    public function __set($name, $value)
+    {
+        $this->initializer5157dd96e8924 && $this->initializer5157dd96e8924->__invoke($this->valueHolder5157dd96e88c0, $this, '__set', array('name' => $name, 'value' => $value));
+
+        $this->valueHolder5157dd96e88c0->$name = $value;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function __isset($name)
+    {
+        $this->initializer5157dd96e8924 && $this->initializer5157dd96e8924->__invoke($this->valueHolder5157dd96e88c0, $this, '__isset', array('name' => $name));
+
+        return isset($this->valueHolder5157dd96e88c0->$name);
+    }
+
+    /**
+     * @param string $name
+     */
+    public function __unset($name)
+    {
+        $this->initializer5157dd96e8924 && $this->initializer5157dd96e8924->__invoke($this->valueHolder5157dd96e88c0, $this, '__unset', array('name' => $name));
+
+        unset($this->valueHolder5157dd96e88c0->$name);
+    }
+
+    /**
+     *
+     */
+    public function __clone()
+    {
+        $this->initializer5157dd96e8924 && $this->initializer5157dd96e8924->__invoke($this->valueHolder5157dd96e88c0, $this, '__clone', array());
+
+        $this->valueHolder5157dd96e88c0 = clone $this->valueHolder5157dd96e88c0;
+    }
+
+    /**
+     *
+     */
+    public function __sleep()
+    {
+        $this->initializer5157dd96e8924 && $this->initializer5157dd96e8924->__invoke($this->valueHolder5157dd96e88c0, $this, '__sleep', array());
+
+        return array('valueHolder5157dd96e88c0');
+    }
+
+    /**
+     *
+     */
+    public function __wakeup()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setProxyInitializer(\Closure $initializer = null)
+    {
+        $this->initializer5157dd96e8924 = $initializer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getProxyInitializer()
+    {
+        return $this->initializer5157dd96e8924;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function initializeProxy() : bool
+    {
+        return $this->initializer5157dd96e8924 && $this->initializer5157dd96e8924->__invoke($this->valueHolder5157dd96e88c0, $this, 'initializeProxy', array());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isProxyInitialized() : bool
+    {
+        return null !== $this->valueHolder5157dd96e88c0;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getWrappedValueHolderValue()
+    {
+        return $this->valueHolder5157dd96e88c0;
+    }
+}

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
@@ -69,7 +69,7 @@ class ProxyDumperTest extends \PHPUnit_Framework_TestCase
         $code = $this->dumper->getProxyFactoryCode($definition, 'foo');
 
         $this->assertStringMatchesFormat(
-            '%wif ($lazyLoad) {%wreturn $this->services[\'foo\'] = new '
+            '%wif ($lazyLoad) {%wreturn $this->services[\'foo\'] =%s'
             .'SymfonyBridgeProxyManagerTestsLazyProxyPhpDumperProxyDumperTest_%s(%wfunction '
             .'(&$wrappedInstance, \ProxyManager\Proxy\LazyLoadingInterface $proxy) {'
             .'%w$wrappedInstance = $this->getFooService(false);%w$proxy->setProxyInitializer(null);'

--- a/src/Symfony/Bridge/ProxyManager/composer.json
+++ b/src/Symfony/Bridge/ProxyManager/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.5.9",
         "symfony/dependency-injection": "~2.8|~3.0",
-        "ocramius/proxy-manager": "~0.4|~1.0"
+        "ocramius/proxy-manager": "~0.4|~1.0|~2.0"
     },
     "require-dev": {
         "symfony/config": "~2.8|~3.0"


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17676 |
| License | MIT |
| Doc PR |  |

Note: tests don't pass because the test asset being used does not respect the return type hints (PHP7) required for ProxyManager v2. Not sure if I should just hack around it, and use the PHP7 hints.
