### PR TITLE
[PropertyInfo] Fix a BC break when the DocBlock is empty

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -193,21 +193,25 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
 
         $ucFirstProperty = ucfirst($property);
 
-        switch (true) {
-            case $docBlock = $this->getDocBlockFromProperty($class, $property):
-                $data = array($docBlock, self::PROPERTY, null);
-                break;
+        try {
+            switch (true) {
+                case $docBlock = $this->getDocBlockFromProperty($class, $property):
+                    $data = array($docBlock, self::PROPERTY, null);
+                    break;
 
-            case list($docBlock) = $this->getDocBlockFromMethod($class, $ucFirstProperty, self::ACCESSOR):
-                $data = array($docBlock, self::ACCESSOR, null);
-                break;
+                case list($docBlock) = $this->getDocBlockFromMethod($class, $ucFirstProperty, self::ACCESSOR):
+                    $data = array($docBlock, self::ACCESSOR, null);
+                    break;
 
-            case list($docBlock, $prefix) = $this->getDocBlockFromMethod($class, $ucFirstProperty, self::MUTATOR):
-                $data = array($docBlock, self::MUTATOR, $prefix);
-                break;
+                case list($docBlock, $prefix) = $this->getDocBlockFromMethod($class, $ucFirstProperty, self::MUTATOR):
+                    $data = array($docBlock, self::MUTATOR, $prefix);
+                    break;
 
-            default:
-                $data = array(null, null, null);
+                default:
+                    $data = array(null, null, null);
+            }
+        } catch (\InvalidArgumentException $e) {
+            $data = array(null, null, null);
         }
 
         return $this->docBlocks[$propertyHash] = $data;

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractors/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractors/PhpDocExtractorTest.php
@@ -70,4 +70,14 @@ class PhpDocExtractorTest extends \PHPUnit_Framework_TestCase
             array('donotexist', null, null, null),
         );
     }
+
+    public function testReturnNullOnEmptyDocBlock()
+    {
+        $this->assertNull($this->extractor->getShortDescription(EmptyDocBlock::class, 'foo'));
+    }
+}
+
+class EmptyDocBlock
+{
+    public $foo;
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | master |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

BC break introduced by #17531.
