### PR TITLE
[CS] fix class element order

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ManagerRegistry.php
+++ b/src/Symfony/Bridge/Doctrine/ManagerRegistry.php
@@ -30,6 +30,14 @@ abstract class ManagerRegistry extends AbstractManagerRegistry implements Contai
     /**
      * {@inheritdoc}
      */
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function getService($name)
     {
         return $this->container->get($name);
@@ -41,13 +49,5 @@ abstract class ManagerRegistry extends AbstractManagerRegistry implements Contai
     protected function resetService($name)
     {
         $this->container->set($name, null);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setContainer(ContainerInterface $container = null)
-    {
-        $this->container = $container;
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Test/DoctrineTestHelper.php
+++ b/src/Symfony/Bridge/Doctrine/Test/DoctrineTestHelper.php
@@ -23,6 +23,13 @@ use Doctrine\ORM\EntityManager;
 class DoctrineTestHelper
 {
     /**
+     * This class cannot be instantiated.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
      * Returns an entity manager for testing.
      *
      * @return EntityManager
@@ -48,12 +55,5 @@ class DoctrineTestHelper
         );
 
         return EntityManager::create($params, $config);
-    }
-
-    /**
-     * This class cannot be instantiated.
-     */
-    private function __construct()
-    {
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/ORMQueryBuilderLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/ORMQueryBuilderLoaderTest.php
@@ -47,35 +47,6 @@ class ORMQueryBuilderLoaderTest extends \PHPUnit_Framework_TestCase
         $this->checkIdentifierType('Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity', Connection::PARAM_INT_ARRAY);
     }
 
-    protected function checkIdentifierType($classname, $expectedType)
-    {
-        $em = DoctrineTestHelper::createTestEntityManager();
-
-        $query = $this->getMockBuilder('QueryMock')
-            ->setMethods(array('setParameter', 'getResult', 'getSql', '_doExecute'))
-            ->getMock();
-
-        $query->expects($this->once())
-            ->method('setParameter')
-            ->with('ORMQueryBuilderLoader_getEntitiesByIds_id', array(1, 2), $expectedType)
-            ->willReturn($query);
-
-        $qb = $this->getMockBuilder('Doctrine\ORM\QueryBuilder')
-            ->setConstructorArgs(array($em))
-            ->setMethods(array('getQuery'))
-            ->getMock();
-
-        $qb->expects($this->once())
-            ->method('getQuery')
-            ->willReturn($query);
-
-        $qb->select('e')
-            ->from($classname, 'e');
-
-        $loader = new ORMQueryBuilderLoader($qb);
-        $loader->getEntitiesByIds('id', array(1, 2));
-    }
-
     public function testFilterNonIntegerValues()
     {
         $em = DoctrineTestHelper::createTestEntityManager();
@@ -137,5 +108,34 @@ class ORMQueryBuilderLoaderTest extends \PHPUnit_Framework_TestCase
 
         $loader = new ORMQueryBuilderLoader($qb);
         $loader->getEntitiesByIds('id.value', array(1, '', 2, 3, 'foo'));
+    }
+
+    protected function checkIdentifierType($classname, $expectedType)
+    {
+        $em = DoctrineTestHelper::createTestEntityManager();
+
+        $query = $this->getMockBuilder('QueryMock')
+            ->setMethods(array('setParameter', 'getResult', 'getSql', '_doExecute'))
+            ->getMock();
+
+        $query->expects($this->once())
+            ->method('setParameter')
+            ->with('ORMQueryBuilderLoader_getEntitiesByIds_id', array(1, 2), $expectedType)
+            ->willReturn($query);
+
+        $qb = $this->getMockBuilder('Doctrine\ORM\QueryBuilder')
+            ->setConstructorArgs(array($em))
+            ->setMethods(array('getQuery'))
+            ->getMock();
+
+        $qb->expects($this->once())
+            ->method('getQuery')
+            ->willReturn($query);
+
+        $qb->select('e')
+            ->from($classname, 'e');
+
+        $loader = new ORMQueryBuilderLoader($qb);
+        $loader->getEntitiesByIds('id', array(1, 2));
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
@@ -30,24 +30,6 @@ class EntityTypePerformanceTest extends FormPerformanceTestCase
      */
     private $em;
 
-    protected function getExtensions()
-    {
-        $manager = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
-
-        $manager->expects($this->any())
-            ->method('getManager')
-            ->will($this->returnValue($this->em));
-
-        $manager->expects($this->any())
-            ->method('getManagerForClass')
-            ->will($this->returnValue($this->em));
-
-        return array(
-            new CoreExtension(),
-            new DoctrineOrmExtension($manager),
-        );
-    }
-
     protected function setUp()
     {
         $this->em = DoctrineTestHelper::createTestEntityManager();
@@ -135,5 +117,23 @@ class EntityTypePerformanceTest extends FormPerformanceTestCase
             // force loading of the choice list
             $form->createView();
         }
+    }
+
+    protected function getExtensions()
+    {
+        $manager = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+
+        $manager->expects($this->any())
+            ->method('getManager')
+            ->will($this->returnValue($this->em));
+
+        $manager->expects($this->any())
+            ->method('getManagerForClass')
+            ->will($this->returnValue($this->em));
+
+        return array(
+            new CoreExtension(),
+            new DoctrineOrmExtension($manager),
+        );
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -76,24 +76,6 @@ class EntityTypeTest extends TypeTestCase
         $this->emRegistry = null;
     }
 
-    protected function getExtensions()
-    {
-        return array_merge(parent::getExtensions(), array(
-            new DoctrineOrmExtension($this->emRegistry),
-        ));
-    }
-
-    protected function persist(array $entities)
-    {
-        foreach ($entities as $entity) {
-            $this->em->persist($entity);
-        }
-
-        $this->em->flush();
-        // no clear, because entities managed by the choice field must
-        // be managed!
-    }
-
     /**
      * @expectedException \Symfony\Component\OptionsResolver\Exception\MissingOptionsException
      */
@@ -739,6 +721,24 @@ class EntityTypeTest extends TypeTestCase
             'required' => false,
             'property' => 'name',
         ));
+    }
+
+    protected function getExtensions()
+    {
+        return array_merge(parent::getExtensions(), array(
+            new DoctrineOrmExtension($this->emRegistry),
+        ));
+    }
+
+    protected function persist(array $entities)
+    {
+        foreach ($entities as $entity) {
+            $this->em->persist($entity);
+        }
+
+        $this->em->flush();
+        // no clear, because entities managed by the choice field must
+        // be managed!
     }
 
     protected function createRegistryMock($name, $em)

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -55,82 +55,6 @@ class UniqueEntityValidatorTest extends AbstractConstraintValidatorTest
         parent::setUp();
     }
 
-    protected function createRegistryMock(ObjectManager $em = null)
-    {
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
-        $registry->expects($this->any())
-                 ->method('getManager')
-                 ->with($this->equalTo(self::EM_NAME))
-                 ->will($this->returnValue($em));
-
-        return $registry;
-    }
-
-    protected function createRepositoryMock()
-    {
-        $repository = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectRepository')
-            ->setMethods(array('findByCustom', 'find', 'findAll', 'findOneBy', 'findBy', 'getClassName'))
-            ->getMock()
-        ;
-
-        return $repository;
-    }
-
-    protected function createEntityManagerMock($repositoryMock)
-    {
-        $em = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectManager')
-            ->getMock()
-        ;
-        $em->expects($this->any())
-             ->method('getRepository')
-             ->will($this->returnValue($repositoryMock))
-        ;
-
-        $classMetadata = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
-        $classMetadata
-            ->expects($this->any())
-            ->method('hasField')
-            ->will($this->returnValue(true))
-        ;
-        $reflParser = $this->getMockBuilder('Doctrine\Common\Reflection\StaticReflectionParser')
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
-        $refl = $this->getMockBuilder('Doctrine\Common\Reflection\StaticReflectionProperty')
-            ->setConstructorArgs(array($reflParser, 'property-name'))
-            ->setMethods(array('getValue'))
-            ->getMock()
-        ;
-        $refl
-            ->expects($this->any())
-            ->method('getValue')
-            ->will($this->returnValue(true))
-        ;
-        $classMetadata->reflFields = array('name' => $refl);
-        $em->expects($this->any())
-             ->method('getClassMetadata')
-             ->will($this->returnValue($classMetadata))
-        ;
-
-        return $em;
-    }
-
-    protected function createValidator()
-    {
-        return new UniqueEntityValidator($this->registry);
-    }
-
-    private function createSchema(ObjectManager $em)
-    {
-        $schemaTool = new SchemaTool($em);
-        $schemaTool->createSchema(array(
-            $em->getClassMetadata('Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity'),
-            $em->getClassMetadata('Symfony\Bridge\Doctrine\Tests\Fixtures\DoubleNameEntity'),
-            $em->getClassMetadata('Symfony\Bridge\Doctrine\Tests\Fixtures\CompositeIntIdEntity'),
-            $em->getClassMetadata('Symfony\Bridge\Doctrine\Tests\Fixtures\AssociationEntity'),
-        ));
-    }
-
     /**
      * This is a functional test as there is a large integration necessary to get the validator working.
      */
@@ -463,5 +387,81 @@ class UniqueEntityValidatorTest extends AbstractConstraintValidatorTest
         $entity = new SingleIntIdEntity(1, null);
 
         $this->validator->validate($entity, $constraint);
+    }
+
+    protected function createRegistryMock(ObjectManager $em = null)
+    {
+        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry->expects($this->any())
+                 ->method('getManager')
+                 ->with($this->equalTo(self::EM_NAME))
+                 ->will($this->returnValue($em));
+
+        return $registry;
+    }
+
+    protected function createRepositoryMock()
+    {
+        $repository = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectRepository')
+            ->setMethods(array('findByCustom', 'find', 'findAll', 'findOneBy', 'findBy', 'getClassName'))
+            ->getMock()
+        ;
+
+        return $repository;
+    }
+
+    protected function createEntityManagerMock($repositoryMock)
+    {
+        $em = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectManager')
+            ->getMock()
+        ;
+        $em->expects($this->any())
+             ->method('getRepository')
+             ->will($this->returnValue($repositoryMock))
+        ;
+
+        $classMetadata = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $classMetadata
+            ->expects($this->any())
+            ->method('hasField')
+            ->will($this->returnValue(true))
+        ;
+        $reflParser = $this->getMockBuilder('Doctrine\Common\Reflection\StaticReflectionParser')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $refl = $this->getMockBuilder('Doctrine\Common\Reflection\StaticReflectionProperty')
+            ->setConstructorArgs(array($reflParser, 'property-name'))
+            ->setMethods(array('getValue'))
+            ->getMock()
+        ;
+        $refl
+            ->expects($this->any())
+            ->method('getValue')
+            ->will($this->returnValue(true))
+        ;
+        $classMetadata->reflFields = array('name' => $refl);
+        $em->expects($this->any())
+             ->method('getClassMetadata')
+             ->will($this->returnValue($classMetadata))
+        ;
+
+        return $em;
+    }
+
+    protected function createValidator()
+    {
+        return new UniqueEntityValidator($this->registry);
+    }
+
+    private function createSchema(ObjectManager $em)
+    {
+        $schemaTool = new SchemaTool($em);
+        $schemaTool->createSchema(array(
+            $em->getClassMetadata('Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity'),
+            $em->getClassMetadata('Symfony\Bridge\Doctrine\Tests\Fixtures\DoubleNameEntity'),
+            $em->getClassMetadata('Symfony\Bridge\Doctrine\Tests\Fixtures\CompositeIntIdEntity'),
+            $em->getClassMetadata('Symfony\Bridge\Doctrine\Tests\Fixtures\AssociationEntity'),
+        ));
     }
 }

--- a/src/Symfony/Bridge/Propel1/DataCollector/PropelDataCollector.php
+++ b/src/Symfony/Bridge/Propel1/DataCollector/PropelDataCollector.php
@@ -24,18 +24,17 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 class PropelDataCollector extends DataCollector
 {
     /**
-     * Propel logger.
-     *
-     * @var PropelLogger
-     */
-    private $logger;
-
-    /**
      * Propel configuration.
      *
      * @var \PropelConfiguration
      */
     protected $propelConfiguration;
+    /**
+     * Propel logger.
+     *
+     * @var PropelLogger
+     */
+    private $logger;
 
     /**
      * Constructor.

--- a/src/Symfony/Bridge/Propel1/Tests/Form/ChoiceList/CompatModelChoiceListTest.php
+++ b/src/Symfony/Bridge/Propel1/Tests/Form/ChoiceList/CompatModelChoiceListTest.php
@@ -30,23 +30,6 @@ class CompatModelChoiceListTest extends AbstractChoiceListTest
     protected $item3;
     protected $item4;
 
-    public function testGetChoicesForValues()
-    {
-        $this->query
-            ->expects($this->once())
-            ->method('filterById')
-            ->with(array(1, 2))
-            ->will($this->returnSelf())
-        ;
-
-        ItemQuery::$result = array(
-            $this->item2,
-            $this->item1,
-        );
-
-        parent::testGetChoicesForValues();
-    }
-
     protected function setUp()
     {
         $this->query = $this->getMock('Symfony\Bridge\Propel1\Tests\Fixtures\ItemQuery', array(
@@ -70,6 +53,23 @@ class CompatModelChoiceListTest extends AbstractChoiceListTest
         );
 
         parent::setUp();
+    }
+
+    public function testGetChoicesForValues()
+    {
+        $this->query
+            ->expects($this->once())
+            ->method('filterById')
+            ->with(array(1, 2))
+            ->will($this->returnSelf())
+        ;
+
+        ItemQuery::$result = array(
+            $this->item2,
+            $this->item1,
+        );
+
+        parent::testGetChoicesForValues();
     }
 
     protected function createItems()

--- a/src/Symfony/Bridge/Propel1/Tests/Form/Type/TranslationCollectionTypeTest.php
+++ b/src/Symfony/Bridge/Propel1/Tests/Form/Type/TranslationCollectionTypeTest.php
@@ -23,11 +23,6 @@ class TranslationCollectionTypeTest extends TypeTestCase
     const TRANSLATABLE_I18N_CLASS = 'Symfony\Bridge\Propel1\Tests\Fixtures\TranslatableItemI18n';
     const NON_TRANSLATION_CLASS = 'Symfony\Bridge\Propel1\Tests\Fixtures\Item';
 
-    protected function getExtensions()
-    {
-        return array(new PropelExtension());
-    }
-
     public function testTranslationsAdded()
     {
         $item = new TranslatableItem();
@@ -147,5 +142,10 @@ class TranslationCollectionTypeTest extends TypeTestCase
                 'data_class' => self::TRANSLATABLE_I18N_CLASS,
             ),
         ));
+    }
+
+    protected function getExtensions()
+    {
+        return array(new PropelExtension());
     }
 }

--- a/src/Symfony/Bridge/Twig/NodeVisitor/TranslationDefaultDomainNodeVisitor.php
+++ b/src/Symfony/Bridge/Twig/NodeVisitor/TranslationDefaultDomainNodeVisitor.php
@@ -37,6 +37,14 @@ class TranslationDefaultDomainNodeVisitor extends \Twig_BaseNodeVisitor
     /**
      * {@inheritdoc}
      */
+    public function getPriority()
+    {
+        return -10;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function doEnterNode(\Twig_Node $node, \Twig_Environment $env)
     {
         if ($node instanceof \Twig_Node_Block || $node instanceof \Twig_Node_Module) {
@@ -100,14 +108,6 @@ class TranslationDefaultDomainNodeVisitor extends \Twig_BaseNodeVisitor
         }
 
         return $node;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getPriority()
-    {
-        return -10;
     }
 
     /**

--- a/src/Symfony/Bridge/Twig/NodeVisitor/TranslationNodeVisitor.php
+++ b/src/Symfony/Bridge/Twig/NodeVisitor/TranslationNodeVisitor.php
@@ -45,6 +45,14 @@ class TranslationNodeVisitor extends \Twig_BaseNodeVisitor
     /**
      * {@inheritdoc}
      */
+    public function getPriority()
+    {
+        return 0;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function doEnterNode(\Twig_Node $node, \Twig_Environment $env)
     {
         if (!$this->enabled) {
@@ -88,14 +96,6 @@ class TranslationNodeVisitor extends \Twig_BaseNodeVisitor
     protected function doLeaveNode(\Twig_Node $node, \Twig_Environment $env)
     {
         return $node;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getPriority()
-    {
-        return 0;
     }
 
     /**

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
@@ -137,6 +137,20 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
         $this->assertSame($expected, $this->extension->isSelectedChoice($choice, $value));
     }
 
+    public static function themeBlockInheritanceProvider()
+    {
+        return array(
+            array(array('theme.html.twig')),
+        );
+    }
+
+    public static function themeInheritanceProvider()
+    {
+        return array(
+            array(array('parent_label.html.twig'), array('child_label.html.twig')),
+        );
+    }
+
     protected function renderForm(FormView $view, array $vars = array())
     {
         return (string) $this->extension->renderer->renderBlock($view, 'form', $vars);
@@ -189,19 +203,5 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
     protected function setTheme(FormView $view, array $themes)
     {
         $this->extension->renderer->setTheme($view, $themes);
-    }
-
-    public static function themeBlockInheritanceProvider()
-    {
-        return array(
-            array(array('theme.html.twig')),
-        );
-    }
-
-    public static function themeInheritanceProvider()
-    {
-        return array(
-            array(array('parent_label.html.twig'), array('child_label.html.twig')),
-        );
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerAwareCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerAwareCommand.php
@@ -28,6 +28,14 @@ abstract class ContainerAwareCommand extends Command implements ContainerAwareIn
     private $container;
 
     /**
+     * {@inheritdoc}
+     */
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    /**
      * @return ContainerInterface
      *
      * @throws \LogicException
@@ -44,13 +52,5 @@ abstract class ContainerAwareCommand extends Command implements ContainerAwareIn
         }
 
         return $this->container;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setContainer(ContainerInterface $container = null)
-    {
-        $this->container = $container;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -132,6 +132,21 @@ class FrameworkExtension extends Extension
     }
 
     /**
+     * Returns the base path for the XSD files.
+     *
+     * @return string The XSD base path
+     */
+    public function getXsdValidationBasePath()
+    {
+        return __DIR__.'/../Resources/config/schema';
+    }
+
+    public function getNamespace()
+    {
+        return 'http://symfony.com/schema/dic/symfony';
+    }
+
+    /**
      * Loads Form configuration.
      *
      * @param array            $config    A configuration array
@@ -693,20 +708,5 @@ class FrameworkExtension extends Extension
             ;
             $container->setAlias('annotation_reader', 'annotations.cached_reader');
         }
-    }
-
-    /**
-     * Returns the base path for the XSD files.
-     *
-     * @return string The XSD base path
-     */
-    public function getXsdValidationBasePath()
-    {
-        return __DIR__.'/../Resources/config/schema';
-    }
-
-    public function getNamespace()
-    {
-        return 'http://symfony.com/schema/dic/symfony';
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/DelegatingEngine.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/DelegatingEngine.php
@@ -55,6 +55,20 @@ class DelegatingEngine extends BaseDelegatingEngine implements EngineInterface
     }
 
     /**
+     * Renders a view and returns a Response.
+     *
+     * @param string   $view       The view name
+     * @param array    $parameters An array of parameters to pass to the view
+     * @param Response $response   A Response instance
+     *
+     * @return Response A Response instance
+     */
+    public function renderResponse($view, array $parameters = array(), Response $response = null)
+    {
+        return $this->getEngine($view)->renderResponse($view, $parameters, $response);
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getEngine($name)
@@ -70,19 +84,5 @@ class DelegatingEngine extends BaseDelegatingEngine implements EngineInterface
         }
 
         throw new \RuntimeException(sprintf('No engine is able to work with the template "%s".', $name));
-    }
-
-    /**
-     * Renders a view and returns a Response.
-     *
-     * @param string   $view       The view name
-     * @param array    $parameters An array of parameters to pass to the view
-     * @param Response $response   A Response instance
-     *
-     * @return Response A Response instance
-     */
-    public function renderResponse($view, array $parameters = array(), Response $response = null)
-    {
-        return $this->getEngine($view)->renderResponse($view, $parameters, $response);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/TemplateLocator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/TemplateLocator.php
@@ -42,18 +42,6 @@ class TemplateLocator implements FileLocatorInterface
     /**
      * Returns a full path for a given file.
      *
-     * @param TemplateReferenceInterface $template A template
-     *
-     * @return string The full path for the file
-     */
-    protected function getCacheKey($template)
-    {
-        return $template->getLogicalName();
-    }
-
-    /**
-     * Returns a full path for a given file.
-     *
      * @param TemplateReferenceInterface $template    A template
      * @param string                     $currentPath Unused
      * @param bool                       $first       Unused
@@ -80,5 +68,17 @@ class TemplateLocator implements FileLocatorInterface
         } catch (\InvalidArgumentException $e) {
             throw new \InvalidArgumentException(sprintf('Unable to find template "%s" : "%s".', $template, $e->getMessage()), 0, $e);
         }
+    }
+
+    /**
+     * Returns a full path for a given file.
+     *
+     * @param TemplateReferenceInterface $template A template
+     *
+     * @return string The full path for the file
+     */
+    protected function getCacheKey($template)
+    {
+        return $template->getLogicalName();
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -30,6 +30,16 @@ abstract class WebTestCase extends \PHPUnit_Framework_TestCase
     protected static $kernel;
 
     /**
+     * Shuts the kernel down if it was used in the test.
+     */
+    protected function tearDown()
+    {
+        if (null !== static::$kernel) {
+            static::$kernel->shutdown();
+        }
+    }
+
+    /**
      * Creates a Client.
      *
      * @param array $options An array of options to pass to the createKernel class
@@ -88,36 +98,6 @@ abstract class WebTestCase extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Finds the value of the CLI configuration option.
-     *
-     * PHPUnit will use the last configuration argument on the command line, so this only returns
-     * the last configuration argument.
-     *
-     * @return string The value of the PHPUnit CLI configuration option
-     */
-    private static function getPhpUnitCliConfigArgument()
-    {
-        $dir = null;
-        $reversedArgs = array_reverse($_SERVER['argv']);
-        foreach ($reversedArgs as $argIndex => $testArg) {
-            if (preg_match('/^-[^ \-]*c$/', $testArg) || $testArg === '--configuration') {
-                $dir = realpath($reversedArgs[$argIndex - 1]);
-                break;
-            } elseif (0 === strpos($testArg, '--configuration=')) {
-                $argPath = substr($testArg, strlen('--configuration='));
-                $dir = realpath($argPath);
-                break;
-            } elseif (0 === strpos($testArg, '-c')) {
-                $argPath = substr($testArg, strlen('-c'));
-                $dir = realpath($argPath);
-                break;
-            }
-        }
-
-        return $dir;
-    }
-
-    /**
      * Attempts to guess the kernel location.
      *
      * When the Kernel is located, the file is required.
@@ -170,12 +150,32 @@ abstract class WebTestCase extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Shuts the kernel down if it was used in the test.
+     * Finds the value of the CLI configuration option.
+     *
+     * PHPUnit will use the last configuration argument on the command line, so this only returns
+     * the last configuration argument.
+     *
+     * @return string The value of the PHPUnit CLI configuration option
      */
-    protected function tearDown()
+    private static function getPhpUnitCliConfigArgument()
     {
-        if (null !== static::$kernel) {
-            static::$kernel->shutdown();
+        $dir = null;
+        $reversedArgs = array_reverse($_SERVER['argv']);
+        foreach ($reversedArgs as $argIndex => $testArg) {
+            if (preg_match('/^-[^ \-]*c$/', $testArg) || $testArg === '--configuration') {
+                $dir = realpath($reversedArgs[$argIndex - 1]);
+                break;
+            } elseif (0 === strpos($testArg, '--configuration=')) {
+                $argPath = substr($testArg, strlen('--configuration='));
+                $dir = realpath($argPath);
+                break;
+            } elseif (0 === strpos($testArg, '-c')) {
+                $argPath = substr($testArg, strlen('-c'));
+                $dir = realpath($argPath);
+                break;
+            }
         }
+
+        return $dir;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
@@ -23,13 +23,6 @@ class TranslationUpdateCommandTest extends \PHPUnit_Framework_TestCase
     private $fs;
     private $translationDir;
 
-    public function testDumpMessagesAndClean()
-    {
-        $tester = $this->createCommandTester($this->getContainer(array('foo' => 'foo')));
-        $tester->execute(array('command' => 'translation:update', 'locale' => 'en', 'bundle' => 'foo', '--dump-messages' => true, '--clean' => true));
-        $this->assertRegExp('/foo/', $tester->getDisplay());
-    }
-
     protected function setUp()
     {
         $this->fs = new Filesystem();
@@ -41,6 +34,13 @@ class TranslationUpdateCommandTest extends \PHPUnit_Framework_TestCase
     protected function tearDown()
     {
         $this->fs->remove($this->translationDir);
+    }
+
+    public function testDumpMessagesAndClean()
+    {
+        $tester = $this->createCommandTester($this->getContainer(array('foo' => 'foo')));
+        $tester->execute(array('command' => 'translation:update', 'locale' => 'en', 'bundle' => 'foo', '--dump-messages' => true, '--clean' => true));
+        $this->assertRegExp('/foo/', $tester->getDisplay());
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
@@ -228,6 +228,11 @@ class RedirectControllerTest extends TestCase
         $this->assertRedirectUrl($returnValue, $expectedUrl);
     }
 
+    public function assertRedirectUrl(Response $returnResponse, $expectedUrl)
+    {
+        $this->assertTrue($returnResponse->isRedirect($expectedUrl), "Expected: $expectedUrl\nGot:      ".$returnResponse->headers->get('Location'));
+    }
+
     private function createRequestObject($scheme, $host, $port, $baseUrl, $queryString = '')
     {
         $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
@@ -288,10 +293,5 @@ class RedirectControllerTest extends TestCase
         $controller->setContainer($container);
 
         return $controller;
-    }
-
-    public function assertRedirectUrl(Response $returnResponse, $expectedUrl)
-    {
-        $this->assertTrue($returnResponse->isRedirect($expectedUrl), "Expected: $expectedUrl\nGot:      ".$returnResponse->headers->get('Location'));
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -20,8 +20,6 @@ abstract class FrameworkExtensionTest extends TestCase
 {
     private static $containerCache = array();
 
-    abstract protected function loadFromFile(ContainerBuilder $container, $file);
-
     public function testCsrfProtection()
     {
         $container = $this->createContainerFromFile('full');
@@ -294,6 +292,8 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertStringEndsWith('Component'.DIRECTORY_SEPARATOR.'Form/Resources/config/validation.xml', $xmlArgs[0]);
         $this->assertStringEndsWith('TestBundle'.DIRECTORY_SEPARATOR.'Resources'.DIRECTORY_SEPARATOR.'config'.DIRECTORY_SEPARATOR.'validation.xml', $xmlArgs[1]);
     }
+
+    abstract protected function loadFromFile(ContainerBuilder $container, $file);
 
     protected function createContainer(array $data = array())
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/YamlFrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/YamlFrameworkExtensionTest.php
@@ -17,16 +17,16 @@ use Symfony\Component\Config\FileLocator;
 
 class YamlFrameworkExtensionTest extends FrameworkExtensionTest
 {
-    protected function loadFromFile(ContainerBuilder $container, $file)
-    {
-        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/Fixtures/yml'));
-        $loader->load($file.'.yml');
-    }
-
     public function testCsrfProtectionShouldBeEnabledByDefault()
     {
         $container = $this->createContainerFromFile('csrf');
 
         $this->assertTrue($container->getParameter('form.type_extension.csrf.enabled'));
+    }
+
+    protected function loadFromFile(ContainerBuilder $container, $file)
+    {
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/Fixtures/yml'));
+        $loader->load($file.'.yml');
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SessionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SessionTest.php
@@ -13,6 +13,20 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
 class SessionTest extends WebTestCase
 {
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->deleteTmpDir('SessionTest');
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        $this->deleteTmpDir('SessionTest');
+    }
+
     /**
      * Tests session attributes persist.
      *
@@ -133,19 +147,5 @@ class SessionTest extends WebTestCase
             array('config.yml', true),
             array('config.yml', false),
         );
-    }
-
-    protected function setUp()
-    {
-        parent::setUp();
-
-        $this->deleteTmpDir('SessionTest');
-    }
-
-    protected function tearDown()
-    {
-        parent::tearDown();
-
-        $this->deleteTmpDir('SessionTest');
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperDivLayoutTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperDivLayoutTest.php
@@ -27,6 +27,27 @@ class FormHelperDivLayoutTest extends AbstractDivLayoutTest
      */
     protected $engine;
 
+    protected function tearDown()
+    {
+        $this->engine = null;
+
+        parent::tearDown();
+    }
+
+    public static function themeBlockInheritanceProvider()
+    {
+        return array(
+            array(array('TestBundle:Parent')),
+        );
+    }
+
+    public static function themeInheritanceProvider()
+    {
+        return array(
+            array(array('TestBundle:Parent'), array('TestBundle:Child')),
+        );
+    }
+
     protected function getExtensions()
     {
         // should be moved to the Form component once absolute file paths are supported
@@ -48,13 +69,6 @@ class FormHelperDivLayoutTest extends AbstractDivLayoutTest
                 'FrameworkBundle:Form',
             )),
         ));
-    }
-
-    protected function tearDown()
-    {
-        $this->engine = null;
-
-        parent::tearDown();
     }
 
     protected function renderForm(FormView $view, array $vars = array())
@@ -109,19 +123,5 @@ class FormHelperDivLayoutTest extends AbstractDivLayoutTest
     protected function setTheme(FormView $view, array $themes)
     {
         $this->engine->get('form')->setTheme($view, $themes);
-    }
-
-    public static function themeBlockInheritanceProvider()
-    {
-        return array(
-            array(array('TestBundle:Parent')),
-        );
-    }
-
-    public static function themeInheritanceProvider()
-    {
-        return array(
-            array(array('TestBundle:Parent'), array('TestBundle:Child')),
-        );
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperTableLayoutTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperTableLayoutTest.php
@@ -27,6 +27,13 @@ class FormHelperTableLayoutTest extends AbstractTableLayoutTest
      */
     protected $engine;
 
+    protected function tearDown()
+    {
+        $this->engine = null;
+
+        parent::tearDown();
+    }
+
     protected function getExtensions()
     {
         // should be moved to the Form component once absolute file paths are supported
@@ -49,13 +56,6 @@ class FormHelperTableLayoutTest extends AbstractTableLayoutTest
                 'FrameworkBundle:FormTable',
             )),
         ));
-    }
-
-    protected function tearDown()
-    {
-        $this->engine = null;
-
-        parent::tearDown();
     }
 
     protected function renderForm(FormView $view, array $vars = array())

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
@@ -32,16 +32,6 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
         $this->deleteTmpDir();
     }
 
-    protected function deleteTmpDir()
-    {
-        if (!file_exists($dir = $this->tmpDir)) {
-            return;
-        }
-
-        $fs = new Filesystem();
-        $fs->remove($dir);
-    }
-
     public function testTransWithoutCaching()
     {
         $translator = $this->getTranslator($this->getLoader());
@@ -235,6 +225,31 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $translator->trans('bar'));
     }
 
+    public function getTranslator($loader, $options = array(), $translatorClass = '\Symfony\Bundle\FrameworkBundle\Translation\Translator')
+    {
+        $translator = $this->createTranslator($loader, $options, $translatorClass);
+
+        $translator->addResource('loader', 'foo', 'fr');
+        $translator->addResource('loader', 'foo', 'en');
+        $translator->addResource('loader', 'foo', 'es');
+        $translator->addResource('loader', 'foo', 'pt-PT'); // European Portuguese
+        $translator->addResource('loader', 'foo', 'pt_BR'); // Brazilian Portuguese
+        $translator->addResource('loader', 'foo', 'fr.UTF-8');
+        $translator->addResource('loader', 'foo', 'sr@latin'); // Latin Serbian
+
+        return $translator;
+    }
+
+    protected function deleteTmpDir()
+    {
+        if (!file_exists($dir = $this->tmpDir)) {
+            return;
+        }
+
+        $fs = new Filesystem();
+        $fs->remove($dir);
+    }
+
     protected function getCatalogue($locale, $messages, $resources = array())
     {
         $catalogue = new MessageCatalogue($locale);
@@ -316,21 +331,6 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
         ;
 
         return $container;
-    }
-
-    public function getTranslator($loader, $options = array(), $translatorClass = '\Symfony\Bundle\FrameworkBundle\Translation\Translator')
-    {
-        $translator = $this->createTranslator($loader, $options, $translatorClass);
-
-        $translator->addResource('loader', 'foo', 'fr');
-        $translator->addResource('loader', 'foo', 'en');
-        $translator->addResource('loader', 'foo', 'es');
-        $translator->addResource('loader', 'foo', 'pt-PT'); // European Portuguese
-        $translator->addResource('loader', 'foo', 'pt_BR'); // Brazilian Portuguese
-        $translator->addResource('loader', 'foo', 'fr.UTF-8');
-        $translator->addResource('loader', 'foo', 'sr@latin'); // Latin Serbian
-
-        return $translator;
     }
 
     private function createTranslator($loader, $options, $translatorClass = '\Symfony\Bundle\FrameworkBundle\Translation\Translator')

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -103,6 +103,37 @@ class SecurityExtension extends Extension
         ));
     }
 
+    public function addSecurityListenerFactory(SecurityFactoryInterface $factory)
+    {
+        $this->factories[$factory->getPosition()][] = $factory;
+    }
+
+    public function addUserProviderFactory(UserProviderFactoryInterface $factory)
+    {
+        $this->userProviderFactories[] = $factory;
+    }
+
+    /**
+     * Returns the base path for the XSD files.
+     *
+     * @return string The XSD base path
+     */
+    public function getXsdValidationBasePath()
+    {
+        return __DIR__.'/../Resources/config/schema';
+    }
+
+    public function getNamespace()
+    {
+        return 'http://symfony.com/schema/dic/security';
+    }
+
+    public function getConfiguration(array $config, ContainerBuilder $container)
+    {
+        // first assemble the factories
+        return new MainConfiguration($this->factories, $this->userProviderFactories);
+    }
+
     private function aclLoad($config, ContainerBuilder $container)
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
@@ -592,36 +623,5 @@ class SecurityExtension extends Extension
         ;
 
         return $this->requestMatchers[$id] = new Reference($id);
-    }
-
-    public function addSecurityListenerFactory(SecurityFactoryInterface $factory)
-    {
-        $this->factories[$factory->getPosition()][] = $factory;
-    }
-
-    public function addUserProviderFactory(UserProviderFactoryInterface $factory)
-    {
-        $this->userProviderFactories[] = $factory;
-    }
-
-    /**
-     * Returns the base path for the XSD files.
-     *
-     * @return string The XSD base path
-     */
-    public function getXsdValidationBasePath()
-    {
-        return __DIR__.'/../Resources/config/schema';
-    }
-
-    public function getNamespace()
-    {
-        return 'http://symfony.com/schema/dic/security';
-    }
-
-    public function getConfiguration(array $config, ContainerBuilder $container)
-    {
-        // first assemble the factories
-        return new MainConfiguration($this->factories, $this->userProviderFactories);
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Templating/Helper/LogoutUrlHelper.php
+++ b/src/Symfony/Bundle/SecurityBundle/Templating/Helper/LogoutUrlHelper.php
@@ -79,6 +79,14 @@ class LogoutUrlHelper extends Helper
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'logout_url';
+    }
+
+    /**
      * Generates the logout URL for the firewall.
      *
      * @param string      $key           The firewall key
@@ -111,13 +119,5 @@ class LogoutUrlHelper extends Helper
         }
 
         return $url;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'logout_url';
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
@@ -21,8 +21,6 @@ abstract class CompleteConfigurationTest extends \PHPUnit_Framework_TestCase
 {
     private static $containerCache = array();
 
-    abstract protected function loadFromFile(ContainerBuilder $container, $file);
-
     public function testRolesHierarchy()
     {
         $container = $this->getContainer('container1');
@@ -181,6 +179,8 @@ abstract class CompleteConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($container->hasDefinition('security.acl.dbal.provider'));
         $this->assertEquals('foo', (string) $container->getAlias('security.acl.provider'));
     }
+
+    abstract protected function loadFromFile(ContainerBuilder $container, $file);
 
     protected function getContainer($file)
     {

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/CsrfFormLoginTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/CsrfFormLoginTest.php
@@ -13,6 +13,16 @@ namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
 class CsrfFormLoginTest extends WebTestCase
 {
+    public static function setUpBeforeClass()
+    {
+        parent::deleteTmpDir('CsrfFormLogin');
+    }
+
+    public static function tearDownAfterClass()
+    {
+        parent::deleteTmpDir('CsrfFormLogin');
+    }
+
     /**
      * @dataProvider getConfigs
      */
@@ -107,15 +117,5 @@ class CsrfFormLoginTest extends WebTestCase
             array('config.yml'),
             array('routes_as_path.yml'),
         );
-    }
-
-    public static function setUpBeforeClass()
-    {
-        parent::deleteTmpDir('CsrfFormLogin');
-    }
-
-    public static function tearDownAfterClass()
-    {
-        parent::deleteTmpDir('CsrfFormLogin');
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FirewallEntryPointTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FirewallEntryPointTest.php
@@ -15,6 +15,16 @@ use Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\FirewallEntryPointBund
 
 class FirewallEntryPointTest extends WebTestCase
 {
+    public static function setUpBeforeClass()
+    {
+        parent::deleteTmpDir('FirewallEntryPoint');
+    }
+
+    public static function tearDownAfterClass()
+    {
+        parent::deleteTmpDir('FirewallEntryPoint');
+    }
+
     public function testItUsesTheConfiguredEntryPointWhenUsingUnknownCredentials()
     {
         $client = $this->createClient(array('test_case' => 'FirewallEntryPoint'));
@@ -42,15 +52,5 @@ class FirewallEntryPointTest extends WebTestCase
             $client->getResponse()->getContent(),
             "Custom entry point wasn't started"
         );
-    }
-
-    public static function setUpBeforeClass()
-    {
-        parent::deleteTmpDir('FirewallEntryPoint');
-    }
-
-    public static function tearDownAfterClass()
-    {
-        parent::deleteTmpDir('FirewallEntryPoint');
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FormLoginTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FormLoginTest.php
@@ -13,6 +13,16 @@ namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
 class FormLoginTest extends WebTestCase
 {
+    public static function setUpBeforeClass()
+    {
+        parent::deleteTmpDir('StandardFormLogin');
+    }
+
+    public static function tearDownAfterClass()
+    {
+        parent::deleteTmpDir('StandardFormLogin');
+    }
+
     /**
      * @dataProvider getConfigs
      */
@@ -79,15 +89,5 @@ class FormLoginTest extends WebTestCase
             array('config.yml'),
             array('routes_as_path.yml'),
         );
-    }
-
-    public static function setUpBeforeClass()
-    {
-        parent::deleteTmpDir('StandardFormLogin');
-    }
-
-    public static function tearDownAfterClass()
-    {
-        parent::deleteTmpDir('StandardFormLogin');
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LocalizedRoutesAsPathTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LocalizedRoutesAsPathTest.php
@@ -13,6 +13,16 @@ namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
 class LocalizedRoutesAsPathTest extends WebTestCase
 {
+    public static function setUpBeforeClass()
+    {
+        parent::deleteTmpDir('StandardFormLogin');
+    }
+
+    public static function tearDownAfterClass()
+    {
+        parent::deleteTmpDir('StandardFormLogin');
+    }
+
     /**
      * @dataProvider getLocales
      */
@@ -75,15 +85,5 @@ class LocalizedRoutesAsPathTest extends WebTestCase
     public function getLocales()
     {
         return array(array('en'), array('de'));
-    }
-
-    public static function setUpBeforeClass()
-    {
-        parent::deleteTmpDir('StandardFormLogin');
-    }
-
-    public static function tearDownAfterClass()
-    {
-        parent::deleteTmpDir('StandardFormLogin');
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityRoutingIntegrationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityRoutingIntegrationTest.php
@@ -13,6 +13,16 @@ namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
 class SecurityRoutingIntegrationTest extends WebTestCase
 {
+    public static function setUpBeforeClass()
+    {
+        parent::deleteTmpDir('StandardFormLogin');
+    }
+
+    public static function tearDownAfterClass()
+    {
+        parent::deleteTmpDir('StandardFormLogin');
+    }
+
     /**
      * @dataProvider getConfigs
      */
@@ -86,6 +96,11 @@ class SecurityRoutingIntegrationTest extends WebTestCase
         $this->assertRestricted($barredClient, '/secured-by-two-ips');
     }
 
+    public function getConfigs()
+    {
+        return array(array('config.yml'), array('routes_as_path.yml'));
+    }
+
     private function assertAllowed($client, $path)
     {
         $client->request('GET', $path);
@@ -96,20 +111,5 @@ class SecurityRoutingIntegrationTest extends WebTestCase
     {
         $client->request('GET', $path);
         $this->assertEquals(302, $client->getResponse()->getStatusCode());
-    }
-
-    public function getConfigs()
-    {
-        return array(array('config.yml'), array('routes_as_path.yml'));
-    }
-
-    public static function setUpBeforeClass()
-    {
-        parent::deleteTmpDir('StandardFormLogin');
-    }
-
-    public static function tearDownAfterClass()
-    {
-        parent::deleteTmpDir('StandardFormLogin');
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SwitchUserTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SwitchUserTest.php
@@ -13,6 +13,16 @@ namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
 class SwitchUserTest extends WebTestCase
 {
+    public static function setUpBeforeClass()
+    {
+        parent::deleteTmpDir('StandardFormLogin');
+    }
+
+    public static function tearDownAfterClass()
+    {
+        parent::deleteTmpDir('StandardFormLogin');
+    }
+
     /**
      * @dataProvider getTestParameters
      */
@@ -69,15 +79,5 @@ class SwitchUserTest extends WebTestCase
         $client->submit($form);
 
         return $client;
-    }
-
-    public static function setUpBeforeClass()
-    {
-        parent::deleteTmpDir('StandardFormLogin');
-    }
-
-    public static function tearDownAfterClass()
-    {
-        parent::deleteTmpDir('StandardFormLogin');
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -127,15 +127,6 @@ class TwigExtension extends Extension
         ));
     }
 
-    private function addTwigPath($twigFilesystemLoaderDefinition, $dir, $bundle)
-    {
-        $name = $bundle;
-        if ('Bundle' === substr($name, -6)) {
-            $name = substr($name, 0, -6);
-        }
-        $twigFilesystemLoaderDefinition->addMethodCall('addPath', array($dir, $name));
-    }
-
     /**
      * Returns the base path for the XSD files.
      *
@@ -149,5 +140,14 @@ class TwigExtension extends Extension
     public function getNamespace()
     {
         return 'http://symfony.com/schema/dic/twig';
+    }
+
+    private function addTwigPath($twigFilesystemLoaderDefinition, $dir, $bundle)
+    {
+        $name = $bundle;
+        if ('Bundle' === substr($name, -6)) {
+            $name = substr($name, 0, -6);
+        }
+        $twigFilesystemLoaderDefinition->addMethodCall('addPath', array($dir, $name));
     }
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
@@ -89,6 +89,13 @@ class WebDebugToolbarListener implements EventSubscriberInterface
         $this->injectToolbar($response);
     }
 
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::RESPONSE => array('onKernelResponse', -128),
+        );
+    }
+
     /**
      * Injects the web debug toolbar into the given Response.
      *
@@ -110,12 +117,5 @@ class WebDebugToolbarListener implements EventSubscriberInterface
             $content = substr($content, 0, $pos).$toolbar.substr($content, $pos);
             $response->setContent($content);
         }
-    }
-
-    public static function getSubscribedEvents()
-    {
-        return array(
-            KernelEvents::RESPONSE => array('onKernelResponse', -128),
-        );
     }
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
@@ -28,20 +28,6 @@ class WebProfilerExtensionTest extends TestCase
      */
     private $container;
 
-    public static function assertSaneContainer(Container $container, $message = '')
-    {
-        $errors = array();
-        foreach ($container->getServiceIds() as $id) {
-            try {
-                $container->get($id);
-            } catch (\Exception $e) {
-                $errors[$id] = $e->getMessage();
-            }
-        }
-
-        self::assertEquals(array(), $errors, $message);
-    }
-
     protected function setUp()
     {
         parent::setUp();
@@ -74,6 +60,20 @@ class WebProfilerExtensionTest extends TestCase
 
         $this->container = null;
         $this->kernel = null;
+    }
+
+    public static function assertSaneContainer(Container $container, $message = '')
+    {
+        $errors = array();
+        foreach ($container->getServiceIds() as $id) {
+            try {
+                $container->get($id);
+            } catch (\Exception $e) {
+                $errors[$id] = $e->getMessage();
+            }
+        }
+
+        self::assertEquals(array(), $errors, $message);
     }
 
     /**

--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -322,97 +322,6 @@ abstract class Client
     }
 
     /**
-     * Makes a request in another process.
-     *
-     * @param object $request An origin request instance
-     *
-     * @return object An origin response instance
-     *
-     * @throws \RuntimeException When processing returns exit code
-     */
-    protected function doRequestInProcess($request)
-    {
-        $process = new PhpProcess($this->getScript($request), null, null);
-        $process->run();
-
-        if (!$process->isSuccessful() || !preg_match('/^O\:\d+\:/', $process->getOutput())) {
-            throw new \RuntimeException(sprintf('OUTPUT: %s ERROR OUTPUT: %s', $process->getOutput(), $process->getErrorOutput()));
-        }
-
-        return unserialize($process->getOutput());
-    }
-
-    /**
-     * Makes a request.
-     *
-     * @param object $request An origin request instance
-     *
-     * @return object An origin response instance
-     */
-    abstract protected function doRequest($request);
-
-    /**
-     * Returns the script to execute when the request must be insulated.
-     *
-     * @param object $request An origin request instance
-     *
-     * @throws \LogicException When this abstract class is not implemented
-     */
-    protected function getScript($request)
-    {
-        // @codeCoverageIgnoreStart
-        throw new \LogicException('To insulate requests, you need to override the getScript() method.');
-        // @codeCoverageIgnoreEnd
-    }
-
-    /**
-     * Filters the BrowserKit request to the origin one.
-     *
-     * @param Request $request The BrowserKit Request to filter
-     *
-     * @return object An origin request instance
-     */
-    protected function filterRequest(Request $request)
-    {
-        return $request;
-    }
-
-    /**
-     * Filters the origin response to the BrowserKit one.
-     *
-     * @param object $response The origin response to filter
-     *
-     * @return Response An BrowserKit Response instance
-     */
-    protected function filterResponse($response)
-    {
-        return $response;
-    }
-
-    /**
-     * Creates a crawler.
-     *
-     * This method returns null if the DomCrawler component is not available.
-     *
-     * @param string $uri     A URI
-     * @param string $content Content for the crawler to use
-     * @param string $type    Content type
-     *
-     * @return Crawler|null
-     */
-    protected function createCrawlerFromContent($uri, $content, $type)
-    {
-        if (!class_exists('Symfony\Component\DomCrawler\Crawler')) {
-            return;
-        }
-
-        $crawler = new Crawler(null, $uri);
-        $crawler->addContent($content, $type);
-
-        return $crawler;
-    }
-
-    /**
      * Goes back in the browser history.
      *
      * @return Crawler
@@ -501,6 +410,97 @@ abstract class Client
     {
         $this->cookieJar->clear();
         $this->history->clear();
+    }
+
+    /**
+     * Makes a request in another process.
+     *
+     * @param object $request An origin request instance
+     *
+     * @return object An origin response instance
+     *
+     * @throws \RuntimeException When processing returns exit code
+     */
+    protected function doRequestInProcess($request)
+    {
+        $process = new PhpProcess($this->getScript($request), null, null);
+        $process->run();
+
+        if (!$process->isSuccessful() || !preg_match('/^O\:\d+\:/', $process->getOutput())) {
+            throw new \RuntimeException(sprintf('OUTPUT: %s ERROR OUTPUT: %s', $process->getOutput(), $process->getErrorOutput()));
+        }
+
+        return unserialize($process->getOutput());
+    }
+
+    /**
+     * Makes a request.
+     *
+     * @param object $request An origin request instance
+     *
+     * @return object An origin response instance
+     */
+    abstract protected function doRequest($request);
+
+    /**
+     * Returns the script to execute when the request must be insulated.
+     *
+     * @param object $request An origin request instance
+     *
+     * @throws \LogicException When this abstract class is not implemented
+     */
+    protected function getScript($request)
+    {
+        // @codeCoverageIgnoreStart
+        throw new \LogicException('To insulate requests, you need to override the getScript() method.');
+        // @codeCoverageIgnoreEnd
+    }
+
+    /**
+     * Filters the BrowserKit request to the origin one.
+     *
+     * @param Request $request The BrowserKit Request to filter
+     *
+     * @return object An origin request instance
+     */
+    protected function filterRequest(Request $request)
+    {
+        return $request;
+    }
+
+    /**
+     * Filters the origin response to the BrowserKit one.
+     *
+     * @param object $response The origin response to filter
+     *
+     * @return Response An BrowserKit Response instance
+     */
+    protected function filterResponse($response)
+    {
+        return $response;
+    }
+
+    /**
+     * Creates a crawler.
+     *
+     * This method returns null if the DomCrawler component is not available.
+     *
+     * @param string $uri     A URI
+     * @param string $content Content for the crawler to use
+     * @param string $type    Content type
+     *
+     * @return Crawler|null
+     */
+    protected function createCrawlerFromContent($uri, $content, $type)
+    {
+        if (!class_exists('Symfony\Component\DomCrawler\Crawler')) {
+            return;
+        }
+
+        $crawler = new Crawler(null, $uri);
+        $crawler->addContent($content, $type);
+
+        return $crawler;
     }
 
     /**

--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -18,6 +18,14 @@ namespace Symfony\Component\BrowserKit;
  */
 class Cookie
 {
+    protected $name;
+    protected $value;
+    protected $expires;
+    protected $path;
+    protected $domain;
+    protected $secure;
+    protected $httponly;
+    protected $rawValue;
     /**
      * Handles dates as defined by RFC 2616 section 3.3.1, and also some other
      * non-standard, but common formats.
@@ -33,15 +41,6 @@ class Cookie
         'D M j G:i:s Y',
         'D M d H:i:s Y T',
     );
-
-    protected $name;
-    protected $value;
-    protected $expires;
-    protected $path;
-    protected $domain;
-    protected $secure;
-    protected $httponly;
-    protected $rawValue;
 
     /**
      * Sets a cookie.
@@ -196,27 +195,6 @@ class Cookie
         );
     }
 
-    private static function parseDate($dateValue)
-    {
-        // trim single quotes around date if present
-        if (($length = strlen($dateValue)) > 1 && "'" === $dateValue[0] && "'" === $dateValue[$length - 1]) {
-            $dateValue = substr($dateValue, 1, -1);
-        }
-
-        foreach (self::$dateFormats as $dateFormat) {
-            if (false !== $date = \DateTime::createFromFormat($dateFormat, $dateValue, new \DateTimeZone('GMT'))) {
-                return $date->getTimestamp();
-            }
-        }
-
-        // attempt a fallback for unusual formatting
-        if (false !== $date = date_create($dateValue, new \DateTimeZone('GMT'))) {
-            return $date->getTimestamp();
-        }
-
-        throw new \InvalidArgumentException(sprintf('Could not parse date "%s".', $dateValue));
-    }
-
     /**
      * Gets the name of the cookie.
      *
@@ -305,5 +283,26 @@ class Cookie
     public function isExpired()
     {
         return null !== $this->expires && 0 !== $this->expires && $this->expires < time();
+    }
+
+    private static function parseDate($dateValue)
+    {
+        // trim single quotes around date if present
+        if (($length = strlen($dateValue)) > 1 && "'" === $dateValue[0] && "'" === $dateValue[$length - 1]) {
+            $dateValue = substr($dateValue, 1, -1);
+        }
+
+        foreach (self::$dateFormats as $dateFormat) {
+            if (false !== $date = \DateTime::createFromFormat($dateFormat, $dateValue, new \DateTimeZone('GMT'))) {
+                return $date->getTimestamp();
+            }
+        }
+
+        // attempt a fallback for unusual formatting
+        if (false !== $date = date_create($dateValue, new \DateTimeZone('GMT'))) {
+            return $date->getTimestamp();
+        }
+
+        throw new \InvalidArgumentException(sprintf('Could not parse date "%s".', $dateValue));
     }
 }

--- a/src/Symfony/Component/BrowserKit/Response.php
+++ b/src/Symfony/Component/BrowserKit/Response.php
@@ -61,19 +61,6 @@ class Response
     }
 
     /**
-     * Returns the build header line.
-     *
-     * @param string $name  The header name
-     * @param string $value The header value
-     *
-     * @return string The built header line
-     */
-    protected function buildHeader($name, $value)
-    {
-        return sprintf("%s: %s\n", $name, $value);
-    }
-
-    /**
      * Gets the response content.
      *
      * @return string The response content
@@ -125,5 +112,18 @@ class Response
         }
 
         return $first ? null : array();
+    }
+
+    /**
+     * Returns the build header line.
+     *
+     * @param string $name  The header name
+     * @param string $value The header value
+     *
+     * @return string The built header line
+     */
+    protected function buildHeader($name, $value)
+    {
+        return sprintf("%s: %s\n", $name, $value);
     }
 }

--- a/src/Symfony/Component/ClassLoader/ApcClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/ApcClassLoader.php
@@ -47,14 +47,13 @@ namespace Symfony\Component\ClassLoader;
  */
 class ApcClassLoader
 {
-    private $prefix;
-
     /**
      * A class loader object that implements the findFile() method.
      *
      * @var object
      */
     protected $decorated;
+    private $prefix;
 
     /**
      * Constructor.

--- a/src/Symfony/Component/ClassLoader/Tests/ClassMapGeneratorTest.php
+++ b/src/Symfony/Component/ClassLoader/Tests/ClassMapGeneratorTest.php
@@ -28,23 +28,6 @@ class ClassMapGeneratorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param string $file
-     */
-    private function clean($file)
-    {
-        if (is_dir($file) && !is_link($file)) {
-            $dir = new \FilesystemIterator($file);
-            foreach ($dir as $childFile) {
-                $this->clean($childFile);
-            }
-
-            rmdir($file);
-        } else {
-            unlink($file);
-        }
-    }
-
-    /**
      * @dataProvider getTestCreateMapTests
      */
     public function testDump($directory)
@@ -146,5 +129,22 @@ class ClassMapGeneratorTest extends \PHPUnit_Framework_TestCase
             $actual[$ns] = str_replace('\\', '/', $path);
         }
         $this->assertEquals($expected, $actual, $message);
+    }
+
+    /**
+     * @param string $file
+     */
+    private function clean($file)
+    {
+        if (is_dir($file) && !is_link($file)) {
+            $dir = new \FilesystemIterator($file);
+            foreach ($dir as $childFile) {
+                $this->clean($childFile);
+            }
+
+            rmdir($file);
+        } else {
+            unlink($file);
+        }
     }
 }

--- a/src/Symfony/Component/ClassLoader/WinCacheClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/WinCacheClassLoader.php
@@ -48,14 +48,13 @@ namespace Symfony\Component\ClassLoader;
  */
 class WinCacheClassLoader
 {
-    private $prefix;
-
     /**
      * A class loader object that implements the findFile() method.
      *
      * @var object
      */
     protected $decorated;
+    private $prefix;
 
     /**
      * Constructor.

--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -57,38 +57,6 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
     }
 
     /**
-     * Normalizes keys between the different configuration formats.
-     *
-     * Namely, you mostly have foo_bar in YAML while you have foo-bar in XML.
-     * After running this method, all keys are normalized to foo_bar.
-     *
-     * If you have a mixed key like foo-bar_moo, it will not be altered.
-     * The key will also not be altered if the target key already exists.
-     *
-     * @param mixed $value
-     *
-     * @return array The value with normalized keys
-     */
-    protected function preNormalize($value)
-    {
-        if (!$this->normalizeKeys || !is_array($value)) {
-            return $value;
-        }
-
-        $normalized = array();
-
-        foreach ($value as $k => $v) {
-            if (false !== strpos($k, '-') && false === strpos($k, '_') && !array_key_exists($normalizedKey = str_replace('-', '_', $k), $value)) {
-                $normalized[$normalizedKey] = $v;
-            } else {
-                $normalized[$k] = $v;
-            }
-        }
-
-        return $normalized;
-    }
-
-    /**
      * Retrieves the children of this node.
      *
      * @return array The children
@@ -221,6 +189,38 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
         }
 
         $this->children[$name] = $node;
+    }
+
+    /**
+     * Normalizes keys between the different configuration formats.
+     *
+     * Namely, you mostly have foo_bar in YAML while you have foo-bar in XML.
+     * After running this method, all keys are normalized to foo_bar.
+     *
+     * If you have a mixed key like foo-bar_moo, it will not be altered.
+     * The key will also not be altered if the target key already exists.
+     *
+     * @param mixed $value
+     *
+     * @return array The value with normalized keys
+     */
+    protected function preNormalize($value)
+    {
+        if (!$this->normalizeKeys || !is_array($value)) {
+            return $value;
+        }
+
+        $normalized = array();
+
+        foreach ($value as $k => $v) {
+            if (false !== strpos($k, '-') && false === strpos($k, '_') && !array_key_exists($normalizedKey = str_replace('-', '_', $k), $value)) {
+                $normalized[$normalizedKey] = $v;
+            } else {
+                $normalized[$k] = $v;
+            }
+        }
+
+        return $normalized;
     }
 
     /**

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -270,18 +270,6 @@ abstract class BaseNode implements NodeInterface
     }
 
     /**
-     * Normalizes the value before any other normalization is applied.
-     *
-     * @param $value
-     *
-     * @return $value The normalized array value
-     */
-    protected function preNormalize($value)
-    {
-        return $value;
-    }
-
-    /**
      * Finalizes a value, applying all finalization closures.
      *
      * @param mixed $value The value to finalize
@@ -309,6 +297,18 @@ abstract class BaseNode implements NodeInterface
             }
         }
 
+        return $value;
+    }
+
+    /**
+     * Normalizes the value before any other normalization is applied.
+     *
+     * @param $value
+     *
+     * @return $value The normalized array value
+     */
+    protected function preNormalize($value)
+    {
         return $value;
     }
 

--- a/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
@@ -21,9 +21,9 @@ use Symfony\Component\Config\Definition\Exception\UnsetKeyException;
  */
 class ExprBuilder
 {
-    protected $node;
     public $ifPart;
     public $thenPart;
+    protected $node;
 
     /**
      * Constructor.

--- a/src/Symfony/Component/Config/Definition/Builder/MergeBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/MergeBuilder.php
@@ -18,9 +18,9 @@ namespace Symfony\Component\Config\Definition\Builder;
  */
 class MergeBuilder
 {
-    protected $node;
     public $allowFalse;
     public $allowOverwrite;
+    protected $node;
 
     /**
      * Constructor.

--- a/src/Symfony/Component/Config/Definition/Builder/NormalizationBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NormalizationBuilder.php
@@ -18,9 +18,9 @@ namespace Symfony\Component\Config\Definition\Builder;
  */
 class NormalizationBuilder
 {
-    protected $node;
     public $before;
     public $remappings;
+    protected $node;
 
     /**
      * Constructor.

--- a/src/Symfony/Component/Config/Definition/Builder/ValidationBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ValidationBuilder.php
@@ -18,8 +18,8 @@ namespace Symfony\Component\Config\Definition\Builder;
  */
 class ValidationBuilder
 {
-    protected $node;
     public $rules;
+    protected $node;
 
     /**
      * Constructor.

--- a/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
@@ -34,22 +34,6 @@ class DirectoryResourceTest extends \PHPUnit_Framework_TestCase
         $this->removeDirectory($this->directory);
     }
 
-    protected function removeDirectory($directory)
-    {
-        $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($directory), \RecursiveIteratorIterator::CHILD_FIRST);
-        foreach ($iterator as $path) {
-            if (preg_match('#[/\\\\]\.\.?$#', $path->__toString())) {
-                continue;
-            }
-            if ($path->isDir()) {
-                rmdir($path->__toString());
-            } else {
-                unlink($path->__toString());
-            }
-        }
-        rmdir($directory);
-    }
-
     public function testGetResource()
     {
         $resource = new DirectoryResource($this->directory);
@@ -162,5 +146,21 @@ class DirectoryResourceTest extends \PHPUnit_Framework_TestCase
         $resourceB = new DirectoryResource($this->directory, '/.yaml$/');
 
         $this->assertEquals(2, count(array_unique(array($resourceA, $resourceB))));
+    }
+
+    protected function removeDirectory($directory)
+    {
+        $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($directory), \RecursiveIteratorIterator::CHILD_FIRST);
+        foreach ($iterator as $path) {
+            if (preg_match('#[/\\\\]\.\.?$#', $path->__toString())) {
+                continue;
+            }
+            if ($path->isDir()) {
+                rmdir($path->__toString());
+            } else {
+                unlink($path->__toString());
+            }
+        }
+        rmdir($directory);
     }
 }

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -745,30 +745,6 @@ class Application
     }
 
     /**
-     * Tries to figure out the terminal width in which this application runs.
-     *
-     * @return int|null
-     */
-    protected function getTerminalWidth()
-    {
-        $dimensions = $this->getTerminalDimensions();
-
-        return $dimensions[0];
-    }
-
-    /**
-     * Tries to figure out the terminal height in which this application runs.
-     *
-     * @return int|null
-     */
-    protected function getTerminalHeight()
-    {
-        $dimensions = $this->getTerminalDimensions();
-
-        return $dimensions[1];
-    }
-
-    /**
      * Tries to figure out the terminal dimensions based on the current environment.
      *
      * @return array Array containing width and height
@@ -798,6 +774,48 @@ class Application
         }
 
         return array(null, null);
+    }
+
+    /**
+     * Returns the namespace part of the command name.
+     *
+     * This method is not part of public API and should not be used directly.
+     *
+     * @param string $name  The full name of the command
+     * @param string $limit The maximum number of parts of the namespace
+     *
+     * @return string The namespace of the command
+     */
+    public function extractNamespace($name, $limit = null)
+    {
+        $parts = explode(':', $name);
+        array_pop($parts);
+
+        return implode(':', null === $limit ? $parts : array_slice($parts, 0, $limit));
+    }
+
+    /**
+     * Tries to figure out the terminal width in which this application runs.
+     *
+     * @return int|null
+     */
+    protected function getTerminalWidth()
+    {
+        $dimensions = $this->getTerminalDimensions();
+
+        return $dimensions[0];
+    }
+
+    /**
+     * Tries to figure out the terminal height in which this application runs.
+     *
+     * @return int|null
+     */
+    protected function getTerminalHeight()
+    {
+        $dimensions = $this->getTerminalDimensions();
+
+        return $dimensions[1];
     }
 
     /**
@@ -994,24 +1012,6 @@ class Application
     private function getAbbreviationSuggestions($abbrevs)
     {
         return sprintf('%s, %s%s', $abbrevs[0], $abbrevs[1], count($abbrevs) > 2 ? sprintf(' and %d more', count($abbrevs) - 2) : '');
-    }
-
-    /**
-     * Returns the namespace part of the command name.
-     *
-     * This method is not part of public API and should not be used directly.
-     *
-     * @param string $name  The full name of the command
-     * @param string $limit The maximum number of parts of the namespace
-     *
-     * @return string The namespace of the command
-     */
-    public function extractNamespace($name, $limit = null)
-    {
-        $parts = explode(':', $name);
-        array_pop($parts);
-
-        return implode(':', null === $limit ? $parts : array_slice($parts, 0, $limit));
     }
 
     /**

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -136,62 +136,6 @@ class Command
     }
 
     /**
-     * Configures the current command.
-     */
-    protected function configure()
-    {
-    }
-
-    /**
-     * Executes the current command.
-     *
-     * This method is not abstract because you can use this class
-     * as a concrete class. In this case, instead of defining the
-     * execute() method, you set the code to execute by passing
-     * a Closure to the setCode() method.
-     *
-     * @param InputInterface  $input  An InputInterface instance
-     * @param OutputInterface $output An OutputInterface instance
-     *
-     * @return null|int null or 0 if everything went fine, or an error code
-     *
-     * @throws \LogicException When this abstract method is not implemented
-     *
-     * @see setCode()
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
-    {
-        throw new \LogicException('You must override the execute() method in the concrete command class.');
-    }
-
-    /**
-     * Interacts with the user.
-     *
-     * This method is executed before the InputDefinition is validated.
-     * This means that this is the only place where the command can
-     * interactively ask for values of missing required arguments.
-     *
-     * @param InputInterface  $input  An InputInterface instance
-     * @param OutputInterface $output An OutputInterface instance
-     */
-    protected function interact(InputInterface $input, OutputInterface $output)
-    {
-    }
-
-    /**
-     * Initializes the command just after the input has been validated.
-     *
-     * This is mainly useful when a lot of commands extends one main command
-     * where some things need to be initialized based on the input arguments and options.
-     *
-     * @param InputInterface  $input  An InputInterface instance
-     * @param OutputInterface $output An OutputInterface instance
-     */
-    protected function initialize(InputInterface $input, OutputInterface $output)
-    {
-    }
-
-    /**
      * Runs the command.
      *
      * The code to execute is either defined directly with the
@@ -572,6 +516,62 @@ class Command
         $descriptor = new XmlDescriptor();
 
         return $descriptor->describe($this, array('as_dom' => $asDom));
+    }
+
+    /**
+     * Configures the current command.
+     */
+    protected function configure()
+    {
+    }
+
+    /**
+     * Executes the current command.
+     *
+     * This method is not abstract because you can use this class
+     * as a concrete class. In this case, instead of defining the
+     * execute() method, you set the code to execute by passing
+     * a Closure to the setCode() method.
+     *
+     * @param InputInterface  $input  An InputInterface instance
+     * @param OutputInterface $output An OutputInterface instance
+     *
+     * @return null|int null or 0 if everything went fine, or an error code
+     *
+     * @throws \LogicException When this abstract method is not implemented
+     *
+     * @see setCode()
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        throw new \LogicException('You must override the execute() method in the concrete command class.');
+    }
+
+    /**
+     * Interacts with the user.
+     *
+     * This method is executed before the InputDefinition is validated.
+     * This means that this is the only place where the command can
+     * interactively ask for values of missing required arguments.
+     *
+     * @param InputInterface  $input  An InputInterface instance
+     * @param OutputInterface $output An OutputInterface instance
+     */
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+    }
+
+    /**
+     * Initializes the command just after the input has been validated.
+     *
+     * This is mainly useful when a lot of commands extends one main command
+     * where some things need to be initialized based on the input arguments and options.
+     *
+     * @param InputInterface  $input  An InputInterface instance
+     * @param OutputInterface $output An OutputInterface instance
+     */
+    protected function initialize(InputInterface $input, OutputInterface $output)
+    {
     }
 
     private function validateName($name)

--- a/src/Symfony/Component/Console/Command/HelpCommand.php
+++ b/src/Symfony/Component/Console/Command/HelpCommand.php
@@ -27,6 +27,16 @@ class HelpCommand extends Command
     private $command;
 
     /**
+     * Sets the command.
+     *
+     * @param Command $command The command to set
+     */
+    public function setCommand(Command $command)
+    {
+        $this->command = $command;
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function configure()
@@ -55,16 +65,6 @@ To display the list of available commands, please use the <info>list</info> comm
 EOF
             )
         ;
-    }
-
-    /**
-     * Sets the command.
-     *
-     * @param Command $command The command to set
-     */
-    public function setCommand(Command $command)
-    {
-        $this->command = $command;
     }
 
     /**

--- a/src/Symfony/Component/Console/Command/ListCommand.php
+++ b/src/Symfony/Component/Console/Command/ListCommand.php
@@ -28,6 +28,14 @@ class ListCommand extends Command
     /**
      * {@inheritdoc}
      */
+    public function getNativeDefinition()
+    {
+        return $this->createDefinition();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function configure()
     {
         $this
@@ -53,14 +61,6 @@ It's also possible to get raw list of commands (useful for embedding command run
 EOF
             )
         ;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getNativeDefinition()
-    {
-        return $this->createDefinition();
     }
 
     /**

--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -23,26 +23,6 @@ class OutputFormatter implements OutputFormatterInterface
     private $styleStack;
 
     /**
-     * Escapes "<" special char in given text.
-     *
-     * @param string $text Text to escape
-     *
-     * @return string Escaped text
-     */
-    public static function escape($text)
-    {
-        $text = preg_replace('/([^\\\\]?)</', '$1\\<', $text);
-
-        if ('\\' === substr($text, -1)) {
-            $len = strlen($text);
-            $text = rtrim($text, '\\');
-            $text .= str_repeat('<<', $len - strlen($text));
-        }
-
-        return $text;
-    }
-
-    /**
      * Initializes console output formatter.
      *
      * @param bool                            $decorated Whether this formatter should actually decorate strings
@@ -62,6 +42,26 @@ class OutputFormatter implements OutputFormatterInterface
         }
 
         $this->styleStack = new OutputFormatterStyleStack();
+    }
+
+    /**
+     * Escapes "<" special char in given text.
+     *
+     * @param string $text Text to escape
+     *
+     * @return string Escaped text
+     */
+    public static function escape($text)
+    {
+        $text = preg_replace('/([^\\\\]?)</', '$1\\<', $text);
+
+        if ('\\' === substr($text, -1)) {
+            $len = strlen($text);
+            $text = rtrim($text, '\\');
+            $text .= str_repeat('<<', $len - strlen($text));
+        }
+
+        return $text;
     }
 
     /**

--- a/src/Symfony/Component/Console/Helper/ProgressHelper.php
+++ b/src/Symfony/Component/Console/Helper/ProgressHelper.php
@@ -320,6 +320,14 @@ class ProgressHelper extends Helper
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'progress';
+    }
+
+    /**
      * Initializes the progress helper.
      */
     private function initialize()
@@ -443,13 +451,5 @@ class ProgressHelper extends Helper
         $output->write($message);
 
         $this->lastMessagesLength = $this->strlen($message);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'progress';
     }
 }

--- a/src/Symfony/Component/Console/Helper/TableHelper.php
+++ b/src/Symfony/Component/Console/Helper/TableHelper.php
@@ -323,6 +323,14 @@ class TableHelper extends Helper
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'table';
+    }
+
+    /**
      * Renders horizontal header separator.
      *
      * Example: +-----+-----------+-------+
@@ -477,13 +485,5 @@ class TableHelper extends Helper
         $formatter->setDecorated($isDecorated);
 
         return $this->strlen($string);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'table';
     }
 }

--- a/src/Symfony/Component/Console/Input/Input.php
+++ b/src/Symfony/Component/Console/Input/Input.php
@@ -61,11 +61,6 @@ abstract class Input implements InputInterface
     }
 
     /**
-     * Processes command line arguments.
-     */
-    abstract protected function parse();
-
-    /**
      * Validates the input.
      *
      * @throws \RuntimeException When not enough arguments are given
@@ -229,4 +224,9 @@ abstract class Input implements InputInterface
     {
         return preg_match('{^[\w-]+$}', $token) ? $token : escapeshellarg($token);
     }
+
+    /**
+     * Processes command line arguments.
+     */
+    abstract protected function parse();
 }

--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -340,24 +340,6 @@ class InputDefinition
     }
 
     /**
-     * Returns the InputOption name given a shortcut.
-     *
-     * @param string $shortcut The shortcut
-     *
-     * @return string The InputOption name
-     *
-     * @throws \InvalidArgumentException When option given does not exist
-     */
-    private function shortcutToName($shortcut)
-    {
-        if (!isset($this->shortcuts[$shortcut])) {
-            throw new \InvalidArgumentException(sprintf('The "-%s" option does not exist.', $shortcut));
-        }
-
-        return $this->shortcuts[$shortcut];
-    }
-
-    /**
      * Gets the synopsis.
      *
      * @return string The synopsis
@@ -409,5 +391,23 @@ class InputDefinition
         $descriptor = new XmlDescriptor();
 
         return $descriptor->describe($this, array('as_dom' => $asDom));
+    }
+
+    /**
+     * Returns the InputOption name given a shortcut.
+     *
+     * @param string $shortcut The shortcut
+     *
+     * @return string The InputOption name
+     *
+     * @throws \InvalidArgumentException When option given does not exist
+     */
+    private function shortcutToName($shortcut)
+    {
+        if (!isset($this->shortcuts[$shortcut])) {
+            throw new \InvalidArgumentException(sprintf('The "-%s" option does not exist.', $shortcut));
+        }
+
+        return $this->shortcuts[$shortcut];
     }
 }

--- a/src/Symfony/Component/Console/Shell.php
+++ b/src/Symfony/Component/Console/Shell.php
@@ -119,6 +119,20 @@ EOF
         }
     }
 
+    public function getProcessIsolation()
+    {
+        return $this->processIsolation;
+    }
+
+    public function setProcessIsolation($processIsolation)
+    {
+        $this->processIsolation = (bool) $processIsolation;
+
+        if ($this->processIsolation && !class_exists('Symfony\\Component\\Process\\Process')) {
+            throw new \RuntimeException('Unable to isolate processes as the Symfony Process Component is not installed.');
+        }
+    }
+
     /**
      * Returns the shell header.
      *
@@ -211,19 +225,5 @@ EOF;
         }
 
         return $line;
-    }
-
-    public function getProcessIsolation()
-    {
-        return $this->processIsolation;
-    }
-
-    public function setProcessIsolation($processIsolation)
-    {
-        $this->processIsolation = (bool) $processIsolation;
-
-        if ($this->processIsolation && !class_exists('Symfony\\Component\\Process\\Process')) {
-            throw new \RuntimeException('Unable to isolate processes as the Symfony Process Component is not installed.');
-        }
     }
 }

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -44,23 +44,6 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         require_once self::$fixturesPath.'/FooSubnamespaced2Command.php';
     }
 
-    protected function normalizeLineBreaks($text)
-    {
-        return str_replace(PHP_EOL, "\n", $text);
-    }
-
-    /**
-     * Replaces the dynamic placeholders of the command help text with a static version.
-     * The placeholder %command.full_name% includes the script path that is not predictable
-     * and can not be tested against.
-     */
-    protected function ensureStaticCommandHelp(Application $application)
-    {
-        foreach ($application->all() as $command) {
-            $command->setHelp(str_replace('%command.full_name%', 'app/console %command.name%', $command->getHelp()));
-        }
-    }
-
     public function testConstructor()
     {
         $application = new Application('foo', 'bar');
@@ -835,6 +818,23 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $tester = new ApplicationTester($application);
         $tester->run(array('command' => 'foo'));
         $this->assertContains('before.foo.caught.after.', $tester->getDisplay());
+    }
+
+    protected function normalizeLineBreaks($text)
+    {
+        return str_replace(PHP_EOL, "\n", $text);
+    }
+
+    /**
+     * Replaces the dynamic placeholders of the command help text with a static version.
+     * The placeholder %command.full_name% includes the script path that is not predictable
+     * and can not be tested against.
+     */
+    protected function ensureStaticCommandHelp(Application $application)
+    {
+        foreach ($application->all() as $command) {
+            $command->setHelp(str_replace('%command.full_name%', 'app/console %command.name%', $command->getHelp()));
+        }
     }
 
     protected function getDispatcher()

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressHelperTest.php
@@ -19,6 +19,8 @@ use Symfony\Component\Console\Output\StreamOutput;
  */
 class ProgressHelperTest extends \PHPUnit_Framework_TestCase
 {
+    protected $lastMessagesLength;
+
     public function testAdvance()
     {
         $progress = new ProgressHelper();
@@ -184,8 +186,6 @@ class ProgressHelperTest extends \PHPUnit_Framework_TestCase
     {
         return new StreamOutput(fopen('php://memory', 'r+', false));
     }
-
-    protected $lastMessagesLength;
 
     protected function generateOutput($expected)
     {

--- a/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
@@ -109,7 +109,7 @@ PHP
         $exceptionCheck = function ($exception) use ($that) {
             $that->assertInstanceOf('Symfony\Component\Debug\Exception\ContextErrorException', $exception);
             $that->assertEquals(E_NOTICE, $exception->getSeverity());
-            $that->assertEquals(__LINE__ + 40, $exception->getLine());
+            $that->assertEquals(222, $exception->getLine());
             $that->assertEquals(__FILE__, $exception->getFile());
             $that->assertRegExp('/^Notice: Undefined variable: (foo|bar)/', $exception->getMessage());
             $that->assertArrayHasKey('foobar', $exception->getContext());
@@ -142,14 +142,6 @@ PHP
         }
 
         restore_error_handler();
-    }
-
-    // dummy function to test trace in error handler.
-    private static function triggerNotice($that)
-    {
-        // dummy variable to check for in error handler.
-        $foobar = 123;
-        $that->assertSame('', $foo.$foo.$bar);
     }
 
     public function testConstruct()
@@ -220,5 +212,13 @@ PHP
         $handler->handle(E_USER_DEPRECATED, 'foo', 'foo.php', 12, array());
 
         restore_error_handler();
+    }
+
+    // dummy function to test trace in error handler.
+    private static function triggerNotice($that)
+    {
+        // dummy variable to check for in error handler.
+        $foobar = 123;
+        $that->assertSame('', $foo.$foo.$bar);
     }
 }

--- a/src/Symfony/Component/Debug/Tests/Exception/FlattenExceptionTest.php
+++ b/src/Symfony/Component/Debug/Tests/Exception/FlattenExceptionTest.php
@@ -208,11 +208,6 @@ class FlattenExceptionTest extends \PHPUnit_Framework_TestCase
         $this->assertNotContains('*value1*', $serializeTrace);
     }
 
-    private function createException($foo)
-    {
-        return new \Exception();
-    }
-
     public function testSetTraceIncompleteClass()
     {
         $flattened = FlattenException::create(new \Exception('test', 123));
@@ -252,5 +247,10 @@ class FlattenExceptionTest extends \PHPUnit_Framework_TestCase
                 ),
             ),
         ), $flattened->toArray());
+    }
+
+    private function createException($foo)
+    {
+        return new \Exception();
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -21,6 +21,7 @@ use Symfony\Component\DependencyInjection\Exception\OutOfBoundsException;
  */
 class Definition
 {
+    protected $arguments;
     private $class;
     private $file;
     private $factoryClass;
@@ -36,8 +37,6 @@ class Definition
     private $abstract;
     private $synchronized;
     private $lazy;
-
-    protected $arguments;
 
     /**
      * Constructor.

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -144,6 +144,22 @@ class PhpDumper extends Dumper
     }
 
     /**
+     * Dumps a parameter.
+     *
+     * @param string $name
+     *
+     * @return string
+     */
+    public function dumpParameter($name)
+    {
+        if ($this->container->isFrozen() && $this->container->hasParameter($name)) {
+            return $this->dumpValue($this->container->getParameter($name), false);
+        }
+
+        return sprintf("\$this->getParameter('%s')", strtolower($name));
+    }
+
+    /**
      * Retrieves the currently set proxy dumper or instantiates one.
      *
      * @return ProxyDumper
@@ -1263,22 +1279,6 @@ EOF;
         } else {
             return $this->export($value);
         }
-    }
-
-    /**
-     * Dumps a parameter.
-     *
-     * @param string $name
-     *
-     * @return string
-     */
-    public function dumpParameter($name)
-    {
-        if ($this->container->isFrozen() && $this->container->hasParameter($name)) {
-            return $this->dumpValue($this->container->getParameter($name), false);
-        }
-
-        return sprintf("\$this->getParameter('%s')", strtolower($name));
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -58,6 +58,33 @@ class XmlDumper extends Dumper
     }
 
     /**
+     * Converts php types to xml types.
+     *
+     * @param mixed $value Value to convert
+     *
+     * @return string
+     *
+     * @throws RuntimeException When trying to dump object or resource
+     */
+    public static function phpToXml($value)
+    {
+        switch (true) {
+            case null === $value:
+                return 'null';
+            case true === $value:
+                return 'true';
+            case false === $value:
+                return 'false';
+            case $value instanceof Parameter:
+                return '%'.$value.'%';
+            case is_object($value) || is_resource($value):
+                throw new RuntimeException('Unable to dump a service container if a parameter is an object or a resource.');
+            default:
+                return (string) $value;
+        }
+    }
+
+    /**
      * Adds parameters.
      *
      * @param \DOMElement $parent
@@ -294,32 +321,5 @@ class XmlDumper extends Dumper
         }
 
         return $args;
-    }
-
-    /**
-     * Converts php types to xml types.
-     *
-     * @param mixed $value Value to convert
-     *
-     * @return string
-     *
-     * @throws RuntimeException When trying to dump object or resource
-     */
-    public static function phpToXml($value)
-    {
-        switch (true) {
-            case null === $value:
-                return 'null';
-            case true === $value:
-                return 'true';
-            case false === $value:
-                return 'false';
-            case $value instanceof Parameter:
-                return '%'.$value.'%';
-            case is_object($value) || is_resource($value):
-                throw new RuntimeException('Unable to dump a service container if a parameter is an object or a resource.');
-            default:
-                return (string) $value;
-        }
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -79,6 +79,42 @@ class YamlFileLoader extends FileLoader
     }
 
     /**
+     * Loads a YAML file.
+     *
+     * @param string $file
+     *
+     * @return array The file content
+     *
+     * @throws InvalidArgumentException when the given file is not a local file or when it does not exist
+     */
+    protected function loadFile($file)
+    {
+        if (!class_exists('Symfony\Component\Yaml\Parser')) {
+            throw new RuntimeException('Unable to load YAML config files as the Symfony Yaml Component is not installed.');
+        }
+
+        if (!stream_is_local($file)) {
+            throw new InvalidArgumentException(sprintf('This is not a local file "%s".', $file));
+        }
+
+        if (!file_exists($file)) {
+            throw new InvalidArgumentException(sprintf('The service file "%s" is not valid.', $file));
+        }
+
+        if (null === $this->yamlParser) {
+            $this->yamlParser = new YamlParser();
+        }
+
+        try {
+            $configuration = $this->yamlParser->parse(file_get_contents($file));
+        } catch (ParseException $e) {
+            throw new InvalidArgumentException(sprintf('The file "%s" does not contain valid YAML.', $file), 0, $e);
+        }
+
+        return $this->validate($configuration, $file);
+    }
+
+    /**
      * Parses all imports.
      *
      * @param array  $content
@@ -263,42 +299,6 @@ class YamlFileLoader extends FileLoader
         }
 
         $this->container->setDefinition($id, $definition);
-    }
-
-    /**
-     * Loads a YAML file.
-     *
-     * @param string $file
-     *
-     * @return array The file content
-     *
-     * @throws InvalidArgumentException when the given file is not a local file or when it does not exist
-     */
-    protected function loadFile($file)
-    {
-        if (!class_exists('Symfony\Component\Yaml\Parser')) {
-            throw new RuntimeException('Unable to load YAML config files as the Symfony Yaml Component is not installed.');
-        }
-
-        if (!stream_is_local($file)) {
-            throw new InvalidArgumentException(sprintf('This is not a local file "%s".', $file));
-        }
-
-        if (!file_exists($file)) {
-            throw new InvalidArgumentException(sprintf('The service file "%s" is not valid.', $file));
-        }
-
-        if (null === $this->yamlParser) {
-            $this->yamlParser = new YamlParser();
-        }
-
-        try {
-            $configuration = $this->yamlParser->parse(file_get_contents($file));
-        } catch (ParseException $e) {
-            throw new InvalidArgumentException(sprintf('The file "%s" does not contain valid YAML.', $file), 0, $e);
-        }
-
-        return $this->validate($configuration, $file);
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -480,20 +480,20 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    protected function getField($obj, $field)
-    {
-        $reflection = new \ReflectionProperty($obj, $field);
-        $reflection->setAccessible(true);
-
-        return $reflection->getValue($obj);
-    }
-
     public function testAlias()
     {
         $c = new ProjectServiceContainer();
 
         $this->assertTrue($c->has('alias'));
         $this->assertSame($c->get('alias'), $c->get('bar'));
+    }
+
+    protected function getField($obj, $field)
+    {
+        $reflection = new \ReflectionProperty($obj, $field);
+        $reflection->setAccessible(true);
+
+        return $reflection->getValue($obj);
     }
 }
 

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -763,6 +763,41 @@ class Crawler extends \SplObjectStorage
     }
 
     /**
+     * @param int $position
+     *
+     * @return \DOMElement|null
+     */
+    protected function getNode($position)
+    {
+        foreach ($this as $i => $node) {
+            if ($i == $position) {
+                return $node;
+            }
+        // @codeCoverageIgnoreStart
+        }
+        // @codeCoverageIgnoreEnd
+    }
+
+    /**
+     * @param \DOMElement $node
+     * @param string      $siblingDir
+     *
+     * @return array
+     */
+    protected function sibling($node, $siblingDir = 'nextSibling')
+    {
+        $nodes = array();
+
+        do {
+            if ($node !== $this->getNode(0) && $node->nodeType === 1) {
+                $nodes[] = $node;
+            }
+        } while ($node = $node->$siblingDir);
+
+        return $nodes;
+    }
+
+    /**
      * Filters the list of nodes with an XPath expression.
      *
      * The XPath expression should already be processed to apply it in the context of each node.
@@ -851,40 +886,5 @@ class Crawler extends \SplObjectStorage
         }
 
         return implode(' | ', $expressions);
-    }
-
-    /**
-     * @param int $position
-     *
-     * @return \DOMElement|null
-     */
-    protected function getNode($position)
-    {
-        foreach ($this as $i => $node) {
-            if ($i == $position) {
-                return $node;
-            }
-        // @codeCoverageIgnoreStart
-        }
-        // @codeCoverageIgnoreEnd
-    }
-
-    /**
-     * @param \DOMElement $node
-     * @param string      $siblingDir
-     *
-     * @return array
-     */
-    protected function sibling($node, $siblingDir = 'nextSibling')
-    {
-        $nodes = array();
-
-        do {
-            if ($node !== $this->getNode(0) && $node->nodeType === 1) {
-                $nodes[] = $node;
-            }
-        } while ($node = $node->$siblingDir);
-
-        return $nodes;
     }
 }

--- a/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
@@ -192,6 +192,41 @@ class ChoiceFormField extends FormField
     }
 
     /**
+     * Checks whether given value is in the existing options.
+     *
+     * @param string $optionValue
+     * @param array  $options
+     *
+     * @return bool
+     */
+    public function containsOption($optionValue, $options)
+    {
+        foreach ($options as $option) {
+            if ($option['value'] == $optionValue) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns list of available field options.
+     *
+     * @return array
+     */
+    public function availableOptionValues()
+    {
+        $values = array();
+
+        foreach ($this->options as $option) {
+            $values[] = $option['value'];
+        }
+
+        return $values;
+    }
+
+    /**
      * Initializes the form field.
      *
      * @throws \LogicException When node type is incorrect
@@ -264,40 +299,5 @@ class ChoiceFormField extends FormField
         $option['disabled'] = $node->hasAttribute('disabled');
 
         return $option;
-    }
-
-    /**
-     * Checks whether given value is in the existing options.
-     *
-     * @param string $optionValue
-     * @param array  $options
-     *
-     * @return bool
-     */
-    public function containsOption($optionValue, $options)
-    {
-        foreach ($options as $option) {
-            if ($option['value'] == $optionValue) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Returns list of available field options.
-     *
-     * @return array
-     */
-    public function availableOptionValues()
-    {
-        $values = array();
-
-        foreach ($this->options as $option) {
-            $values[] = $option['value'];
-        }
-
-        return $values;
     }
 }

--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -209,11 +209,6 @@ class Form extends Link implements \ArrayAccess
         return $uri;
     }
 
-    protected function getRawUri()
-    {
-        return $this->node->getAttribute('action');
-    }
-
     /**
      * Gets the form method.
      *
@@ -335,6 +330,11 @@ class Form extends Link implements \ArrayAccess
     public function offsetUnset($name)
     {
         $this->fields->remove($name);
+    }
+
+    protected function getRawUri()
+    {
+        return $this->node->getAttribute('action');
     }
 
     /**

--- a/src/Symfony/Component/DomCrawler/Tests/FormTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/FormTest.php
@@ -833,6 +833,22 @@ class FormTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Component\DomCrawler\Field\ChoiceFormField', $form->get('option'));
     }
 
+    public function testgetPhpValuesWithEmptyTextarea()
+    {
+        $dom = new \DOMDocument();
+        $dom->loadHTML('
+              <html>
+                  <form>
+                      <textarea name="example"></textarea>
+                  </form>
+              </html>
+          ');
+
+        $nodes = $dom->getElementsByTagName('form');
+        $form = new Form($nodes->item(0), 'http://example.com');
+        $this->assertEquals($form->getPhpValues(), array('example' => ''));
+    }
+
     protected function getFormFieldMock($name, $value = null)
     {
         $field = $this
@@ -933,21 +949,5 @@ class FormTest extends \PHPUnit_Framework_TestCase
         </html>');
 
         return $dom;
-    }
-
-    public function testgetPhpValuesWithEmptyTextarea()
-    {
-        $dom = new \DOMDocument();
-        $dom->loadHTML('
-              <html>
-                  <form>
-                      <textarea name="example"></textarea>
-                  </form>
-              </html>
-          ');
-
-        $nodes = $dom->getElementsByTagName('form');
-        $form = new Form($nodes->item(0), 'http://example.com');
-        $this->assertEquals($form->getPhpValues(), array('example' => ''));
     }
 }

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -268,22 +268,6 @@ class Filesystem
     }
 
     /**
-     * Tells whether a file exists and is readable.
-     *
-     * @param string $filename Path to the file.
-     *
-     * @throws IOException When windows path is longer than 258 characters
-     */
-    private function isReadable($filename)
-    {
-        if ('\\' === DIRECTORY_SEPARATOR && strlen($filename) > 258) {
-            throw new IOException(sprintf('Could not check if file is readable because path length exceeds 258 characters for file "%s"', $filename));
-        }
-
-        return is_readable($filename);
-    }
-
-    /**
      * Creates a symbolic link or copy a directory.
      *
      * @param string $originDir     The origin directory path
@@ -459,20 +443,6 @@ class Filesystem
     }
 
     /**
-     * @param mixed $files
-     *
-     * @return \Traversable
-     */
-    private function toIterator($files)
-    {
-        if (!$files instanceof \Traversable) {
-            $files = new \ArrayObject(is_array($files) ? $files : array($files));
-        }
-
-        return $files;
-    }
-
-    /**
      * Atomically dumps content into a file.
      *
      * @param string   $filename The file to be written to.
@@ -502,5 +472,35 @@ class Filesystem
             $this->chmod($tmpFile, $mode);
         }
         $this->rename($tmpFile, $filename, true);
+    }
+
+    /**
+     * Tells whether a file exists and is readable.
+     *
+     * @param string $filename Path to the file.
+     *
+     * @throws IOException When windows path is longer than 258 characters
+     */
+    private function isReadable($filename)
+    {
+        if ('\\' === DIRECTORY_SEPARATOR && strlen($filename) > 258) {
+            throw new IOException(sprintf('Could not check if file is readable because path length exceeds 258 characters for file "%s"', $filename));
+        }
+
+        return is_readable($filename);
+    }
+
+    /**
+     * @param mixed $files
+     *
+     * @return \Traversable
+     */
+    private function toIterator($files)
+    {
+        if (!$files instanceof \Traversable) {
+            $files = new \ArrayObject(is_array($files) ? $files : array($files));
+        }
+
+        return $files;
     }
 }

--- a/src/Symfony/Component/Finder/Adapter/AbstractFindAdapter.php
+++ b/src/Symfony/Component/Finder/Adapter/AbstractFindAdapter.php
@@ -145,6 +145,19 @@ abstract class AbstractFindAdapter extends AbstractAdapter
     }
 
     /**
+     * @param Command $command
+     * @param string  $sort
+     */
+    abstract protected function buildFormatSorting(Command $command, $sort);
+
+    /**
+     * @param Command $command
+     * @param array   $contains
+     * @param bool    $not
+     */
+    abstract protected function buildContentFiltering(Command $command, array $contains, $not = false);
+
+    /**
      * @param Command  $command
      * @param string[] $names
      * @param bool     $not
@@ -311,17 +324,4 @@ abstract class AbstractFindAdapter extends AbstractAdapter
     {
         $this->buildFormatSorting($command, $sort);
     }
-
-    /**
-     * @param Command $command
-     * @param string  $sort
-     */
-    abstract protected function buildFormatSorting(Command $command, $sort);
-
-    /**
-     * @param Command $command
-     * @param array   $contains
-     * @param bool    $not
-     */
-    abstract protected function buildContentFiltering(Command $command, array $contains, $not = false);
 }

--- a/src/Symfony/Component/Finder/Expression/Expression.php
+++ b/src/Symfony/Component/Finder/Expression/Expression.php
@@ -26,16 +26,6 @@ class Expression implements ValueInterface
 
     /**
      * @param string $expr
-     *
-     * @return Expression
-     */
-    public static function create($expr)
-    {
-        return new self($expr);
-    }
-
-    /**
-     * @param string $expr
      */
     public function __construct($expr)
     {
@@ -44,6 +34,16 @@ class Expression implements ValueInterface
         } catch (\InvalidArgumentException $e) {
             $this->value = new Glob($expr);
         }
+    }
+
+    /**
+     * @param string $expr
+     *
+     * @return Expression
+     */
+    public static function create($expr)
+    {
+        return new self($expr);
     }
 
     /**

--- a/src/Symfony/Component/Finder/Expression/Regex.php
+++ b/src/Symfony/Component/Finder/Expression/Regex.php
@@ -53,6 +53,22 @@ class Regex implements ValueInterface
     private $endJoker;
 
     /**
+     * @param string $pattern
+     * @param string $options
+     * @param string $delimiter
+     */
+    public function __construct($pattern, $options = '', $delimiter = null)
+    {
+        if (null !== $delimiter) {
+            // removes delimiter escaping
+            $pattern = str_replace('\\'.$delimiter, $delimiter, $pattern);
+        }
+
+        $this->parsePattern($pattern);
+        $this->options = $options;
+    }
+
+    /**
      * @param string $expr
      *
      * @return Regex
@@ -75,22 +91,6 @@ class Regex implements ValueInterface
         }
 
         throw new \InvalidArgumentException('Given expression is not a regex.');
-    }
-
-    /**
-     * @param string $pattern
-     * @param string $options
-     * @param string $delimiter
-     */
-    public function __construct($pattern, $options = '', $delimiter = null)
-    {
-        if (null !== $delimiter) {
-            // removes delimiter escaping
-            $pattern = str_replace('\\'.$delimiter, $delimiter, $pattern);
-        }
-
-        $this->parsePattern($pattern);
-        $this->options = $options;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/ChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/ChoiceList.php
@@ -92,31 +92,6 @@ class ChoiceList implements ChoiceListInterface
     }
 
     /**
-     * Initializes the list with choices.
-     *
-     * Safe to be called multiple times. The list is cleared on every call.
-     *
-     * @param array|\Traversable $choices          The choices to write into the list.
-     * @param array              $labels           The labels belonging to the choices.
-     * @param array              $preferredChoices The choices to display with priority.
-     */
-    protected function initialize($choices, array $labels, array $preferredChoices)
-    {
-        $this->choices = array();
-        $this->values = array();
-        $this->preferredViews = array();
-        $this->remainingViews = array();
-
-        $this->addChoices(
-            $this->preferredViews,
-            $this->remainingViews,
-            $choices,
-            $labels,
-            $preferredChoices
-        );
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function getChoices()
@@ -242,6 +217,31 @@ class ChoiceList implements ChoiceListInterface
         }
 
         return $indices;
+    }
+
+    /**
+     * Initializes the list with choices.
+     *
+     * Safe to be called multiple times. The list is cleared on every call.
+     *
+     * @param array|\Traversable $choices          The choices to write into the list.
+     * @param array              $labels           The labels belonging to the choices.
+     * @param array              $preferredChoices The choices to display with priority.
+     */
+    protected function initialize($choices, array $labels, array $preferredChoices)
+    {
+        $this->choices = array();
+        $this->values = array();
+        $this->preferredViews = array();
+        $this->remainingViews = array();
+
+        $this->addChoices(
+            $this->preferredViews,
+            $this->remainingViews,
+            $choices,
+            $labels,
+            $preferredChoices
+        );
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Csrf/EventListener/CsrfValidationListener.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/EventListener/CsrfValidationListener.php
@@ -64,13 +64,6 @@ class CsrfValidationListener implements EventSubscriberInterface
      */
     private $translationDomain;
 
-    public static function getSubscribedEvents()
-    {
-        return array(
-            FormEvents::PRE_SUBMIT => 'preSubmit',
-        );
-    }
-
     public function __construct($fieldName, CsrfProviderInterface $csrfProvider, $intention, $errorMessage, TranslatorInterface $translator = null, $translationDomain = null)
     {
         $this->fieldName = $fieldName;
@@ -79,6 +72,13 @@ class CsrfValidationListener implements EventSubscriberInterface
         $this->errorMessage = $errorMessage;
         $this->translator = $translator;
         $this->translationDomain = $translationDomain;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            FormEvents::PRE_SUBMIT => 'preSubmit',
+        );
     }
 
     public function preSubmit(FormEvent $event)

--- a/src/Symfony/Component/Form/Extension/Validator/EventListener/ValidationListener.php
+++ b/src/Symfony/Component/Form/Extension/Validator/EventListener/ValidationListener.php
@@ -27,18 +27,18 @@ class ValidationListener implements EventSubscriberInterface
 
     private $violationMapper;
 
+    public function __construct(ValidatorInterface $validator, ViolationMapperInterface $violationMapper)
+    {
+        $this->validator = $validator;
+        $this->violationMapper = $violationMapper;
+    }
+
     /**
      * {@inheritdoc}
      */
     public static function getSubscribedEvents()
     {
         return array(FormEvents::POST_SUBMIT => 'validateForm');
-    }
-
-    public function __construct(ValidatorInterface $validator, ViolationMapperInterface $violationMapper)
-    {
-        $this->validator = $validator;
-        $this->violationMapper = $violationMapper;
     }
 
     /**

--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -28,6 +28,10 @@ use Symfony\Component\EventDispatcher\ImmutableEventDispatcher;
 class FormConfigBuilder implements FormConfigBuilderInterface
 {
     /**
+     * @var bool
+     */
+    protected $locked = false;
+    /**
      * Caches a globally unique {@link NativeRequestHandler} instance.
      *
      * @var NativeRequestHandler
@@ -46,11 +50,6 @@ class FormConfigBuilder implements FormConfigBuilderInterface
         'DELETE',
         'PATCH',
     );
-
-    /**
-     * @var bool
-     */
-    protected $locked = false;
 
     /**
      * @var EventDispatcherInterface

--- a/src/Symfony/Component/Form/FormError.php
+++ b/src/Symfony/Component/Form/FormError.php
@@ -19,11 +19,6 @@ namespace Symfony\Component\Form;
 class FormError
 {
     /**
-     * @var string
-     */
-    private $message;
-
-    /**
      * The template for the error message.
      *
      * @var string
@@ -43,6 +38,10 @@ class FormError
      * @var int|null
      */
     protected $messagePluralization;
+    /**
+     * @var string
+     */
+    private $message;
 
     /**
      * Constructor.

--- a/src/Symfony/Component/Form/FormEvent.php
+++ b/src/Symfony/Component/Form/FormEvent.php
@@ -18,8 +18,8 @@ use Symfony\Component\EventDispatcher\Event;
  */
 class FormEvent extends Event
 {
-    private $form;
     protected $data;
+    private $form;
 
     /**
      * Constructs an event.

--- a/src/Symfony/Component/Form/FormRegistry.php
+++ b/src/Symfony/Component/Form/FormRegistry.php
@@ -90,39 +90,6 @@ class FormRegistry implements FormRegistryInterface
     }
 
     /**
-     * Wraps a type into a ResolvedFormTypeInterface implementation and connects
-     * it with its parent type.
-     *
-     * @param FormTypeInterface $type The type to resolve.
-     *
-     * @return ResolvedFormTypeInterface The resolved type.
-     */
-    private function resolveAndAddType(FormTypeInterface $type)
-    {
-        $parentType = $type->getParent();
-
-        if ($parentType instanceof FormTypeInterface) {
-            $this->resolveAndAddType($parentType);
-            $parentType = $parentType->getName();
-        }
-
-        $typeExtensions = array();
-
-        foreach ($this->extensions as $extension) {
-            $typeExtensions = array_merge(
-                $typeExtensions,
-                $extension->getTypeExtensions($type->getName())
-            );
-        }
-
-        $this->types[$type->getName()] = $this->resolvedTypeFactory->createResolvedType(
-            $type,
-            $typeExtensions,
-            $parentType ? $this->getType($parentType) : null
-        );
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function hasType($name)
@@ -168,5 +135,38 @@ class FormRegistry implements FormRegistryInterface
     public function getExtensions()
     {
         return $this->extensions;
+    }
+
+    /**
+     * Wraps a type into a ResolvedFormTypeInterface implementation and connects
+     * it with its parent type.
+     *
+     * @param FormTypeInterface $type The type to resolve.
+     *
+     * @return ResolvedFormTypeInterface The resolved type.
+     */
+    private function resolveAndAddType(FormTypeInterface $type)
+    {
+        $parentType = $type->getParent();
+
+        if ($parentType instanceof FormTypeInterface) {
+            $this->resolveAndAddType($parentType);
+            $parentType = $parentType->getName();
+        }
+
+        $typeExtensions = array();
+
+        foreach ($this->extensions as $extension) {
+            $typeExtensions = array_merge(
+                $typeExtensions,
+                $extension->getTypeExtensions($type->getName())
+            );
+        }
+
+        $this->types[$type->getName()] = $this->resolvedTypeFactory->createResolvedType(
+            $type,
+            $typeExtensions,
+            $parentType ? $this->getType($parentType) : null
+        );
     }
 }

--- a/src/Symfony/Component/Form/Forms.php
+++ b/src/Symfony/Component/Form/Forms.php
@@ -154,6 +154,13 @@ use Symfony\Component\Form\Extension\Core\CoreExtension;
 final class Forms
 {
     /**
+     * This class cannot be instantiated.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
      * Creates a form factory with the default configuration.
      *
      * @return FormFactoryInterface The form factory.
@@ -174,12 +181,5 @@ final class Forms
         $builder->addExtension(new CoreExtension());
 
         return $builder;
-    }
-
-    /**
-     * This class cannot be instantiated.
-     */
-    private function __construct()
-    {
     }
 }

--- a/src/Symfony/Component/Form/Guess/Guess.php
+++ b/src/Symfony/Component/Form/Guess/Guess.php
@@ -63,6 +63,23 @@ abstract class Guess
     private $confidence;
 
     /**
+     * Constructor.
+     *
+     * @param int $confidence The confidence
+     *
+     * @throws InvalidArgumentException if the given value of confidence is unknown
+     */
+    public function __construct($confidence)
+    {
+        if (self::VERY_HIGH_CONFIDENCE !== $confidence && self::HIGH_CONFIDENCE !== $confidence &&
+            self::MEDIUM_CONFIDENCE !== $confidence && self::LOW_CONFIDENCE !== $confidence) {
+            throw new InvalidArgumentException('The confidence should be one of the constants defined in Guess.');
+        }
+
+        $this->confidence = $confidence;
+    }
+
+    /**
      * Returns the guess most likely to be correct from a list of guesses.
      *
      * If there are multiple guesses with the same, highest confidence, the
@@ -85,23 +102,6 @@ abstract class Guess
         }
 
         return $result;
-    }
-
-    /**
-     * Constructor.
-     *
-     * @param int $confidence The confidence
-     *
-     * @throws InvalidArgumentException if the given value of confidence is unknown
-     */
-    public function __construct($confidence)
-    {
-        if (self::VERY_HIGH_CONFIDENCE !== $confidence && self::HIGH_CONFIDENCE !== $confidence &&
-            self::MEDIUM_CONFIDENCE !== $confidence && self::LOW_CONFIDENCE !== $confidence) {
-            throw new InvalidArgumentException('The confidence should be one of the constants defined in Guess.');
-        }
-
-        $this->confidence = $confidence;
     }
 
     /**

--- a/src/Symfony/Component/Form/NativeRequestHandler.php
+++ b/src/Symfony/Component/Form/NativeRequestHandler.php
@@ -27,14 +27,6 @@ class NativeRequestHandler implements RequestHandlerInterface
     private $serverParams;
 
     /**
-     * {@inheritdoc}
-     */
-    public function __construct(ServerParams $params = null)
-    {
-        $this->serverParams = $params ?: new ServerParams();
-    }
-
-    /**
      * The allowed keys of the $_FILES array.
      *
      * @var array
@@ -46,6 +38,14 @@ class NativeRequestHandler implements RequestHandlerInterface
         'tmp_name',
         'type',
     );
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(ServerParams $params = null)
+    {
+        $this->serverParams = $params ?: new ServerParams();
+    }
 
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Form/Test/FormPerformanceTestCase.php
+++ b/src/Symfony/Component/Form/Test/FormPerformanceTestCase.php
@@ -27,27 +27,6 @@ abstract class FormPerformanceTestCase extends FormIntegrationTestCase
     protected $maxRunningTime = 0;
 
     /**
-     * {@inheritdoc}
-     */
-    protected function runTest()
-    {
-        $s = microtime(true);
-        parent::runTest();
-        $time = microtime(true) - $s;
-
-        if ($this->maxRunningTime != 0 && $time > $this->maxRunningTime) {
-            $this->fail(
-                sprintf(
-                    'expected running time: <= %s but was: %s',
-
-                    $this->maxRunningTime,
-                    $time
-                )
-            );
-        }
-    }
-
-    /**
      * @param int $maxRunningTime
      *
      * @throws \InvalidArgumentException
@@ -69,5 +48,26 @@ abstract class FormPerformanceTestCase extends FormIntegrationTestCase
     public function getMaxRunningTime()
     {
         return $this->maxRunningTime;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function runTest()
+    {
+        $s = microtime(true);
+        parent::runTest();
+        $time = microtime(true) - $s;
+
+        if ($this->maxRunningTime != 0 && $time > $this->maxRunningTime) {
+            $this->fail(
+                sprintf(
+                    'expected running time: <= %s but was: %s',
+
+                    $this->maxRunningTime,
+                    $time
+                )
+            );
+        }
     }
 }

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -32,95 +32,12 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         parent::setUp();
     }
 
-    protected function getExtensions()
-    {
-        return array(
-            new CsrfExtension($this->csrfProvider),
-        );
-    }
-
     protected function tearDown()
     {
         $this->csrfProvider = null;
 
         parent::tearDown();
     }
-
-    protected function assertXpathNodeValue(\DomElement $element, $expression, $nodeValue)
-    {
-        $xpath = new \DOMXPath($element->ownerDocument);
-        $nodeList = $xpath->evaluate($expression);
-        $this->assertEquals(1, $nodeList->length);
-        $this->assertEquals($nodeValue, $nodeList->item(0)->nodeValue);
-    }
-
-    protected function assertMatchesXpath($html, $expression, $count = 1)
-    {
-        $dom = new \DomDocument('UTF-8');
-        try {
-            // Wrap in <root> node so we can load HTML with multiple tags at
-            // the top level
-            $dom->loadXML('<root>'.$html.'</root>');
-        } catch (\Exception $e) {
-            $this->fail(sprintf(
-                "Failed loading HTML:\n\n%s\n\nError: %s",
-                $html,
-                $e->getMessage()
-            ));
-        }
-        $xpath = new \DOMXPath($dom);
-        $nodeList = $xpath->evaluate('/root'.$expression);
-
-        if ($nodeList->length != $count) {
-            $dom->formatOutput = true;
-            $this->fail(sprintf(
-                "Failed asserting that \n\n%s\n\nmatches exactly %s. Matches %s in \n\n%s",
-                $expression,
-                $count == 1 ? 'once' : $count.' times',
-                $nodeList->length == 1 ? 'once' : $nodeList->length.' times',
-                // strip away <root> and </root>
-                substr($dom->saveHTML(), 6, -8)
-            ));
-        }
-    }
-
-    protected function assertWidgetMatchesXpath(FormView $view, array $vars, $xpath)
-    {
-        // include ampersands everywhere to validate escaping
-        $html = $this->renderWidget($view, array_merge(array(
-            'id' => 'my&id',
-            'attr' => array('class' => 'my&class'),
-        ), $vars));
-
-        $xpath = trim($xpath).'
-    [@id="my&id"]
-    [@class="my&class"]';
-
-        $this->assertMatchesXpath($html, $xpath);
-    }
-
-    abstract protected function renderForm(FormView $view, array $vars = array());
-
-    protected function renderEnctype(FormView $view)
-    {
-        $this->markTestSkipped(sprintf('Legacy %s::renderEnctype() is not implemented.', get_class($this)));
-    }
-
-    abstract protected function renderLabel(FormView $view, $label = null, array $vars = array());
-
-    abstract protected function renderErrors(FormView $view);
-
-    abstract protected function renderWidget(FormView $view, array $vars = array());
-
-    abstract protected function renderRow(FormView $view, array $vars = array());
-
-    abstract protected function renderRest(FormView $view, array $vars = array());
-
-    abstract protected function renderStart(FormView $view, array $vars = array());
-
-    abstract protected function renderEnd(FormView $view, array $vars = array());
-
-    abstract protected function setTheme(FormView $view, array $themes);
 
     /**
      * @group legacy
@@ -1914,4 +1831,87 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         $this->assertMatchesXpath($html, '/form//input[@title="[trans]Foo[/trans]"]');
         $this->assertMatchesXpath($html, '/form//input[@placeholder="[trans]Bar[/trans]"]');
     }
+
+    protected function getExtensions()
+    {
+        return array(
+            new CsrfExtension($this->csrfProvider),
+        );
+    }
+
+    protected function assertXpathNodeValue(\DomElement $element, $expression, $nodeValue)
+    {
+        $xpath = new \DOMXPath($element->ownerDocument);
+        $nodeList = $xpath->evaluate($expression);
+        $this->assertEquals(1, $nodeList->length);
+        $this->assertEquals($nodeValue, $nodeList->item(0)->nodeValue);
+    }
+
+    protected function assertMatchesXpath($html, $expression, $count = 1)
+    {
+        $dom = new \DomDocument('UTF-8');
+        try {
+            // Wrap in <root> node so we can load HTML with multiple tags at
+            // the top level
+            $dom->loadXML('<root>'.$html.'</root>');
+        } catch (\Exception $e) {
+            $this->fail(sprintf(
+                "Failed loading HTML:\n\n%s\n\nError: %s",
+                $html,
+                $e->getMessage()
+            ));
+        }
+        $xpath = new \DOMXPath($dom);
+        $nodeList = $xpath->evaluate('/root'.$expression);
+
+        if ($nodeList->length != $count) {
+            $dom->formatOutput = true;
+            $this->fail(sprintf(
+                "Failed asserting that \n\n%s\n\nmatches exactly %s. Matches %s in \n\n%s",
+                $expression,
+                $count == 1 ? 'once' : $count.' times',
+                $nodeList->length == 1 ? 'once' : $nodeList->length.' times',
+                // strip away <root> and </root>
+                substr($dom->saveHTML(), 6, -8)
+            ));
+        }
+    }
+
+    protected function assertWidgetMatchesXpath(FormView $view, array $vars, $xpath)
+    {
+        // include ampersands everywhere to validate escaping
+        $html = $this->renderWidget($view, array_merge(array(
+            'id' => 'my&id',
+            'attr' => array('class' => 'my&class'),
+        ), $vars));
+
+        $xpath = trim($xpath).'
+    [@id="my&id"]
+    [@class="my&class"]';
+
+        $this->assertMatchesXpath($html, $xpath);
+    }
+
+    abstract protected function renderForm(FormView $view, array $vars = array());
+
+    protected function renderEnctype(FormView $view)
+    {
+        $this->markTestSkipped(sprintf('Legacy %s::renderEnctype() is not implemented.', get_class($this)));
+    }
+
+    abstract protected function renderLabel(FormView $view, $label = null, array $vars = array());
+
+    abstract protected function renderErrors(FormView $view);
+
+    abstract protected function renderWidget(FormView $view, array $vars = array());
+
+    abstract protected function renderRow(FormView $view, array $vars = array());
+
+    abstract protected function renderRest(FormView $view, array $vars = array());
+
+    abstract protected function renderStart(FormView $view, array $vars = array());
+
+    abstract protected function renderEnd(FormView $view, array $vars = array());
+
+    abstract protected function setTheme(FormView $view, array $themes);
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
@@ -39,43 +39,6 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
         $this->mapper = new PropertyPathMapper($this->propertyAccessor);
     }
 
-    /**
-     * @param $path
-     *
-     * @return \PHPUnit_Framework_MockObject_MockObject
-     */
-    private function getPropertyPath($path)
-    {
-        return $this->getMockBuilder('Symfony\Component\PropertyAccess\PropertyPath')
-            ->setConstructorArgs(array($path))
-            ->setMethods(array('getValue', 'setValue'))
-            ->getMock();
-    }
-
-    /**
-     * @param FormConfigInterface $config
-     * @param bool                $synchronized
-     *
-     * @return \PHPUnit_Framework_MockObject_MockObject
-     */
-    private function getForm(FormConfigInterface $config, $synchronized = true, $submitted = true)
-    {
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
-            ->setConstructorArgs(array($config))
-            ->setMethods(array('isSynchronized', 'isSubmitted'))
-            ->getMock();
-
-        $form->expects($this->any())
-            ->method('isSynchronized')
-            ->will($this->returnValue($synchronized));
-
-        $form->expects($this->any())
-            ->method('isSubmitted')
-            ->will($this->returnValue($submitted));
-
-        return $form;
-    }
-
     public function testMapDataToFormsPassesObjectRefIfByReference()
     {
         $car = new \stdClass();
@@ -356,5 +319,42 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
         $form = $this->getForm($config);
 
         $this->mapper->mapFormsToData(array($form), $car);
+    }
+
+    /**
+     * @param $path
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getPropertyPath($path)
+    {
+        return $this->getMockBuilder('Symfony\Component\PropertyAccess\PropertyPath')
+            ->setConstructorArgs(array($path))
+            ->setMethods(array('getValue', 'setValue'))
+            ->getMock();
+    }
+
+    /**
+     * @param FormConfigInterface $config
+     * @param bool                $synchronized
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getForm(FormConfigInterface $config, $synchronized = true, $submitted = true)
+    {
+        $form = $this->getMockBuilder('Symfony\Component\Form\Form')
+            ->setConstructorArgs(array($config))
+            ->setMethods(array('isSynchronized', 'isSubmitted'))
+            ->getMock();
+
+        $form->expects($this->any())
+            ->method('isSynchronized')
+            ->will($this->returnValue($synchronized));
+
+        $form->expects($this->any())
+            ->method('isSubmitted')
+            ->will($this->returnValue($submitted));
+
+        return $form;
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/MergeCollectionListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/MergeCollectionListenerTest.php
@@ -34,20 +34,6 @@ abstract class MergeCollectionListenerTest extends \PHPUnit_Framework_TestCase
         $this->form = null;
     }
 
-    abstract protected function getBuilder($name = 'name');
-
-    protected function getForm($name = 'name', $propertyPath = null)
-    {
-        $propertyPath = $propertyPath ?: $name;
-
-        return $this->getBuilder($name)->setAttribute('property_path', $propertyPath)->getForm();
-    }
-
-    protected function getMockForm()
-    {
-        return $this->getMock('Symfony\Component\Form\Test\FormInterface');
-    }
-
     public function getBooleanMatrix1()
     {
         return array(
@@ -65,8 +51,6 @@ abstract class MergeCollectionListenerTest extends \PHPUnit_Framework_TestCase
             array(false, false),
         );
     }
-
-    abstract protected function getData(array $data);
 
     /**
      * @dataProvider getBooleanMatrix1
@@ -252,4 +236,20 @@ abstract class MergeCollectionListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($event->getData());
     }
+
+    abstract protected function getBuilder($name = 'name');
+
+    protected function getForm($name = 'name', $propertyPath = null)
+    {
+        $propertyPath = $propertyPath ?: $name;
+
+        return $this->getBuilder($name)->setAttribute('property_path', $propertyPath)->getForm();
+    }
+
+    protected function getMockForm()
+    {
+        return $this->getMock('Symfony\Component\Form\Test\FormInterface');
+    }
+
+    abstract protected function getData(array $data);
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
@@ -39,29 +39,6 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
         $this->form = null;
     }
 
-    protected function getBuilder($name = 'name')
-    {
-        return new FormBuilder($name, null, $this->dispatcher, $this->factory);
-    }
-
-    protected function getForm($name = 'name')
-    {
-        return $this->getBuilder($name)->getForm();
-    }
-
-    /**
-     * @return \PHPUnit_Framework_MockObject_MockObject
-     */
-    private function getDataMapper()
-    {
-        return $this->getMock('Symfony\Component\Form\DataMapperInterface');
-    }
-
-    protected function getMockForm()
-    {
-        return $this->getMock('Symfony\Component\Form\Test\FormInterface');
-    }
-
     public function testPreSetDataResizesForm()
     {
         $this->form->add($this->getForm('0'));
@@ -273,5 +250,28 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertArrayNotHasKey(0, $event->getData());
         $this->assertArrayNotHasKey(2, $event->getData());
+    }
+
+    protected function getBuilder($name = 'name')
+    {
+        return new FormBuilder($name, null, $this->dispatcher, $this->factory);
+    }
+
+    protected function getForm($name = 'name')
+    {
+        return $this->getBuilder($name)->getForm();
+    }
+
+    protected function getMockForm()
+    {
+        return $this->getMock('Symfony\Component\Form\Test\FormInterface');
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getDataMapper()
+    {
+        return $this->getMock('Symfony\Component\Form\DataMapperInterface');
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -16,6 +16,17 @@ use Symfony\Component\Form\Extension\Core\View\ChoiceView;
 
 class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 {
+    protected $groupedChoices = array(
+        'Symfony' => array(
+            'a' => 'Bernhard',
+            'b' => 'Fabien',
+            'c' => 'Kris',
+        ),
+        'Doctrine' => array(
+            'd' => 'Jon',
+            'e' => 'Roman',
+        ),
+    );
     private $choices = array(
         'a' => 'Bernhard',
         'b' => 'Fabien',
@@ -33,18 +44,6 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     );
 
     private $objectChoices;
-
-    protected $groupedChoices = array(
-        'Symfony' => array(
-            'a' => 'Bernhard',
-            'b' => 'Fabien',
-            'c' => 'Kris',
-        ),
-        'Doctrine' => array(
-            'd' => 'Jon',
-            'e' => 'Roman',
-        ),
-    );
 
     protected function setUp()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/EventListener/CsrfValidationListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/EventListener/CsrfValidationListenerTest.php
@@ -39,6 +39,19 @@ class CsrfValidationListenerTest extends \PHPUnit_Framework_TestCase
         $this->form = null;
     }
 
+    // https://github.com/symfony/symfony/pull/5838
+    public function testStringFormData()
+    {
+        $data = 'XP4HUzmHPi';
+        $event = new FormEvent($this->form, $data);
+
+        $validation = new CsrfValidationListener('csrf', $this->csrfProvider, 'unknown', 'Invalid.');
+        $validation->preSubmit($event);
+
+        // Validate accordingly
+        $this->assertSame($data, $event->getData());
+    }
+
     protected function getBuilder($name = 'name')
     {
         return new FormBuilder($name, null, $this->dispatcher, $this->factory, array('compound' => true));
@@ -57,18 +70,5 @@ class CsrfValidationListenerTest extends \PHPUnit_Framework_TestCase
     protected function getMockForm()
     {
         return $this->getMock('Symfony\Component\Form\Test\FormInterface');
-    }
-
-    // https://github.com/symfony/symfony/pull/5838
-    public function testStringFormData()
-    {
-        $data = 'XP4HUzmHPi';
-        $event = new FormEvent($this->form, $data);
-
-        $validation = new CsrfValidationListener('csrf', $this->csrfProvider, 'unknown', 'Invalid.');
-        $validation->preSubmit($event);
-
-        // Validate accordingly
-        $this->assertSame($data, $event->getData());
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
@@ -60,13 +60,6 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
         parent::tearDown();
     }
 
-    protected function getExtensions()
-    {
-        return array_merge(parent::getExtensions(), array(
-            new CsrfExtension($this->csrfProvider, $this->translator),
-        ));
-    }
-
     public function testCsrfProtectionByDefaultIfRootAndCompound()
     {
         $view = $this->factory
@@ -395,5 +388,12 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
 
         $this->assertGreaterThan(0, count($errors));
         $this->assertEquals(new FormError('[trans]Foobar[/trans]'), $errors[0]);
+    }
+
+    protected function getExtensions()
+    {
+        return array_merge(parent::getExtensions(), array(
+            new CsrfExtension($this->csrfProvider, $this->translator),
+        ));
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorPerformanceTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorPerformanceTest.php
@@ -20,13 +20,6 @@ use Symfony\Component\Validator\Validation;
  */
 class FormValidatorPerformanceTest extends FormPerformanceTestCase
 {
-    protected function getExtensions()
-    {
-        return array(
-            new ValidatorExtension(Validation::createValidator()),
-        );
-    }
-
     /**
      * findClickedButton() used to have an exponential number of calls.
      *
@@ -50,5 +43,12 @@ class FormValidatorPerformanceTest extends FormPerformanceTestCase
         $form = $builder->getForm();
 
         $form->submit(null);
+    }
+
+    protected function getExtensions()
+    {
+        return array(
+            new ValidatorExtension(Validation::createValidator()),
+        );
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -30,17 +30,16 @@ class FormValidatorTest extends AbstractConstraintValidatorTest
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
+    protected $serverParams;
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
     private $dispatcher;
 
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
     private $factory;
-
-    /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
-     */
-    protected $serverParams;
 
     protected function setUp()
     {
@@ -52,11 +51,6 @@ class FormValidatorTest extends AbstractConstraintValidatorTest
         );
 
         parent::setUp();
-    }
-
-    protected function createValidator()
-    {
-        return new FormValidator($this->serverParams);
     }
 
     public function testValidate()
@@ -567,6 +561,11 @@ class FormValidatorTest extends AbstractConstraintValidatorTest
     public function getValidationGroups(FormInterface $form)
     {
         return array('group1', 'group2');
+    }
+
+    protected function createValidator()
+    {
+        return new FormValidator($this->serverParams);
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/EventListener/ValidationListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/EventListener/ValidationListenerTest.php
@@ -63,32 +63,6 @@ class ValidationListenerTest extends \PHPUnit_Framework_TestCase
         $this->params = array('foo' => 'bar');
     }
 
-    private function getConstraintViolation($code = null)
-    {
-        return new ConstraintViolation($this->message, $this->messageTemplate, $this->params, null, 'prop.path', null, null, $code);
-    }
-
-    private function getBuilder($name = 'name', $propertyPath = null, $dataClass = null)
-    {
-        $builder = new FormBuilder($name, $dataClass, $this->dispatcher, $this->factory);
-        $builder->setPropertyPath(new PropertyPath($propertyPath ?: $name));
-        $builder->setAttribute('error_mapping', array());
-        $builder->setErrorBubbling(false);
-        $builder->setMapped(true);
-
-        return $builder;
-    }
-
-    private function getForm($name = 'name', $propertyPath = null, $dataClass = null)
-    {
-        return $this->getBuilder($name, $propertyPath, $dataClass)->getForm();
-    }
-
-    private function getMockForm()
-    {
-        return $this->getMock('Symfony\Component\Form\Test\FormInterface');
-    }
-
     // More specific mapping tests can be found in ViolationMapperTest
     public function testMapViolation()
     {
@@ -137,5 +111,31 @@ class ValidationListenerTest extends \PHPUnit_Framework_TestCase
             ->method('mapViolation');
 
         $this->listener->validateForm(new FormEvent($form, null));
+    }
+
+    private function getConstraintViolation($code = null)
+    {
+        return new ConstraintViolation($this->message, $this->messageTemplate, $this->params, null, 'prop.path', null, null, $code);
+    }
+
+    private function getBuilder($name = 'name', $propertyPath = null, $dataClass = null)
+    {
+        $builder = new FormBuilder($name, $dataClass, $this->dispatcher, $this->factory);
+        $builder->setPropertyPath(new PropertyPath($propertyPath ?: $name));
+        $builder->setAttribute('error_mapping', array());
+        $builder->setErrorBubbling(false);
+        $builder->setMapped(true);
+
+        return $builder;
+    }
+
+    private function getForm($name = 'name', $propertyPath = null, $dataClass = null)
+    {
+        return $this->getBuilder($name, $propertyPath, $dataClass)->getForm();
+    }
+
+    private function getMockForm()
+    {
+        return $this->getMock('Symfony\Component\Form\Test\FormInterface');
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
@@ -67,53 +67,6 @@ class ViolationMapperTest extends \PHPUnit_Framework_TestCase
         $this->params = array('foo' => 'bar');
     }
 
-    protected function getForm($name = 'name', $propertyPath = null, $dataClass = null, $errorMapping = array(), $inheritData = false, $synchronized = true)
-    {
-        $config = new FormConfigBuilder($name, $dataClass, $this->dispatcher, array(
-            'error_mapping' => $errorMapping,
-        ));
-        $config->setMapped(true);
-        $config->setInheritData($inheritData);
-        $config->setPropertyPath($propertyPath);
-        $config->setCompound(true);
-        $config->setDataMapper($this->getDataMapper());
-
-        if (!$synchronized) {
-            $config->addViewTransformer(new CallbackTransformer(
-                function ($normData) { return $normData; },
-                function () { throw new TransformationFailedException(); }
-            ));
-        }
-
-        return new Form($config);
-    }
-
-    /**
-     * @return \PHPUnit_Framework_MockObject_MockObject
-     */
-    private function getDataMapper()
-    {
-        return $this->getMock('Symfony\Component\Form\DataMapperInterface');
-    }
-
-    /**
-     * @param $propertyPath
-     *
-     * @return ConstraintViolation
-     */
-    protected function getConstraintViolation($propertyPath)
-    {
-        return new ConstraintViolation($this->message, $this->messageTemplate, $this->params, null, $propertyPath, null);
-    }
-
-    /**
-     * @return FormError
-     */
-    protected function getFormError()
-    {
-        return new FormError($this->message, $this->messageTemplate, $this->params);
-    }
-
     public function testMapToFormInheritingParentDataIfDataDoesNotMatch()
     {
         $violation = $this->getConstraintViolation('children[address].data.foo');
@@ -1494,5 +1447,52 @@ class ViolationMapperTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(0, $child1->getErrors(), $child1->getName().' should not have an error, but has one');
         $this->assertCount(0, $child2->getErrors(), $child2->getName().' should not have an error, but has one');
         $this->assertEquals(array($this->getFormError()), $grandChild->getErrors(), $grandChild->getName().' should have an error, but has none');
+    }
+
+    protected function getForm($name = 'name', $propertyPath = null, $dataClass = null, $errorMapping = array(), $inheritData = false, $synchronized = true)
+    {
+        $config = new FormConfigBuilder($name, $dataClass, $this->dispatcher, array(
+            'error_mapping' => $errorMapping,
+        ));
+        $config->setMapped(true);
+        $config->setInheritData($inheritData);
+        $config->setPropertyPath($propertyPath);
+        $config->setCompound(true);
+        $config->setDataMapper($this->getDataMapper());
+
+        if (!$synchronized) {
+            $config->addViewTransformer(new CallbackTransformer(
+                function ($normData) { return $normData; },
+                function () { throw new TransformationFailedException(); }
+            ));
+        }
+
+        return new Form($config);
+    }
+
+    /**
+     * @param $propertyPath
+     *
+     * @return ConstraintViolation
+     */
+    protected function getConstraintViolation($propertyPath)
+    {
+        return new ConstraintViolation($this->message, $this->messageTemplate, $this->params, null, $propertyPath, null);
+    }
+
+    /**
+     * @return FormError
+     */
+    protected function getFormError()
+    {
+        return new FormError($this->message, $this->messageTemplate, $this->params);
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getDataMapper()
+    {
+        return $this->getMock('Symfony\Component\Form\DataMapperInterface');
     }
 }

--- a/src/Symfony/Component/Form/Tests/ResolvedFormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/ResolvedFormTypeTest.php
@@ -231,6 +231,17 @@ class ResolvedFormTypeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @param string $name
+     * @param array  $options
+     *
+     * @return FormBuilder
+     */
+    protected function getBuilder($name = 'name', array $options = array())
+    {
+        return new FormBuilder($name, null, $this->dispatcher, $this->factory, $options);
+    }
+
+    /**
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
     private function getMockFormType()
@@ -252,16 +263,5 @@ class ResolvedFormTypeTest extends \PHPUnit_Framework_TestCase
     private function getMockFormFactory()
     {
         return $this->getMock('Symfony\Component\Form\FormFactoryInterface');
-    }
-
-    /**
-     * @param string $name
-     * @param array  $options
-     *
-     * @return FormBuilder
-     */
-    protected function getBuilder($name = 'name', array $options = array())
-    {
-        return new FormBuilder($name, null, $this->dispatcher, $this->factory, $options);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -253,19 +253,6 @@ class BinaryFileResponse extends Response
         return $this;
     }
 
-    private function hasValidIfRangeHeader($header)
-    {
-        if ($this->getEtag() === $header) {
-            return true;
-        }
-
-        if (null === $lastModified = $this->getLastModified()) {
-            return false;
-        }
-
-        return $lastModified->format('D, d M Y H:i:s').' GMT' === $header;
-    }
-
     /**
      * Sends the file.
      *
@@ -320,5 +307,18 @@ class BinaryFileResponse extends Response
     public static function trustXSendfileTypeHeader()
     {
         self::$trustXSendfileTypeHeader = true;
+    }
+
+    private function hasValidIfRangeHeader($header)
+    {
+        if ($this->getEtag() === $header) {
+            return true;
+        }
+
+        if (null === $lastModified = $this->getLastModified()) {
+            return false;
+        }
+
+        return $lastModified->format('D, d M Y H:i:s').' GMT' === $header;
     }
 }

--- a/src/Symfony/Component/HttpFoundation/File/MimeType/ExtensionGuesser.php
+++ b/src/Symfony/Component/HttpFoundation/File/MimeType/ExtensionGuesser.php
@@ -26,6 +26,12 @@ namespace Symfony\Component\HttpFoundation\File\MimeType;
 class ExtensionGuesser implements ExtensionGuesserInterface
 {
     /**
+     * All registered ExtensionGuesserInterface instances.
+     *
+     * @var array
+     */
+    protected $guessers = array();
+    /**
      * The singleton instance.
      *
      * @var ExtensionGuesser
@@ -33,11 +39,12 @@ class ExtensionGuesser implements ExtensionGuesserInterface
     private static $instance = null;
 
     /**
-     * All registered ExtensionGuesserInterface instances.
-     *
-     * @var array
+     * Registers all natively provided extension guessers.
      */
-    protected $guessers = array();
+    private function __construct()
+    {
+        $this->register(new MimeTypeExtensionGuesser());
+    }
 
     /**
      * Returns the singleton instance.
@@ -51,14 +58,6 @@ class ExtensionGuesser implements ExtensionGuesserInterface
         }
 
         return self::$instance;
-    }
-
-    /**
-     * Registers all natively provided extension guessers.
-     */
-    private function __construct()
-    {
-        $this->register(new MimeTypeExtensionGuesser());
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/File/MimeType/MimeTypeGuesser.php
+++ b/src/Symfony/Component/HttpFoundation/File/MimeType/MimeTypeGuesser.php
@@ -40,6 +40,12 @@ use Symfony\Component\HttpFoundation\File\Exception\AccessDeniedException;
 class MimeTypeGuesser implements MimeTypeGuesserInterface
 {
     /**
+     * All registered MimeTypeGuesserInterface instances.
+     *
+     * @var array
+     */
+    protected $guessers = array();
+    /**
      * The singleton instance.
      *
      * @var MimeTypeGuesser
@@ -47,11 +53,18 @@ class MimeTypeGuesser implements MimeTypeGuesserInterface
     private static $instance = null;
 
     /**
-     * All registered MimeTypeGuesserInterface instances.
-     *
-     * @var array
+     * Registers all natively provided mime type guessers.
      */
-    protected $guessers = array();
+    private function __construct()
+    {
+        if (FileBinaryMimeTypeGuesser::isSupported()) {
+            $this->register(new FileBinaryMimeTypeGuesser());
+        }
+
+        if (FileinfoMimeTypeGuesser::isSupported()) {
+            $this->register(new FileinfoMimeTypeGuesser());
+        }
+    }
 
     /**
      * Returns the singleton instance.
@@ -73,20 +86,6 @@ class MimeTypeGuesser implements MimeTypeGuesserInterface
     public static function reset()
     {
         self::$instance = null;
-    }
-
-    /**
-     * Registers all natively provided mime type guessers.
-     */
-    private function __construct()
-    {
-        if (FileBinaryMimeTypeGuesser::isSupported()) {
-            $this->register(new FileBinaryMimeTypeGuesser());
-        }
-
-        if (FileinfoMimeTypeGuesser::isSupported()) {
-            $this->register(new FileinfoMimeTypeGuesser());
-        }
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -33,34 +33,6 @@ class Request
     const HEADER_CLIENT_PROTO = 'client_proto';
     const HEADER_CLIENT_PORT = 'client_port';
 
-    protected static $trustedProxies = array();
-
-    /**
-     * @var string[]
-     */
-    protected static $trustedHostPatterns = array();
-
-    /**
-     * @var string[]
-     */
-    protected static $trustedHosts = array();
-
-    /**
-     * Names for headers that can be trusted when
-     * using trusted proxies.
-     *
-     * The default names are non-standard, but widely used
-     * by popular reverse proxies (like Apache mod_proxy or Amazon EC2).
-     */
-    protected static $trustedHeaders = array(
-        self::HEADER_CLIENT_IP => 'X_FORWARDED_FOR',
-        self::HEADER_CLIENT_HOST => 'X_FORWARDED_HOST',
-        self::HEADER_CLIENT_PROTO => 'X_FORWARDED_PROTO',
-        self::HEADER_CLIENT_PORT => 'X_FORWARDED_PORT',
-    );
-
-    protected static $httpMethodParameterOverride = false;
-
     /**
      * Custom parameters.
      *
@@ -109,6 +81,34 @@ class Request
      * @var \Symfony\Component\HttpFoundation\HeaderBag
      */
     public $headers;
+
+    protected static $trustedProxies = array();
+
+    /**
+     * @var string[]
+     */
+    protected static $trustedHostPatterns = array();
+
+    /**
+     * @var string[]
+     */
+    protected static $trustedHosts = array();
+
+    /**
+     * Names for headers that can be trusted when
+     * using trusted proxies.
+     *
+     * The default names are non-standard, but widely used
+     * by popular reverse proxies (like Apache mod_proxy or Amazon EC2).
+     */
+    protected static $trustedHeaders = array(
+        self::HEADER_CLIENT_IP => 'X_FORWARDED_FOR',
+        self::HEADER_CLIENT_HOST => 'X_FORWARDED_HOST',
+        self::HEADER_CLIENT_PROTO => 'X_FORWARDED_PROTO',
+        self::HEADER_CLIENT_PORT => 'X_FORWARDED_PORT',
+    );
+
+    protected static $httpMethodParameterOverride = false;
 
     /**
      * @var string

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -24,31 +24,6 @@ class Response
     public $headers;
 
     /**
-     * @var string
-     */
-    protected $content;
-
-    /**
-     * @var string
-     */
-    protected $version;
-
-    /**
-     * @var int
-     */
-    protected $statusCode;
-
-    /**
-     * @var string
-     */
-    protected $statusText;
-
-    /**
-     * @var string
-     */
-    protected $charset;
-
-    /**
      * Status codes translation table.
      *
      * The list of codes is complete according to the
@@ -122,6 +97,31 @@ class Response
         510 => 'Not Extended',                                                // RFC2774
         511 => 'Network Authentication Required',                             // RFC6585
     );
+
+    /**
+     * @var string
+     */
+    protected $content;
+
+    /**
+     * @var string
+     */
+    protected $version;
+
+    /**
+     * @var int
+     */
+    protected $statusCode;
+
+    /**
+     * @var string
+     */
+    protected $statusText;
+
+    /**
+     * @var string
+     */
+    protected $charset;
 
     /**
      * Constructor.

--- a/src/Symfony/Component/HttpFoundation/Session/Attribute/AttributeBag.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Attribute/AttributeBag.php
@@ -16,17 +16,16 @@ namespace Symfony\Component\HttpFoundation\Session\Attribute;
  */
 class AttributeBag implements AttributeBagInterface, \IteratorAggregate, \Countable
 {
+    /**
+     * @var array
+     */
+    protected $attributes = array();
     private $name = 'attributes';
 
     /**
      * @var string
      */
     private $storageKey;
-
-    /**
-     * @var array
-     */
-    protected $attributes = array();
 
     /**
      * Constructor.

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/MetadataBag.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/MetadataBag.php
@@ -27,6 +27,11 @@ class MetadataBag implements SessionBagInterface
     const LIFETIME = 'l';
 
     /**
+     * @var array
+     */
+    protected $meta = array();
+
+    /**
      * @var string
      */
     private $name = '__metadata';
@@ -35,11 +40,6 @@ class MetadataBag implements SessionBagInterface
      * @var string
      */
     private $storageKey;
-
-    /**
-     * @var array
-     */
-    protected $meta = array();
 
     /**
      * Unix timestamp.

--- a/src/Symfony/Component/HttpFoundation/Tests/File/MimeType/MimeTypeTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/MimeType/MimeTypeTest.php
@@ -21,6 +21,15 @@ class MimeTypeTest extends \PHPUnit_Framework_TestCase
 {
     protected $path;
 
+    public static function tearDownAfterClass()
+    {
+        $path = __DIR__.'/../Fixtures/to_delete';
+        if (file_exists($path)) {
+            @chmod($path, 0666);
+            @unlink($path);
+        }
+    }
+
     public function testGuessImageWithoutExtension()
     {
         $this->assertEquals('image/gif', MimeTypeGuesser::getInstance()->guess(__DIR__.'/../Fixtures/test'));
@@ -75,15 +84,6 @@ class MimeTypeTest extends \PHPUnit_Framework_TestCase
             MimeTypeGuesser::getInstance()->guess($path);
         } else {
             $this->markTestSkipped('Can not verify chmod operations, change of file permissions failed');
-        }
-    }
-
-    public static function tearDownAfterClass()
-    {
-        $path = __DIR__.'/../Fixtures/to_delete';
-        if (file_exists($path)) {
-            @chmod($path, 0666);
-            @unlink($path);
         }
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/FileBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/FileBagTest.php
@@ -22,6 +22,20 @@ use Symfony\Component\HttpFoundation\FileBag;
  */
 class FileBagTest extends \PHPUnit_Framework_TestCase
 {
+    protected function setUp()
+    {
+        mkdir(sys_get_temp_dir().'/form_test', 0777, true);
+    }
+
+    protected function tearDown()
+    {
+        foreach (glob(sys_get_temp_dir().'/form_test/*') as $file) {
+            unlink($file);
+        }
+
+        rmdir(sys_get_temp_dir().'/form_test');
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      */
@@ -130,19 +144,5 @@ class FileBagTest extends \PHPUnit_Framework_TestCase
     protected function createTempFile()
     {
         return tempnam(sys_get_temp_dir().'/form_test', 'FormTest');
-    }
-
-    protected function setUp()
-    {
-        mkdir(sys_get_temp_dir().'/form_test', 0777, true);
-    }
-
-    protected function tearDown()
-    {
-        foreach (glob(sys_get_temp_dir().'/form_test/*') as $file) {
-            unlink($file);
-        }
-
-        rmdir(sys_get_temp_dir().'/form_test');
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1425,32 +1425,6 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    private function disableHttpMethodParameterOverride()
-    {
-        $class = new \ReflectionClass('Symfony\\Component\\HttpFoundation\\Request');
-        $property = $class->getProperty('httpMethodParameterOverride');
-        $property->setAccessible(true);
-        $property->setValue(false);
-    }
-
-    private function getRequestInstanceForClientIpTests($remoteAddr, $httpForwardedFor, $trustedProxies)
-    {
-        $request = new Request();
-
-        $server = array('REMOTE_ADDR' => $remoteAddr);
-        if (null !== $httpForwardedFor) {
-            $server['HTTP_X_FORWARDED_FOR'] = $httpForwardedFor;
-        }
-
-        if ($trustedProxies) {
-            Request::setTrustedProxies($trustedProxies);
-        }
-
-        $request->initialize(array(), array(), array(), array(), array(), $server);
-
-        return $request;
-    }
-
     public function testTrustedProxies()
     {
         $request = Request::create('http://example.com/');
@@ -1710,6 +1684,32 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             array('a'.str_repeat('.a', 40000)),
             array(str_repeat(':', 101)),
         );
+    }
+
+    private function disableHttpMethodParameterOverride()
+    {
+        $class = new \ReflectionClass('Symfony\\Component\\HttpFoundation\\Request');
+        $property = $class->getProperty('httpMethodParameterOverride');
+        $property->setAccessible(true);
+        $property->setValue(false);
+    }
+
+    private function getRequestInstanceForClientIpTests($remoteAddr, $httpForwardedFor, $trustedProxies)
+    {
+        $request = new Request();
+
+        $server = array('REMOTE_ADDR' => $remoteAddr);
+        if (null !== $httpForwardedFor) {
+            $server['HTTP_X_FORWARDED_FOR'] = $httpForwardedFor;
+        }
+
+        if ($trustedProxies) {
+            Request::setTrustedProxies($trustedProxies);
+        }
+
+        $request->initialize(array(), array(), array(), array(), array(), $server);
+
+        return $request;
     }
 }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/AutoExpireFlashBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/AutoExpireFlashBagTest.php
@@ -21,14 +21,13 @@ use Symfony\Component\HttpFoundation\Session\Flash\AutoExpireFlashBag as FlashBa
 class AutoExpireFlashBagTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var \Symfony\Component\HttpFoundation\Session\Flash\AutoExpireFlashBag
-     */
-    private $bag;
-
-    /**
      * @var array
      */
     protected $array = array();
+    /**
+     * @var \Symfony\Component\HttpFoundation\Session\Flash\AutoExpireFlashBag
+     */
+    private $bag;
 
     protected function setUp()
     {

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/FlashBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Flash/FlashBagTest.php
@@ -21,14 +21,13 @@ use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
 class FlashBagTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var \Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface
-     */
-    private $bag;
-
-    /**
      * @var array
      */
     protected $array = array();
+    /**
+     * @var \Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface
+     */
+    private $bag;
 
     protected function setUp()
     {

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
@@ -20,12 +20,12 @@ use Symfony\Component\HttpFoundation\Session\Storage\Handler\MongoDbSessionHandl
  */
 class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
 {
+    public $options;
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
     private $mongo;
     private $storage;
-    public $options;
 
     protected function setUp()
     {

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockFileSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockFileSessionStorageTest.php
@@ -23,14 +23,13 @@ use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
 class MockFileSessionStorageTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var string
-     */
-    private $sessionDir;
-
-    /**
      * @var MockFileSessionStorage
      */
     protected $storage;
+    /**
+     * @var string
+     */
+    private $sessionDir;
 
     protected function setUp()
     {

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -53,19 +53,6 @@ class NativeSessionStorageTest extends \PHPUnit_Framework_TestCase
         $this->savePath = null;
     }
 
-    /**
-     * @param array $options
-     *
-     * @return NativeSessionStorage
-     */
-    protected function getStorage(array $options = array())
-    {
-        $storage = new NativeSessionStorage($options);
-        $storage->registerBag(new AttributeBag());
-
-        return $storage;
-    }
-
     public function testBag()
     {
         $storage = $this->getStorage();
@@ -260,5 +247,18 @@ class NativeSessionStorageTest extends \PHPUnit_Framework_TestCase
         $storage->start();
         $this->assertSame($id, $storage->getId(), 'Same session ID after restarting');
         $this->assertSame(7, $storage->getBag('attributes')->get('lucky'), 'Data still available');
+    }
+
+    /**
+     * @param array $options
+     *
+     * @return NativeSessionStorage
+     */
+    protected function getStorage(array $options = array())
+    {
+        $storage = new NativeSessionStorage($options);
+        $storage->registerBag(new AttributeBag());
+
+        return $storage;
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/PhpBridgeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/PhpBridgeSessionStorageTest.php
@@ -48,17 +48,6 @@ class PhpBridgeSessionStorageTest extends \PHPUnit_Framework_TestCase
         $this->savePath = null;
     }
 
-    /**
-     * @return PhpBridgeSessionStorage
-     */
-    protected function getStorage()
-    {
-        $storage = new PhpBridgeSessionStorage();
-        $storage->registerBag(new AttributeBag());
-
-        return $storage;
-    }
-
     public function testPhpSession53()
     {
         if (PHP_VERSION_ID >= 50400) {
@@ -118,5 +107,16 @@ class PhpBridgeSessionStorageTest extends \PHPUnit_Framework_TestCase
         $storage->clear();
         $this->assertEquals($_SESSION[$key], array());
         $this->assertEquals($_SESSION['drak'], 'loves symfony');
+    }
+
+    /**
+     * @return PhpBridgeSessionStorage
+     */
+    protected function getStorage()
+    {
+        $storage = new PhpBridgeSessionStorage();
+        $storage->registerBag(new AttributeBag());
+
+        return $storage;
     }
 }

--- a/src/Symfony/Component/HttpKernel/DataCollector/RouterDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RouterDataCollector.php
@@ -53,11 +53,6 @@ class RouterDataCollector extends DataCollector
         unset($this->controllers[$request]);
     }
 
-    protected function guessRoute(Request $request, $controller)
-    {
-        return 'n/a';
-    }
-
     /**
      * Remembers the controller associated to each request.
      *
@@ -98,5 +93,10 @@ class RouterDataCollector extends DataCollector
     public function getName()
     {
         return 'router';
+    }
+
+    protected function guessRoute(Request $request, $controller)
+    {
+        return 'n/a';
     }
 }

--- a/src/Symfony/Component/HttpKernel/EventListener/FragmentListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/FragmentListener.php
@@ -72,6 +72,13 @@ class FragmentListener implements EventSubscriberInterface
         $request->query->remove('_path');
     }
 
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::REQUEST => array(array('onKernelRequest', 48)),
+        );
+    }
+
     protected function validateRequest(Request $request)
     {
         // is the Request safe?
@@ -96,12 +103,5 @@ class FragmentListener implements EventSubscriberInterface
     protected function getLocalIpAddresses()
     {
         return array('127.0.0.1', 'fe80::1', '::1');
-    }
-
-    public static function getSubscribedEvents()
-    {
-        return array(
-            KernelEvents::REQUEST => array(array('onKernelRequest', 48)),
-        );
     }
 }

--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -120,6 +120,13 @@ class RouterListener implements EventSubscriberInterface
         }
     }
 
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::REQUEST => array(array('onKernelRequest', 32)),
+        );
+    }
+
     private function parametersToString(array $parameters)
     {
         $pieces = array();
@@ -128,12 +135,5 @@ class RouterListener implements EventSubscriberInterface
         }
 
         return implode(', ', $pieces);
-    }
-
-    public static function getSubscribedEvents()
-    {
-        return array(
-            KernelEvents::REQUEST => array(array('onKernelRequest', 32)),
-        );
     }
 }

--- a/src/Symfony/Component/HttpKernel/Fragment/HIncludeFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/HIncludeFragmentRenderer.php
@@ -125,6 +125,14 @@ class HIncludeFragmentRenderer extends RoutableFragmentRenderer
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'hinclude';
+    }
+
+    /**
      * @param string $template
      *
      * @return bool
@@ -152,13 +160,5 @@ class HIncludeFragmentRenderer extends RoutableFragmentRenderer
         }
 
         return false;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'hinclude';
     }
 }

--- a/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
@@ -111,6 +111,14 @@ class InlineFragmentRenderer extends RoutableFragmentRenderer
         }
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'inline';
+    }
+
     protected function createSubRequest($uri, Request $request)
     {
         $cookies = $request->cookies->all();
@@ -141,13 +149,5 @@ class InlineFragmentRenderer extends RoutableFragmentRenderer
         }
 
         return $subRequest;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'inline';
     }
 }

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -596,6 +596,13 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
         $this->store->unlock($request);
     }
 
+    protected function processResponseBody(Request $request, Response $response)
+    {
+        if (null !== $this->esi && $this->esi->needsEsiParsing($response)) {
+            $this->esi->process($request, $response);
+        }
+    }
+
     /**
      * Restores the Response body.
      *
@@ -633,13 +640,6 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
         }
 
         $response->headers->remove('X-Body-File');
-    }
-
-    protected function processResponseBody(Request $request, Response $response)
-    {
-        if (null !== $this->esi && $this->esi->needsEsiParsing($response)) {
-            $this->esi->process($request, $response);
-        }
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -212,18 +212,6 @@ class Store implements StoreInterface
     }
 
     /**
-     * Returns content digest for $response.
-     *
-     * @param Response $response
-     *
-     * @return string
-     */
-    protected function generateContentDigest(Response $response)
-    {
-        return 'en'.sha1($response->getContent());
-    }
-
-    /**
      * Invalidates all cache entries that match the request.
      *
      * @param Request $request A Request instance
@@ -250,6 +238,41 @@ class Store implements StoreInterface
         if ($modified && false === $this->save($key, serialize($entries))) {
             throw new \RuntimeException('Unable to store the metadata.');
         }
+    }
+
+    /**
+     * Purges data for the given URL.
+     *
+     * @param string $url A URL
+     *
+     * @return bool true if the URL exists and has been purged, false otherwise
+     */
+    public function purge($url)
+    {
+        if (is_file($path = $this->getPath($this->getCacheKey(Request::create($url))))) {
+            unlink($path);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public function getPath($key)
+    {
+        return $this->root.DIRECTORY_SEPARATOR.substr($key, 0, 2).DIRECTORY_SEPARATOR.substr($key, 2, 2).DIRECTORY_SEPARATOR.substr($key, 4, 2).DIRECTORY_SEPARATOR.substr($key, 6);
+    }
+
+    /**
+     * Returns content digest for $response.
+     *
+     * @param Response $response
+     *
+     * @return string
+     */
+    protected function generateContentDigest(Response $response)
+    {
+        return 'en'.sha1($response->getContent());
     }
 
     /**
@@ -299,24 +322,6 @@ class Store implements StoreInterface
     }
 
     /**
-     * Purges data for the given URL.
-     *
-     * @param string $url A URL
-     *
-     * @return bool true if the URL exists and has been purged, false otherwise
-     */
-    public function purge($url)
-    {
-        if (is_file($path = $this->getPath($this->getCacheKey(Request::create($url))))) {
-            unlink($path);
-
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
      * Loads data for the given key.
      *
      * @param string $key The store key
@@ -361,11 +366,6 @@ class Store implements StoreInterface
         }
 
         @chmod($path, 0666 & ~umask());
-    }
-
-    public function getPath($key)
-    {
-        return $this->root.DIRECTORY_SEPARATOR.substr($key, 0, 2).DIRECTORY_SEPARATOR.substr($key, 2, 2).DIRECTORY_SEPARATOR.substr($key, 4, 2).DIRECTORY_SEPARATOR.substr($key, 6);
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Profiler/MemcacheProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/MemcacheProfilerStorage.php
@@ -24,6 +24,16 @@ class MemcacheProfilerStorage extends BaseMemcacheProfilerStorage
     private $memcache;
 
     /**
+     * Set instance of the Memcache.
+     *
+     * @param \Memcache $memcache
+     */
+    public function setMemcache($memcache)
+    {
+        $this->memcache = $memcache;
+    }
+
+    /**
      * Internal convenience method that returns the instance of the Memcache.
      *
      * @return \Memcache
@@ -47,16 +57,6 @@ class MemcacheProfilerStorage extends BaseMemcacheProfilerStorage
         }
 
         return $this->memcache;
-    }
-
-    /**
-     * Set instance of the Memcache.
-     *
-     * @param \Memcache $memcache
-     */
-    public function setMemcache($memcache)
-    {
-        $this->memcache = $memcache;
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Profiler/MemcachedProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/MemcachedProfilerStorage.php
@@ -24,6 +24,16 @@ class MemcachedProfilerStorage extends BaseMemcacheProfilerStorage
     private $memcached;
 
     /**
+     * Set instance of the Memcached.
+     *
+     * @param \Memcached $memcached
+     */
+    public function setMemcached($memcached)
+    {
+        $this->memcached = $memcached;
+    }
+
+    /**
      * Internal convenience method that returns the instance of the Memcached.
      *
      * @return \Memcached
@@ -51,16 +61,6 @@ class MemcachedProfilerStorage extends BaseMemcacheProfilerStorage
         }
 
         return $this->memcached;
-    }
-
-    /**
-     * Set instance of the Memcached.
-     *
-     * @param \Memcached $memcached
-     */
-    public function setMemcached($memcached)
-    {
-        $this->memcached = $memcached;
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
@@ -194,6 +194,16 @@ class RedisProfilerStorage implements ProfilerStorageInterface
     }
 
     /**
+     * Set instance of the Redis.
+     *
+     * @param \Redis $redis
+     */
+    public function setRedis($redis)
+    {
+        $this->redis = $redis;
+    }
+
+    /**
      * Internal convenience method that returns the instance of Redis.
      *
      * @return \Redis
@@ -230,16 +240,6 @@ class RedisProfilerStorage implements ProfilerStorageInterface
         }
 
         return $this->redis;
-    }
-
-    /**
-     * Set instance of the Redis.
-     *
-     * @param \Redis $redis
-     */
-    public function setRedis($redis)
-    {
-        $this->redis = $redis;
     }
 
     private function createProfileFromData($token, $data, $parent = null)

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
@@ -164,17 +164,6 @@ class RequestDataCollectorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Inject the given controller callable into the data collector.
-     */
-    protected function injectController($collector, $controller, $request)
-    {
-        $resolver = $this->getMock('Symfony\\Component\\HttpKernel\\Controller\\ControllerResolverInterface');
-        $httpKernel = new HttpKernel(new EventDispatcher(), $resolver);
-        $event = new FilterControllerEvent($httpKernel, $controller, $request, HttpKernelInterface::MASTER_REQUEST);
-        $collector->onKernelController($event);
-    }
-
-    /**
      * Dummy method used as controller callable.
      */
     public static function staticControllerMethod()
@@ -196,5 +185,16 @@ class RequestDataCollectorTest extends \PHPUnit_Framework_TestCase
     public static function __callStatic($method, $args)
     {
         throw new \LogicException('Unexpected method call');
+    }
+
+    /**
+     * Inject the given controller callable into the data collector.
+     */
+    protected function injectController($collector, $controller, $request)
+    {
+        $resolver = $this->getMock('Symfony\\Component\\HttpKernel\\Controller\\ControllerResolverInterface');
+        $httpKernel = new HttpKernel(new EventDispatcher(), $resolver);
+        $event = new FilterControllerEvent($httpKernel, $controller, $request, HttpKernelInterface::MASTER_REQUEST);
+        $collector->onKernelController($event);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
@@ -54,20 +54,6 @@ class RouterListenerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param string $uri
-     *
-     * @return GetResponseEvent
-     */
-    private function createGetResponseEventForUri($uri)
-    {
-        $kernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
-        $request = Request::create($uri);
-        $request->attributes->set('_controller', null); // Prevents going in to routing process
-
-        return new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
-    }
-
-    /**
      * @expectedException \InvalidArgumentException
      */
     public function testInvalidMatcher()
@@ -149,5 +135,19 @@ class RouterListenerTest extends \PHPUnit_Framework_TestCase
             array(array('_route' => 'foo'), 'Matched route "foo" (parameters: "_route": "foo")'),
             array(array(), 'Matched route "n/a" (parameters: )'),
         );
+    }
+
+    /**
+     * @param string $uri
+     *
+     * @return GetResponseEvent
+     */
+    private function createGetResponseEventForUri($uri)
+    {
+        $kernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
+        $request = Request::create($uri);
+        $request->attributes->set('_controller', null); // Prevents going in to routing process
+
+        return new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
@@ -94,34 +94,6 @@ class InlineFragmentRendererTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $strategy->render('/', Request::create('/'), array('ignore_errors' => true, 'alt' => '/foo'))->getContent());
     }
 
-    private function getKernel($returnValue)
-    {
-        $kernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
-        $kernel
-            ->expects($this->any())
-            ->method('handle')
-            ->will($returnValue)
-        ;
-
-        return $kernel;
-    }
-
-    /**
-     * Creates a Kernel expecting a request equals to $request
-     * Allows delta in comparison in case REQUEST_TIME changed by 1 second.
-     */
-    private function getKernelExpectingRequest(Request $request)
-    {
-        $kernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
-        $kernel
-            ->expects($this->any())
-            ->method('handle')
-            ->with($this->equalTo($request, 1))
-        ;
-
-        return $kernel;
-    }
-
     public function testExceptionInSubRequestsDoesNotMangleOutputBuffers()
     {
         $resolver = $this->getMock('Symfony\\Component\\HttpKernel\\Controller\\ControllerResolverInterface');
@@ -178,5 +150,33 @@ class InlineFragmentRendererTest extends \PHPUnit_Framework_TestCase
         $this->testESIHeaderIsKeptInSubrequest();
 
         Request::setTrustedHeaderName(Request::HEADER_CLIENT_IP, $trustedHeaderName);
+    }
+
+    private function getKernel($returnValue)
+    {
+        $kernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
+        $kernel
+            ->expects($this->any())
+            ->method('handle')
+            ->will($returnValue)
+        ;
+
+        return $kernel;
+    }
+
+    /**
+     * Creates a Kernel expecting a request equals to $request
+     * Allows delta in comparison in case REQUEST_TIME changed by 1 second.
+     */
+    private function getKernelExpectingRequest(Request $request)
+    {
+        $kernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
+        $kernel
+            ->expects($this->any())
+            ->method('handle')
+            ->with($this->equalTo($request, 1))
+        ;
+
+        return $kernel;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -395,21 +395,6 @@ EOF;
         $this->assertTrue($kernel->isClassInActiveBundle(__NAMESPACE__.'\Fixtures\FooBarBundle\SomeClass'));
     }
 
-    protected function getKernelMockForIsClassInActiveBundleTest()
-    {
-        $bundle = new FooBarBundle();
-
-        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest')
-            ->disableOriginalConstructor()
-            ->setMethods(array('getBundles'))
-            ->getMock();
-        $kernel->expects($this->once())
-            ->method('getBundles')
-            ->will($this->returnValue(array($bundle)));
-
-        return $kernel;
-    }
-
     public function testGetRootDir()
     {
         $kernel = new KernelForTest('test', true);
@@ -847,6 +832,21 @@ EOF;
 
         $kernel->setIsBooted(true);
         $kernel->terminate(Request::create('/'), new Response());
+    }
+
+    protected function getKernelMockForIsClassInActiveBundleTest()
+    {
+        $bundle = new FooBarBundle();
+
+        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getBundles'))
+            ->getMock();
+        $kernel->expects($this->once())
+            ->method('getBundles')
+            ->will($this->returnValue(array($bundle)));
+
+        return $kernel;
     }
 
     protected function getBundle($dir = null, $parent = null, $className = null, $bundleName = null)

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/FileProfilerStorageTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/FileProfilerStorageTest.php
@@ -19,19 +19,6 @@ class FileProfilerStorageTest extends AbstractProfilerStorageTest
     protected static $tmpDir;
     protected static $storage;
 
-    protected static function cleanDir()
-    {
-        $flags = \FilesystemIterator::SKIP_DOTS;
-        $iterator = new \RecursiveDirectoryIterator(self::$tmpDir, $flags);
-        $iterator = new \RecursiveIteratorIterator($iterator, \RecursiveIteratorIterator::SELF_FIRST);
-
-        foreach ($iterator as $file) {
-            if (is_file($file)) {
-                unlink($file);
-            }
-        }
-    }
-
     public static function setUpBeforeClass()
     {
         self::$tmpDir = sys_get_temp_dir().'/sf2_profiler_file_storage';
@@ -49,14 +36,6 @@ class FileProfilerStorageTest extends AbstractProfilerStorageTest
     protected function setUp()
     {
         self::$storage->purge();
-    }
-
-    /**
-     * @return \Symfony\Component\HttpKernel\Profiler\ProfilerStorageInterface
-     */
-    protected function getStorage()
-    {
-        return self::$storage;
     }
 
     public function testMultiRowIndexFile()
@@ -96,5 +75,26 @@ class FileProfilerStorageTest extends AbstractProfilerStorageTest
 
         $this->assertEquals('line2', $r->invoke(self::$storage, $h));
         $this->assertEquals('line1', $r->invoke(self::$storage, $h));
+    }
+
+    protected static function cleanDir()
+    {
+        $flags = \FilesystemIterator::SKIP_DOTS;
+        $iterator = new \RecursiveDirectoryIterator(self::$tmpDir, $flags);
+        $iterator = new \RecursiveIteratorIterator($iterator, \RecursiveIteratorIterator::SELF_FIRST);
+
+        foreach ($iterator as $file) {
+            if (is_file($file)) {
+                unlink($file);
+            }
+        }
+    }
+
+    /**
+     * @return \Symfony\Component\HttpKernel\Profiler\ProfilerStorageInterface
+     */
+    protected function getStorage()
+    {
+        return self::$storage;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/RedisMock.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/RedisMock.php
@@ -222,6 +222,19 @@ class RedisMock
         return true;
     }
 
+    public function select($dbnum)
+    {
+        if (!$this->connected) {
+            return false;
+        }
+
+        if (0 > $dbnum) {
+            return false;
+        }
+
+        return true;
+    }
+
     private function getData($key)
     {
         if (isset($this->storage[$key])) {
@@ -234,19 +247,6 @@ class RedisMock
     private function storeData($key, $value)
     {
         $this->storage[$key] = serialize($value);
-
-        return true;
-    }
-
-    public function select($dbnum)
-    {
-        if (!$this->connected) {
-            return false;
-        }
-
-        if (0 > $dbnum) {
-            return false;
-        }
 
         return true;
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/MongoDbProfilerStorageTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/MongoDbProfilerStorageTest.php
@@ -72,6 +72,15 @@ class MongoDbProfilerStorageTest extends AbstractProfilerStorageTest
         }
     }
 
+    protected function setUp()
+    {
+        if (self::$storage) {
+            self::$storage->purge();
+        } else {
+            $this->markTestSkipped('A MongoDB server on localhost is required.');
+        }
+    }
+
     public function getDsns()
     {
         return array(
@@ -153,14 +162,5 @@ class MongoDbProfilerStorageTest extends AbstractProfilerStorageTest
     protected function getStorage()
     {
         return self::$storage;
-    }
-
-    protected function setUp()
-    {
-        if (self::$storage) {
-            self::$storage->purge();
-        } else {
-            $this->markTestSkipped('A MongoDB server on localhost is required.');
-        }
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/ProfilerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/ProfilerTest.php
@@ -22,6 +22,27 @@ class ProfilerTest extends \PHPUnit_Framework_TestCase
     private $tmp;
     private $storage;
 
+    protected function setUp()
+    {
+        $this->tmp = tempnam(sys_get_temp_dir(), 'sf2_profiler');
+        if (file_exists($this->tmp)) {
+            @unlink($this->tmp);
+        }
+
+        $this->storage = new FileProfilerStorage('file:'.$this->tmp);
+        $this->storage->purge();
+    }
+
+    protected function tearDown()
+    {
+        if (null !== $this->storage) {
+            $this->storage->purge();
+            $this->storage = null;
+
+            @unlink($this->tmp);
+        }
+    }
+
     public function testCollect()
     {
         $request = new Request();
@@ -56,26 +77,5 @@ class ProfilerTest extends \PHPUnit_Framework_TestCase
         $profiler = new Profiler($this->storage);
 
         $this->assertCount(0, $profiler->find(null, null, null, null, 'some string', ''));
-    }
-
-    protected function setUp()
-    {
-        $this->tmp = tempnam(sys_get_temp_dir(), 'sf2_profiler');
-        if (file_exists($this->tmp)) {
-            @unlink($this->tmp);
-        }
-
-        $this->storage = new FileProfilerStorage('file:'.$this->tmp);
-        $this->storage->purge();
-    }
-
-    protected function tearDown()
-    {
-        if (null !== $this->storage) {
-            $this->storage->purge();
-            $this->storage = null;
-
-            @unlink($this->tmp);
-        }
     }
 }

--- a/src/Symfony/Component/Intl/Data/Util/RecursiveArrayAccess.php
+++ b/src/Symfony/Component/Intl/Data/Util/RecursiveArrayAccess.php
@@ -20,6 +20,10 @@ use Symfony\Component\Intl\Exception\OutOfBoundsException;
  */
 class RecursiveArrayAccess
 {
+    private function __construct()
+    {
+    }
+
     public static function get($array, array $indices)
     {
         foreach ($indices as $index) {
@@ -43,9 +47,5 @@ class RecursiveArrayAccess
         }
 
         return $array;
-    }
-
-    private function __construct()
-    {
     }
 }

--- a/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
+++ b/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
@@ -46,6 +46,16 @@ use Symfony\Component\Intl\Locale\Locale;
  */
 class IntlDateFormatter
 {
+    /* date/time format types */
+    const NONE = -1;
+    const FULL = 0;
+    const LONG = 1;
+    const MEDIUM = 2;
+    const SHORT = 3;
+
+    /* calendar formats */
+    const TRADITIONAL = 0;
+    const GREGORIAN = 1;
     /**
      * The error code from the last operation.
      *
@@ -59,17 +69,6 @@ class IntlDateFormatter
      * @var string
      */
     protected $errorMessage = 'U_ZERO_ERROR';
-
-    /* date/time format types */
-    const NONE = -1;
-    const FULL = 0;
-    const LONG = 1;
-    const MEDIUM = 2;
-    const SHORT = 3;
-
-    /* calendar formats */
-    const TRADITIONAL = 0;
-    const GREGORIAN = 1;
 
     /**
      * Patterns used to format the date when no pattern is provided.

--- a/src/Symfony/Component/Intl/Intl.php
+++ b/src/Symfony/Component/Intl/Intl.php
@@ -99,6 +99,13 @@ final class Intl
     private static $entryReader;
 
     /**
+     * This class must not be instantiated.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
      * Returns whether the intl extension is installed.
      *
      * @return bool Returns true if the intl extension is installed, false otherwise.
@@ -262,12 +269,5 @@ final class Intl
         }
 
         return self::$entryReader;
-    }
-
-    /**
-     * This class must not be instantiated.
-     */
-    private function __construct()
-    {
     }
 }

--- a/src/Symfony/Component/Intl/Locale.php
+++ b/src/Symfony/Component/Intl/Locale.php
@@ -26,6 +26,13 @@ final class Locale extends \Locale
     private static $defaultFallback = 'en';
 
     /**
+     * This class must not be instantiated.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
      * Sets the default fallback locale.
      *
      * The default fallback locale is used as fallback for locales that have no
@@ -82,12 +89,5 @@ final class Locale extends \Locale
         }
 
         return substr($locale, 0, $pos);
-    }
-
-    /**
-     * This class must not be instantiated.
-     */
-    private function __construct()
-    {
     }
 }

--- a/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractCurrencyDataProviderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractCurrencyDataProviderTest.php
@@ -570,8 +570,6 @@ abstract class AbstractCurrencyDataProviderTest extends AbstractDataProviderTest
         );
     }
 
-    abstract protected function getDataDirectory();
-
     public function testGetCurrencies()
     {
         $this->assertSame(static::$currencies, $this->dataProvider->getCurrencies());
@@ -764,6 +762,8 @@ abstract class AbstractCurrencyDataProviderTest extends AbstractDataProviderTest
     {
         $this->dataProvider->forNumericCode($currency);
     }
+
+    abstract protected function getDataDirectory();
 
     private function getNumericToAlpha3Mapping()
     {

--- a/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractLanguageDataProviderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractLanguageDataProviderTest.php
@@ -832,8 +832,6 @@ abstract class AbstractLanguageDataProviderTest extends AbstractDataProviderTest
         );
     }
 
-    abstract protected function getDataDirectory();
-
     public function testGetLanguages()
     {
         $this->assertEquals(static::$languages, $this->dataProvider->getLanguages());
@@ -930,4 +928,6 @@ abstract class AbstractLanguageDataProviderTest extends AbstractDataProviderTest
     {
         $this->dataProvider->getAlpha3Code($currency);
     }
+
+    abstract protected function getDataDirectory();
 }

--- a/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractLocaleDataProviderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractLocaleDataProviderTest.php
@@ -35,8 +35,6 @@ abstract class AbstractLocaleDataProviderTest extends AbstractDataProviderTest
         );
     }
 
-    abstract protected function getDataDirectory();
-
     public function testGetLocales()
     {
         $this->assertSame($this->getLocales(), $this->dataProvider->getLocales());
@@ -105,4 +103,6 @@ abstract class AbstractLocaleDataProviderTest extends AbstractDataProviderTest
             $this->assertSame($name, $this->dataProvider->getName($locale));
         }
     }
+
+    abstract protected function getDataDirectory();
 }

--- a/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractRegionDataProviderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractRegionDataProviderTest.php
@@ -298,8 +298,6 @@ abstract class AbstractRegionDataProviderTest extends AbstractDataProviderTest
         );
     }
 
-    abstract protected function getDataDirectory();
-
     public function testGetRegions()
     {
         $this->assertSame(static::$territories, $this->dataProvider->getRegions());
@@ -352,4 +350,6 @@ abstract class AbstractRegionDataProviderTest extends AbstractDataProviderTest
             $this->assertSame($name, $this->dataProvider->getName($country, $displayLocale));
         }
     }
+
+    abstract protected function getDataDirectory();
 }

--- a/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractScriptDataProviderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractScriptDataProviderTest.php
@@ -199,8 +199,6 @@ abstract class AbstractScriptDataProviderTest extends AbstractDataProviderTest
         );
     }
 
-    abstract protected function getDataDirectory();
-
     public function testGetScripts()
     {
         $this->assertSame(static::$scripts, $this->dataProvider->getScripts());
@@ -264,4 +262,6 @@ abstract class AbstractScriptDataProviderTest extends AbstractDataProviderTest
             $this->assertSame($name, $this->dataProvider->getName($script));
         }
     }
+
+    abstract protected function getDataDirectory();
 }

--- a/src/Symfony/Component/Intl/Util/IcuVersion.php
+++ b/src/Symfony/Component/Intl/Util/IcuVersion.php
@@ -19,6 +19,13 @@ namespace Symfony\Component\Intl\Util;
 class IcuVersion
 {
     /**
+     * Must not be instantiated.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
      * Compares two ICU versions with an operator.
      *
      * This method is identical to {@link version_compare()}, except that you
@@ -96,12 +103,5 @@ class IcuVersion
         }
 
         return Version::normalize($version, $precision);
-    }
-
-    /**
-     * Must not be instantiated.
-     */
-    private function __construct()
-    {
     }
 }

--- a/src/Symfony/Component/Intl/Util/IntlTestHelper.php
+++ b/src/Symfony/Component/Intl/Util/IntlTestHelper.php
@@ -27,6 +27,13 @@ use Symfony\Component\Intl\Intl;
 class IntlTestHelper
 {
     /**
+     * Must not be instantiated.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
      * Should be called before tests that work fine with the stub implementation.
      *
      * @param \PhpUnit_Framework_TestCase $testCase
@@ -109,12 +116,5 @@ class IntlTestHelper
         if (8 !== PHP_INT_SIZE) {
             $testCase->markTestSkipped('PHP 64 bit is required.');
         }
-    }
-
-    /**
-     * Must not be instantiated.
-     */
-    private function __construct()
-    {
     }
 }

--- a/src/Symfony/Component/Intl/Util/SvnRepository.php
+++ b/src/Symfony/Component/Intl/Util/SvnRepository.php
@@ -37,6 +37,16 @@ class SvnRepository
     private $lastCommit;
 
     /**
+     * Reads the SVN repository at the given path.
+     *
+     * @param string $path The path to the repository.
+     */
+    public function __construct($path)
+    {
+        $this->path = $path;
+    }
+
+    /**
      * Downloads the ICU data for the given version.
      *
      * @param string $url       The URL to download from.
@@ -68,16 +78,6 @@ class SvnRepository
         }
 
         return new static(realpath($targetDir));
-    }
-
-    /**
-     * Reads the SVN repository at the given path.
-     *
-     * @param string $path The path to the repository.
-     */
-    public function __construct($path)
-    {
-        $this->path = $path;
     }
 
     /**

--- a/src/Symfony/Component/Intl/Util/Version.php
+++ b/src/Symfony/Component/Intl/Util/Version.php
@@ -19,6 +19,13 @@ namespace Symfony\Component\Intl\Util;
 class Version
 {
     /**
+     * Must not be instantiated.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
      * Compares two versions with an operator.
      *
      * This method is identical to {@link version_compare()}, except that you
@@ -87,12 +94,5 @@ class Version
         }
 
         return $matches[0];
-    }
-
-    /**
-     * Must not be instantiated.
-     */
-    private function __construct()
-    {
     }
 }

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -37,35 +37,6 @@ class Process
     // Timeout Precision in seconds.
     const TIMEOUT_PRECISION = 0.2;
 
-    private $callback;
-    private $commandline;
-    private $cwd;
-    private $env;
-    private $stdin;
-    private $starttime;
-    private $timeout;
-    private $options;
-    private $exitcode;
-    private $fallbackStatus = array();
-    private $processInformation;
-    private $stdout;
-    private $stderr;
-    private $enhanceWindowsCompatibility = true;
-    private $enhanceSigchildCompatibility;
-    private $process;
-    private $status = self::STATUS_READY;
-    private $incrementalOutputOffset = 0;
-    private $incrementalErrorOutputOffset = 0;
-    private $tty;
-
-    private $useFileHandles = false;
-    /** @var ProcessPipes */
-    private $processPipes;
-
-    private $latestSignal;
-
-    private static $sigchild;
-
     /**
      * Exit codes translation table.
      *
@@ -115,6 +86,35 @@ class Process
         // 158 - not defined
         159 => 'Bad syscall',
     );
+
+    private $callback;
+    private $commandline;
+    private $cwd;
+    private $env;
+    private $stdin;
+    private $starttime;
+    private $timeout;
+    private $options;
+    private $exitcode;
+    private $fallbackStatus = array();
+    private $processInformation;
+    private $stdout;
+    private $stderr;
+    private $enhanceWindowsCompatibility = true;
+    private $enhanceSigchildCompatibility;
+    private $process;
+    private $status = self::STATUS_READY;
+    private $incrementalOutputOffset = 0;
+    private $incrementalErrorOutputOffset = 0;
+    private $tty;
+
+    private $useFileHandles = false;
+    /** @var ProcessPipes */
+    private $processPipes;
+
+    private $latestSignal;
+
+    private static $sigchild;
 
     /**
      * Constructor.
@@ -982,18 +982,6 @@ class Process
     }
 
     /**
-     * Creates the descriptors needed by the proc_open.
-     *
-     * @return array
-     */
-    private function getDescriptors()
-    {
-        $this->processPipes = new ProcessPipes($this->useFileHandles, $this->tty);
-
-        return $this->processPipes->getDescriptors();
-    }
-
-    /**
      * Builds up the callback used by wait().
      *
      * The callbacks adds all occurred output to the specific buffer and calls
@@ -1065,6 +1053,18 @@ class Process
         phpinfo(INFO_GENERAL);
 
         return self::$sigchild = false !== strpos(ob_get_clean(), '--enable-sigchild');
+    }
+
+    /**
+     * Creates the descriptors needed by the proc_open.
+     *
+     * @return array
+     */
+    private function getDescriptors()
+    {
+        $this->processPipes = new ProcessPipes($this->useFileHandles, $this->tty);
+
+        return $this->processPipes->getDescriptors();
     }
 
     /**

--- a/src/Symfony/Component/Process/ProcessPipes.php
+++ b/src/Symfony/Component/Process/ProcessPipes.php
@@ -18,6 +18,7 @@ use Symfony\Component\Process\Exception\RuntimeException;
  */
 class ProcessPipes
 {
+    const CHUNK_SIZE = 16384;
     /** @var array */
     public $pipes = array();
     /** @var array */
@@ -30,8 +31,6 @@ class ProcessPipes
     private $useFiles;
     /** @var bool    */
     private $ttyMode;
-
-    const CHUNK_SIZE = 16384;
 
     public function __construct($useFiles, $ttyMode)
     {

--- a/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
+++ b/src/Symfony/Component/Process/Tests/ExecutableFinderTest.php
@@ -28,12 +28,6 @@ class ExecutableFinderTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    private function setPath($path)
-    {
-        $this->path = getenv('PATH');
-        putenv('PATH='.$path);
-    }
-
     /**
      * @requires PHP 5.4
      */
@@ -126,6 +120,12 @@ class ExecutableFinderTest extends \PHPUnit_Framework_TestCase
         $result = $finder->find($this->getPhpBinaryName(), false);
 
         $this->assertSamePath(PHP_BINARY, $result);
+    }
+
+    private function setPath($path)
+    {
+        $this->path = getenv('PATH');
+        putenv('PATH='.$path);
     }
 
     private function assertSamePath($expected, $tested)

--- a/src/Symfony/Component/PropertyAccess/PropertyAccess.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccess.php
@@ -19,6 +19,13 @@ namespace Symfony\Component\PropertyAccess;
 final class PropertyAccess
 {
     /**
+     * This class cannot be instantiated.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
      * Creates a property accessor with the default configuration.
      *
      * @return PropertyAccessor The new property accessor
@@ -49,12 +56,5 @@ final class PropertyAccess
     public static function getPropertyAccessor()
     {
         return self::createPropertyAccessor();
-    }
-
-    /**
-     * This class cannot be instantiated.
-     */
-    private function __construct()
-    {
     }
 }

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTest.php
@@ -126,8 +126,6 @@ abstract class PropertyAccessorCollectionTest extends \PHPUnit_Framework_TestCas
         $this->propertyAccessor = new PropertyAccessor();
     }
 
-    abstract protected function getCollection(array $array);
-
     public function testGetValueReadsArrayAccess()
     {
         $object = $this->getCollection(array('firstName' => 'Bernhard'));
@@ -309,4 +307,6 @@ abstract class PropertyAccessorCollectionTest extends \PHPUnit_Framework_TestCas
 
         return $data;
     }
+
+    abstract protected function getCollection(array $array);
 }

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -137,6 +137,57 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
     }
 
     /**
+     * Returns the target path as relative reference from the base path.
+     *
+     * Only the URIs path component (no schema, host etc.) is relevant and must be given, starting with a slash.
+     * Both paths must be absolute and not contain relative parts.
+     * Relative URLs from one resource to another are useful when generating self-contained downloadable document archives.
+     * Furthermore, they can be used to reduce the link size in documents.
+     *
+     * Example target paths, given a base path of "/a/b/c/d":
+     * - "/a/b/c/d"     -> ""
+     * - "/a/b/c/"      -> "./"
+     * - "/a/b/"        -> "../"
+     * - "/a/b/c/other" -> "other"
+     * - "/a/x/y"       -> "../../x/y"
+     *
+     * @param string $basePath   The base path
+     * @param string $targetPath The target path
+     *
+     * @return string The relative target path
+     */
+    public static function getRelativePath($basePath, $targetPath)
+    {
+        if ($basePath === $targetPath) {
+            return '';
+        }
+
+        $sourceDirs = explode('/', isset($basePath[0]) && '/' === $basePath[0] ? substr($basePath, 1) : $basePath);
+        $targetDirs = explode('/', isset($targetPath[0]) && '/' === $targetPath[0] ? substr($targetPath, 1) : $targetPath);
+        array_pop($sourceDirs);
+        $targetFile = array_pop($targetDirs);
+
+        foreach ($sourceDirs as $i => $dir) {
+            if (isset($targetDirs[$i]) && $dir === $targetDirs[$i]) {
+                unset($sourceDirs[$i], $targetDirs[$i]);
+            } else {
+                break;
+            }
+        }
+
+        $targetDirs[] = $targetFile;
+        $path = str_repeat('../', count($sourceDirs)).implode('/', $targetDirs);
+
+        // A reference to the same base directory or an empty subdirectory must be prefixed with "./".
+        // This also applies to a segment with a colon character (e.g., "file:colon") that cannot be used
+        // as the first segment of a relative-path reference, as it would be mistaken for a scheme name
+        // (see http://tools.ietf.org/html/rfc3986#section-4.2).
+        return '' === $path || '/' === $path[0]
+            || false !== ($colonPos = strpos($path, ':')) && ($colonPos < ($slashPos = strpos($path, '/')) || false === $slashPos)
+            ? "./$path" : $path;
+    }
+
+    /**
      * @throws MissingMandatoryParametersException When some parameters are missing that are mandatory for the route
      * @throws InvalidParameterException           When a parameter value for a placeholder is not correct because
      *                                             it does not match the requirement
@@ -263,56 +314,5 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
         }
 
         return $url;
-    }
-
-    /**
-     * Returns the target path as relative reference from the base path.
-     *
-     * Only the URIs path component (no schema, host etc.) is relevant and must be given, starting with a slash.
-     * Both paths must be absolute and not contain relative parts.
-     * Relative URLs from one resource to another are useful when generating self-contained downloadable document archives.
-     * Furthermore, they can be used to reduce the link size in documents.
-     *
-     * Example target paths, given a base path of "/a/b/c/d":
-     * - "/a/b/c/d"     -> ""
-     * - "/a/b/c/"      -> "./"
-     * - "/a/b/"        -> "../"
-     * - "/a/b/c/other" -> "other"
-     * - "/a/x/y"       -> "../../x/y"
-     *
-     * @param string $basePath   The base path
-     * @param string $targetPath The target path
-     *
-     * @return string The relative target path
-     */
-    public static function getRelativePath($basePath, $targetPath)
-    {
-        if ($basePath === $targetPath) {
-            return '';
-        }
-
-        $sourceDirs = explode('/', isset($basePath[0]) && '/' === $basePath[0] ? substr($basePath, 1) : $basePath);
-        $targetDirs = explode('/', isset($targetPath[0]) && '/' === $targetPath[0] ? substr($targetPath, 1) : $targetPath);
-        array_pop($sourceDirs);
-        $targetFile = array_pop($targetDirs);
-
-        foreach ($sourceDirs as $i => $dir) {
-            if (isset($targetDirs[$i]) && $dir === $targetDirs[$i]) {
-                unset($sourceDirs[$i], $targetDirs[$i]);
-            } else {
-                break;
-            }
-        }
-
-        $targetDirs[] = $targetFile;
-        $path = str_repeat('../', count($sourceDirs)).implode('/', $targetDirs);
-
-        // A reference to the same base directory or an empty subdirectory must be prefixed with "./".
-        // This also applies to a segment with a colon character (e.g., "file:colon") that cannot be used
-        // as the first segment of a relative-path reference, as it would be mistaken for a scheme name
-        // (see http://tools.ietf.org/html/rfc3986#section-4.2).
-        return '' === $path || '/' === $path[0]
-            || false !== ($colonPos = strpos($path, ':')) && ($colonPos < ($slashPos = strpos($path, '/')) || false === $slashPos)
-            ? "./$path" : $path;
     }
 }

--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -171,6 +171,28 @@ abstract class AnnotationClassLoader implements LoaderInterface
         return $collection;
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($resource, $type = null)
+    {
+        return is_string($resource) && preg_match('/^(?:\\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)+$/', $resource) && (!$type || 'annotation' === $type);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setResolver(LoaderResolverInterface $resolver)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getResolver()
+    {
+    }
+
     protected function addRoute(RouteCollection $collection, $annot, $globals, \ReflectionClass $class, \ReflectionMethod $method)
     {
         $name = $annot->getName();
@@ -199,28 +221,6 @@ abstract class AnnotationClassLoader implements LoaderInterface
         $this->configureRoute($route, $class, $method, $annot);
 
         $collection->add($name, $route);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function supports($resource, $type = null)
-    {
-        return is_string($resource) && preg_match('/^(?:\\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)+$/', $resource) && (!$type || 'annotation' === $type);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setResolver(LoaderResolverInterface $resolver)
-    {
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getResolver()
-    {
     }
 
     /**

--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -61,6 +61,14 @@ class XmlFileLoader extends FileLoader
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function supports($resource, $type = null)
+    {
+        return is_string($resource) && 'xml' === pathinfo($resource, PATHINFO_EXTENSION) && (!$type || 'xml' === $type);
+    }
+
+    /**
      * Parses a node from a loaded XML file.
      *
      * @param RouteCollection $collection Collection to associate with the node
@@ -86,14 +94,6 @@ class XmlFileLoader extends FileLoader
             default:
                 throw new \InvalidArgumentException(sprintf('Unknown tag "%s" used in file "%s". Expected "route" or "import".', $node->localName, $path));
         }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function supports($resource, $type = null)
-    {
-        return is_string($resource) && 'xml' === pathinfo($resource, PATHINFO_EXTENSION) && (!$type || 'xml' === $type);
     }
 
     /**

--- a/src/Symfony/Component/Routing/Matcher/Dumper/DumperCollection.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/DumperCollection.php
@@ -94,26 +94,6 @@ class DumperCollection implements \IteratorAggregate
     }
 
     /**
-     * Returns the parent collection.
-     *
-     * @return DumperCollection|null The parent collection or null if the collection has no parent
-     */
-    protected function getParent()
-    {
-        return $this->parent;
-    }
-
-    /**
-     * Sets the parent collection.
-     *
-     * @param DumperCollection $parent The parent collection
-     */
-    protected function setParent(DumperCollection $parent)
-    {
-        $this->parent = $parent;
-    }
-
-    /**
      * Returns true if the attribute is defined.
      *
      * @param string $name The attribute name
@@ -157,5 +137,25 @@ class DumperCollection implements \IteratorAggregate
     public function setAttributes($attributes)
     {
         $this->attributes = $attributes;
+    }
+
+    /**
+     * Returns the parent collection.
+     *
+     * @return DumperCollection|null The parent collection or null if the collection has no parent
+     */
+    protected function getParent()
+    {
+        return $this->parent;
+    }
+
+    /**
+     * Sets the parent collection.
+     *
+     * @param DumperCollection $parent The parent collection
+     */
+    protected function setParent(DumperCollection $parent)
+    {
+        $this->parent = $parent;
     }
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
@@ -108,29 +108,6 @@ abstract class UserAuthenticationProvider implements AuthenticationProviderInter
     }
 
     /**
-     * Retrieves roles from user and appends SwitchUserRole if original token contained one.
-     *
-     * @param UserInterface  $user  The user
-     * @param TokenInterface $token The token
-     *
-     * @return array The user roles
-     */
-    private function getRoles(UserInterface $user, TokenInterface $token)
-    {
-        $roles = $user->getRoles();
-
-        foreach ($token->getRoles() as $role) {
-            if ($role instanceof SwitchUserRole) {
-                $roles[] = $role;
-
-                break;
-            }
-        }
-
-        return $roles;
-    }
-
-    /**
      * Retrieves the user from an implementation-specific location.
      *
      * @param string                $username The username to retrieve
@@ -152,4 +129,27 @@ abstract class UserAuthenticationProvider implements AuthenticationProviderInter
      * @throws AuthenticationException if the credentials could not be validated
      */
     abstract protected function checkAuthentication(UserInterface $user, UsernamePasswordToken $token);
+
+    /**
+     * Retrieves roles from user and appends SwitchUserRole if original token contained one.
+     *
+     * @param UserInterface  $user  The user
+     * @param TokenInterface $token The token
+     *
+     * @return array The user roles
+     */
+    private function getRoles(UserInterface $user, TokenInterface $token)
+    {
+        $roles = $user->getRoles();
+
+        foreach ($token->getRoles() as $role) {
+            if ($role instanceof SwitchUserRole) {
+                $roles[] = $role;
+
+                break;
+            }
+        }
+
+        return $roles;
+    }
 }

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
@@ -96,6 +96,15 @@ abstract class AbstractPreAuthenticatedListener implements ListenerInterface
     }
 
     /**
+     * Gets the user and credentials from the Request.
+     *
+     * @param Request $request A Request instance
+     *
+     * @return array An array composed of the user and the credentials
+     */
+    abstract protected function getPreAuthenticatedData(Request $request);
+
+    /**
      * Clears a PreAuthenticatedToken for this provider (if present).
      *
      * @param AuthenticationException $exception
@@ -111,13 +120,4 @@ abstract class AbstractPreAuthenticatedListener implements ListenerInterface
             }
         }
     }
-
-    /**
-     * Gets the user and credentials from the Request.
-     *
-     * @param Request $request A Request instance
-     *
-     * @return array An array composed of the user and the credentials
-     */
-    abstract protected function getPreAuthenticatedData(Request $request);
 }

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -94,6 +94,17 @@ class ExceptionListener
         } while (null !== $exception = $exception->getPrevious());
     }
 
+    /**
+     * @param Request $request
+     */
+    protected function setTargetPath(Request $request)
+    {
+        // session isn't required when using HTTP basic authentication mechanism for example
+        if ($request->hasSession() && $request->isMethodSafe() && !$request->isXmlHttpRequest()) {
+            $request->getSession()->set('_security.'.$this->providerKey.'.target_path', $request->getUri());
+        }
+    }
+
     private function handleAuthenticationException(GetResponseForExceptionEvent $event, AuthenticationException $exception)
     {
         if (null !== $this->logger) {
@@ -190,16 +201,5 @@ class ExceptionListener
         }
 
         return $this->authenticationEntryPoint->start($request, $authException);
-    }
-
-    /**
-     * @param Request $request
-     */
-    protected function setTargetPath(Request $request)
-    {
-        // session isn't required when using HTTP basic authentication mechanism for example
-        if ($request->hasSession() && $request->isMethodSafe() && !$request->isXmlHttpRequest()) {
-            $request->getSession()->set('_security.'.$this->providerKey.'.target_path', $request->getUri());
-        }
     }
 }

--- a/src/Symfony/Component/Security/Tests/Acl/Dbal/MutableAclProviderTest.php
+++ b/src/Symfony/Component/Security/Tests/Acl/Dbal/MutableAclProviderTest.php
@@ -34,6 +34,25 @@ class MutableAclProviderTest extends \PHPUnit_Framework_TestCase
 {
     protected $con;
 
+    protected function setUp()
+    {
+        $this->con = DriverManager::getConnection(array(
+            'driver' => 'pdo_sqlite',
+            'memory' => true,
+        ));
+
+        // import the schema
+        $schema = new Schema($this->getOptions());
+        foreach ($schema->toSql($this->con->getDatabasePlatform()) as $sql) {
+            $this->con->exec($sql);
+        }
+    }
+
+    protected function tearDown()
+    {
+        $this->con = null;
+    }
+
     public static function assertAceEquals(EntryInterface $a, EntryInterface $b)
     {
         self::assertInstanceOf(get_class($a), $b);
@@ -413,6 +432,14 @@ class MutableAclProviderTest extends \PHPUnit_Framework_TestCase
         $provider->updateAcl($acl);
     }
 
+    public function setField($object, $field, $value)
+    {
+        $reflection = new \ReflectionProperty($object, $field);
+        $reflection->setAccessible(true);
+        $reflection->setValue($object, $value);
+        $reflection->setAccessible(false);
+    }
+
     /**
      * Imports acls.
      *
@@ -484,39 +511,12 @@ class MutableAclProviderTest extends \PHPUnit_Framework_TestCase
         return $method->invokeArgs($object, $args);
     }
 
-    protected function setUp()
-    {
-        $this->con = DriverManager::getConnection(array(
-            'driver' => 'pdo_sqlite',
-            'memory' => true,
-        ));
-
-        // import the schema
-        $schema = new Schema($this->getOptions());
-        foreach ($schema->toSql($this->con->getDatabasePlatform()) as $sql) {
-            $this->con->exec($sql);
-        }
-    }
-
-    protected function tearDown()
-    {
-        $this->con = null;
-    }
-
     protected function getField($object, $field)
     {
         $reflection = new \ReflectionProperty($object, $field);
         $reflection->setAccessible(true);
 
         return $reflection->getValue($object);
-    }
-
-    public function setField($object, $field, $value)
-    {
-        $reflection = new \ReflectionProperty($object, $field);
-        $reflection->setAccessible(true);
-        $reflection->setValue($object, $value);
-        $reflection->setAccessible(false);
     }
 
     protected function getOptions()

--- a/src/Symfony/Component/Security/Tests/Core/Authorization/AccessDecisionManagerTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Authorization/AccessDecisionManagerTest.php
@@ -93,20 +93,6 @@ class AccessDecisionManagerTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    protected function getVoterFor2Roles($token, $vote1, $vote2)
-    {
-        $voter = $this->getMock('Symfony\Component\Security\Core\Authorization\Voter\VoterInterface');
-        $voter->expects($this->any())
-              ->method('vote')
-              ->will($this->returnValueMap(array(
-                  array($token, null, array('ROLE_FOO'), $vote1),
-                  array($token, null, array('ROLE_BAR'), $vote2),
-              )))
-        ;
-
-        return $voter;
-    }
-
     public function getStrategyTests()
     {
         return array(
@@ -140,6 +126,20 @@ class AccessDecisionManagerTest extends \PHPUnit_Framework_TestCase
             array('unanimous', $this->getVoters(0, 0, 2), false, true, false),
             array('unanimous', $this->getVoters(0, 0, 2), true, true, true),
         );
+    }
+
+    protected function getVoterFor2Roles($token, $vote1, $vote2)
+    {
+        $voter = $this->getMock('Symfony\Component\Security\Core\Authorization\Voter\VoterInterface');
+        $voter->expects($this->any())
+              ->method('vote')
+              ->will($this->returnValueMap(array(
+                  array($token, null, array('ROLE_FOO'), $vote1),
+                  array($token, null, array('ROLE_BAR'), $vote2),
+              )))
+        ;
+
+        return $voter;
     }
 
     protected function getVoters($grants, $denies, $abstains)

--- a/src/Symfony/Component/Security/Tests/Core/User/InMemoryUserProviderTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/User/InMemoryUserProviderTest.php
@@ -39,20 +39,6 @@ class InMemoryUserProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($refreshedUser->isCredentialsNonExpired());
     }
 
-    /**
-     * @return InMemoryUserProvider
-     */
-    protected function createProvider()
-    {
-        return new InMemoryUserProvider(array(
-            'fabien' => array(
-                'password' => 'foo',
-                'enabled' => false,
-                'roles' => array('ROLE_USER'),
-            ),
-        ));
-    }
-
     public function testCreateUser()
     {
         $provider = new InMemoryUserProvider();
@@ -79,5 +65,19 @@ class InMemoryUserProviderTest extends \PHPUnit_Framework_TestCase
     {
         $provider = new InMemoryUserProvider();
         $provider->loadUserByUsername('fabien');
+    }
+
+    /**
+     * @return InMemoryUserProvider
+     */
+    protected function createProvider()
+    {
+        return new InMemoryUserProvider(array(
+            'fabien' => array(
+                'password' => 'foo',
+                'enabled' => false,
+                'roles' => array('ROLE_USER'),
+            ),
+        ));
     }
 }

--- a/src/Symfony/Component/Security/Tests/Http/Firewall/DigestDataTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Firewall/DigestDataTest.php
@@ -15,6 +15,11 @@ use Symfony\Component\Security\Http\Firewall\DigestData;
 
 class DigestDataTest extends \PHPUnit_Framework_TestCase
 {
+    protected function setUp()
+    {
+        class_exists('Symfony\Component\Security\Http\Firewall\DigestAuthenticationListener', true);
+    }
+
     public function testGetResponse()
     {
         $digestAuth = new DigestData(
@@ -154,11 +159,6 @@ class DigestDataTest extends \PHPUnit_Framework_TestCase
         $digestAuth->validateAndDecode($key, 'Welcome, robot!');
 
         $this->assertFalse($digestAuth->isNonceExpired());
-    }
-
-    protected function setUp()
-    {
-        class_exists('Symfony\Component\Security\Http\Firewall\DigestAuthenticationListener', true);
     }
 
     private function calculateServerDigest($username, $realm, $password, $key, $nc, $cnonce, $qop, $method, $uri)

--- a/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
@@ -18,6 +18,7 @@ namespace Symfony\Component\Serializer\Encoder;
  */
 class JsonDecode implements DecoderInterface
 {
+    protected $serializer;
     /**
      * Specifies if the returned result should be an associative array or a nested stdClass object hierarchy.
      *
@@ -33,7 +34,6 @@ class JsonDecode implements DecoderInterface
     private $recursionDepth;
 
     private $lastError = JSON_ERROR_NONE;
-    protected $serializer;
 
     /**
      * Constructs a new JsonDecode instance.

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -176,6 +176,22 @@ class GetSetMethodNormalizer extends SerializerAwareNormalizer implements Normal
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && $this->supports(get_class($data));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $this->supports($type);
+    }
+
+    /**
      * Format attribute name to access parameters or methods
      * As option, if attribute name is found on camelizedAttributes array
      * returns attribute name in camelcase format.
@@ -195,22 +211,6 @@ class GetSetMethodNormalizer extends SerializerAwareNormalizer implements Normal
         }
 
         return $attributeName;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function supportsNormalization($data, $format = null)
-    {
-        return is_object($data) && $this->supports(get_class($data));
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function supportsDenormalization($data, $type, $format = null)
-    {
-        return $this->supports($type);
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -170,6 +170,38 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
     /**
      * {@inheritdoc}
      */
+    final public function encode($data, $format, array $context = array())
+    {
+        return $this->encoder->encode($data, $format, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    final public function decode($data, $format, array $context = array())
+    {
+        return $this->decoder->decode($data, $format, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsEncoding($format)
+    {
+        return $this->encoder->supportsEncoding($format);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsDecoding($format)
+    {
+        return $this->decoder->supportsDecoding($format);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     private function getNormalizer($data, $format = null)
     {
         foreach ($this->normalizers as $normalizer) {
@@ -193,22 +225,6 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
         }
 
         throw new RuntimeException(sprintf('No denormalizer found for format "%s".', $format));
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    final public function encode($data, $format, array $context = array())
-    {
-        return $this->encoder->encode($data, $format, $context);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    final public function decode($data, $format, array $context = array())
-    {
-        return $this->decoder->decode($data, $format, $context);
     }
 
     /**
@@ -275,21 +291,5 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
         }
 
         throw new UnexpectedValueException(sprintf('Could not denormalize object of type %s, no supporting normalizer found.', $class));
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function supportsEncoding($format)
-    {
-        return $this->encoder->supportsEncoding($format);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function supportsDecoding($format)
-    {
-        return $this->decoder->supportsDecoding($format);
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -256,8 +256,8 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
 class GetSetDummy
 {
     protected $foo;
-    private $bar;
     protected $camelCase;
+    private $bar;
 
     public function getFoo()
     {

--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -136,43 +136,6 @@ class PhpEngine implements EngineInterface, \ArrayAccess
     }
 
     /**
-     * Evaluates a template.
-     *
-     * @param Storage $template   The template to render
-     * @param array   $parameters An array of parameters to pass to the template
-     *
-     * @return string|false The evaluated template, or false if the engine is unable to render the template
-     *
-     * @throws \InvalidArgumentException
-     */
-    protected function evaluate(Storage $template, array $parameters = array())
-    {
-        $__template__ = $template;
-
-        if (isset($parameters['__template__'])) {
-            throw new \InvalidArgumentException('Invalid parameter (__template__)');
-        }
-
-        if ($__template__ instanceof FileStorage) {
-            extract($parameters, EXTR_SKIP);
-            $view = $this;
-            ob_start();
-            require $__template__;
-
-            return ob_get_clean();
-        } elseif ($__template__ instanceof StringStorage) {
-            extract($parameters, EXTR_SKIP);
-            $view = $this;
-            ob_start();
-            eval('; ?>'.$__template__.'<?php ;');
-
-            return ob_get_clean();
-        }
-
-        return false;
-    }
-
-    /**
      * Gets a helper value.
      *
      * @param string $name The helper name
@@ -401,6 +364,75 @@ class PhpEngine implements EngineInterface, \ArrayAccess
     }
 
     /**
+     * Convert a string from one encoding to another.
+     *
+     * @param string $string The string to convert
+     * @param string $to     The input encoding
+     * @param string $from   The output encoding
+     *
+     * @return string The string with the new encoding
+     *
+     * @throws \RuntimeException if no suitable encoding function is found (iconv or mbstring)
+     */
+    public function convertEncoding($string, $to, $from)
+    {
+        if (function_exists('mb_convert_encoding')) {
+            return mb_convert_encoding($string, $to, $from);
+        } elseif (function_exists('iconv')) {
+            return iconv($from, $to, $string);
+        }
+
+        throw new \RuntimeException('No suitable convert encoding function (use UTF-8 as your encoding or install the iconv or mbstring extension).');
+    }
+
+    /**
+     * Gets the loader associated with this engine.
+     *
+     * @return LoaderInterface A LoaderInterface instance
+     */
+    public function getLoader()
+    {
+        return $this->loader;
+    }
+
+    /**
+     * Evaluates a template.
+     *
+     * @param Storage $template   The template to render
+     * @param array   $parameters An array of parameters to pass to the template
+     *
+     * @return string|false The evaluated template, or false if the engine is unable to render the template
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function evaluate(Storage $template, array $parameters = array())
+    {
+        $__template__ = $template;
+
+        if (isset($parameters['__template__'])) {
+            throw new \InvalidArgumentException('Invalid parameter (__template__)');
+        }
+
+        if ($__template__ instanceof FileStorage) {
+            extract($parameters, EXTR_SKIP);
+            $view = $this;
+            ob_start();
+            require $__template__;
+
+            return ob_get_clean();
+        } elseif ($__template__ instanceof StringStorage) {
+            extract($parameters, EXTR_SKIP);
+            $view = $this;
+            ob_start();
+            eval('; ?>'.$__template__.'<?php ;');
+
+            return ob_get_clean();
+        }
+
+        return false;
+    }
+
+    /**
      * Initializes the built-in escapers.
      *
      * Each function specifies a way for applying a transformation to a string
@@ -482,38 +514,6 @@ class PhpEngine implements EngineInterface, \ArrayAccess
         );
 
         self::$escaperCache = array();
-    }
-
-    /**
-     * Convert a string from one encoding to another.
-     *
-     * @param string $string The string to convert
-     * @param string $to     The input encoding
-     * @param string $from   The output encoding
-     *
-     * @return string The string with the new encoding
-     *
-     * @throws \RuntimeException if no suitable encoding function is found (iconv or mbstring)
-     */
-    public function convertEncoding($string, $to, $from)
-    {
-        if (function_exists('mb_convert_encoding')) {
-            return mb_convert_encoding($string, $to, $from);
-        } elseif (function_exists('iconv')) {
-            return iconv($from, $to, $string);
-        }
-
-        throw new \RuntimeException('No suitable convert encoding function (use UTF-8 as your encoding or install the iconv or mbstring extension).');
-    }
-
-    /**
-     * Gets the loader associated with this engine.
-     *
-     * @return LoaderInterface A LoaderInterface instance
-     */
-    public function getLoader()
-    {
-        return $this->loader;
     }
 
     /**

--- a/src/Symfony/Component/Translation/Catalogue/AbstractOperation.php
+++ b/src/Symfony/Component/Translation/Catalogue/AbstractOperation.php
@@ -37,14 +37,14 @@ abstract class AbstractOperation implements OperationInterface
     protected $result;
 
     /**
-     * @var null|array
-     */
-    private $domains;
-
-    /**
      * @var array
      */
     protected $messages;
+
+    /**
+     * @var null|array
+     */
+    private $domains;
 
     /**
      * @param MessageCatalogueInterface $source

--- a/src/Symfony/Component/Translation/Dumper/IcuResFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/IcuResFileDumper.php
@@ -105,6 +105,14 @@ class IcuResFileDumper implements DumperInterface
         return $header.$root.$data;
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    protected function getExtension()
+    {
+        return 'res';
+    }
+
     private function writePadding($data)
     {
         $padding = strlen($data) % 4;
@@ -117,13 +125,5 @@ class IcuResFileDumper implements DumperInterface
     private function getPosition($data)
     {
         return (strlen($data) + 28) / 4;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getExtension()
-    {
-        return 'res';
     }
 }

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -231,38 +231,6 @@ class Translator implements TranslatorInterface
         $this->loadFallbackCatalogues($locale);
     }
 
-    private function doLoadCatalogue($locale)
-    {
-        $this->catalogues[$locale] = new MessageCatalogue($locale);
-
-        if (isset($this->resources[$locale])) {
-            foreach ($this->resources[$locale] as $resource) {
-                if (!isset($this->loaders[$resource[0]])) {
-                    throw new \RuntimeException(sprintf('The "%s" translation loader is not registered.', $resource[0]));
-                }
-                $this->catalogues[$locale]->addCatalogue($this->loaders[$resource[0]]->load($resource[1], $locale, $resource[2]));
-            }
-        }
-    }
-
-    private function loadFallbackCatalogues($locale)
-    {
-        $current = $this->catalogues[$locale];
-
-        foreach ($this->computeFallbackLocales($locale) as $fallback) {
-            if (!isset($this->catalogues[$fallback])) {
-                $this->doLoadCatalogue($fallback);
-            }
-
-            $fallbackCatalogue = new MessageCatalogue($fallback, $this->catalogues[$fallback]->all());
-            foreach ($this->catalogues[$fallback]->getResources() as $resource) {
-                $fallbackCatalogue->addResource($resource);
-            }
-            $current->addFallbackCatalogue($fallbackCatalogue);
-            $current = $fallbackCatalogue;
-        }
-    }
-
     protected function computeFallbackLocales($locale)
     {
         $locales = array();
@@ -292,6 +260,38 @@ class Translator implements TranslatorInterface
     {
         if (1 !== preg_match('/^[a-z0-9@_\\.\\-]*$/i', $locale)) {
             throw new \InvalidArgumentException(sprintf('Invalid "%s" locale.', $locale));
+        }
+    }
+
+    private function doLoadCatalogue($locale)
+    {
+        $this->catalogues[$locale] = new MessageCatalogue($locale);
+
+        if (isset($this->resources[$locale])) {
+            foreach ($this->resources[$locale] as $resource) {
+                if (!isset($this->loaders[$resource[0]])) {
+                    throw new \RuntimeException(sprintf('The "%s" translation loader is not registered.', $resource[0]));
+                }
+                $this->catalogues[$locale]->addCatalogue($this->loaders[$resource[0]]->load($resource[1], $locale, $resource[2]));
+            }
+        }
+    }
+
+    private function loadFallbackCatalogues($locale)
+    {
+        $current = $this->catalogues[$locale];
+
+        foreach ($this->computeFallbackLocales($locale) as $fallback) {
+            if (!isset($this->catalogues[$fallback])) {
+                $this->doLoadCatalogue($fallback);
+            }
+
+            $fallbackCatalogue = new MessageCatalogue($fallback, $this->catalogues[$fallback]->all());
+            foreach ($this->catalogues[$fallback]->getResources() as $resource) {
+                $fallbackCatalogue->addResource($resource);
+            }
+            $current->addFallbackCatalogue($fallbackCatalogue);
+            $current = $fallbackCatalogue;
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/Ip.php
+++ b/src/Symfony/Component/Validator/Constraints/Ip.php
@@ -44,6 +44,10 @@ class Ip extends Constraint
     const V6_ONLY_PUBLIC = '6_public';
     const ALL_ONLY_PUBLIC = 'all_public';
 
+    public $version = self::V4;
+
+    public $message = 'This is not a valid IP address.';
+
     protected static $versions = array(
         self::V4,
         self::V6,
@@ -61,10 +65,6 @@ class Ip extends Constraint
         self::V6_ONLY_PUBLIC,
         self::ALL_ONLY_PUBLIC,
     );
-
-    public $version = self::V4;
-
-    public $message = 'This is not a valid IP address.';
 
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -266,18 +266,6 @@ class ClassMetadata extends ElementMetadata implements MetadataInterface, ClassB
     }
 
     /**
-     * Adds a member metadata.
-     *
-     * @param MemberMetadata $metadata
-     */
-    protected function addMemberMetadata(MemberMetadata $metadata)
-    {
-        $property = $metadata->getPropertyName();
-
-        $this->members[$property][] = $metadata;
-    }
-
-    /**
      * Returns true if metadatas of members is present for the given property.
      *
      * @param string $property The name of the property
@@ -425,5 +413,17 @@ class ClassMetadata extends ElementMetadata implements MetadataInterface, ClassB
     public function isGroupSequenceProvider()
     {
         return $this->groupSequenceProvider;
+    }
+
+    /**
+     * Adds a member metadata.
+     *
+     * @param MemberMetadata $metadata
+     */
+    protected function addMemberMetadata(MemberMetadata $metadata)
+    {
+        $property = $metadata->getPropertyName();
+
+        $this->members[$property][] = $metadata;
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/AllValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AllValidatorTest.php
@@ -18,11 +18,6 @@ use Symfony\Component\Validator\Constraints\Range;
 
 class AllValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected function createValidator()
-    {
-        return new AllValidator();
-    }
-
     public function testNullIsValid()
     {
         $this->validator->validate(null, new All(new Range(array('min' => 4))));
@@ -83,5 +78,10 @@ class AllValidatorTest extends AbstractConstraintValidatorTest
             array(array(5, 6, 7)),
             array(new \ArrayObject(array(5, 6, 7))),
         );
+    }
+
+    protected function createValidator()
+    {
+        return new AllValidator();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/BlankValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/BlankValidatorTest.php
@@ -16,11 +16,6 @@ use Symfony\Component\Validator\Constraints\BlankValidator;
 
 class BlankValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected function createValidator()
-    {
-        return new BlankValidator();
-    }
-
     public function testNullIsValid()
     {
         $this->validator->validate(null, new Blank());
@@ -59,5 +54,10 @@ class BlankValidatorTest extends AbstractConstraintValidatorTest
             array(false, 'false'),
             array(1234, '1234'),
         );
+    }
+
+    protected function createValidator()
+    {
+        return new BlankValidator();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CallbackValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CallbackValidatorTest.php
@@ -45,11 +45,6 @@ class CallbackValidatorTest_Object
 
 class CallbackValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected function createValidator()
-    {
-        return new CallbackValidator();
-    }
-
     public function testNullIsValid()
     {
         $this->validator->validate(null, new Callback(array('foo')));
@@ -186,5 +181,10 @@ class CallbackValidatorTest extends AbstractConstraintValidatorTest
         $constraint = new Callback(array('value' => array(__CLASS__.'_Class', 'validateCallback')));
 
         $this->assertEquals(new Callback(array(__CLASS__.'_Class', 'validateCallback')), $constraint);
+    }
+
+    protected function createValidator()
+    {
+        return new CallbackValidator();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CardSchemeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CardSchemeValidatorTest.php
@@ -16,11 +16,6 @@ use Symfony\Component\Validator\Constraints\CardSchemeValidator;
 
 class CardSchemeValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected function createValidator()
-    {
-        return new CardSchemeValidator();
-    }
-
     public function testNullIsValid()
     {
         $this->validator->validate(null, new CardScheme(array('schemes' => array())));
@@ -123,5 +118,10 @@ class CardSchemeValidatorTest extends AbstractConstraintValidatorTest
             array('DINERS', '3056930'), // only first part of the number
             array('DISCOVER', '1117'), // only last 4 digits
         );
+    }
+
+    protected function createValidator()
+    {
+        return new CardSchemeValidator();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
@@ -21,11 +21,6 @@ function choice_callback()
 
 class ChoiceValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected function createValidator()
-    {
-        return new ChoiceValidator();
-    }
-
     public static function staticCallback()
     {
         return array('foo', 'bar');
@@ -283,5 +278,10 @@ class ChoiceValidatorTest extends AbstractConstraintValidatorTest
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"3"')
             ->assertRaised();
+    }
+
+    protected function createValidator()
+    {
+        return new ChoiceValidator();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTest.php
@@ -20,13 +20,6 @@ use Symfony\Component\Validator\Constraints\Required;
 
 abstract class CollectionValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected function createValidator()
-    {
-        return new CollectionValidator();
-    }
-
-    abstract protected function prepareTestData(array $contents);
-
     public function testNullIsValid()
     {
         $this->validator->validate(null, new Collection(array('fields' => array(
@@ -377,4 +370,11 @@ abstract class CollectionValidatorTest extends AbstractConstraintValidatorTest
             'foo' => 3,
         ), (array) $value);
     }
+
+    protected function createValidator()
+    {
+        return new CollectionValidator();
+    }
+
+    abstract protected function prepareTestData(array $contents);
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorTest.php
@@ -19,13 +19,6 @@ use Symfony\Component\Validator\Constraints\CountValidator;
  */
 abstract class CountValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected function createValidator()
-    {
-        return new CountValidator();
-    }
-
-    abstract protected function createCollection(array $content);
-
     public function testNullIsValid()
     {
         $this->validator->validate(null, new Count(6));
@@ -177,4 +170,11 @@ abstract class CountValidatorTest extends AbstractConstraintValidatorTest
         $this->assertEquals(5, $constraint->min);
         $this->assertEquals(5, $constraint->max);
     }
+
+    protected function createValidator()
+    {
+        return new CountValidator();
+    }
+
+    abstract protected function createCollection(array $content);
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountryValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountryValidatorTest.php
@@ -17,11 +17,6 @@ use Symfony\Component\Validator\Constraints\CountryValidator;
 
 class CountryValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected function createValidator()
-    {
-        return new CountryValidator();
-    }
-
     public function testNullIsValid()
     {
         $this->validator->validate(null, new Country());
@@ -99,5 +94,10 @@ class CountryValidatorTest extends AbstractConstraintValidatorTest
         $this->validator->validate($existingCountry, new Country());
 
         $this->assertNoViolation();
+    }
+
+    protected function createValidator()
+    {
+        return new CountryValidator();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CurrencyValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CurrencyValidatorTest.php
@@ -17,11 +17,6 @@ use Symfony\Component\Validator\Constraints\CurrencyValidator;
 
 class CurrencyValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected function createValidator()
-    {
-        return new CurrencyValidator();
-    }
-
     public function testNullIsValid()
     {
         $this->validator->validate(null, new Currency());
@@ -101,5 +96,10 @@ class CurrencyValidatorTest extends AbstractConstraintValidatorTest
             array('EN'),
             array('foobar'),
         );
+    }
+
+    protected function createValidator()
+    {
+        return new CurrencyValidator();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
@@ -16,11 +16,6 @@ use Symfony\Component\Validator\Constraints\DateTimeValidator;
 
 class DateTimeValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected function createValidator()
-    {
-        return new DateTimeValidator();
-    }
-
     public function testNullIsValid()
     {
         $this->validator->validate(null, new DateTime());
@@ -99,5 +94,10 @@ class DateTimeValidatorTest extends AbstractConstraintValidatorTest
             array('2010-01-01 00:60:00'),
             array('2010-01-01 00:00:60'),
         );
+    }
+
+    protected function createValidator()
+    {
+        return new DateTimeValidator();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
@@ -16,11 +16,6 @@ use Symfony\Component\Validator\Constraints\DateValidator;
 
 class DateValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected function createValidator()
-    {
-        return new DateValidator();
-    }
-
     public function testNullIsValid()
     {
         $this->validator->validate(null, new Date());
@@ -95,5 +90,10 @@ class DateValidatorTest extends AbstractConstraintValidatorTest
             array('2010-04-32'),
             array('2010-02-29'),
         );
+    }
+
+    protected function createValidator()
+    {
+        return new DateValidator();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
@@ -16,11 +16,6 @@ use Symfony\Component\Validator\Constraints\EmailValidator;
 
 class EmailValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected function createValidator()
-    {
-        return new EmailValidator(false);
-    }
-
     public function testNullIsValid()
     {
         $this->validator->validate(null, new Email());
@@ -85,5 +80,10 @@ class EmailValidatorTest extends AbstractConstraintValidatorTest
             array('example@'),
             array('example@localhost'),
         );
+    }
+
+    protected function createValidator()
+    {
+        return new EmailValidator(false);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/EqualToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EqualToValidatorTest.php
@@ -19,16 +19,6 @@ use Symfony\Component\Validator\Constraints\EqualToValidator;
  */
 class EqualToValidatorTest extends AbstractComparisonValidatorTestCase
 {
-    protected function createValidator()
-    {
-        return new EqualToValidator();
-    }
-
-    protected function createConstraint(array $options)
-    {
-        return new EqualTo($options);
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -55,5 +45,15 @@ class EqualToValidatorTest extends AbstractComparisonValidatorTestCase
             array(new \DateTime('2001-01-01'), 'Jan 1, 2001, 12:00 AM', new \DateTime('2000-01-01'), 'Jan 1, 2000, 12:00 AM', 'DateTime'),
             array(new ComparisonTest_Class(4), '4', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'),
         );
+    }
+
+    protected function createValidator()
+    {
+        return new EqualToValidator();
+    }
+
+    protected function createConstraint(array $options)
+    {
+        return new EqualTo($options);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorPathTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorPathTest.php
@@ -15,11 +15,6 @@ use Symfony\Component\Validator\Constraints\File;
 
 class FileValidatorPathTest extends FileValidatorTest
 {
-    protected function getFile($filename)
-    {
-        return $filename;
-    }
-
     public function testFileNotFound()
     {
         $constraint = new File(array(
@@ -31,5 +26,10 @@ class FileValidatorPathTest extends FileValidatorTest
         $this->buildViolation('myMessage')
             ->setParameter('{{ file }}', '"foobar"')
             ->assertRaised();
+    }
+
+    protected function getFile($filename)
+    {
+        return $filename;
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -22,16 +22,6 @@ abstract class FileValidatorTest extends AbstractConstraintValidatorTest
 
     protected $file;
 
-    protected function getApiVersion()
-    {
-        return Validation::API_VERSION_2_5;
-    }
-
-    protected function createValidator()
-    {
-        return new FileValidator();
-    }
-
     protected function setUp()
     {
         parent::setUp();
@@ -384,6 +374,16 @@ abstract class FileValidatorTest extends AbstractConstraintValidatorTest
         }
 
         return $tests;
+    }
+
+    protected function getApiVersion()
+    {
+        return Validation::API_VERSION_2_5;
+    }
+
+    protected function createValidator()
+    {
+        return new FileValidator();
     }
 
     abstract protected function getFile($filename);

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorTest.php
@@ -19,16 +19,6 @@ use Symfony\Component\Validator\Constraints\GreaterThanOrEqualValidator;
  */
 class GreaterThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
 {
-    protected function createValidator()
-    {
-        return new GreaterThanOrEqualValidator();
-    }
-
-    protected function createConstraint(array $options)
-    {
-        return new GreaterThanOrEqual($options);
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -55,5 +45,15 @@ class GreaterThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCas
             array(new \DateTime('2000/01/01'), 'Jan 1, 2000, 12:00 AM', new \DateTime('2005/01/01'), 'Jan 1, 2005, 12:00 AM', 'DateTime'),
             array('b', '"b"', 'c', '"c"', 'string'),
         );
+    }
+
+    protected function createValidator()
+    {
+        return new GreaterThanOrEqualValidator();
+    }
+
+    protected function createConstraint(array $options)
+    {
+        return new GreaterThanOrEqual($options);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorTest.php
@@ -19,16 +19,6 @@ use Symfony\Component\Validator\Constraints\GreaterThanValidator;
  */
 class GreaterThanValidatorTest extends AbstractComparisonValidatorTestCase
 {
-    protected function createValidator()
-    {
-        return new GreaterThanValidator();
-    }
-
-    protected function createConstraint(array $options)
-    {
-        return new GreaterThan($options);
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -58,5 +48,15 @@ class GreaterThanValidatorTest extends AbstractComparisonValidatorTestCase
             array('22', '"22"', '333', '"333"', 'string'),
             array('22', '"22"', '22', '"22"', 'string'),
         );
+    }
+
+    protected function createValidator()
+    {
+        return new GreaterThanValidator();
+    }
+
+    protected function createConstraint(array $options)
+    {
+        return new GreaterThan($options);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IbanValidatorTest.php
@@ -16,11 +16,6 @@ use Symfony\Component\Validator\Constraints\IbanValidator;
 
 class IbanValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected function createValidator()
-    {
-        return new IbanValidator();
-    }
-
     public function testNullIsValid()
     {
         $this->validator->validate(null, new Iban());
@@ -182,5 +177,10 @@ class IbanValidatorTest extends AbstractConstraintValidatorTest
             array('Ae260211000000230064016'),
             array('ae260211000000230064016'),
         );
+    }
+
+    protected function createValidator()
+    {
+        return new IbanValidator();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToValidatorTest.php
@@ -19,16 +19,6 @@ use Symfony\Component\Validator\Constraints\IdenticalToValidator;
  */
 class IdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
 {
-    protected function createValidator()
-    {
-        return new IdenticalToValidator();
-    }
-
-    protected function createConstraint(array $options)
-    {
-        return new IdenticalTo($options);
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -59,5 +49,15 @@ class IdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
             array(new \DateTime('2001-01-01'), 'Jan 1, 2001, 12:00 AM', new \DateTime('1999-01-01'), 'Jan 1, 1999, 12:00 AM', 'DateTime'),
             array(new ComparisonTest_Class(4), '4', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'),
         );
+    }
+
+    protected function createValidator()
+    {
+        return new IdenticalToValidator();
+    }
+
+    protected function createConstraint(array $options)
+    {
+        return new IdenticalTo($options);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
@@ -26,11 +26,6 @@ class ImageValidatorTest extends AbstractConstraintValidatorTest
     protected $imageLandscape;
     protected $imagePortrait;
 
-    protected function createValidator()
-    {
-        return new ImageValidator();
-    }
-
     protected function setUp()
     {
         parent::setUp();
@@ -181,5 +176,10 @@ class ImageValidatorTest extends AbstractConstraintValidatorTest
         ));
 
         $this->validator->validate($this->image, $constraint);
+    }
+
+    protected function createValidator()
+    {
+        return new ImageValidator();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/IpValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IpValidatorTest.php
@@ -16,11 +16,6 @@ use Symfony\Component\Validator\Constraints\IpValidator;
 
 class IpValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected function createValidator()
-    {
-        return new IpValidator();
-    }
-
     public function testNullIsValid()
     {
         $this->validator->validate(null, new Ip());
@@ -434,5 +429,10 @@ class IpValidatorTest extends AbstractConstraintValidatorTest
     public function getInvalidPublicIpsAll()
     {
         return array_merge($this->getInvalidPublicIpsV4(), $this->getInvalidPublicIpsV6());
+    }
+
+    protected function createValidator()
+    {
+        return new IpValidator();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/IsFalseValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IsFalseValidatorTest.php
@@ -16,11 +16,6 @@ use Symfony\Component\Validator\Constraints\IsFalseValidator;
 
 class IsFalseValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected function createValidator()
-    {
-        return new IsFalseValidator();
-    }
-
     public function testNullIsValid()
     {
         $this->validator->validate(null, new IsFalse());
@@ -46,5 +41,10 @@ class IsFalseValidatorTest extends AbstractConstraintValidatorTest
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', 'true')
             ->assertRaised();
+    }
+
+    protected function createValidator()
+    {
+        return new IsFalseValidator();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/IsNullValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IsNullValidatorTest.php
@@ -16,11 +16,6 @@ use Symfony\Component\Validator\Constraints\IsNullValidator;
 
 class IsNullValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected function createValidator()
-    {
-        return new IsNullValidator();
-    }
-
     public function testNullIsValid()
     {
         $this->validator->validate(null, new IsNull());
@@ -56,5 +51,10 @@ class IsNullValidatorTest extends AbstractConstraintValidatorTest
             array(new \stdClass(), 'object'),
             array(array(), 'array'),
         );
+    }
+
+    protected function createValidator()
+    {
+        return new IsNullValidator();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/IsTrueValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IsTrueValidatorTest.php
@@ -16,11 +16,6 @@ use Symfony\Component\Validator\Constraints\IsTrueValidator;
 
 class IsTrueValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected function createValidator()
-    {
-        return new IsTrueValidator();
-    }
-
     public function testNullIsValid()
     {
         $this->validator->validate(null, new IsTrue());
@@ -46,5 +41,10 @@ class IsTrueValidatorTest extends AbstractConstraintValidatorTest
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', 'false')
             ->assertRaised();
+    }
+
+    protected function createValidator()
+    {
+        return new IsTrueValidator();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/IsbnValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IsbnValidatorTest.php
@@ -19,11 +19,6 @@ use Symfony\Component\Validator\Constraints\IsbnValidator;
  */
 class IsbnValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected function createValidator()
-    {
-        return new IsbnValidator();
-    }
-
     public function getValidIsbn10()
     {
         return array(
@@ -235,5 +230,10 @@ class IsbnValidatorTest extends AbstractConstraintValidatorTest
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$isbn.'"')
             ->assertRaised();
+    }
+
+    protected function createValidator()
+    {
+        return new IsbnValidator();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/IssnValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IssnValidatorTest.php
@@ -19,11 +19,6 @@ use Symfony\Component\Validator\Constraints\IssnValidator;
  */
 class IssnValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected function createValidator()
-    {
-        return new IssnValidator();
-    }
-
     public function getValidLowerCasedIssn()
     {
         return array(
@@ -220,5 +215,10 @@ class IssnValidatorTest extends AbstractConstraintValidatorTest
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"'.$issn.'"')
             ->assertRaised();
+    }
+
+    protected function createValidator()
+    {
+        return new IssnValidator();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LanguageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LanguageValidatorTest.php
@@ -17,11 +17,6 @@ use Symfony\Component\Validator\Constraints\LanguageValidator;
 
 class LanguageValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected function createValidator()
-    {
-        return new LanguageValidator();
-    }
-
     public function testNullIsValid()
     {
         $this->validator->validate(null, new Language());
@@ -99,5 +94,10 @@ class LanguageValidatorTest extends AbstractConstraintValidatorTest
         )));
 
         $this->assertNoViolation();
+    }
+
+    protected function createValidator()
+    {
+        return new LanguageValidator();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LengthValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LengthValidatorTest.php
@@ -16,11 +16,6 @@ use Symfony\Component\Validator\Constraints\LengthValidator;
 
 class LengthValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected function createValidator()
-    {
-        return new LengthValidator();
-    }
-
     public function testNullIsValid()
     {
         $this->validator->validate(null, new Length(6));
@@ -227,5 +222,10 @@ class LengthValidatorTest extends AbstractConstraintValidatorTest
 
         $this->assertEquals(5, $constraint->min);
         $this->assertEquals(5, $constraint->max);
+    }
+
+    protected function createValidator()
+    {
+        return new LengthValidator();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorTest.php
@@ -19,16 +19,6 @@ use Symfony\Component\Validator\Constraints\LessThanOrEqualValidator;
  */
 class LessThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
 {
-    protected function createValidator()
-    {
-        return new LessThanOrEqualValidator();
-    }
-
-    protected function createConstraint(array $options)
-    {
-        return new LessThanOrEqual($options);
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -58,5 +48,15 @@ class LessThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
             array(new ComparisonTest_Class(5), '5', new ComparisonTest_Class(4), '4', __NAMESPACE__.'\ComparisonTest_Class'),
             array('c', '"c"', 'b', '"b"', 'string'),
         );
+    }
+
+    protected function createValidator()
+    {
+        return new LessThanOrEqualValidator();
+    }
+
+    protected function createConstraint(array $options)
+    {
+        return new LessThanOrEqual($options);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorTest.php
@@ -19,16 +19,6 @@ use Symfony\Component\Validator\Constraints\LessThanValidator;
  */
 class LessThanValidatorTest extends AbstractComparisonValidatorTestCase
 {
-    protected function createValidator()
-    {
-        return new LessThanValidator();
-    }
-
-    protected function createConstraint(array $options)
-    {
-        return new LessThan($options);
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -57,5 +47,15 @@ class LessThanValidatorTest extends AbstractComparisonValidatorTestCase
             array(new ComparisonTest_Class(6), '6', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'),
             array('333', '"333"', '22', '"22"', 'string'),
         );
+    }
+
+    protected function createValidator()
+    {
+        return new LessThanValidator();
+    }
+
+    protected function createConstraint(array $options)
+    {
+        return new LessThan($options);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LocaleValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LocaleValidatorTest.php
@@ -16,11 +16,6 @@ use Symfony\Component\Validator\Constraints\LocaleValidator;
 
 class LocaleValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected function createValidator()
-    {
-        return new LocaleValidator();
-    }
-
     public function testNullIsValid()
     {
         $this->validator->validate(null, new Locale());
@@ -86,5 +81,10 @@ class LocaleValidatorTest extends AbstractConstraintValidatorTest
             array('EN'),
             array('foobar'),
         );
+    }
+
+    protected function createValidator()
+    {
+        return new LocaleValidator();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LuhnValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LuhnValidatorTest.php
@@ -16,11 +16,6 @@ use Symfony\Component\Validator\Constraints\LuhnValidator;
 
 class LuhnValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected function createValidator()
-    {
-        return new LuhnValidator();
-    }
-
     public function testNullIsValid()
     {
         $this->validator->validate(null, new Luhn());
@@ -114,5 +109,10 @@ class LuhnValidatorTest extends AbstractConstraintValidatorTest
             array(378282246310005),
             array(371449635398431),
         );
+    }
+
+    protected function createValidator()
+    {
+        return new LuhnValidator();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotBlankValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotBlankValidatorTest.php
@@ -16,11 +16,6 @@ use Symfony\Component\Validator\Constraints\NotBlankValidator;
 
 class NotBlankValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected function createValidator()
-    {
-        return new NotBlankValidator();
-    }
-
     /**
      * @dataProvider getValidValues
      */
@@ -92,5 +87,10 @@ class NotBlankValidatorTest extends AbstractConstraintValidatorTest
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', 'array')
             ->assertRaised();
+    }
+
+    protected function createValidator()
+    {
+        return new NotBlankValidator();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToValidatorTest.php
@@ -19,16 +19,6 @@ use Symfony\Component\Validator\Constraints\NotEqualToValidator;
  */
 class NotEqualToValidatorTest extends AbstractComparisonValidatorTestCase
 {
-    protected function createValidator()
-    {
-        return new NotEqualToValidator();
-    }
-
-    protected function createConstraint(array $options)
-    {
-        return new NotEqualTo($options);
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -55,5 +45,15 @@ class NotEqualToValidatorTest extends AbstractComparisonValidatorTestCase
             array(new \DateTime('2000-01-01'), 'Jan 1, 2000, 12:00 AM', new \DateTime('2000-01-01'), 'Jan 1, 2000, 12:00 AM', 'DateTime'),
             array(new ComparisonTest_Class(5), '5', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'),
         );
+    }
+
+    protected function createValidator()
+    {
+        return new NotEqualToValidator();
+    }
+
+    protected function createConstraint(array $options)
+    {
+        return new NotEqualTo($options);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToValidatorTest.php
@@ -19,16 +19,6 @@ use Symfony\Component\Validator\Constraints\NotIdenticalToValidator;
  */
 class NotIdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
 {
-    protected function createValidator()
-    {
-        return new NotIdenticalToValidator();
-    }
-
-    protected function createConstraint(array $options)
-    {
-        return new NotIdenticalTo($options);
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -58,5 +48,15 @@ class NotIdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
             array($date, 'Jan 1, 2000, 12:00 AM', $date, 'Jan 1, 2000, 12:00 AM', 'DateTime'),
             array($object, '2', $object, '2', __NAMESPACE__.'\ComparisonTest_Class'),
         );
+    }
+
+    protected function createValidator()
+    {
+        return new NotIdenticalToValidator();
+    }
+
+    protected function createConstraint(array $options)
+    {
+        return new NotIdenticalTo($options);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotNullValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotNullValidatorTest.php
@@ -16,11 +16,6 @@ use Symfony\Component\Validator\Constraints\NotNullValidator;
 
 class NotNullValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected function createValidator()
-    {
-        return new NotNullValidator();
-    }
-
     /**
      * @dataProvider getValidValues
      */
@@ -50,5 +45,10 @@ class NotNullValidatorTest extends AbstractConstraintValidatorTest
         $this->validator->validate(null, $constraint);
 
         $this->buildViolation('myMessage')->assertRaised();
+    }
+
+    protected function createValidator()
+    {
+        return new NotNullValidator();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/RangeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RangeValidatorTest.php
@@ -16,11 +16,6 @@ use Symfony\Component\Validator\Constraints\RangeValidator;
 
 class RangeValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected function createValidator()
-    {
-        return new RangeValidator();
-    }
-
     public function testNullIsValid()
     {
         $this->validator->validate(null, new Range(array('min' => 10, 'max' => 20)));
@@ -225,5 +220,10 @@ class RangeValidatorTest extends AbstractConstraintValidatorTest
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', '"abcd"')
             ->assertRaised();
+    }
+
+    protected function createValidator()
+    {
+        return new RangeValidator();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
@@ -16,11 +16,6 @@ use Symfony\Component\Validator\Constraints\RegexValidator;
 
 class RegexValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected function createValidator()
-    {
-        return new RegexValidator();
-    }
-
     public function testNullIsValid()
     {
         $this->validator->validate(null, new Regex(array('pattern' => '/^[0-9]+$/')));
@@ -87,5 +82,10 @@ class RegexValidatorTest extends AbstractConstraintValidatorTest
             array('abcd'),
             array('090foo'),
         );
+    }
+
+    protected function createValidator()
+    {
+        return new RegexValidator();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimeValidatorTest.php
@@ -16,11 +16,6 @@ use Symfony\Component\Validator\Constraints\TimeValidator;
 
 class TimeValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected function createValidator()
-    {
-        return new TimeValidator();
-    }
-
     public function testNullIsValid()
     {
         $this->validator->validate(null, new Time());
@@ -96,5 +91,10 @@ class TimeValidatorTest extends AbstractConstraintValidatorTest
             array('00:60:00'),
             array('00:00:60'),
         );
+    }
+
+    protected function createValidator()
+    {
+        return new TimeValidator();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/TypeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TypeValidatorTest.php
@@ -18,9 +18,12 @@ class TypeValidatorTest extends AbstractConstraintValidatorTest
 {
     protected static $file;
 
-    protected function createValidator()
+    public static function tearDownAfterClass()
     {
-        return new TypeValidator();
+        if (static::$file) {
+            fclose(static::$file);
+            static::$file = null;
+        }
     }
 
     public function testNullIsValid()
@@ -160,6 +163,11 @@ class TypeValidatorTest extends AbstractConstraintValidatorTest
         );
     }
 
+    protected function createValidator()
+    {
+        return new TypeValidator();
+    }
+
     protected function createFile()
     {
         if (!static::$file) {
@@ -167,13 +175,5 @@ class TypeValidatorTest extends AbstractConstraintValidatorTest
         }
 
         return static::$file;
-    }
-
-    public static function tearDownAfterClass()
-    {
-        if (static::$file) {
-            fclose(static::$file);
-            static::$file = null;
-        }
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
@@ -16,11 +16,6 @@ use Symfony\Component\Validator\Constraints\UrlValidator;
 
 class UrlValidatorTest extends AbstractConstraintValidatorTest
 {
-    protected function createValidator()
-    {
-        return new UrlValidator();
-    }
-
     public function testNullIsValid()
     {
         $this->validator->validate(null, new Url());
@@ -180,6 +175,11 @@ class UrlValidatorTest extends AbstractConstraintValidatorTest
             array('file://127.0.0.1'),
             array('git://[::1]/'),
         );
+    }
+
+    protected function createValidator()
+    {
+        return new UrlValidator();
     }
 }
 

--- a/src/Symfony/Component/Validator/Validation.php
+++ b/src/Symfony/Component/Validator/Validation.php
@@ -19,6 +19,13 @@ namespace Symfony\Component\Validator;
 final class Validation
 {
     /**
+     * This class cannot be instantiated.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
      * Creates a new validator.
      *
      * If you want to configure the validator, use
@@ -39,12 +46,5 @@ final class Validation
     public static function createValidatorBuilder()
     {
         return new ValidatorBuilder();
-    }
-
-    /**
-     * This class cannot be instantiated.
-     */
-    private function __construct()
-    {
     }
 }

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -146,40 +146,6 @@ class Inline
     }
 
     /**
-     * Dumps a PHP array to a YAML string.
-     *
-     * @param array $value                  The PHP array to dump
-     * @param bool  $exceptionOnInvalidType true if an exception must be thrown on invalid types (a PHP resource or object), false otherwise
-     * @param bool  $objectSupport          true if object support is enabled, false otherwise
-     *
-     * @return string The YAML string representing the PHP array
-     */
-    private static function dumpArray($value, $exceptionOnInvalidType, $objectSupport)
-    {
-        // array
-        $keys = array_keys($value);
-        $keysCount = count($keys);
-        if ((1 === $keysCount && '0' == $keys[0])
-            || ($keysCount > 1 && array_reduce($keys, function ($v, $w) { return (int) $v + $w; }, 0) === $keysCount * ($keysCount - 1) / 2)
-        ) {
-            $output = array();
-            foreach ($value as $val) {
-                $output[] = self::dump($val, $exceptionOnInvalidType, $objectSupport);
-            }
-
-            return sprintf('[%s]', implode(', ', $output));
-        }
-
-        // mapping
-        $output = array();
-        foreach ($value as $key => $val) {
-            $output[] = sprintf('%s: %s', self::dump($key, $exceptionOnInvalidType, $objectSupport), self::dump($val, $exceptionOnInvalidType, $objectSupport));
-        }
-
-        return sprintf('{ %s }', implode(', ', $output));
-    }
-
-    /**
      * Parses a scalar to a YAML string.
      *
      * @param string $scalar
@@ -228,6 +194,40 @@ class Inline
         }
 
         return $output;
+    }
+
+    /**
+     * Dumps a PHP array to a YAML string.
+     *
+     * @param array $value                  The PHP array to dump
+     * @param bool  $exceptionOnInvalidType true if an exception must be thrown on invalid types (a PHP resource or object), false otherwise
+     * @param bool  $objectSupport          true if object support is enabled, false otherwise
+     *
+     * @return string The YAML string representing the PHP array
+     */
+    private static function dumpArray($value, $exceptionOnInvalidType, $objectSupport)
+    {
+        // array
+        $keys = array_keys($value);
+        $keysCount = count($keys);
+        if ((1 === $keysCount && '0' == $keys[0])
+            || ($keysCount > 1 && array_reduce($keys, function ($v, $w) { return (int) $v + $w; }, 0) === $keysCount * ($keysCount - 1) / 2)
+        ) {
+            $output = array();
+            foreach ($value as $val) {
+                $output[] = self::dump($val, $exceptionOnInvalidType, $objectSupport);
+            }
+
+            return sprintf('[%s]', implode(', ', $output));
+        }
+
+        // mapping
+        $output = array();
+        foreach ($value as $key => $val) {
+            $output[] = sprintf('%s: %s', self::dump($key, $exceptionOnInvalidType, $objectSupport), self::dump($val, $exceptionOnInvalidType, $objectSupport));
+        }
+
+        return sprintf('{ %s }', implode(', ', $output));
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | 2.3 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

I'm working on a new CS fixer for ordering class elements (according to symfony coding standards): https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/1628
The question is: Should the fixer be added to symfony level?

I guess the answer is "no", for the same reasons as in https://github.com/symfony/symfony/pull/17828#issuecomment-185570165.
(which is a very comprehensible reason!)
