### PR TITLE
[HttpFoundation] Add a dependency on the mbstring polyfill

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "doctrine/common": "~2.4",
         "paragonie/random_compat": "~1.0",
         "symfony/polyfill-apcu": "~1.1",
+        "symfony/polyfill-mbstring": "~1.1",
         "twig/twig": "~1.23|~2.0",
         "psr/log": "~1.0"
     },

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -36,7 +36,13 @@ class BinaryFileResponseTest extends ResponseTestCase
 
     public function testConstructWithNonAsciiFilename()
     {
-        new BinaryFileResponse(__DIR__.'/Fixtures/föö.html', 200, array(), true, 'attachment');
+        touch(sys_get_temp_dir().'/fööö.html');
+
+        $response = new BinaryFileResponse(sys_get_temp_dir().'/fööö.html', 200, array(), true, 'attachment');
+
+        @unlink(sys_get_temp_dir().'/fööö.html');
+
+        $this->assertSame('fööö.html', $response->getFile()->getFilename());
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/composer.json
+++ b/src/Symfony/Component/HttpFoundation/composer.json
@@ -16,7 +16,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.3.3",
+        "symfony/polyfill-mbstring": "~1.1"
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\HttpFoundation\\": "" },


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | 2.3 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Alternative for #18029.
