### PR TITLE
[2.3][WebProfilerBundle] fix debug toolbar rendering by removing inadvertently added links

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_item.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_item.html.twig
@@ -1,4 +1,4 @@
-{% if link|default(true) %}
+{% if link is not defined or link %}
     {% set icon %}
         <a href="{{ path('_profiler', { 'token': token, 'panel': name }) }}">{{ icon }}</a>
     {% endset %}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | 2.3+ |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The debug toolbar was broken by #17527...

**before**
![debug-toolbar-link-a](https://cloud.githubusercontent.com/assets/800119/13433728/7c48c382-dfd3-11e5-8432-299bfa143647.png)

**and after**
![debug-toolbar-link-b](https://cloud.githubusercontent.com/assets/800119/13433732/7fd97dc0-dfd3-11e5-80c6-62c009447a2e.png)

**explanation**
If `false` is explicitly passed for `link` then `link | default(true)` would evaluate to `true`, which is not what we want. The correct expression `link is not defined or link` was suggested originally in #16653.
