### PR TITLE
[HttpKernel] early return for Bundle#getContainerExtension()

### DIFF
--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -81,34 +81,30 @@ abstract class Bundle implements BundleInterface
      */
     public function getContainerExtension()
     {
-        if (null === $this->extension) {
-            $extension = $this->createContainerExtension();
-
-            if (null !== $extension) {
-                if (!$extension instanceof ExtensionInterface) {
-                    throw new \LogicException(sprintf('Extension %s must implement Symfony\Component\DependencyInjection\Extension\ExtensionInterface.', get_class($extension)));
-                }
-
-                // check naming convention
-                $basename = preg_replace('/Bundle$/', '', $this->getName());
-                $expectedAlias = Container::underscore($basename);
-
-                if ($expectedAlias != $extension->getAlias()) {
-                    throw new \LogicException(sprintf(
-                        'Users will expect the alias of the default extension of a bundle to be the underscored version of the bundle name ("%s"). You can override "Bundle::getContainerExtension()" if you want to use "%s" or another alias.',
-                        $expectedAlias, $extension->getAlias()
-                    ));
-                }
-
-                $this->extension = $extension;
-            } else {
-                $this->extension = false;
-            }
+        if (null !== $this->extension) {
+            return $this->extension ? $this->extension : null;
         }
+        $extension = $this->createContainerExtension();
+        if (null === $extension) {
+            $this->extension = false;
 
-        if ($this->extension) {
-            return $this->extension;
+            return;
         }
+        if (!$extension instanceof ExtensionInterface) {
+            throw new \LogicException(sprintf('Extension %s must implement Symfony\Component\DependencyInjection\Extension\ExtensionInterface.', get_class($extension)));
+        }
+        // check naming convention
+        $basename = preg_replace('/Bundle$/', '', $this->getName());
+        $expectedAlias = Container::underscore($basename);
+        if ($expectedAlias != $extension->getAlias()) {
+            throw new \LogicException(sprintf(
+                'Users will expect the alias of the default extension of a bundle to be the underscored version of the bundle name ("%s"). You can override "Bundle::getContainerExtension()" if you want to use "%s" or another alias.',
+                $expectedAlias, $extension->getAlias()
+            ));
+        }
+        $this->extension = $extension;
+
+        return $this->extension ? $this->extension : null;
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -82,7 +82,7 @@ abstract class Bundle implements BundleInterface
     public function getContainerExtension()
     {
         if (null !== $this->extension) {
-            return $this->extension ? $this->extension : null;
+            return $this->extension ?: null;
         }
         $extension = $this->createContainerExtension();
         if (null === $extension) {
@@ -104,7 +104,7 @@ abstract class Bundle implements BundleInterface
         }
         $this->extension = $extension;
 
-        return $this->extension ? $this->extension : null;
+        return $this->extension ?: null;
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

In the previous version, `Bundle#getContainerExtension()` wrapped almost the whole
body in an if statement.

This Pull request offers a small refactoring: switching to early returns.
