### PR TITLE
[Config] Allow infinity value for IntegerNode

### DIFF
--- a/src/Symfony/Component/Config/Definition/IntegerNode.php
+++ b/src/Symfony/Component/Config/Definition/IntegerNode.php
@@ -26,7 +26,12 @@ class IntegerNode extends NumericNode
     protected function validateType($value)
     {
         if (!is_int($value)) {
-            $ex = new InvalidTypeException(sprintf('Invalid type for path "%s". Expected int, but got %s.', $this->getPath(), gettype($value)));
+            // INF is valid
+            if (is_float($value) && is_infinite($value)) {
+                return;
+            }
+
+            $ex = new InvalidTypeException(sprintf('Invalid type for path "%s". Expected int or infinity, but got %s.', $this->getPath(), gettype($value)));
             $ex->setPath($this->getPath());
 
             throw $ex;

--- a/src/Symfony/Component/Config/Tests/Definition/IntegerNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/IntegerNodeTest.php
@@ -43,6 +43,8 @@ class IntegerNodeTest extends \PHPUnit_Framework_TestCase
             array(1798),
             array(-678),
             array(0),
+            array(INF),
+            array(-INF),
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | 2.3 or master (wasn't sure, this isn't exactly a new feature...) |
| Bug fix? | yes and no (not exactly a bug) |
| New feature? | yes and no (not exactly a new feature) |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17996 |
| License | MIT |

Like I said, I wasn't sure this was or not a new feature. so if it should target the 3.1 release. It just adds a check if the value is infinity and doesn't trigger the `InvalidTypeException` if it is.
