### PR TITLE
Allow to use all tags with private services

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FormPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FormPass.php
@@ -36,7 +36,10 @@ class FormPass implements CompilerPassInterface
         foreach ($container->findTaggedServiceIds('form.type') as $serviceId => $tag) {
             $serviceDefinition = $container->getDefinition($serviceId);
             if (!$serviceDefinition->isPublic()) {
-                throw new \InvalidArgumentException(sprintf('The service "%s" must be public as form types are lazy-loaded.', $serviceId));
+                $alias = sprintf('public_services.%s', $serviceId);
+                $container->setAlias($alias, $serviceId);
+
+                $serviceId = $alias;
             }
 
             // Support type access by FQCN
@@ -50,7 +53,10 @@ class FormPass implements CompilerPassInterface
         foreach ($container->findTaggedServiceIds('form.type_extension') as $serviceId => $tag) {
             $serviceDefinition = $container->getDefinition($serviceId);
             if (!$serviceDefinition->isPublic()) {
-                throw new \InvalidArgumentException(sprintf('The service "%s" must be public as form type extensions are lazy-loaded.', $serviceId));
+                $alias = sprintf('public_services.%s', $serviceId);
+                $container->setAlias($alias, $serviceId);
+
+                $serviceId = $alias;
             }
 
             if (isset($tag[0]['extended_type'])) {
@@ -66,10 +72,13 @@ class FormPass implements CompilerPassInterface
 
         // Find all services annotated with "form.type_guesser"
         $guessers = array_keys($container->findTaggedServiceIds('form.type_guesser'));
-        foreach ($guessers as $serviceId) {
+        foreach ($guessers as &$serviceId) {
             $serviceDefinition = $container->getDefinition($serviceId);
             if (!$serviceDefinition->isPublic()) {
-                throw new \InvalidArgumentException(sprintf('The service "%s" must be public as form type guessers are lazy-loaded.', $serviceId));
+                $alias = sprintf('public_services.%s', $serviceId);
+                $container->setAlias($alias, $serviceId);
+
+                $serviceId = $alias;
             }
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FormPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FormPass.php
@@ -35,12 +35,7 @@ class FormPass implements CompilerPassInterface
 
         foreach ($container->findTaggedServiceIds('form.type') as $serviceId => $tag) {
             $serviceDefinition = $container->getDefinition($serviceId);
-            if (!$serviceDefinition->isPublic()) {
-                $alias = sprintf('public_services.%s', $serviceId);
-                $container->setAlias($alias, $serviceId);
-
-                $serviceId = $alias;
-            }
+            $serviceDefinition->setPublic(true);
 
             // Support type access by FQCN
             $types[$serviceDefinition->getClass()] = $serviceId;
@@ -52,12 +47,7 @@ class FormPass implements CompilerPassInterface
 
         foreach ($container->findTaggedServiceIds('form.type_extension') as $serviceId => $tag) {
             $serviceDefinition = $container->getDefinition($serviceId);
-            if (!$serviceDefinition->isPublic()) {
-                $alias = sprintf('public_services.%s', $serviceId);
-                $container->setAlias($alias, $serviceId);
-
-                $serviceId = $alias;
-            }
+            $serviceDefinition->setPublic(true);
 
             if (isset($tag[0]['extended_type'])) {
                 $extendedType = $tag[0]['extended_type'];
@@ -72,14 +62,9 @@ class FormPass implements CompilerPassInterface
 
         // Find all services annotated with "form.type_guesser"
         $guessers = array_keys($container->findTaggedServiceIds('form.type_guesser'));
-        foreach ($guessers as &$serviceId) {
+        foreach ($guessers as $serviceId) {
             $serviceDefinition = $container->getDefinition($serviceId);
-            if (!$serviceDefinition->isPublic()) {
-                $alias = sprintf('public_services.%s', $serviceId);
-                $container->setAlias($alias, $serviceId);
-
-                $serviceId = $alias;
-            }
+            $serviceDefinition->setPublic(true);
         }
 
         $definition->replaceArgument(3, $guessers);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/FormPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/FormPassTest.php
@@ -166,21 +166,22 @@ class FormPassTest extends \PHPUnit_Framework_TestCase
         ));
 
         $container->setDefinition('form.extension', $extDefinition);
-        $container->register($id, 'stdClass')->setPublic(false)->addTag($tagName, array('extended_type' => 'stdClass'));
+        $extension = $container->register($id, 'stdClass')->setPublic(false)->addTag($tagName, array('extended_type' => 'stdClass'));
 
         $container->compile();
 
         $extDefinition = $container->getDefinition('form.extension');
 
         $this->assertSame($expectedArguments, $extDefinition->getArgument($argument));
+        $this->assertTrue($extension->isPublic());
     }
 
     public function privateTaggedServicesProvider()
     {
         return array(
-            array('my.type', 'form.type', 1, array('stdClass' => 'public_services.my.type')),
-            array('my.type_extension', 'form.type_extension', 2, array('stdClass' => array('public_services.my.type_extension'))),
-            array('my.guesser', 'form.type_guesser', 3, array('public_services.my.guesser')),
+            array('my.type', 'form.type', 1, array('stdClass' => 'my.type')),
+            array('my.type_extension', 'form.type_extension', 2, array('stdClass' => array('my.type_extension'))),
+            array('my.guesser', 'form.type_guesser', 3, array('my.guesser')),
         );
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/FormPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/FormPassTest.php
@@ -152,7 +152,7 @@ class FormPassTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider privateTaggedServicesProvider
      */
-    public function testPrivateTaggedServices($id, $tagName, $expectedExceptionMessage)
+    public function testPrivateTaggedServices($id, $tagName, $argument, $expectedArguments)
     {
         $container = new ContainerBuilder();
         $container->addCompilerPass(new FormPass());
@@ -166,19 +166,21 @@ class FormPassTest extends \PHPUnit_Framework_TestCase
         ));
 
         $container->setDefinition('form.extension', $extDefinition);
-        $container->register($id, 'stdClass')->setPublic(false)->addTag($tagName);
-
-        $this->setExpectedException('\InvalidArgumentException', $expectedExceptionMessage);
+        $container->register($id, 'stdClass')->setPublic(false)->addTag($tagName, array('extended_type' => 'stdClass'));
 
         $container->compile();
+
+        $extDefinition = $container->getDefinition('form.extension');
+
+        $this->assertSame($expectedArguments, $extDefinition->getArgument($argument));
     }
 
     public function privateTaggedServicesProvider()
     {
         return array(
-            array('my.type', 'form.type', 'The service "my.type" must be public as form types are lazy-loaded'),
-            array('my.type_extension', 'form.type_extension', 'The service "my.type_extension" must be public as form type extensions are lazy-loaded'),
-            array('my.guesser', 'form.type_guesser', 'The service "my.guesser" must be public as form type guessers are lazy-loaded'),
+            array('my.type', 'form.type', 1, array('stdClass' => 'public_services.my.type')),
+            array('my.type_extension', 'form.type_extension', 2, array('stdClass' => array('public_services.my.type_extension'))),
+            array('my.guesser', 'form.type_guesser', 3, array('public_services.my.guesser')),
         );
     }
 }

--- a/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
+++ b/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
@@ -58,12 +58,7 @@ class RegisterListenersPass implements CompilerPassInterface
 
         foreach ($container->findTaggedServiceIds($this->listenerTag) as $id => $events) {
             $def = $container->getDefinition($id);
-            if (!$def->isPublic()) {
-                $alias = sprintf('public_services.%s', $id);
-                $container->setAlias($alias, $id);
-
-                $id = $alias;
-            }
+            $def->setPublic(true);
 
             if ($def->isAbstract()) {
                 throw new \InvalidArgumentException(sprintf('The service "%s" must not be abstract as event listeners are lazy-loaded.', $id));
@@ -90,12 +85,7 @@ class RegisterListenersPass implements CompilerPassInterface
 
         foreach ($container->findTaggedServiceIds($this->subscriberTag) as $id => $attributes) {
             $def = $container->getDefinition($id);
-            if (!$def->isPublic()) {
-                $alias = sprintf('public_services.%s', $id);
-                $container->setAlias($alias, $id);
-
-                $id = $alias;
-            }
+            $def->setPublic(true);
 
             if ($def->isAbstract()) {
                 throw new \InvalidArgumentException(sprintf('The service "%s" must not be abstract as event subscribers are lazy-loaded.', $id));

--- a/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
+++ b/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
@@ -59,7 +59,10 @@ class RegisterListenersPass implements CompilerPassInterface
         foreach ($container->findTaggedServiceIds($this->listenerTag) as $id => $events) {
             $def = $container->getDefinition($id);
             if (!$def->isPublic()) {
-                throw new \InvalidArgumentException(sprintf('The service "%s" must be public as event listeners are lazy-loaded.', $id));
+                $alias = sprintf('public_services.%s', $id);
+                $container->setAlias($alias, $id);
+
+                $id = $alias;
             }
 
             if ($def->isAbstract()) {
@@ -88,7 +91,10 @@ class RegisterListenersPass implements CompilerPassInterface
         foreach ($container->findTaggedServiceIds($this->subscriberTag) as $id => $attributes) {
             $def = $container->getDefinition($id);
             if (!$def->isPublic()) {
-                throw new \InvalidArgumentException(sprintf('The service "%s" must be public as event subscribers are lazy-loaded.', $id));
+                $alias = sprintf('public_services.%s', $id);
+                $container->setAlias($alias, $id);
+
+                $id = $alias;
             }
 
             if ($def->isAbstract()) {

--- a/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
@@ -31,8 +31,8 @@ class RegisterListenersPassTest extends \PHPUnit_Framework_TestCase
 
         $definition = $this->getMock('Symfony\Component\DependencyInjection\Definition');
         $definition->expects($this->atLeastOnce())
-            ->method('isPublic')
-            ->will($this->returnValue(true));
+            ->method('setPublic')
+            ->with(true);
         $definition->expects($this->atLeastOnce())
             ->method('getClass')
             ->will($this->returnValue('stdClass'));
@@ -66,8 +66,8 @@ class RegisterListenersPassTest extends \PHPUnit_Framework_TestCase
 
         $definition = $this->getMock('Symfony\Component\DependencyInjection\Definition');
         $definition->expects($this->atLeastOnce())
-            ->method('isPublic')
-            ->will($this->returnValue(true));
+            ->method('setPublic')
+            ->with(true);
         $definition->expects($this->atLeastOnce())
             ->method('getClass')
             ->will($this->returnValue('Symfony\Component\EventDispatcher\Tests\DependencyInjection\SubscriberService'));
@@ -103,7 +103,7 @@ class RegisterListenersPassTest extends \PHPUnit_Framework_TestCase
     public function testPrivateEventListenerAndSubscriber($tag, array $tagAttributes, array $methodCalls)
     {
         $container = new ContainerBuilder();
-        $container
+        $listener = $container
             ->register('foo', SubscriberService::class)
             ->setPublic(false)
             ->addTag($tag, $tagAttributes);
@@ -113,16 +113,17 @@ class RegisterListenersPassTest extends \PHPUnit_Framework_TestCase
         $registerListenersPass->process($container);
 
         $this->assertSame($methodCalls, $eventDispatcher->getMethodCalls());
+        $this->assertTrue($listener->isPublic());
     }
 
     public function privateTaggedServicesProvider()
     {
         return array(
             array('kernel.event_subscriber', array(), array(
-                array('addSubscriberService', array('public_services.foo', SubscriberService::class)),
+                array('addSubscriberService', array('foo', SubscriberService::class)),
             )),
             array('kernel.event_listener', array('event' => 'foo_bar'), array(
-                array('addListenerService', array('foo_bar', array('public_services.foo', 'onFoobar'), 0)),
+                array('addListenerService', array('foo_bar', array('foo', 'onFoobar'), 0)),
             )),
         );
     }

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/FragmentRendererPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/FragmentRendererPass.php
@@ -44,7 +44,10 @@ class FragmentRendererPass implements CompilerPassInterface
         foreach ($container->findTaggedServiceIds($this->rendererTag) as $id => $tags) {
             $def = $container->getDefinition($id);
             if (!$def->isPublic()) {
-                throw new \InvalidArgumentException(sprintf('The service "%s" must be public as fragment renderer are lazy-loaded.', $id));
+                $alias = sprintf('public_services.%s', $id);
+                $container->setAlias($alias, $id);
+
+                $id = $alias;
             }
 
             if ($def->isAbstract()) {

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/FragmentRendererPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/FragmentRendererPass.php
@@ -43,12 +43,7 @@ class FragmentRendererPass implements CompilerPassInterface
         $definition = $container->getDefinition($this->handlerService);
         foreach ($container->findTaggedServiceIds($this->rendererTag) as $id => $tags) {
             $def = $container->getDefinition($id);
-            if (!$def->isPublic()) {
-                $alias = sprintf('public_services.%s', $id);
-                $container->setAlias($alias, $id);
-
-                $id = $alias;
-            }
+            $def->setPublic(true);
 
             if ($def->isAbstract()) {
                 throw new \InvalidArgumentException(sprintf('The service "%s" must not be abstract as fragment renderer are lazy-loaded.', $id));

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/FragmentRendererPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/FragmentRendererPassTest.php
@@ -72,7 +72,7 @@ class FragmentRendererPassTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue('Symfony\Component\HttpKernel\Tests\DependencyInjection\RendererService'));
         $definition
             ->expects($this->once())
-            ->method('isPublic')
+            ->method('setPublic')
             ->will($this->returnValue(true))
         ;
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/pull/18101 |
| License | MIT |

This PR allows to register private event listeners/subscribers, private form extensions and private fragment renderers.
