### PR TITLE
[DX][Finder] Add a simple way to get the first result of a finder

### DIFF
--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -624,6 +624,19 @@ class Finder implements \IteratorAggregate, \Countable
     }
 
     /**
+     * Returns the first file matched by this finder.
+     *
+     * @return SplFileInfo|null
+     */
+    public function first()
+    {
+        $iterator = $this->getIterator();
+        $iterator->rewind();
+
+        return $iterator->current();
+    }
+
+    /**
      * @param $dir
      *
      * @return \Iterator

--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -630,10 +630,9 @@ class Finder implements \IteratorAggregate, \Countable
      */
     public function first()
     {
-        $iterator = $this->getIterator();
-        $iterator->rewind();
-
-        return $iterator->current();
+        foreach ($this as $file) {
+            return $file;
+        }
     }
 
     /**

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -695,6 +695,16 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $this->assertEquals($path, $firstPath);
     }
 
+    public function testFirstReturnsNull()
+    {
+        $finder = $this->buildFinder();
+        $finder->files()->in(self::$tmpDir);
+        $finder->name('nosuchfile.php');
+
+        $firstFile = $finder->first();
+        $this->assertNull($firstFile);
+    }
+
     protected function buildFinder()
     {
         return Finder::create();

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -673,6 +673,28 @@ class FinderTest extends Iterator\RealIteratorTestCase
         }
     }
 
+    public function testFirst()
+    {
+        $finder = $this->buildFinder();
+        $finder->files()->in(self::$tmpDir);
+
+        $firstFile = $finder->first();
+        $this->assertInstanceOf(\SplFileInfo::class, $firstFile);
+        $firstPath = str_replace('/', DIRECTORY_SEPARATOR, $finder->first()->getPathname());
+
+        $path = $this->toAbsolute(array('foo/bar.tmp'))[0];
+        str_replace('/', DIRECTORY_SEPARATOR, $path);
+
+        $this->assertEquals($path, $firstPath);
+
+        // call a second time to make sure we still get the first result
+        $firstFile = $finder->first();
+        $this->assertInstanceOf(\SplFileInfo::class, $firstFile);
+        $firstPath = str_replace('/', DIRECTORY_SEPARATOR, $finder->first()->getPathname());
+
+        $this->assertEquals($path, $firstPath);
+    }
+
     protected function buildFinder()
     {
         return Finder::create();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

I often find myself using the Finder find a single file, and currently not easy to access this one result. I think this would be a useful function.

I am not sure of the implementation, but couldn't see a better option.
I'm not sure why the `rewind` call is needed, but without it I always get a null result.

I'll add some tests if the idea is accepted
