### PR TITLE
[PoC][WiP] Caching controller information for annotations

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Adapter/AnnotationAdapterInterface.php
+++ b/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Adapter/AnnotationAdapterInterface.php
@@ -1,0 +1,33 @@
+<?php
+namespace Symfony\Bundle\FrameworkBundle\ControllerMetadata\Adapter;
+
+use Doctrine\Common\Annotations\Annotation;
+
+/**
+ * Allows a custom adapter to be implemented.
+ *
+ * @author Iltar van der Berg <kjarli@gmail.com>
+ */
+interface AnnotationAdapterInterface
+{
+    /**
+     * The identifier for the annotation.
+     *
+     * @return string
+     */
+    public function getIdentifier();
+
+    /**
+     * The actual annotation found.
+     *
+     * @return mixed
+     */
+    public function getAnnotation();
+
+    /**
+     * Indicates whether the given annotation may be used multiple times on a given method or class.
+     *
+     * @return bool
+     */
+    public function allowMultiple();
+}

--- a/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Adapter/ConfigurationAnnotationAdapter.php
+++ b/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Adapter/ConfigurationAnnotationAdapter.php
@@ -1,0 +1,52 @@
+<?php
+namespace Symfony\Bundle\FrameworkBundle\ControllerMetadata\Adapter;
+
+use Doctrine\Common\Annotations\Annotation;
+use Symfony\Bundle\FrameworkBundle\ControllerMetadata\Configuration\ConfigurationAnnotation;
+
+/**
+ * Wraps the Annotation into a usable layer.
+ *
+ * @author Iltar van der Berg <kjarli@gmail.com>
+ */
+final class ConfigurationAnnotationAdapter implements AnnotationAdapterInterface
+{
+    /**
+     * @var ConfigurationAnnotation
+     */
+    private $annotation;
+
+    /**
+     * @param ConfigurationAnnotation $annotation
+     */
+    public function __construct(ConfigurationAnnotation $annotation)
+    {
+        $this->annotation = $annotation;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIdentifier()
+    {
+        return $this->annotation->getAliasName();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @returns ConfigurationAnnotation
+     */
+    public function getAnnotation()
+    {
+        return $this->annotation;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function allowMultiple()
+    {
+        return $this->annotation->allowArray();
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Adapter/RouteAnnotationAdapter.php
+++ b/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Adapter/RouteAnnotationAdapter.php
@@ -1,0 +1,54 @@
+<?php
+namespace Symfony\Bundle\FrameworkBundle\ControllerMetadata\Adapter;
+
+use Doctrine\Common\Annotations\Annotation;
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * Wraps the Route into a usable layer.
+ *
+ * @author Iltar van der Berg <kjarli@gmail.com>
+ */
+final class RouteAnnotationAdapter implements AnnotationAdapterInterface
+{
+    /**
+     * @var Route
+     */
+    private $annotation;
+
+    /**
+     * @param Route $annotation
+     */
+    public function __construct(Route $annotation)
+    {
+        $this->annotation = $annotation;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIdentifier()
+    {
+        return $this->annotation->getName();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @returns Route
+     */
+    public function getAnnotation()
+    {
+        return $this->annotation;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return bool always true
+     */
+    public function allowMultiple()
+    {
+        return true;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/ClassMetadata.php
+++ b/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/ClassMetadata.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\ControllerMetadata;
+
+use Symfony\Bundle\FrameworkBundle\ControllerMetadata\Adapter\AnnotationAdapterInterface;
+
+/**
+ * Responsible for storing metadata of a controller.
+ *
+ * @author Iltar van der Berg <kjarli@gmail.com>
+ */
+final class ClassMetadata implements \Serializable
+{
+    /**
+     * @var string
+     */
+    private $className;
+
+    /**
+     * @var AnnotationAdapterInterface[]
+     */
+    private $annotations;
+
+    /**
+     * @var array
+     */
+    private $methods;
+
+    /**
+     * @param string                       $className
+     * @param MethodMetadata[]             $methods
+     * @param AnnotationAdapterInterface[] $annotations
+     */
+    public function __construct($className, array $methods = [], array $annotations = [])
+    {
+        $this->className = $className;
+        $this->methods = $methods;
+        $this->annotations = $annotations;
+    }
+
+    public function getClassName()
+    {
+        return $this->className;
+    }
+
+    public function getAnnotations()
+    {
+        return $this->annotations;
+    }
+
+    public function serialize()
+    {
+        return serialize(array($this->className, $this->methods, $this->annotations));
+    }
+
+    public function unserialize($serialized)
+    {
+        list($this->className, $this->methods, $this->annotations) = unserialize($serialized);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Configuration/Cache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Configuration/Cache.php
@@ -1,0 +1,248 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\ControllerMetadata\Configuration;
+
+/**
+ * The Cache class handles the Cache annotation parts.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @Annotation
+ */
+class Cache extends ConfigurationAnnotation
+{
+    /**
+     * The expiration date as a valid date for the strtotime() function.
+     *
+     * @var string
+     */
+    protected $expires;
+
+    /**
+     * The number of seconds that the response is considered fresh by a private
+     * cache like a web browser.
+     *
+     * @var int
+     */
+    protected $maxage;
+
+    /**
+     * The number of seconds that the response is considered fresh by a public
+     * cache like a reverse proxy cache.
+     *
+     * @var int
+     */
+    protected $smaxage;
+
+    /**
+     * Whether the response is public or not.
+     *
+     * @var bool
+     */
+    protected $public;
+
+    /**
+     * Additional "Vary:"-headers.
+     *
+     * @var array
+     */
+    protected $vary;
+
+    /**
+     * An expression to compute the Last-Modified HTTP header.
+     *
+     * @var string
+     */
+    protected $lastModified;
+
+    /**
+     * An expression to compute the ETag HTTP header.
+     *
+     * @var string
+     */
+    protected $etag;
+
+    /**
+     * Returns the expiration date for the Expires header field.
+     *
+     * @return string
+     */
+    public function getExpires()
+    {
+        return $this->expires;
+    }
+
+    /**
+     * Sets the expiration date for the Expires header field.
+     *
+     * @param string $expires A valid php date
+     */
+    public function setExpires($expires)
+    {
+        $this->expires = $expires;
+    }
+
+    /**
+     * Sets the number of seconds for the max-age cache-control header field.
+     *
+     * @param int $maxage A number of seconds
+     */
+    public function setMaxAge($maxage)
+    {
+        $this->maxage = $maxage;
+    }
+
+    /**
+     * Returns the number of seconds the response is considered fresh by a
+     * private cache.
+     *
+     * @return int
+     */
+    public function getMaxAge()
+    {
+        return $this->maxage;
+    }
+
+    /**
+     * Sets the number of seconds for the s-maxage cache-control header field.
+     *
+     * @param int $smaxage A number of seconds
+     */
+    public function setSMaxAge($smaxage)
+    {
+        $this->smaxage = $smaxage;
+    }
+
+    /**
+     * Returns the number of seconds the response is considered fresh by a
+     * public cache.
+     *
+     * @return int
+     */
+    public function getSMaxAge()
+    {
+        return $this->smaxage;
+    }
+
+    /**
+     * Returns whether or not a response is public.
+     *
+     * @return bool
+     */
+    public function isPublic()
+    {
+        return $this->public === true;
+    }
+
+    /**
+     * Returns whether or not a response is private.
+     *
+     * @return bool
+     */
+    public function isPrivate()
+    {
+        return $this->public === false;
+    }
+
+    /**
+     * Sets a response public.
+     *
+     * @param bool $public A boolean value
+     */
+    public function setPublic($public)
+    {
+        $this->public = (bool) $public;
+    }
+
+    /**
+     * Returns the custom "Vary"-headers.
+     *
+     * @return array
+     */
+    public function getVary()
+    {
+        return $this->vary;
+    }
+
+    /**
+     * Add additional "Vary:"-headers.
+     *
+     * @param array $vary
+     */
+    public function setVary($vary)
+    {
+        $this->vary = $vary;
+    }
+
+    /**
+     * Sets the "Last-Modified"-header expression.
+     *
+     * @param string $expression
+     */
+    public function setLastModified($expression)
+    {
+        $this->lastModified = $expression;
+    }
+
+    /**
+     * Returns the "Last-Modified"-header expression.
+     *
+     * @return string
+     */
+    public function getLastModified()
+    {
+        return $this->lastModified;
+    }
+
+    /**
+     * Sets the "ETag"-header expression.
+     *
+     * @param string $expression
+     */
+    public function setETag($expression)
+    {
+        $this->etag = $expression;
+    }
+
+    /**
+     * Returns the "ETag"-header expression.
+     *
+     * @return string
+     */
+    public function getETag()
+    {
+        return $this->etag;
+    }
+
+    /**
+     * Returns the annotation alias name.
+     *
+     * @return string
+     *
+     * @see ConfigurationInterface
+     */
+    public function getAliasName()
+    {
+        return 'cache';
+    }
+
+    /**
+     * Only one cache directive is allowed.
+     *
+     * @return bool
+     *
+     * @see ConfigurationInterface
+     */
+    public function allowArray()
+    {
+        return false;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Configuration/ConfigurationAnnotation.php
+++ b/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Configuration/ConfigurationAnnotation.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\ControllerMetadata\Configuration;
+
+/**
+ * Base configuration annotation.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+abstract class ConfigurationAnnotation implements ConfigurationInterface
+{
+    public function __construct(array $values)
+    {
+        foreach ($values as $k => $v) {
+            if (!method_exists($this, $name = 'set'.$k)) {
+                throw new \RuntimeException(sprintf('Unknown key "%s" for annotation "@%s".', $k, get_class($this)));
+            }
+
+            $this->$name($v);
+        }
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Configuration/ConfigurationInterface.php
+++ b/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Configuration/ConfigurationInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\ControllerMetadata\Configuration;
+
+/**
+ * ConfigurationInterface.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+interface ConfigurationInterface
+{
+    /**
+     * Returns the alias name for an annotated configuration.
+     *
+     * @return string
+     */
+    public function getAliasName();
+
+    /**
+     * Returns whether multiple annotations of this type are allowed.
+     *
+     * @return bool
+     */
+    public function allowArray();
+}

--- a/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Configuration/Method.php
+++ b/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Configuration/Method.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\ControllerMetadata\Configuration;
+
+/**
+ * The Method class handles the Method annotation parts.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @Annotation
+ */
+class Method extends ConfigurationAnnotation
+{
+    /**
+     * An array of restricted HTTP methods.
+     *
+     * @var array
+     */
+    protected $methods = array();
+
+    /**
+     * Returns the array of HTTP methods.
+     *
+     * @return array
+     */
+    public function getMethods()
+    {
+        return $this->methods;
+    }
+
+    /**
+     * Sets the HTTP methods.
+     *
+     * @param array|string $methods An HTTP method or an array of HTTP methods
+     */
+    public function setMethods($methods)
+    {
+        $this->methods = is_array($methods) ? $methods : array($methods);
+    }
+
+    /**
+     * Sets the HTTP methods.
+     *
+     * @param array|string $methods An HTTP method or an array of HTTP methods
+     */
+    public function setValue($methods)
+    {
+        $this->setMethods($methods);
+    }
+
+    /**
+     * Returns the annotation alias name.
+     *
+     * @return string
+     *
+     * @see ConfigurationInterface
+     */
+    public function getAliasName()
+    {
+        return 'method';
+    }
+
+    /**
+     * Only one method directive is allowed.
+     *
+     * @return bool
+     *
+     * @see ConfigurationInterface
+     */
+    public function allowArray()
+    {
+        return false;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Configuration/ParamConverter.php
+++ b/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Configuration/ParamConverter.php
@@ -1,0 +1,190 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\ControllerMetadata\Configuration;
+
+/**
+ * The ParamConverter class handles the ParamConverter annotation parts.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @Annotation
+ */
+class ParamConverter extends ConfigurationAnnotation
+{
+    /**
+     * The parameter name.
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * The parameter class.
+     *
+     * @var string
+     */
+    protected $class;
+
+    /**
+     * An array of options.
+     *
+     * @var array
+     */
+    protected $options = array();
+
+    /**
+     * Whether or not the parameter is optional.
+     *
+     * @var bool
+     */
+    protected $optional = false;
+
+    /**
+     * Use explicitly named converter instead of iterating by priorities.
+     *
+     * @var string
+     */
+    protected $converter;
+
+    /**
+     * Returns the parameter name.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Sets the parameter name.
+     *
+     * @param string $name The parameter name
+     */
+    public function setValue($name)
+    {
+        $this->setName($name);
+    }
+
+    /**
+     * Sets the parameter name.
+     *
+     * @param string $name The parameter name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * Returns the parameter class name.
+     *
+     * @return string $name
+     */
+    public function getClass()
+    {
+        return $this->class;
+    }
+
+    /**
+     * Sets the parameter class name.
+     *
+     * @param string $class The parameter class name
+     */
+    public function setClass($class)
+    {
+        $this->class = $class;
+    }
+
+    /**
+     * Returns an array of options.
+     *
+     * @return array
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    /**
+     * Sets an array of options.
+     *
+     * @param array $options An array of options
+     */
+    public function setOptions($options)
+    {
+        $this->options = $options;
+    }
+
+    /**
+     * Sets whether or not the parameter is optional.
+     *
+     * @param bool $optional Whether the parameter is optional
+     */
+    public function setIsOptional($optional)
+    {
+        $this->optional = (bool) $optional;
+    }
+
+    /**
+     * Returns whether or not the parameter is optional.
+     *
+     * @return bool
+     */
+    public function isOptional()
+    {
+        return $this->optional;
+    }
+
+    /**
+     * Get explicit converter name.
+     *
+     * @return string
+     */
+    public function getConverter()
+    {
+        return $this->converter;
+    }
+
+    /**
+     * Set explicit converter name.
+     *
+     * @param string $converter
+     */
+    public function setConverter($converter)
+    {
+        $this->converter = $converter;
+    }
+
+    /**
+     * Returns the annotation alias name.
+     *
+     * @return string
+     *
+     * @see ConfigurationInterface
+     */
+    public function getAliasName()
+    {
+        return 'converters';
+    }
+
+    /**
+     * Multiple ParamConverters are allowed.
+     *
+     * @return bool
+     *
+     * @see ConfigurationInterface
+     */
+    public function allowArray()
+    {
+        return true;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Configuration/Route.php
+++ b/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Configuration/Route.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\ControllerMetadata\Configuration;
+
+use Symfony\Component\Routing\Annotation\Route as BaseRoute;
+
+/**
+ * @author Kris Wallsmith <kris@symfony.com>
+ * @Annotation
+ */
+class Route extends BaseRoute
+{
+    protected $service;
+
+    public function setService($service)
+    {
+        // avoid a BC notice in case of @Route(service="") with sf ^2.7
+        if (null === $this->getPath()) {
+            $this->setPath('');
+        }
+        $this->service = $service;
+    }
+
+    public function getService()
+    {
+        return $this->service;
+    }
+
+    /**
+     * Multiple route annotations are allowed.
+     *
+     * @return bool
+     *
+     * @see ConfigurationInterface
+     */
+    public function allowArray()
+    {
+        return true;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Configuration/Security.php
+++ b/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Configuration/Security.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\ControllerMetadata\Configuration;
+
+/**
+ * The Security class handles the Security annotation.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @Annotation
+ */
+class Security extends ConfigurationAnnotation
+{
+    protected $expression;
+
+    public function getExpression()
+    {
+        return $this->expression;
+    }
+
+    public function setExpression($expression)
+    {
+        $this->expression = $expression;
+    }
+
+    public function setValue($expression)
+    {
+        $this->setExpression($expression);
+    }
+
+    public function getAliasName()
+    {
+        return 'security';
+    }
+
+    public function allowArray()
+    {
+        return false;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Configuration/Template.php
+++ b/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Configuration/Template.php
@@ -1,0 +1,186 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\ControllerMetadata\Configuration;
+
+use Symfony\Bundle\FrameworkBundle\Templating\TemplateReference;
+
+/**
+ * The Template class handles the Template annotation parts.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @Annotation
+ */
+class Template extends ConfigurationAnnotation
+{
+    /**
+     * The template reference.
+     *
+     * @var TemplateReference|string
+     */
+    protected $template;
+
+    /**
+     * The template engine used when a specific template isn't specified.
+     *
+     * @var string
+     */
+    protected $engine = 'twig';
+
+    /**
+     * The associative array of template variables.
+     *
+     * @var array
+     */
+    protected $vars = array();
+
+    /**
+     * Should the template be streamed?
+     *
+     * @var bool
+     */
+    protected $streamable = false;
+
+    /**
+     * The controller (+action) this annotation is set to.
+     *
+     * @var array
+     */
+    private $owner;
+
+    /**
+     * Returns the array of templates variables.
+     *
+     * @return array
+     */
+    public function getVars()
+    {
+        return $this->vars;
+    }
+
+    /**
+     * @param bool $streamable
+     */
+    public function setIsStreamable($streamable)
+    {
+        $this->streamable = $streamable;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isStreamable()
+    {
+        return (bool) $this->streamable;
+    }
+
+    /**
+     * Sets the template variables.
+     *
+     * @param array $vars The template variables
+     */
+    public function setVars($vars)
+    {
+        $this->vars = $vars;
+    }
+
+    /**
+     * Returns the engine used when guessing template names.
+     *
+     * @return string
+     */
+    public function getEngine()
+    {
+        return $this->engine;
+    }
+
+    /**
+     * Sets the engine used when guessing template names.
+     *
+     * @param string
+     */
+    public function setEngine($engine)
+    {
+        $this->engine = $engine;
+    }
+
+    /**
+     * Sets the template logic name.
+     *
+     * @param string $template The template logic name
+     */
+    public function setValue($template)
+    {
+        $this->setTemplate($template);
+    }
+
+    /**
+     * Returns the template reference.
+     *
+     * @return TemplateReference
+     */
+    public function getTemplate()
+    {
+        return $this->template;
+    }
+
+    /**
+     * Sets the template reference.
+     *
+     * @param TemplateReference|string $template The template reference
+     */
+    public function setTemplate($template)
+    {
+        $this->template = $template;
+    }
+
+    /**
+     * Returns the annotation alias name.
+     *
+     * @return string
+     *
+     * @see ConfigurationInterface
+     */
+    public function getAliasName()
+    {
+        return 'template';
+    }
+
+    /**
+     * Only one template directive is allowed.
+     *
+     * @return bool
+     *
+     * @see ConfigurationInterface
+     */
+    public function allowArray()
+    {
+        return false;
+    }
+
+    /**
+     * @param array $owner
+     */
+    public function setOwner(array $owner)
+    {
+        $this->owner = $owner;
+    }
+
+    /**
+     * The controller (+action) this annotation is attached to.
+     *
+     * @return array
+     */
+    public function getOwner()
+    {
+        return $this->owner;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Exception/NoMatchingFactoryFoundException.php
+++ b/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Exception/NoMatchingFactoryFoundException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\ControllerMetadata\Exception;
+
+/**
+ * @author Iltar van der Berg <kjarli@gmail.com>
+ */
+class NoMatchingFactoryFoundException extends \InvalidArgumentException
+{
+    public function __construct($annotationClass)
+    {
+        parent::__construct(sprintf('No matching AnnotationAdapterFactory found for %s.', $annotationClass));
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Exception/UnsupportedAnnotationException.php
+++ b/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Exception/UnsupportedAnnotationException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\ControllerMetadata\Exception;
+
+/**
+ * @author Iltar van der Berg <kjarli@gmail.com>
+ */
+class UnsupportedAnnotationException extends \InvalidArgumentException
+{
+    public function __construct($factoryClass, $annotationClass)
+    {
+        parent::__construct(sprintf('%s only accepts %s annotations.', $factoryClass, $annotationClass));
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Factory/AnnotationAdapterFactoryInterface.php
+++ b/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Factory/AnnotationAdapterFactoryInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\ControllerMetadata\Factory;
+
+use Doctrine\Common\Annotations\Annotation;
+use Symfony\Bundle\FrameworkBundle\ControllerMetadata\Adapter\AnnotationAdapterInterface;
+use Symfony\Bundle\FrameworkBundle\ControllerMetadata\Exception\UnsupportedAnnotationException;
+
+/**
+ * Responsible for adapter creation.
+ *
+ * @author Iltar van der Berg <kjarli@gmail.com>
+ */
+interface AnnotationAdapterFactoryInterface
+{
+    /**
+     * @param mixed $annotation
+     * @return AnnotationAdapterInterface
+     *
+     * @throws UnsupportedAnnotationException
+     */
+    public function createForAnnotation($annotation);
+}

--- a/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Factory/ChainAnnotationAdapterFactory.php
+++ b/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Factory/ChainAnnotationAdapterFactory.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\ControllerMetadata\Factory;
+
+use Doctrine\Common\Annotations\Annotation;
+use Symfony\Bundle\FrameworkBundle\ControllerMetadata\Adapter\AnnotationAdapterInterface;
+use Symfony\Bundle\FrameworkBundle\ControllerMetadata\Exception\NoMatchingFactoryFoundException;
+use Symfony\Bundle\FrameworkBundle\ControllerMetadata\Exception\UnsupportedAnnotationException;
+
+/**
+ * Allows different factories to try and create adapters for annotations.
+ *
+ * @author Iltar van der Berg <kjarli@gmail.com>
+ */
+final class ChainAnnotationAdapterFactory implements AnnotationAdapterFactoryInterface
+{
+    /**
+     * @var AnnotationAdapterFactoryInterface[]
+     */
+    private $factories;
+
+    /**
+     * @param AnnotationAdapterFactoryInterface[] $factories
+     */
+    public function __construct(array $factories)
+    {
+        $this->factories = $factories;
+    }
+
+    /**
+     * Checks all registered annotation adapter factories until one is found that supports this annotation.
+     *
+     * @param mixed $annotation
+     * @return AnnotationAdapterInterface
+     *
+     * @throws NoMatchingFactoryFoundException
+     */
+    public function createForAnnotation($annotation)
+    {
+        foreach ($this->factories as $factory) {
+            try {
+                return $factory->createForAnnotation($annotation);
+            } catch (UnsupportedAnnotationException $e) {
+                continue;
+            }
+        }
+
+        throw new NoMatchingFactoryFoundException(get_class($annotation));
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Factory/ConfigurationAnnotationAdapterFactory.php
+++ b/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Factory/ConfigurationAnnotationAdapterFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\ControllerMetadata\Factory;
+
+use Doctrine\Common\Annotations\Annotation;
+use Symfony\Bundle\FrameworkBundle\ControllerMetadata\Adapter\ConfigurationAnnotationAdapter;
+use Symfony\Bundle\FrameworkBundle\ControllerMetadata\Configuration\ConfigurationAnnotation;
+use Symfony\Bundle\FrameworkBundle\ControllerMetadata\Exception\UnsupportedAnnotationException;
+
+/**
+ * Responsible for adapter creation for the SensioFrameworkExtraBundle.
+ *
+ * @author Iltar van der Berg <kjarli@gmail.com>
+ */
+final class ConfigurationAnnotationAdapterFactory implements AnnotationAdapterFactoryInterface
+{
+    public function createForAnnotation($annotation)
+    {
+        if (!$annotation instanceof ConfigurationAnnotation) {
+            throw new UnsupportedAnnotationException(__CLASS__, get_class($annotation));
+        }
+
+        return new ConfigurationAnnotationAdapter($annotation);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Factory/RouteAnnotationAdapterFactory.php
+++ b/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/Factory/RouteAnnotationAdapterFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\ControllerMetadata\Factory;
+
+use Doctrine\Common\Annotations\Annotation;
+use Symfony\Bundle\FrameworkBundle\ControllerMetadata\Adapter\RouteAnnotationAdapter;
+use Symfony\Bundle\FrameworkBundle\ControllerMetadata\Exception\NoMatchingFactoryFoundException;
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * Responsible for adapter creation of the Symfony Route annotation.
+ *
+ * @author Iltar van der Berg <kjarli@gmail.com>
+ */
+final class RouteAnnotationAdapterFactory implements AnnotationAdapterFactoryInterface
+{
+    public function createForAnnotation($annotation)
+    {
+        if (!$annotation instanceof Route) {
+            throw new NoMatchingFactoryFoundException(__CLASS__, Route::class);
+        }
+
+        return new RouteAnnotationAdapter($annotation);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/MethodMetadata.php
+++ b/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/MethodMetadata.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\ControllerMetadata;
+
+use Symfony\Bundle\FrameworkBundle\ControllerMetadata\Adapter\AnnotationAdapterInterface;
+
+/**
+ * Responsible for storing metadata of a controller method.
+ *
+ * @author Iltar van der Berg <kjarli@gmail.com>
+ */
+final class MethodMetadata implements \Serializable
+{
+    /**
+     * @var string
+     */
+    private $methodName;
+
+    /**
+     * @var AnnotationAdapterInterface[]
+     */
+    private $annotations;
+
+    /**
+     * @param string                       $methodName
+     * @param AnnotationAdapterInterface[] $annotations
+     */
+    public function __construct($methodName, array $annotations = [])
+    {
+        $this->methodName  = $methodName;
+        $this->annotations = $annotations;
+    }
+
+    public function getMethodName()
+    {
+        return $this->methodName;
+    }
+
+    public function getAnnotations()
+    {
+        return $this->annotations;
+    }
+
+    public function serialize()
+    {
+        return serialize(array($this->methodName, $this->annotations));
+    }
+
+    public function unserialize($serialized)
+    {
+        list($this->methodName, $this->annotations) = unserialize($serialized);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/ControllerMetadata/ClassMetadataTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/ControllerMetadata/ClassMetadataTest.php
@@ -1,0 +1,242 @@
+<?php
+namespace Symfony\Bundle\FrameworkBundle\Tests\ControllerMetadata;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use Symfony\Bundle\FrameworkBundle\ControllerMetadata\Factory\ConfigurationAnnotationAdapterFactory;
+use Symfony\Bundle\FrameworkBundle\ControllerMetadata\ClassMetadata;
+use Symfony\Bundle\FrameworkBundle\ControllerMetadata\Factory\ChainAnnotationAdapterFactory;
+use Symfony\Bundle\FrameworkBundle\ControllerMetadata\Factory\RouteAnnotationAdapterFactory;
+use Symfony\Bundle\FrameworkBundle\ControllerMetadata\MethodMetadata;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * @covers Symfony\Bundle\FrameworkBundle\Tests\ControllerMetadata\ClassMetadata
+ */
+class ClassMetadataTest extends KernelTestCase
+{
+    public function testOldFew()
+    {
+        echo "\nRunning current situation with a few controllers, annotations and reflection loaded each request\n";
+        $times = 1000;
+        $before = microtime(true);
+
+        AnnotationRegistry::registerLoader('class_exists');
+        $reader = new AnnotationReader();
+
+        $controllers = [
+            InvokableClassLevelController::class,
+            InvokableContainerController::class,
+            InvokableController::class,
+            MultipleActionsClassLevelTemplateController::class,
+            SimpleController::class,
+        ];
+
+        $data = [];
+        $total = 0;
+
+        for ($i = 0; $i < $times; $i++) {
+            $annotations = [];
+            foreach ($controllers as $controller) {
+                $c = new \ReflectionClass($controller);
+                $annotations[$controller] = $reader->getClassAnnotations($c);
+                $total += count($annotations[$controller]);
+                foreach ($c->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+                    $annotations[$method->getName()] = $reader->getMethodAnnotations($method);
+                    $total += count($annotations[$method->getName()]);
+                }
+            }
+            $data[] = $annotations;
+        }
+
+        $after = microtime(true);
+        $time = round(($after - $before) * 1000);
+        $pr = round($time / $times, 2);
+        echo " * Executed $times times: $time ms\n   - 5 controllers\n   - $total annotations total\n   - $pr ms/request\n\n";
+    }
+
+    public function testOldMany()
+    {
+        echo "\nRunning current situation with many controllers, annotations and reflection loaded each request\n";
+        $times = 10;
+        $controllerCount = 100;
+        $before = microtime(true);
+
+        AnnotationRegistry::registerLoader('class_exists');
+        $reader = new AnnotationReader();
+
+        $controllers = [
+            InvokableClassLevelController::class,
+            InvokableContainerController::class,
+            InvokableController::class,
+            MultipleActionsClassLevelTemplateController::class,
+            SimpleController::class,
+        ];
+
+        $total = 0;
+
+        for ($j = 0; $j < $controllerCount; $j++) {
+            $data = [];
+            for ($i = 0; $i < $times; $i++) {
+                $annotations = [];
+                foreach ($controllers as $controller) {
+                    $c = new \ReflectionClass($controller);
+                    $annotations[$controller] = $reader->getClassAnnotations($c);
+                    $total += count($annotations[$controller]);
+                    foreach ($c->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+                        $annotations[$method->getName()] = $reader->getMethodAnnotations($method);
+                        $total += count($annotations[$method->getName()]);
+                    }
+                }
+                $data[] = $annotations;
+            }
+        }
+
+        $after = microtime(true);
+        $time = round(($after - $before) * 1000);
+        $c = count($controllers) * $controllerCount;
+        $pr = round($time / $times, 2);
+        $sr = round($pr / $c, 2);
+        echo " * Executed $times times: $time ms\n   - $c controllers\n   - $total annotations total\n   - $pr ms/request\n   - $sr ms/sub-request\n\n";
+    }
+
+    public function testBootstrapFewControllers()
+    {
+        echo "\nRunning new situation with a few controllers, annotations and reflection loaded during cache warmup\n";
+        $before = microtime(true);
+
+        $reader = new AnnotationReader();
+
+        $f1 = new ConfigurationAnnotationAdapterFactory();
+        $f2 = new RouteAnnotationAdapterFactory([$f1]);
+        $f3 = new ChainAnnotationAdapterFactory([$f1, $f2]);
+
+        $controllers = [
+            InvokableClassLevelController::class,
+            InvokableContainerController::class,
+            InvokableController::class,
+            MultipleActionsClassLevelTemplateController::class,
+            SimpleController::class,
+        ];
+
+        $data = [];
+        $total = 0;
+
+        foreach ($controllers as $controller) {
+            $classAnnotations = [];
+            $c                = new \ReflectionClass($controller);
+            foreach ($reader->getClassAnnotations($c) as $annotation) {
+                $classAnnotations[] = $f3->createForAnnotation($annotation);
+            }
+            $total += count($classAnnotations);
+            $methods = [];
+            foreach ($c->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+                $methodAnnotations = [];
+                foreach ($reader->getMethodAnnotations($method) as $annotation) {
+                    $methodAnnotations[] = $f3->createForAnnotation($annotation);
+                }
+                $total += count($methodAnnotations);
+                $methods[] = new MethodMetadata($method->getName(), $methodAnnotations);
+            }
+            $data[] = new ClassMetadata($c->getName(), $methods, $classAnnotations);
+        }
+
+        file_put_contents(__DIR__.'/dump_few.serialized', serialize($data));
+
+        $after = microtime(true);
+        $time = round(($after - $before) * 1000);
+        echo " * bootstrap executed in $time ms\n   - 4 controllers\n   - $total annotations\n";
+    }
+
+    /**
+     * @depends testBootstrapFewControllers
+     */
+    public function testNewFewControllers()
+    {
+        $times = 1000;
+        $before = microtime(true);
+        $data = [];
+
+        for ($i = 0; $i < $times; $i++) {
+            $data = unserialize(file_get_contents(__DIR__.'/dump_few.serialized'));
+        }
+
+        $after = microtime(true);
+        $time = round(($after - $before) * 1000);
+        $c = count($data);
+        $pr = round($time / $times, 2);
+        echo " * Executed $times times: $time ms\n   - $c controllers\n   - $pr ms/request\n";
+    }
+
+
+    public function testBootstrapManyControllers()
+    {
+        echo "\n\nRunning new situation with many controllers, annotations and reflection loaded during cache warmup\n";
+        $before = microtime(true);
+
+        $reader = new AnnotationReader();
+
+        $f1 = new ConfigurationAnnotationAdapterFactory();
+        $f2 = new RouteAnnotationAdapterFactory([$f1]);
+        $f3 = new ChainAnnotationAdapterFactory([$f1, $f2]);
+
+        $controllers = [
+            InvokableClassLevelController::class,
+            InvokableContainerController::class,
+            InvokableController::class,
+            MultipleActionsClassLevelTemplateController::class,
+            SimpleController::class,
+        ];
+
+        $data = [];
+        $total = 0;
+
+        for ($i = 0; $i < 100; $i++)
+        foreach ($controllers as $controller) {
+            $classAnnotations = [];
+            $c                = new \ReflectionClass($controller);
+            foreach ($reader->getClassAnnotations($c) as $annotation) {
+                $classAnnotations[] = $f3->createForAnnotation($annotation);
+            }
+            $total += count($classAnnotations);
+            $methods = [];
+            foreach ($c->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+                $methodAnnotations = [];
+                foreach ($reader->getMethodAnnotations($method) as $annotation) {
+                    $methodAnnotations[] = $f3->createForAnnotation($annotation);
+                }
+                $total += count($methodAnnotations);
+                $methods[] = new MethodMetadata($method->getName(), $methodAnnotations);
+            }
+            $data[] = new ClassMetadata($c->getName(), $methods, $classAnnotations);
+        }
+
+
+        file_put_contents(__DIR__.'/dump_many.serialized', serialize($data));
+
+        $after = microtime(true);
+        $time = round(($after - $before) * 1000);
+        $c = $i * 5;
+        echo " * new bootstrap executed in $time ms\n   - $c controllers\n   - $total annotations\n";
+    }
+
+    /**
+     * @depends testBootstrapManyControllers
+     */
+    public function testNewManyControllers()
+    {
+        $times = 1000;
+        $before = microtime(true);
+
+        $data = [];
+        for ($i = 0; $i < $times; $i++) {
+            $data = unserialize(file_get_contents(__DIR__.'/dump_many.serialized'));
+        }
+
+        $after = microtime(true);
+        $time = round(($after - $before) * 1000);
+        $c = count($data);
+        $pr = round($time / $times, 2);
+        echo " * New Executed $times times: $time ms\n   - $c controllers\n   - $pr ms/request\n";
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/ControllerMetadata/InvokableClassLevelController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/ControllerMetadata/InvokableClassLevelController.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\ControllerMetadata;
+
+use Symfony\Bundle\FrameworkBundle\ControllerMetadata\Configuration\Route;
+use Symfony\Bundle\FrameworkBundle\ControllerMetadata\Configuration\Template;
+
+/**
+ * @Route(service="test.invokable_class_level.predefined")
+ * @Template("FooBundle:Invokable:predefined.html.twig")
+ */
+class InvokableClassLevelController
+{
+    /**
+     * @Route("/invokable/class-level/service/")
+     */
+    public function __invoke()
+    {
+        return array(
+            'foo' => 'bar',
+        );
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/ControllerMetadata/InvokableContainerController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/ControllerMetadata/InvokableContainerController.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\ControllerMetadata;
+
+use Symfony\Bundle\FrameworkBundle\ControllerMetadata\Configuration\Route;
+use Symfony\Bundle\FrameworkBundle\ControllerMetadata\Configuration\Template;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+class InvokableContainerController extends Controller
+{
+    /**
+     * @Route("/invokable/variable/container/{variable}/")
+     * @Template()
+     */
+    public function variableAction($variable)
+    {
+    }
+
+    /**
+     * @Route("/invokable/another-variable/container/{variable}/")
+     * @Template("FooBundle:InvokableContainer:variable.html.twig")
+     */
+    public function anotherVariableAction($variable)
+    {
+        return array(
+            'variable' => $variable,
+        );
+    }
+
+    /**
+     * @Route("/invokable/variable/container/{variable}/{another_variable}/")
+     * @Template("FooBundle:InvokableContainer:another_variable.html.twig")
+     */
+    public function doubleVariableAction($variable, $another_variable)
+    {
+        return array(
+            'variable' => $variable,
+            'another_variable' => $another_variable,
+        );
+    }
+
+    /**
+     * @Route("/invokable/predefined/container/")
+     * @Template("FooBundle:Invokable:predefined.html.twig")
+     */
+    public function __invoke()
+    {
+        return array(
+            'foo' => 'bar',
+        );
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/ControllerMetadata/InvokableController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/ControllerMetadata/InvokableController.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\ControllerMetadata;
+
+use Symfony\Bundle\FrameworkBundle\ControllerMetadata\Configuration\Route;
+use Symfony\Bundle\FrameworkBundle\ControllerMetadata\Configuration\Template;
+
+/**
+ * @Route(service="test.invokable.predefined")
+ */
+class InvokableController
+{
+    /**
+     * @Route("/invokable/predefined/service/")
+     * @Template("FooBundle:Invokable:predefined.html.twig")
+     */
+    public function __invoke()
+    {
+        return array(
+            'foo' => 'bar',
+        );
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/ControllerMetadata/MultipleActionsClassLevelTemplateController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/ControllerMetadata/MultipleActionsClassLevelTemplateController.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\ControllerMetadata;
+
+use Symfony\Bundle\FrameworkBundle\ControllerMetadata\Configuration\Route;
+use Symfony\Bundle\FrameworkBundle\ControllerMetadata\Configuration\Template;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+/**
+ * @Template("FooBundle:Invokable:predefined.html.twig")
+ */
+class MultipleActionsClassLevelTemplateController extends Controller
+{
+    /**
+     * @Route("/multi/one-template/1/")
+     */
+    public function firstAction()
+    {
+        return array(
+            'foo' => 'bar',
+        );
+    }
+
+    /**
+     * @Route("/multi/one-template/2/")
+     * @Route("/multi/one-template/3/")
+     */
+    public function secondAction()
+    {
+        return array(
+            'foo' => 'bar',
+        );
+    }
+
+    /**
+     * @Route("/multi/one-template/4/")
+     * @Template("FooBundle::overwritten.html.twig")
+     */
+    public function overwriteAction()
+    {
+        return array(
+            'foo' => 'foo bar baz',
+        );
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/ControllerMetadata/SimpleController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/ControllerMetadata/SimpleController.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\ControllerMetadata;
+
+use Symfony\Bundle\FrameworkBundle\ControllerMetadata\Configuration\Route;
+use Symfony\Bundle\FrameworkBundle\ControllerMetadata\Configuration\Template;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @Route(service="test.simple.multiple")
+ */
+class SimpleController
+{
+    /**
+     * @Route("/simple/multiple/", defaults={"a": "a", "b": "b"})
+     * @Template()
+     */
+    public function someAction($a, $b, $c = 'c')
+    {
+    }
+
+    /**
+     * @Route("/simple/multiple/{a}/{b}/")
+     * @Template("FooBundle:Simple:some.html.twig")
+     */
+    public function someMoreAction($a, $b, $c = 'c')
+    {
+    }
+
+    /**
+     * @Route("/simple/multiple-with-vars/", defaults={"a": "a", "b": "b"})
+     * @Template(vars={"a", "b"})
+     */
+    public function anotherAction($a, $b, $c = 'c')
+    {
+    }
+
+    /**
+     * @Route("/no-listener/")
+     */
+    public function noListenerAction()
+    {
+        return new Response('<html><body>I did not get rendered via twig</body></html>');
+    }
+
+    /**
+     * @Route("/streamed/")
+     * @Template(isStreamable=true)
+     */
+    public function streamedAction()
+    {
+        return array(
+            'foo' => 'foo',
+            'bar' => 'bar',
+        );
+    }
+}


### PR DESCRIPTION
**_DO NOT MERGE**_
Branch I'm working on: https://github.com/iltar/symfony/tree/feature/cached-controllers
### What is this about?

Controllers and Annotations. We use Controllers in every web application and [the best practices](http://symfony.com/doc/current/best_practices/controllers.html) recommend us to use Annotations to configure them.

> Make your controller extend the FrameworkBundle base controller and use annotations to configure routing, caching and security whenever possible. 
#### So what about `@Template()`?

> Don't use the `@Template()` annotation to configure the template used by the controller. The `@Template` annotation is useful, but also involves some magic. We don't think its benefit is worth the magic, and so recommend against using it.

While I disagree with some points, I agree with the fact that Annotations are really useful in Symfony (and in general). 
#### So what about `@ParamConverter()`?

> Use the ParamConverter trick to automatically query for Doctrine entities when it's simple and convenient.

Again, a recommendation to use annotations, awesome!

PS. The paramconverter uses a lot more magic than `@Template()` _(but that's non of my business)_
### So what is the problem?

Overhead and complexity. 

First off, you need the [SensioFrameworkExtraBundle](http://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/index.html) to get this to work. This will require an extra package which is not maintained in the core and follows a different release scheme. 

Second, the logic in here is [quite complex and cumbersome](https://github.com/sensiolabs/SensioFrameworkExtraBundle/blob/v3.0.13/EventListener/ControllerListener.php), not to mention slow! This is executed every single `kernel.controller` event, which means every sub-request and I often have at least 5 sub-requests on a page. 

Afaik there have been discussions about wanting to integrate this into the core and to be honest, I understand why this should not be in there. However, I would like to have the functionality in here for several reasons:
- Easier to extend
- Easier to maintain (those who contribute to the FWEB know what I mean)
- Follows the same release cycle
- Best practices can be implemented without having to use a non `symfony/` vendor package! In my opinion, if you recommend it, it should be in the core.
### So what's my solution?

When routing cache is loaded, it already [uses reflection to read Annotations](https://github.com/symfony/symfony/blob/a729462ce1405497b9bec285d2e83f6e60b987d5/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php#L111) regarding the `@Route`, however [the actual implementation is in the SensioFrameworkExtraBundle](https://github.com/sensiolabs/SensioFrameworkExtraBundle/blob/99a2e6eb83c8ae93dea2ee8cb5e86146a979c709/Routing/AnnotatedRouteControllerLoader.php#L27). At this point, the metadata of the controllers could also be extracted and cached away. This means that during runtime, no additional reflection classes/methods or Annotation reading has to be done.

This PR contains the changes I made including some benchmarking (I hope I did it correct) in the unit-test provided. One thing I have not yet added is argument scanning (say for the `Request $request` parameter or `@ParamConverter()`), but is a piece of cake to add.

The benchmark is done with different test cases in both the old and the new setup. The old setup is where the SensioFrameworkExtraBundle does it for every single `kernel.controller` and the new tests where it's cached away via `serialize()`. 

_Note that this is not the actual caching strategy but can be designed if this would be actually implemented, could provide different default strategies for this in a key/value storage. The classes are not complete and are missing functionality. This is merely the storage idea I had._
### What will this solve?
- It will create a generic extension point for people to add custom annotations to their actions. Take for example the [ControllerExtraBundle](https://github.com/mmoreram/ControllerExtraBundle/blob/master/EventListener/ResolverEventListener.php#L143), which has to do a lot of extra logic each request. The same goes for the FrameworkExtraBundle. 
- By having the `ConfigurationAnnotation` in the core, all symfony/sensio annotations can use it
- The annotation adapter and adapter factory will allow everyone to create their adapter which can be cached away automatically. The PR features one for the `Route` and one for the `ConfigurationAnnotation` as example.
- It will improve run-time performance for every single `kernel.controller` (~2ms per subrequest) for just the resolving, this is excluding any performance gains from annotation specific listeners!
- It will make maintaining the logic behind the annotation reading a lot less complex and will reduce a lot of code required for each annotation to work, avoiding a lot of bugs and pull requests on multiple repositories.
### Basic concept

Each public method in a controller gets scanned and all annotations are stored in the `MethodMetadata`. The controller annotations, name and `MethodMetadata`-s are stored in a `MethodMetadata`.  Every single piece of code that needs to know something about the controller annotations (`service="..."`, route information, security rules etc) can be read from this cached variant via a special interface, most likely something like `$metadataRepository->get(ControllerName::class);`.

```
current situation, a few controllers, annotations and reflection loaded each request
 * Executed 1000 times: 2233 ms
   - 5 controllers
   - 30000 annotations total
   - 2.23 ms/request


current situation, many controllers, annotations and reflection loaded each request
 * Executed 10 times: 2182 ms
   - 500 controllers
   - 30000 annotations total
   - 218.2 ms/request
   - 0.44 ms/sub-request


new situation, few controllers, annotations and reflection loaded during cache warmup
 * bootstrap executed in 5 ms
   - 4 controllers
   - 30 annotations
 * Executed 1000 times: 112 ms
   - 5 controllers
   - 0.11 ms/request


new situation, many controllers, annotations and reflection loaded during cache warmup
 * new bootstrap executed in 342 ms
   - 500 controllers
   - 3000 annotations
 * New Executed 1000 times: 20139 ms
   - 500 controllers
   - 20.14 ms/request
```

Serializing everything in 1 file is a bad thing, but I'm no caching expert. You could also write it away to `%kernel.cache_dir%/metadata/controller/md5(Controller::class)`, but that's up to a caching layer.

A bunch of files are copied over from the SFEB, they will ofc not be included here.

**It would be really nice to have (most of) the Annotations in the core so the best-practices can be followed without having to install additional bundles outside of the Symfony vendor namespace**.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

/cc @mmoreram as author of the ControllerExtraBundle your opinion is valued :)
