### PR TITLE
[Console] Return actual object when choosing from array of objects

### DIFF
--- a/src/Symfony/Component/Console/Question/ChoiceQuestion.php
+++ b/src/Symfony/Component/Console/Question/ChoiceQuestion.php
@@ -150,6 +150,11 @@ class ChoiceQuestion extends Question
 
                 $result = array_search($value, $choices);
 
+                // Always return numeric keys as string
+                if (false !== $result) {
+                    $result = (string) $result;
+                }
+
                 if (!$isAssoc) {
                     if (false !== $result) {
                         $result = $choices[$result];
@@ -164,7 +169,7 @@ class ChoiceQuestion extends Question
                     throw new InvalidArgumentException(sprintf($errorMessage, $value));
                 }
 
-                $multiselectChoices[] = (string) $result;
+                $multiselectChoices[] = $result;
             }
 
             if ($multiselect) {

--- a/src/Symfony/Component/Console/Tests/Fixtures/ChoiceObject.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/ChoiceObject.php
@@ -1,0 +1,16 @@
+<?php
+
+class ChoiceObject
+{
+    private $env;
+
+    public function __construct($env)
+    {
+        $this->env = $env;
+    }
+
+    public function __toString()
+    {
+        return $this->env;
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -25,6 +25,14 @@ use Symfony\Component\Console\Question\Question;
  */
 class QuestionHelperTest extends \PHPUnit_Framework_TestCase
 {
+    protected static $fixturesPath;
+
+    public static function setUpBeforeClass()
+    {
+        self::$fixturesPath = realpath(__DIR__.'/../Fixtures/');
+        require_once self::$fixturesPath.'/ChoiceObject.php';
+    }
+
     public function testAskChoice()
     {
         $questionHelper = new QuestionHelper();
@@ -342,6 +350,27 @@ class QuestionHelperTest extends \PHPUnit_Framework_TestCase
             array('env_3', 'env_3'),
             array('My environment 1', 'env_1'),
         );
+    }
+
+    public function testSelectObjectFromChoiceList()
+    {
+        $possibleChoices = array(
+            0 => new \ChoiceObject('No Environment'),
+            1 => new \ChoiceObject('My Environment 1'),
+            2 => new \ChoiceObject('My Environment 2'),
+        );
+
+        $dialog = new QuestionHelper();
+        $dialog->setInputStream($this->getInputStream("1\n"));
+        $helperSet = new HelperSet(array(new FormatterHelper()));
+        $dialog->setHelperSet($helperSet);
+
+        $question = new ChoiceQuestion('Please select the environment to load', $possibleChoices);
+        $question->setMaxAttempts(1);
+
+        $answer = $dialog->ask($this->createInputInterfaceMock(), $this->createOutputInterface(), $question);
+
+        $this->assertSame($possibleChoices[1], $answer);
     }
 
     public function testNoInteraction()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | master |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | maybe? |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The `ChoiceQuestion` always allowed passing in an array of objects to choose from, as long as all those objects implement `__toString()`. However, the answer you got back would be the output of the `__toString()` method instead of the object itself. This PR fixes that.

I'm not sure if this causes a BC break. Perhaps some people rely on this bug and try to parse the answer string in order to find the original object? But in most cases that should still just work since the object answer will be implicitly converted to string when you try to parse it.
