### PR TITLE
[Bridge] The WebProcessor now forwards the client IP

### DIFF
--- a/src/Symfony/Bridge/Monolog/Processor/WebProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/WebProcessor.php
@@ -31,6 +31,7 @@ class WebProcessor extends BaseWebProcessor
     {
         if ($event->isMasterRequest()) {
             $this->serverData = $event->getRequest()->server->all();
+            $this->serverData['REMOTE_ADDR'] = $event->getRequest()->getClientIp();
         }
     }
 }

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
@@ -33,6 +33,23 @@ class WebProcessorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($server['HTTP_REFERER'], $record['extra']['referrer']);
     }
 
+    public function testUseRequestClientIp()
+    {
+        Request::setTrustedProxies(['192.168.0.1']);
+        list($event, $server) = $this->createRequestEvent(array('X_FORWARDED_FOR' => '192.168.0.2'));
+
+        $processor = new WebProcessor();
+        $processor->onKernelRequest($event);
+        $record = $processor($this->getRecord());
+
+        $this->assertCount(5, $record['extra']);
+        $this->assertEquals($server['REQUEST_URI'], $record['extra']['url']);
+        $this->assertEquals($server['X_FORWARDED_FOR'], $record['extra']['ip']);
+        $this->assertEquals($server['REQUEST_METHOD'], $record['extra']['http_method']);
+        $this->assertEquals($server['SERVER_NAME'], $record['extra']['server']);
+        $this->assertEquals($server['HTTP_REFERER'], $record['extra']['referrer']);
+    }
+
     public function testCanBeConstructedWithExtraFields()
     {
         if (!$this->isExtraFieldsSupported()) {
@@ -53,18 +70,22 @@ class WebProcessorTest extends \PHPUnit_Framework_TestCase
     /**
      * @return array
      */
-    private function createRequestEvent()
+    private function createRequestEvent($additionalServerParameters = array())
     {
-        $server = array(
-            'REQUEST_URI' => 'A',
-            'REMOTE_ADDR' => 'B',
-            'REQUEST_METHOD' => 'C',
-            'SERVER_NAME' => 'D',
-            'HTTP_REFERER' => 'E',
+        $server = array_merge(
+            array(
+                'REQUEST_URI' => 'A',
+                'REMOTE_ADDR' => '192.168.0.1',
+                'REQUEST_METHOD' => 'C',
+                'SERVER_NAME' => 'D',
+                'HTTP_REFERER' => 'E',
+            ),
+            $additionalServerParameters
         );
 
         $request = new Request();
         $request->server->replace($server);
+        $request->headers->replace($server);
 
         $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')
             ->disableOriginalConstructor()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #17905 |
| License | MIT |
