### PR TITLE
[Yaml] option to dump multi line strings as scalar blocks

### DIFF
--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 3.1.0
 -----
 
+ * Added support for dumping multi line strings as literal blocks.
+
  * Added support for parsing base64 encoded binary data when they are tagged
    with the `!!binary` tag.
 

--- a/src/Symfony/Component/Yaml/Dumper.php
+++ b/src/Symfony/Component/Yaml/Dumper.php
@@ -84,6 +84,16 @@ class Dumper
             $isAHash = array_keys($input) !== range(0, count($input) - 1);
 
             foreach ($input as $key => $value) {
+                if ($inline > 1 && Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK & $flags && is_string($value) && false !== strpos($value, "\n")) {
+                    $output .= sprintf("%s%s%s |\n", $prefix, $isAHash ? Inline::dump($key, $flags).':' : '-', '');
+
+                    foreach (preg_split('/\n|\r\n/', $value) as $row) {
+                        $output .= sprintf("%s%s%s\n", $prefix, str_repeat(' ', $this->indentation), $row);
+                    }
+
+                    continue;
+                }
+
                 $willBeInlined = $inline - 1 <= 0 || !is_array($value) || empty($value);
 
                 $output .= sprintf('%s%s%s%s',

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -332,6 +332,21 @@ EOF;
 
         return $tests;
     }
+
+    public function testDumpMultiLineStringAsScalarBlock()
+    {
+        $data = array(
+            'data' => array(
+                'single_line' => 'foo bar baz',
+                'multi_line' => "foo\nline with trailing spaces:\n  \nbar\r\ninteger like line:\n123456789\nempty line:\n\nbaz",
+                'nested_inlined_multi_line_string' => array(
+                    'inlined_multi_line' => "foo\nbar\r\nempty line:\n\nbaz",
+                ),
+            ),
+        );
+
+        $this->assertSame(file_get_contents(__DIR__.'/Fixtures/multiple_lines_as_literal_block.yml'), $this->dumper->dump($data, 3, 0, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK));
+    }
 }
 
 class A

--- a/src/Symfony/Component/Yaml/Tests/Fixtures/multiple_lines_as_literal_block.yml
+++ b/src/Symfony/Component/Yaml/Tests/Fixtures/multiple_lines_as_literal_block.yml
@@ -1,0 +1,14 @@
+data:
+    single_line: 'foo bar baz'
+    multi_line: |
+        foo
+        line with trailing spaces:
+          
+        bar
+        integer like line:
+        123456789
+        empty line:
+        
+        baz
+    nested_inlined_multi_line_string:
+        inlined_multi_line: "foo\nbar\r\nempty line:\n\nbaz"

--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -28,6 +28,7 @@ class Yaml
     const PARSE_DATETIME = 32;
     const DUMP_BASE64_BINARY_DATA = 64;
     const DUMP_OBJECT_AS_MAP = 128;
+    const DUMP_MULTI_LINE_LITERAL_BLOCK = 256;
 
     /**
      * Parses YAML into a PHP value.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16236, #16604, #17912, #17391 |
| License | MIT |
| Doc PR | symfony/symfony-docs#6226 |
