### PR TITLE
[Form] allow `entry_options` option of CollectionType to be dynamic

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
@@ -29,7 +29,9 @@ class ResizeFormListener implements EventSubscriberInterface
     protected $type;
 
     /**
-     * @var array
+     * A callable get passed each entry as only argument.
+     *
+     * @var array|callable
      */
     protected $options;
 
@@ -52,7 +54,7 @@ class ResizeFormListener implements EventSubscriberInterface
      */
     private $deleteEmpty;
 
-    public function __construct($type, array $options = array(), $allowAdd = false, $allowDelete = false, $deleteEmpty = false)
+    public function __construct($type, $options = array(), $allowAdd = false, $allowDelete = false, $deleteEmpty = false)
     {
         $this->type = $type;
         $this->allowAdd = $allowAdd;
@@ -91,9 +93,10 @@ class ResizeFormListener implements EventSubscriberInterface
 
         // Then add all rows again in the correct order
         foreach ($data as $name => $value) {
+
             $form->add($name, $this->type, array_replace(array(
                 'property_path' => '['.$name.']',
-            ), $this->options));
+            ), $this->getOptionsForEntry($value)));
         }
     }
 
@@ -125,7 +128,7 @@ class ResizeFormListener implements EventSubscriberInterface
                 if (!$form->has($name)) {
                     $form->add($name, $this->type, array_replace(array(
                         'property_path' => '['.$name.']',
-                    ), $this->options));
+                    ), $this->getOptionsForEntry($value)));
                 }
             }
         }
@@ -179,5 +182,17 @@ class ResizeFormListener implements EventSubscriberInterface
         }
 
         $event->setData($data);
+    }
+
+    /**
+     * If options are dynamic pass the item value to the callable.
+     *
+     * @param mixed $value Data value of a collection item
+     *
+     * @return array The options
+     */
+    protected function getOptionsForEntry($value)
+    {
+        return is_callable($this->options) ? call_user_func($this->options, $value) : $this->options;
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -27,16 +27,7 @@ class CollectionType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         if ($options['allow_add'] && $options['prototype']) {
-            $prototypeOptions = array_replace(array(
-                'required' => $options['required'],
-                'label' => $options['prototype_name'].'label__',
-            ), $options['entry_options']);
-
-            if (null !== $options['prototype_data']) {
-                $prototypeOptions['data'] = $options['prototype_data'];
-            }
-
-            $prototype = $builder->create($options['prototype_name'], $options['entry_type'], $prototypeOptions);
+            $prototype = $builder->create($options['prototype_name'], $options['entry_type'], $options['prototype_options']);
             $builder->setAttribute('prototype', $prototype->getForm());
         }
 
@@ -81,24 +72,53 @@ class CollectionType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $entryOptionsNormalizer = function (Options $options, $value) {
-            $value['block_name'] = 'entry';
+        $entryOptionsNormalizer = function (Options $options, $entryOptions) {
+            $entryOptions['block_name'] = 'entry';
 
-            return $value;
+            return $entryOptions;
+        };
+
+        $prototypeOptionsNormalizer = function (Options $options, $prototypeOptions) {
+            // Default to 'entry_options' option
+            $prototypeOptions = array_replace($options['entry_options'], $prototypeOptions);
+
+            if (null !== $options['prototype_data']) {
+                @trigger_error('The "prototype_data" option is deprecated since version 3.1 and will be removed in 4.0. You should use "prototype_options" option instead.', E_USER_DEPRECATED);
+
+                // BC, Let 'prototype_data' option override `$entryOptions['data']`
+                $prototypeOptions['data'] = $options['prototype_data'];
+            }
+
+            return array_replace(array(
+                // Use the collection required state
+                'required' => $options['required'],
+                'label' => $options['prototype_name'].'label__',
+            ), $prototypeOptions);
         };
 
         $resolver->setDefaults(array(
-            'allow_add' => false,
-            'allow_delete' => false,
-            'prototype' => true,
-            'prototype_data' => null,
-            'prototype_name' => '__name__',
             'entry_type' => __NAMESPACE__.'\TextType',
             'entry_options' => array(),
+            'prototype' => true,
+            'prototype_data' => null, // deprecated
+            'prototype_name' => '__name__',
+            'prototype_options' => array(),
+            'allow_add' => false,
+            'allow_delete' => false,
             'delete_empty' => false,
         ));
 
         $resolver->setNormalizer('entry_options', $entryOptionsNormalizer);
+        $resolver->setNormalizer('prototype_options', $prototypeOptionsNormalizer);
+
+        $resolver->setAllowedTypes('entry_type', array('string', 'Symfony\Component\Form\FormTypeInterface'));
+        $resolver->setAllowedTypes('entry_options', 'array');
+        $resolver->setAllowedTypes('prototype', 'bool');
+        $resolver->setAllowedTypes('prototype_name', 'string');
+        $resolver->setAllowedTypes('prototype_options', 'array');
+        $resolver->setAllowedTypes('allow_add', 'bool');
+        $resolver->setAllowedTypes('allow_delete', 'bool');
+        $resolver->setAllowedTypes('delete_empty', 'bool');
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -273,6 +273,9 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertSame('__test__label__', $form->createView()->vars['prototype']->vars['label']);
     }
 
+    /**
+     * @group legacy
+     */
     public function testPrototypeData()
     {
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', array(), array(
@@ -288,6 +291,31 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
         $this->assertSame('foo', $form->createView()->vars['prototype']->vars['value']);
         $this->assertFalse($form->createView()->vars['prototype']->vars['label']);
+    }
+
+    public function testPrototypeOptions()
+    {
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', array(), array(
+            'allow_add' => true,
+            'prototype' => true,
+            'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+            'entry_options' => array(
+                'data' => 'foo',
+                'label' => 'Item:',
+                'attr' => array('class' => 'my&item&class'),
+                'label_attr' => array('class' => 'my&item&label&class'),
+            ),
+            'prototype_options' => array(
+                'data' => 'bar',
+                'label' => false,
+                'attr' => array('class' => 'my&prototype&class'),
+            ),
+        ));
+
+        $this->assertSame('bar', $form->createView()->vars['prototype']->vars['value']);
+        $this->assertFalse($form->createView()->vars['prototype']->vars['label']);
+        $this->assertSame('my&prototype&class', $form->createView()->vars['prototype']->vars['attr']['class']);
+        $this->assertSame('my&item&label&class', $form->createView()->vars['prototype']->vars['label_attr']['class']);
     }
 
     public function testPrototypeDefaultRequired()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -343,4 +343,182 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertFalse($form->createView()->vars['required'], 'collection is not required');
         $this->assertFalse($form->createView()->vars['prototype']->vars['required'], '"prototype" should not be required');
     }
+
+    public function testEntryOptions()
+    {
+        $data = array(
+            'foo',
+            'bar',
+        );
+
+        $expectedAttr = array('class' => 'my&item&class', 'data-value' => 'my&value');
+
+        $view = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', $data, array(
+            'allow_add' => true,
+            'prototype' => true,
+            'prototype_name' => '__test__',
+            'entry_options' => array(
+                'label' => 'Item Label:',
+                'attr' => $expectedAttr,
+            ),
+        ))->createView();
+
+        $this->assertSame('Item Label:', $view->children[0]->vars['label']);
+        $this->assertSame('Item Label:', $view->children[1]->vars['label']);
+        $this->assertSame($expectedAttr, $view->children[0]->vars['attr']);
+        $this->assertSame($expectedAttr, $view->children[1]->vars['attr']);
+        $this->assertSame('_collection_entry', $view->children[0]->vars['unique_block_prefix']);
+        $this->assertSame('_collection_entry', $view->children[1]->vars['unique_block_prefix']);
+    }
+
+    public function testEntryOptionsAsCallable()
+    {
+        $data = array(
+            'foo',
+            'bar',
+        );
+
+        $view = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', $data, array(
+            'allow_add' => true,
+            'prototype' => true,
+            'prototype_name' => '__test__',
+            'entry_options' => function ($entry) {
+                return array(
+                    'label' => ucfirst($entry).':',
+                    'attr' => array('class' => $entry.'&class', 'data-upper' => strtoupper($entry)),
+                );
+            },
+        ))->createView();
+
+        $expectedAttr = array(
+            array('class' => 'foo&class', 'data-upper' => 'FOO'),
+            array('class' => 'bar&class', 'data-upper' => 'BAR'),
+        );
+
+        $this->assertSame('Foo:', $view->children[0]->vars['label']);
+        $this->assertSame('Bar:', $view->children[1]->vars['label']);
+        $this->assertSame($expectedAttr[0], $view->children[0]->vars['attr']);
+        $this->assertSame($expectedAttr[1], $view->children[1]->vars['attr']);
+        $this->assertSame('_collection_entry', $view->children[0]->vars['unique_block_prefix']);
+        $this->assertSame('_collection_entry', $view->children[1]->vars['unique_block_prefix']);
+    }
+
+    public function setEntryOptions($entry)
+    {
+        return array(
+            'label' => ucfirst($entry).':',
+            'attr' => array('class' => $entry.'&class', 'data-upper' => strtoupper($entry)),
+        );
+    }
+
+    public function testEntryOptionsAsCallableInArray()
+    {
+        $data = array(
+            'foo',
+            'bar',
+        );
+
+        $view = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', $data, array(
+            'allow_add' => true,
+            'prototype' => true,
+            'prototype_name' => '__test__',
+            'entry_options' => array($this, 'setEntryOptions'),
+        ))->createView();
+
+        $expectedAttr = array(
+            array('class' => 'foo&class', 'data-upper' => 'FOO'),
+            array('class' => 'bar&class', 'data-upper' => 'BAR'),
+        );
+
+        $this->assertSame('Foo:', $view->children[0]->vars['label']);
+        $this->assertSame('Bar:', $view->children[1]->vars['label']);
+        $this->assertSame($expectedAttr[0], $view->children[0]->vars['attr']);
+        $this->assertSame($expectedAttr[1], $view->children[1]->vars['attr']);
+        $this->assertSame('_collection_entry', $view->children[0]->vars['unique_block_prefix']);
+        $this->assertSame('_collection_entry', $view->children[1]->vars['unique_block_prefix']);
+    }
+
+    public function testEntryOptionsAsCallableWithPrototypeUsePrototypeOptionsData()
+    {
+        $data = array(
+            'foo',
+            'bar',
+        );
+
+        $view = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', $data, array(
+            'allow_add' => true,
+            'prototype' => true,
+            'prototype_name' => '__test__',
+            'entry_options' => function ($entry) {
+                return array(
+                    'label' => ucfirst($entry).':',
+                    'attr' => array('class' => $entry.'&class', 'data-upper' => strtoupper($entry)),
+                );
+            },
+            'prototype_options' => array(
+                'data' => 'baz',
+                'required' => false,
+            ),
+        ))->createView();
+
+        $expectedAttr = array(
+            'entry1' => array('class' => 'foo&class', 'data-upper' => 'FOO'),
+            'entry2' => array('class' => 'bar&class', 'data-upper' => 'BAR'),
+            'prototype' => array('class' => 'baz&class', 'data-upper' => 'BAZ'),
+        );
+
+        $this->assertSame('Foo:', $view->children[0]->vars['label']);
+        $this->assertSame('Bar:', $view->children[1]->vars['label']);
+        $this->assertSame($expectedAttr['entry1'], $view->children[0]->vars['attr']);
+        $this->assertSame($expectedAttr['entry2'], $view->children[1]->vars['attr']);
+        $this->assertSame($expectedAttr['prototype'], $view->vars['prototype']->vars['attr']);
+        $this->assertFalse($view->vars['prototype']->vars['required']);
+        $this->assertSame('_collection_entry', $view->children[0]->vars['unique_block_prefix']);
+        $this->assertSame('_collection_entry', $view->children[1]->vars['unique_block_prefix']);
+        $this->assertSame('_collection_entry', $view->vars['prototype']->vars['unique_block_prefix']);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testEntryOptionsAsCallableWithPrototypeUsePrototypeData()
+    {
+        $data = array(
+            'foo',
+            'bar',
+        );
+
+        $view = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\CollectionType', $data, array(
+            'allow_add' => true,
+            'prototype' => true,
+            'prototype_name' => '__test__',
+            'entry_options' => function ($entry) {
+                return array(
+                    'label' => ucfirst($entry).':',
+                    'attr' => array('class' => $entry.'&class', 'data-upper' => strtoupper($entry)),
+                );
+            },
+            'prototype_options' => array(
+                'required' => false,
+            ),
+            'prototype_data' => 'baz',
+        ))->createView();
+
+        $expectedAttr = array(
+            'entry1' => array('class' => 'foo&class', 'data-upper' => 'FOO'),
+            'entry2' => array('class' => 'bar&class', 'data-upper' => 'BAR'),
+            'prototype' => array('class' => 'baz&class', 'data-upper' => 'BAZ'),
+        );
+
+        $this->assertSame('Foo:', $view->children[0]->vars['label']);
+        $this->assertSame('Bar:', $view->children[1]->vars['label']);
+        $this->assertSame('Baz:', $view->vars['prototype']->vars['label']);
+        $this->assertSame($expectedAttr['entry1'], $view->children[0]->vars['attr']);
+        $this->assertSame($expectedAttr['entry2'], $view->children[1]->vars['attr']);
+        $this->assertSame($expectedAttr['prototype'], $view->vars['prototype']->vars['attr']);
+        $this->assertFalse($view->vars['prototype']->vars['required']);
+        $this->assertSame('_collection_entry', $view->children[0]->vars['unique_block_prefix']);
+        $this->assertSame('_collection_entry', $view->children[1]->vars['unique_block_prefix']);
+        $this->assertSame('_collection_entry', $view->vars['prototype']->vars['unique_block_prefix']);
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | symfony/symfony-docs#6319 |
- Deprecate usage of `prototype_data` option in favor of `prototype_options`.
- The `ResizeFormListener` now passes each entry of the collection to the `entry_options` option if it is a callable.
