### PR TITLE
[Form] Add javascript template fragment

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -65,6 +65,7 @@ class FormExtension extends \Twig_Extension implements \Twig_Extension_InitRunti
             new \Twig_SimpleFunction('form_errors', null, array('node_class' => 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', 'is_safe' => array('html'))),
             new \Twig_SimpleFunction('form_label', null, array('node_class' => 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', 'is_safe' => array('html'))),
             new \Twig_SimpleFunction('form_row', null, array('node_class' => 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', 'is_safe' => array('html'))),
+            new \Twig_SimpleFunction('form_javascript', null, array('node_class' => 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', 'is_safe' => array('html'))),
             new \Twig_SimpleFunction('form_rest', null, array('node_class' => 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', 'is_safe' => array('html'))),
             new \Twig_SimpleFunction('form', null, array('node_class' => 'Symfony\Bridge\Twig\Node\RenderBlockNode', 'is_safe' => array('html'))),
             new \Twig_SimpleFunction('form_start', null, array('node_class' => 'Symfony\Bridge\Twig\Node\RenderBlockNode', 'is_safe' => array('html'))),

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -305,6 +305,14 @@
     {%- endfor %}
 {% endblock form_rest %}
 
+{%- block form_javascript -%}
+    {% for child in form -%}
+        {{- form_javascript(child) -}}
+    {%- endfor %}
+{% endblock form_javascript %}
+
+{% block button_javascript '' %}
+
 {# Support #}
 
 {%- block form_rows -%}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/templates/form/javascript.html.twig
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/templates/form/javascript.html.twig
@@ -1,0 +1,5 @@
+{% block text_javascript %}
+{% spaceless %}
+    <script type="text/javascript">text</script>
+{% endspaceless %}
+{% endblock text_javascript %}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
@@ -35,6 +35,7 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
         $rendererEngine = new TwigRendererEngine(array(
             'form_div_layout.html.twig',
             'custom_widgets.html.twig',
+            'javascript.html.twig',
         ));
         $renderer = new TwigRenderer($rendererEngine, $this->getMock('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface'));
 
@@ -154,6 +155,29 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
         $this->assertSame('<form name="form" method="get" action="0">', $html);
     }
 
+    public function testFormJavascript()
+    {
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\FormType');
+
+        $this->assertEmpty($this->renderJavascript($form->createView()));
+    }
+
+    public function testButtonJavascript()
+    {
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ButtonType');
+
+        $this->assertEmpty($this->renderJavascript($form->createView()));
+    }
+
+    public function testCustomJavascript()
+    {
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TextType');
+
+        $html = $this->renderJavascript($form->createView());
+
+        $this->assertSame('<script type="text/javascript">text</script>', $html);
+    }
+
     protected function renderForm(FormView $view, array $vars = array())
     {
         return (string) $this->extension->renderer->renderBlock($view, 'form', $vars);
@@ -196,6 +220,11 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
     protected function renderEnd(FormView $view, array $vars = array())
     {
         return (string) $this->extension->renderer->renderBlock($view, 'form_end', $vars);
+    }
+
+    protected function renderJavascript(FormView $view, array $vars = array())
+    {
+        return (string) $this->extension->renderer->searchAndRenderBlock($view, 'javascript', $vars);
     }
 
     protected function setTheme(FormView $view, array $themes)

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_javascript.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_javascript.html.php
@@ -1,0 +1,3 @@
+<?php foreach ($form as $child) : ?>
+    <?php echo $view['form']->javascript($child) ?>
+<?php endforeach; ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
@@ -187,6 +187,19 @@ class FormHelper extends Helper
     }
 
     /**
+     * Renders the javascript of the given view.
+     *
+     * @param FormView $view      The view to render the javascript for
+     * @param array    $variables Additional variables passed to the template
+     *
+     * @return string The HTML markup
+     */
+    public function javascript(FormView $view, array $variables = array())
+    {
+        return $this->renderer->searchAndRenderBlock($view, 'javascript', $variables);
+    }
+
+    /**
      * Renders views which have not already been rendered.
      *
      * @param FormView $view      The parent view

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperDivLayoutTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperDivLayoutTest.php
@@ -46,6 +46,7 @@ class FormHelperDivLayoutTest extends AbstractDivLayoutTest
         return array_merge(parent::getExtensions(), array(
             new TemplatingExtension($this->engine, $this->csrfTokenManager, array(
                 'FrameworkBundle:Form',
+                'TestBundle:Javascript',
             )),
         ));
     }
@@ -79,6 +80,29 @@ class FormHelperDivLayoutTest extends AbstractDivLayoutTest
         $html = $this->renderStart($form->createView());
 
         $this->assertSame('<form name="form" method="get" action="0">', $html);
+    }
+
+    public function testFormJavascript()
+    {
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\FormType');
+
+        $this->assertEmpty($this->renderJavascript($form->createView()));
+    }
+
+    public function testButtonJavascript()
+    {
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\ButtonType');
+
+        $this->assertEmpty($this->renderJavascript($form->createView()));
+    }
+
+    public function testCustomJavascript()
+    {
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TextType');
+
+        $html = $this->renderJavascript($form->createView());
+
+        $this->assertSame('<script type="text/javascript">text</script>', $html);
     }
 
     protected function renderForm(FormView $view, array $vars = array())
@@ -119,6 +143,11 @@ class FormHelperDivLayoutTest extends AbstractDivLayoutTest
     protected function renderEnd(FormView $view, array $vars = array())
     {
         return (string) $this->engine->get('form')->end($view, $vars);
+    }
+
+    protected function renderJavascript(FormView $view, array $vars = array())
+    {
+        return (string) $this->engine->get('form')->javascript($view, $vars);
     }
 
     protected function setTheme(FormView $view, array $themes)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/Resources/Javascript/text_javascript.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/Resources/Javascript/text_javascript.html.php
@@ -1,0 +1,1 @@
+<script type="text/javascript">text</script>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17935 |
| License | MIT |
| Doc PR | ~ |

Hey!

This PR add a javascript fragment to the form component. For tests, not sure if it is the way to do them...
