### PR TITLE
[HttpFoundation] Fix the build on windows (with mbstring extension missing)

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -161,17 +161,7 @@ class BinaryFileResponse extends Response
         }
 
         if ('' === $filenameFallback && (!preg_match('/^[\x20-\x7e]*$/', $filename) || false !== strpos($filename, '%'))) {
-            $encoding = mb_detect_encoding($filename, null, true);
-
-            for ($i = 0; $i < mb_strlen($filename, $encoding); ++$i) {
-                $char = mb_substr($filename, $i, 1, $encoding);
-
-                if ('%' === $char || ord($char) < 32 || ord($char) > 126) {
-                    $filenameFallback .= '_';
-                } else {
-                    $filenameFallback .= $char;
-                }
-            }
+            $filenameFallback = preg_replace('/[^\x20-\x7e]|%/u', '_', $filename);
         }
 
         $dispositionHeader = $this->headers->makeDisposition($disposition, $filename, $filenameFallback);

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -36,7 +36,13 @@ class BinaryFileResponseTest extends ResponseTestCase
 
     public function testConstructWithNonAsciiFilename()
     {
-        new BinaryFileResponse(__DIR__.'/Fixtures/föö.html', 200, array(), true, 'attachment');
+        touch(sys_get_temp_dir().'/fööö.html');
+
+        $response = new BinaryFileResponse(sys_get_temp_dir().'/fööö.html', 200, array(), true, 'attachment');
+
+        $this->assertSame('fööö.html', $response->getFile()->getFilename());
+
+        @unlink(sys_get_temp_dir().'/fööö.html');
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | 2.3 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

An alternative approach to #16656 that works without the mbstring extension. If we tried to follow the current approach and make it work without mbstring it would make code quite more complex.
