### PR TITLE
Backporting the validateName() documentation from later branches

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -574,6 +574,15 @@ class Command
         return $descriptor->describe($this, array('as_dom' => $asDom));
     }
 
+    /**
+     * Validates a command name.
+     *
+     * It must be non-empty and parts can optionally be separated by ":".
+     *
+     * @param string $name
+     *
+     * @throws \InvalidArgumentException When the name is invalid
+     */
     private function validateName($name)
     {
         if (!preg_match('/^[^\:]+(\:[^\:]+)*$/', $name)) {

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -579,9 +579,9 @@ class Command
      *
      * It must be non-empty and parts can optionally be separated by ":".
      *
-     * @param string      $name
+     * @param string $name
      *
-     * @throws    \InvalidArgumentException When the name is invalid
+     * @throws \InvalidArgumentException When the name is invalid
      */
     private function validateName( $name )
     {

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -579,14 +579,14 @@ class Command
      *
      * It must be non-empty and parts can optionally be separated by ":".
      *
-     * @param string $name
+     * @param string      $name
      *
-     * @throws \InvalidArgumentException When the name is invalid
+     * @throws    \InvalidArgumentException When the name is invalid
      */
     private function validateName( $name )
     {
         if ( !preg_match('/^[^\:]+(\:[^\:]+)*$/', $name) ) {
-            throw new \InvalidArgumentException(sprintf('Command name "%s" is invalid.', $name));
+            throw new     \InvalidArgumentException(sprintf('Command name "%s" is invalid.', $name));
         }
     }
 }

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -583,9 +583,9 @@ class Command
      *
      * @throws \InvalidArgumentException When the name is invalid
      */
-    private function validateName($name)
+    private function validateName( $name )
     {
-        if (!preg_match('/^[^\:]+(\:[^\:]+)*$/', $name)) {
+        if ( !preg_match('/^[^\:]+(\:[^\:]+)*$/', $name) ) {
             throw new \InvalidArgumentException(sprintf('Command name "%s" is invalid.', $name));
         }
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | 2.3 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18092 |
| License | MIT |
| Doc PR | n/a |
