### PR TITLE
[FrameworkBundle] Fix PropertyInfo registration when using reflection-docblock 3

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1010,7 +1010,7 @@ class FrameworkExtension extends Extension
 
         $loader->load('property_info.xml');
 
-        if (class_exists('phpDocumentor\Reflection\Types\ContextFactory')) {
+        if (class_exists('phpDocumentor\Reflection\DocBlockFactoryInterface')) {
             $definition = $container->register('property_info.php_doc_extractor', 'Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor');
             $definition->addTag('property_info.description_extractor', array('priority' => -1000));
             $definition->addTag('property_info.type_extractor', array('priority' => -1001));

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1010,7 +1010,7 @@ class FrameworkExtension extends Extension
 
         $loader->load('property_info.xml');
 
-        if (class_exists('phpDocumentor\Reflection\ClassReflector')) {
+        if (class_exists('phpDocumentor\Reflection\Types\ContextFactory')) {
             $definition = $container->register('property_info.php_doc_extractor', 'Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor');
             $definition->addTag('property_info.description_extractor', array('priority' => -1000));
             $definition->addTag('property_info.type_extractor', array('priority' => -1001));

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -50,7 +50,10 @@
         "symfony/validator": "~2.8|~3.0",
         "symfony/yaml": "~2.8|~3.0",
         "symfony/property-info": "~2.8|~3.0",
-        "phpdocumentor/reflection": "^1.0.7"
+        "phpdocumentor/reflection-docblock": "^3.0"
+    },
+    "conflict": {
+        "phpdocumentor/reflection-docblock": "<3.0"
     },
     "suggest": {
         "symfony/console": "For using the console commands",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Currently, the PHPDoc extractor of PropertyInfo is not registered anymore because #17531 was merged.
