### PR TITLE
[Cache] Add namespace handling to all adapters

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
@@ -32,7 +32,7 @@ abstract class AbstractAdapter implements CacheItemPoolInterface, LoggerAwareInt
 
     protected function __construct($namespace = '', $defaultLifetime = 0)
     {
-        $this->namespace = $namespace;
+        $this->namespace = $this->getId($namespace, true);
         $this->createCacheItem = \Closure::bind(
             function ($key, $value, $isHit) use ($defaultLifetime) {
                 $item = new CacheItem();
@@ -331,12 +331,12 @@ abstract class AbstractAdapter implements CacheItemPoolInterface, LoggerAwareInt
         }
     }
 
-    private function getId($key)
+    private function getId($key, $ns = false)
     {
         if (!is_string($key)) {
             throw new InvalidArgumentException(sprintf('Cache key must be string, "%s" given', is_object($key) ? get_class($key) : gettype($key)));
         }
-        if (!isset($key[0])) {
+        if (!isset($key[0]) && !$ns) {
             throw new InvalidArgumentException('Cache key length must be greater than zero');
         }
         if (isset($key[strcspn($key, '{}()/\@:')])) {

--- a/src/Symfony/Component/Cache/Adapter/DoctrineAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/DoctrineAdapter.php
@@ -20,9 +20,9 @@ class DoctrineAdapter extends AbstractAdapter
 {
     private $provider;
 
-    public function __construct(CacheProvider $provider, $defaultLifetime = null)
+    public function __construct(CacheProvider $provider, $defaultLifetime = 0, $namespace = '')
     {
-        parent::__construct('', $defaultLifetime);
+        parent::__construct($namespace, $defaultLifetime);
         $this->provider = $provider;
     }
 

--- a/src/Symfony/Component/Cache/Adapter/FilesystemAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/FilesystemAdapter.php
@@ -20,10 +20,16 @@ class FilesystemAdapter extends AbstractAdapter
 {
     private $directory;
 
-    public function __construct($directory, $defaultLifetime = null)
+    public function __construct($directory, $defaultLifetime = 0, $namespace = '')
     {
         parent::__construct('', $defaultLifetime);
 
+        if (!isset($directory[0])) {
+            $directory = sys_get_temp_dir().'/symfony-cache';
+        }
+        if (isset($namespace[0])) {
+            $directory .= '/'.$namespace;
+        }
         if (!file_exists($dir = $directory.'/.')) {
             @mkdir($directory, 0777, true);
         }

--- a/src/Symfony/Component/Cache/Tests/Adapter/ApcuAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ApcuAdapterTest.php
@@ -28,6 +28,6 @@ class ApcuAdapterTest extends CachePoolTest
             $this->markTestSkipped('Fails transiently on Windows.');
         }
 
-        return new ApcuAdapter(__CLASS__);
+        return new ApcuAdapter(str_replace('\\', '.', __CLASS__));
     }
 }

--- a/src/Symfony/Component/Cache/Tests/Adapter/NamespacedProxyAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/NamespacedProxyAdapterTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Adapter;
+
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\ProxyAdapter;
+
+/**
+ * @group time-sensitive
+ */
+class NamespacedProxyAdapterTest extends ProxyAdapterTest
+{
+    public function createCachePool()
+    {
+        return new ProxyAdapter(new ArrayAdapter(), 0, 'foo');
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This allows more flexible handling of adapters, allowing e.g. to take one cache pool and split in in several sub-pools by using ProxyAdapter.
