### PR TITLE
[Validator] Fix the locale validator so it treats a locale alias as a valid locale

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/LocaleValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LocaleValidator.php
@@ -38,8 +38,9 @@ class LocaleValidator extends ConstraintValidator
 
         $value = (string) $value;
         $locales = Intl::getLocaleBundle()->getLocaleNames();
+        $aliases = Intl::getLocaleBundle()->getAliases();
 
-        if (!isset($locales[$value])) {
+        if (!isset($locales[$value]) && !in_array($value, $aliases)) {
             $this->context->addViolation($constraint->message, array(
                 '{{ value }}' => $this->formatValue($value),
             ));

--- a/src/Symfony/Component/Validator/Tests/Constraints/LocaleValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LocaleValidatorTest.php
@@ -61,6 +61,7 @@ class LocaleValidatorTest extends AbstractConstraintValidatorTest
             array('pt'),
             array('pt_PT'),
             array('zh_Hans'),
+            array('fil_PH'),
         );
     }
 

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "doctrine/common": "~2.3",
         "symfony/http-foundation": "~2.1",
-        "symfony/intl": "~2.3",
+        "symfony/intl": "^2.3.21",
         "symfony/yaml": "~2.0,>=2.0.5",
         "symfony/config": "~2.2"
     },


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | 2.3 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12583 |
| License | MIT |
| Doc PR | - |
