### PR TITLE
#18035 Fix for Router doesn't take additional get parameter if default value is set

### DIFF
--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -274,6 +274,14 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
 
         // add a query string if needed
         $extra = array_diff_key($parameters, $variables, $defaults);
+        foreach($parameters as $key => $value) {
+            if (isset($defaults[$key]) &&
+                !array_key_exists($key, $variables) &&
+                $defaults[$key] !== $value
+            ) {
+                $extra[$key] = $value;
+            }
+        }
         if ($extra && $query = http_build_query($extra, '', '&')) {
             // "/" and "?" can be left decoded for better user experience, see
             // http://tools.ietf.org/html/rfc3986#section-3.4

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -323,7 +323,6 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('/app.php/test?default=foo', $this->getGenerator($routes)->generate('test', array('default' => 'foo')));
         $this->assertSame('/app.php/test', $this->getGenerator($routes)->generate('test', array('default' => 'value')));
         $this->assertSame('/app.php/test', $this->getGenerator($routes)->generate('test'));
-
     }
 
     public function testGenerateWithSpecialRouteName()

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -323,6 +323,7 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('/app.php/test?default=foo', $this->getGenerator($routes)->generate('test', array('default' => 'foo')));
         $this->assertSame('/app.php/test', $this->getGenerator($routes)->generate('test', array('default' => 'value')));
         $this->assertSame('/app.php/test', $this->getGenerator($routes)->generate('test'));
+
     }
 
     public function testGenerateWithSpecialRouteName()

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -117,6 +117,27 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://localhost/app.php/testing?foo=bar', $url);
     }
 
+    public function testAbsoluteUrlWithExtraParametersAndDefault()
+    {
+        $routes = $this->getRoutes('test', new Route('/testing', array('foo' => 'bell')));
+        $url = $this->getGenerator($routes)->generate('test', array('foo' => 'bar'), UrlGeneratorInterface::ABSOLUTE_URL);
+        $this->assertEquals('http://localhost/app.php/testing?foo=bar', $url);
+    }
+
+    public function testAbsoluteUrlWithExtraParametersAndArrayDefault()
+    {
+        $routes = $this->getRoutes('test', new Route('/testing', array('foo' => array('bell'))));
+        $url = $this->getGenerator($routes)->generate('test', array('foo' => array('bar')), UrlGeneratorInterface::ABSOLUTE_URL);
+        $this->assertEquals('http://localhost/app.php/testing?foo%5B0%5D=bar', $url);
+    }
+
+    public function testAbsoluteUrlWithoutExtraParametersAndArrayDefault()
+    {
+        $routes = $this->getRoutes('test', new Route('/testing', array('foo' => array('bell'))));
+        $url = $this->getGenerator($routes)->generate('test', array('foo' => array('bell')), UrlGeneratorInterface::ABSOLUTE_URL);
+        $this->assertEquals('http://localhost/app.php/testing', $url);
+    }
+
     public function testUrlWithNullExtraParameters()
     {
         $routes = $this->getRoutes('test', new Route('/testing'));
@@ -299,7 +320,7 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $routes = $this->getRoutes('test', new Route('/test', array('default' => 'value')));
 
-        $this->assertSame('/app.php/test', $this->getGenerator($routes)->generate('test', array('default' => 'foo')));
+        $this->assertSame('/app.php/test?default=foo', $this->getGenerator($routes)->generate('test', array('default' => 'foo')));
         $this->assertSame('/app.php/test', $this->getGenerator($routes)->generate('test', array('default' => 'value')));
         $this->assertSame('/app.php/test', $this->getGenerator($routes)->generate('test'));
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | Yes |
| Fixed tickets | #18035 |
| License | MIT |
| Doc PR |  |
