### PR TITLE
[Yaml] Fix tests

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -588,7 +588,7 @@ class Inline
                         return (float) str_replace(',', '', $scalar);
                     case preg_match(self::getTimestampRegex(), $scalar):
                         if (Yaml::PARSE_DATETIME & $flags) {
-                            return new \DateTime($scalar,new \DateTimeZone('UTC'));
+                            return new \DateTime($scalar, new \DateTimeZone('UTC'));
                         }
 
                         $timeZone = date_default_timezone_get();

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -495,7 +495,8 @@ class InlineTest extends \PHPUnit_Framework_TestCase
      */
     public function testParseTimestampAsDateTimeObject($yaml, $year, $month, $day, $hour, $minute, $second)
     {
-        $expected = new \DateTime('now', new \DateTimeZone('UTC'));
+        $expected = new \DateTime($yaml);
+        $expected->setTimeZone(new \DateTimeZone('UTC'));
         $expected->setDate($year, $month, $day);
         $expected->setTime($hour, $minute, $second);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | #18093 |
| License | MIT |
| Doc PR | - |

`now` contains a TZ info (the current default TZ), so that the following ignores the injected TZ:
`new \DateTime('now', new \DateTimeZone('UTC'))`

An other fix is that since PHP 5.5.14, timestamps contains sub-seconds numbers that where previously ignored.

This fixes both issues.
