### PR TITLE
[HttpFoundation] Set the Content-Range header if the requested Range is unsatisfied

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -252,6 +252,7 @@ class BinaryFileResponse extends Response
                 if ($start <= $end) {
                     if ($start < 0 || $end > $fileSize - 1) {
                         $this->setStatusCode(416);
+                        $this->headers->set('Content-Range', sprintf('bytes */%s', $fileSize));
                     } elseif ($start !== 0 || $end !== $fileSize - 1) {
                         $this->maxlen = $end < $fileSize ? $end - $start + 1 : -1;
                         $this->offset = $start;

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -211,7 +211,7 @@ class BinaryFileResponseTest extends ResponseTestCase
         $response->sendContent();
 
         $this->assertEquals(416, $response->getStatusCode());
-        #$this->assertEquals('', $response->headers->get('Content-Range'));
+        $this->assertEquals('bytes */35', $response->headers->get('Content-Range'));
     }
 
     public function provideInvalidRanges()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | 2.3 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This is a followup to https://github.com/symfony/symfony/pull/17150#issuecomment-174509954

[RFC2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html) specifies the Content-Range header SHOULD be included with a _416 Requested Range Not Satisfiable_ response:

>    When this status code is returned for a byte-range request, the response SHOULD include a Content-Range entity-header field specifying the current length of the selected resource (see section 14.16). This response MUST NOT use the multipart/byteranges content- type.

[RFC 7233](https://tools.ietf.org/html/rfc7233#section-4.2) specifies what should be the header's value. It's in the "Request for comments" state, but it's the best definition I could find. This value is valid according to rfc2616 as well.
