### PR TITLE
[Form] FormValidator removed code related to removed `cascade_validation` option

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -103,7 +103,7 @@ class FormValidatorTest extends AbstractConstraintValidatorTest
         $this->assertNoViolation();
     }
 
-    public function testValidateIfChildWithValidConstraint()
+    public function testValidateChildIfValidConstraint()
     {
         $object = $this->getMock('\stdClass');
 
@@ -161,7 +161,7 @@ class FormValidatorTest extends AbstractConstraintValidatorTest
         $this->assertNoViolation();
     }
 
-    public function testValidateConstraintsOptionEvenIfParentWithoutValidConstraint()
+    public function testValidateConstraintsOptionEvenIfNoValidConstraint()
     {
         $object = $this->getMock('\stdClass');
         $constraint1 = new NotNull(array('groups' => array('group1', 'group2')));

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -103,28 +103,6 @@ class FormValidatorTest extends AbstractConstraintValidatorTest
         $this->assertNoViolation();
     }
 
-    public function testValidateIfParentWithCascadeValidation()
-    {
-        $object = $this->getMock('\stdClass');
-
-        $parent = $this->getBuilder('parent', null, array('cascade_validation' => true))
-            ->setCompound(true)
-            ->setDataMapper($this->getDataMapper())
-            ->getForm();
-        $options = array('validation_groups' => array('group1', 'group2'));
-        $form = $this->getBuilder('name', '\stdClass', $options)->getForm();
-        $parent->add($form);
-
-        $form->setData($object);
-
-        $this->expectValidateAt(0, 'data', $object, 'group1');
-        $this->expectValidateAt(1, 'data', $object, 'group2');
-
-        $this->validator->validate($form, new Form());
-
-        $this->assertNoViolation();
-    }
-
     public function testValidateIfChildWithValidConstraint()
     {
         $object = $this->getMock('\stdClass');
@@ -149,11 +127,11 @@ class FormValidatorTest extends AbstractConstraintValidatorTest
         $this->assertNoViolation();
     }
 
-    public function testDontValidateIfParentWithoutCascadeValidation()
+    public function testDontValidateIfParentWithoutValidConstraint()
     {
         $object = $this->getMock('\stdClass');
 
-        $parent = $this->getBuilder('parent', null, array('cascade_validation' => false))
+        $parent = $this->getBuilder('parent', null)
             ->setCompound(true)
             ->setDataMapper($this->getDataMapper())
             ->getForm();
@@ -183,13 +161,13 @@ class FormValidatorTest extends AbstractConstraintValidatorTest
         $this->assertNoViolation();
     }
 
-    public function testValidateConstraintsEvenIfNoCascadeValidation()
+    public function testValidateConstraintsOptionEvenIfParentWithoutValidConstraint()
     {
         $object = $this->getMock('\stdClass');
         $constraint1 = new NotNull(array('groups' => array('group1', 'group2')));
         $constraint2 = new NotBlank(array('groups' => 'group2'));
 
-        $parent = $this->getBuilder('parent', null, array('cascade_validation' => false))
+        $parent = $this->getBuilder('parent', null)
             ->setCompound(true)
             ->setDataMapper($this->getDataMapper())
             ->getForm();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | 3.0 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18063 |
| License | MIT |
