### PR TITLE
[Serializer] Harden the ObjectNormalizer

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -11,8 +11,10 @@
 
 namespace Symfony\Component\Serializer\Normalizer;
 
+use Symfony\Component\PropertyAccess\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\CircularReferenceException;
 use Symfony\Component\Serializer\Exception\LogicException;
+use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 
 /**
  * Base class for a normalizer dealing with objects.
@@ -172,7 +174,11 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             $ignored = in_array($attribute, $this->ignoredAttributes);
 
             if ($allowed && !$ignored) {
-                $this->setAttributeValue($object, $attribute, $value, $format, $context);
+                try {
+                    $this->setAttributeValue($object, $attribute, $value, $format, $context);
+                } catch (InvalidArgumentException $e) {
+                    throw new UnexpectedValueException($e->getMessage(), $e->getCode(), $e);
+                }
             }
         }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -498,6 +498,14 @@ class ObjectNormalizerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $result);
     }
+
+    /**
+     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
+     */
+    public function testThrowUnexpectedValueException()
+    {
+        $this->normalizer->denormalize(array('foo' => 'bar'), ObjectTypeHinted::class);
+    }
 }
 
 class ObjectDummy
@@ -656,5 +664,12 @@ class ObjectWithStaticPropertiesAndMethods
     public static function getBaz()
     {
         return 'L';
+    }
+}
+
+class ObjectTypeHinted
+{
+    public function setFoo(array $f)
+    {
     }
 }

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -27,6 +27,9 @@
         "doctrine/annotations": "~1.0",
         "doctrine/cache": "~1.0"
     },
+    "conflict": {
+        "symfony/property-access": ">=3.0,<3.0.4|>=2.8,<2.8.4"
+    },
     "suggest": {
         "psr/cache-implementation": "For using the metadata cache.",
         "symfony/yaml": "For using the default YAML mapping loader.",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Transform `\TypeError`s to catchable serializer exceptions.

Follows #17738 and completes #17660.
