### PR TITLE
[HttpFoundation] Remove @throws from ParameterBag::get() PHPDoc

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -82,8 +82,6 @@ class ParameterBag implements \IteratorAggregate, \Countable
      * @param mixed  $default The default value if the parameter key does not exist
      *
      * @return mixed
-     *
-     * @throws \InvalidArgumentException
      */
     public function get($key, $default = null)
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

This was for the now removed deep flag.
