### PR TITLE
Enhance Yaml Component readme

### DIFF
--- a/src/Symfony/Component/Yaml/README.md
+++ b/src/Symfony/Component/Yaml/README.md
@@ -1,21 +1,33 @@
 Yaml Component
 ==============
 
-YAML implements most of the YAML 1.2 specification.
+[![Package version](https://img.shields.io/packagist/v/symfony/yaml.svg)](https://packagist.org/packages/symfony/yaml)
 
-```php
-use Symfony\Component\Yaml\Yaml;
+The Yaml Component implements most of the
+[YAML 1.2 specification](http://yaml.org/spec/1.2/spec.html).
 
-$array = Yaml::parse(file_get_contents(filename));
+[See the Documentation](http://symfony.com/doc/current/components/yaml).
 
-print Yaml::dump($array);
+Contributing
+------------
+
+Read the [Symfony Contribution Guide](http://symfony.com/doc/current/contributing/index.html)
+for all informations relative on how to contribute, the conventions and so on.
+
+To run the unit tests with the following command:
+
+```bash
+$ cd path/to/src/Symfony/Component/Yaml/
+$ composer install
+$ phpunit
 ```
 
-Resources
+Changelog
 ---------
 
-You can run the unit tests with the following command:
+Full changelog available [here](CHANGELOG.md).
 
-    $ cd path/to/Symfony/Component/Yaml/
-    $ composer install
-    $ phpunit
+License
+-------
+
+This project is under the [MIT License](LICENSE).


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | 2.3 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

Users, though GitHub, Google or Symfony doc, may be redirected to the [Yaml Component GitHub](https://github.com/symfony/yaml). While the lack of info in the readme is not that big of an issue, as we can guess there is more doc elsewhere and not that many users come there, it can still feel annoying or harmful for others.

This PR aims at proposing simple changes to provide a better experience to people coming on the repo by giving all the info they may require on it:
- a badge to give the latest version published on composer
- a link to the official and complete documentation
- a quick guide on how to contribute to the project (gives the references to the Symfony Guide and how to run tests for the component)
- a link to the changelog
- a mention of the license

Also note that this could easily be enforced for other components/bridges as well: it requires minimal change without the risk of breaking any PR.
