### PR TITLE
[Process] Remove unreachable return statement.

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1263,8 +1263,6 @@ class Process
                 call_user_func($callback, $type, $data);
             }
         };
-
-        return $callback;
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

[This return](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Process/Process.php#L1267) is [unreachable](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Process/Process.php#L1255) after #17427.
