### PR TITLE
Adding a parameter that allows you to globally set an autowiring map

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -136,6 +136,13 @@ class AutowirePass implements CompilerPassInterface
         foreach ($this->container->getDefinitions() as $id => $definition) {
             $this->populateAvailableType($id, $definition);
         }
+
+        if ($this->container->hasParameter('autowiring.map')) {
+            $this->types = array_merge(
+                $this->types,
+                $this->container->getParameter('autowiring.map')
+            );
+        }
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -412,6 +412,29 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
             $definition->getArguments()
         );
     }
+
+    public function testGlobalParameterMapSet()
+    {
+        $container = new ContainerBuilder();
+
+        // two services matching CollisionInterface
+        // c1 is configured to autowire for CollisionInterface
+        $container->register('c1', __NAMESPACE__.'\CollisionA')
+            ->addAutowiringType(__NAMESPACE__.'\CollisionInterface');
+        $container->register('c2', __NAMESPACE__.'\CollisionB');
+        $aDefinition = $container->register('a', __NAMESPACE__.'\CannotBeAutowired');
+        $aDefinition->setAutowired(true);
+
+        $container->setParameter('autowiring.map', array(
+            __NAMESPACE__.'\CollisionInterface' => 'c2'
+        ));
+
+        $pass = new AutowirePass();
+        $pass->process($container);
+
+        $aDefinition = $container->getDefinition('a');
+        $this->assertEquals(array(new Reference('c2')), $aDefinition->getArguments());
+    }
 }
 
 class Foo


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17783 |
| License | MIT |
| Doc PR | todo |

Hi guys!

This allows end-users to override an autowiring type - e.g.

``` yml
parameters:
    autowiring.map:
        Psr\Log\LoggerInterface: 'my_logger'
```

Using parameters for this was by far the easiest implementation, but not the most user friendly - it's not my _favorite_ to have random magic keys like this do things. There is no precedent (that I'm aware of) for using parameters in this special way. However, why not? If we wanted to deprecate or change it in the future, we can do that easily where we use the parameter.

Cheers!
