### PR TITLE
[HttpKernel] Fixed a typo in the collect() method of Profiler

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
@@ -200,7 +200,7 @@ class Profiler
         foreach ($this->collectors as $collector) {
             $collector->collect($request, $response, $exception);
 
-            // forces collectors to become "read/only" (they loose their object dependencies)
+            // forces collectors to become "read/only" (they lose their object dependencies)
             $profile->addCollector(unserialize(serialize($collector)));
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | 2.3 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18088 |
| License | MIT |
| Doc PR |  |
