### PR TITLE
[FrameworkBundle] Fix PhpDocExtractor registration

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1010,7 +1010,7 @@ class FrameworkExtension extends Extension
 
         $loader->load('property_info.xml');
 
-        if (class_exists('phpDocumentor\Reflection\DocBlockFactoryInterface')) {
+        if (interface_exists('phpDocumentor\Reflection\DocBlockFactoryInterface')) {
             $definition = $container->register('property_info.php_doc_extractor', 'Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor');
             $definition->addTag('property_info.description_extractor', array('priority' => -1000));
             $definition->addTag('property_info.type_extractor', array('priority' => -1001));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | master |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Fix for the fix... (#17931). `class_exists` on an interface will never work. I've tested this one in real condition and it works.
