### PR TITLE
[2.8] update readme files for new components

### DIFF
--- a/src/Symfony/Component/Ldap/README.md
+++ b/src/Symfony/Component/Ldap/README.md
@@ -18,10 +18,7 @@ The documentation for the component can be found [online] [0].
 Resources
 ---------
 
-You can run the unit tests with the following command:
-
-    $ cd path/to/Symfony/Component/Ldap/
-    $ composer install
-    $ phpunit
-
-[0]: https://symfony.com/doc/2.8/components/ldap.html
+  * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+  * [Report issues](https://github.com/symfony/symfony/issues) and
+    [send Pull Requests](https://github.com/symfony/symfony/pulls)
+    in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/PropertyInfo/README.md
+++ b/src/Symfony/Component/PropertyInfo/README.md
@@ -7,8 +7,7 @@ of popular sources.
 Resources
 ---------
 
-You can run the unit tests with the following command:
-
-    $ cd path/to/Symfony/Component/PropertyInfo/
-    $ composer install
-    $ phpunit
+  * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+  * [Report issues](https://github.com/symfony/symfony/issues) and
+    [send Pull Requests](https://github.com/symfony/symfony/pulls)
+    in the [main Symfony repository](https://github.com/symfony/symfony)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | 2.8 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17997 |
| License | MIT |
| Doc PR |  |

This completes @javiereguiluz's great work from #17997 by adapting the readme files of components added in Symfony 2.8.
