### PR TITLE
[Validator] Fixing inaccurate typehint in docblock

### DIFF
--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -69,7 +69,7 @@ abstract class Constraint
     /**
      * Returns the name of the given error code.
      *
-     * @param int $errorCode The error code
+     * @param string $errorCode The error code
      *
      * @return string The name of the error code
      *


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | 2.8 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

As of Symfony 2.8, constraint errors are now string UUIDs rather than integers.  The corresponding docblock typehint in `Symfony\Component\Validator\Constraint::getErrorName` should reflect this change.
