### PR TITLE
[HttpKernel] Fix mem usage when stripping the prod container

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -650,10 +650,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
             $dumper->setProxyDumper(new ProxyDumper(md5((string) $cache)));
         }
 
-        $content = $dumper->dump(array('class' => $class, 'base_class' => $baseClass, 'file' => (string) $cache));
-        if (!$this->debug) {
-            $content = static::stripComments($content);
-        }
+        $content = $dumper->dump(array('class' => $class, 'base_class' => $baseClass, 'file' => (string) $cache, 'debug' => $this->debug));
 
         $cache->write($content, $container->getResources());
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | 2.3 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18007 |
| License | MIT |
| Doc PR | - |

I propose to just replace doc comments by regular comments, so that the parser removes them and opcache doesn't have to keep them in memory, which is the target.
