### PR TITLE
[Console] Allow to register commands privately

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddConsoleCommandPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddConsoleCommandPass.php
@@ -24,13 +24,10 @@ class AddConsoleCommandPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         $commandServices = $container->findTaggedServiceIds('console.command');
+        $serviceIds = array();
 
         foreach ($commandServices as $id => $tags) {
             $definition = $container->getDefinition($id);
-
-            if (!$definition->isPublic()) {
-                throw new \InvalidArgumentException(sprintf('The service "%s" tagged "console.command" must be public.', $id));
-            }
 
             if ($definition->isAbstract()) {
                 throw new \InvalidArgumentException(sprintf('The service "%s" tagged "console.command" must not be abstract.', $id));
@@ -40,9 +37,10 @@ class AddConsoleCommandPass implements CompilerPassInterface
             if (!is_subclass_of($class, 'Symfony\\Component\\Console\\Command\\Command')) {
                 throw new \InvalidArgumentException(sprintf('The service "%s" tagged "console.command" must be a subclass of "Symfony\\Component\\Console\\Command\\Command".', $id));
             }
-            $container->setAlias('console.command.'.strtolower(str_replace('\\', '_', $class)), $id);
+            $container->setAlias($serviceId = 'console.command.'.strtolower(str_replace('\\', '_', $class)), $id);
+            $serviceIds[] = $serviceId;
         }
 
-        $container->setParameter('console.command.ids', array_keys($commandServices));
+        $container->setParameter('console.command.ids', $serviceIds);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddConsoleCommandPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddConsoleCommandPassTest.php
@@ -19,41 +19,42 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class AddConsoleCommandPassTest extends \PHPUnit_Framework_TestCase
 {
-    public function testProcess()
+    /**
+     * @dataProvider visibilityProvider
+     */
+    public function testProcess($public)
     {
         $container = new ContainerBuilder();
         $container->addCompilerPass(new AddConsoleCommandPass());
         $container->setParameter('my-command.class', 'Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler\MyCommand');
 
         $definition = new Definition('%my-command.class%');
+        $definition->setPublic($public);
         $definition->addTag('console.command');
         $container->setDefinition('my-command', $definition);
 
         $container->compile();
 
         $alias = 'console.command.symfony_bundle_frameworkbundle_tests_dependencyinjection_compiler_mycommand';
-        $this->assertTrue($container->hasAlias($alias));
-        $this->assertSame('my-command', (string) $container->getAlias($alias));
+        if ($container->hasAlias($alias)) {
+            $this->assertSame('my-command', (string) $container->getAlias($alias));
+        } else {
+            // The alias is replaced by a Definition by the ReplaceAliasByActualDefinitionPass
+            // in case the original service is private
+            $this->assertFalse($container->hasDefinition('my-command'));
+            $this->assertTrue($container->hasDefinition($alias));
+        }
 
         $this->assertTrue($container->hasParameter('console.command.ids'));
-        $this->assertSame(array('my-command'), $container->getParameter('console.command.ids'));
+        $this->assertSame(array('console.command.symfony_bundle_frameworkbundle_tests_dependencyinjection_compiler_mycommand'), $container->getParameter('console.command.ids'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The service "my-command" tagged "console.command" must be public.
-     */
-    public function testProcessThrowAnExceptionIfTheServiceIsNotPublic()
+    public function visibilityProvider()
     {
-        $container = new ContainerBuilder();
-        $container->addCompilerPass(new AddConsoleCommandPass());
-
-        $definition = new Definition('Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler\MyCommand');
-        $definition->addTag('console.command');
-        $definition->setPublic(false);
-        $container->setDefinition('my-command', $definition);
-
-        $container->compile();
+        return array(
+            array(true),
+            array(false),
+        );
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

I'm not sure if this should be considered as a bug or a feature.

It allows to declare command services as private (the command alias is used). I don't see a good reason to force the user to declare his services as public as the limitation is more internal than in his own code.
