### PR TITLE
[DoctrineBridge] reference form type by name on Symfony 2.7

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -796,7 +796,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->persist(array($entity1, $entity2));
 
-        $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
+        $field = $this->factory->createNamed('name', 'entity', null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
             'choice_label' => 'name',


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Note: This change must be reverted after being merged into the `2.8` branch.
