### PR TITLE
[Translation] Make class XliffFileDumper extendable

### DIFF
--- a/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/XliffFileDumper.php
@@ -54,7 +54,15 @@ class XliffFileDumper extends FileDumper
         return 'xlf';
     }
 
-    private function dumpXliff1($defaultLocale, MessageCatalogue $messages, $domain, array $options = array())
+    /**
+     * @param string           $defaultLocale
+     * @param MessageCatalogue $messages
+     * @param string           $domain
+     * @param array            $options
+     *
+     * @return string
+     */
+    protected function dumpXliff1($defaultLocale, MessageCatalogue $messages, $domain, array $options = array())
     {
         $toolInfo = array('tool-id' => 'symfony', 'tool-name' => 'Symfony');
         if (array_key_exists('tool_info', $options)) {
@@ -87,8 +95,7 @@ class XliffFileDumper extends FileDumper
             $translation->setAttribute('id', md5($source));
             $translation->setAttribute('resname', $source);
 
-            $s = $translation->appendChild($dom->createElement('source'));
-            $s->appendChild($dom->createTextNode($source));
+            $this->addSource($dom, $translation, $source, $target);
 
             // Does the target contain characters requiring a CDATA section?
             $text = 1 === preg_match('/[&<>]/', $target) ? $dom->createCDATASection($target) : $dom->createTextNode($target);
@@ -128,7 +135,15 @@ class XliffFileDumper extends FileDumper
         return $dom->saveXML();
     }
 
-    private function dumpXliff2($defaultLocale, MessageCatalogue $messages, $domain, array $options = array())
+    /**
+     * @param string           $defaultLocale
+     * @param MessageCatalogue $messages
+     * @param string           $domain
+     * @param array            $options
+     *
+     * @return string
+     */
+    protected function dumpXliff2($defaultLocale, MessageCatalogue $messages, $domain, array $options = array())
     {
         $dom = new \DOMDocument('1.0', 'utf-8');
         $dom->formatOutput = true;
@@ -148,8 +163,7 @@ class XliffFileDumper extends FileDumper
 
             $segment = $translation->appendChild($dom->createElement('segment'));
 
-            $s = $segment->appendChild($dom->createElement('source'));
-            $s->appendChild($dom->createTextNode($source));
+            $this->addSource($dom, $segment, $source, $target);
 
             // Does the target contain characters requiring a CDATA section?
             $text = 1 === preg_match('/[&<>]/', $target) ? $dom->createCDATASection($target) : $dom->createTextNode($target);
@@ -171,12 +185,26 @@ class XliffFileDumper extends FileDumper
     }
 
     /**
+     * Add the source tag.
+     *
+     * @param DOMDocument $dom
+     * @param DOMElement  $node
+     * @param string      $source
+     * @param string      $target
+     */
+    protected function addSource(\DOMDocument $dom, \DOMElement $node, $source, $target)
+    {
+        $sourceDomElement = $node->appendChild($dom->createElement('source'));
+        $sourceDomElement->appendChild($dom->createTextNode($source));
+    }
+
+    /**
      * @param string     $key
      * @param array|null $metadata
      *
      * @return bool
      */
-    private function hasMetadataArrayInfo($key, $metadata = null)
+    protected function hasMetadataArrayInfo($key, $metadata = null)
     {
         return null !== $metadata && array_key_exists($key, $metadata) && ($metadata[$key] instanceof \Traversable || is_array($metadata[$key]));
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | master for features and deprecations / lowest applicable and maintained version otherwise |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Updating the `XliffFileDumper` private methods to protected, isolating the source tag creation - i need to be able to override that single part when using the translation update command and my translations use keywords for an id.
