### PR TITLE
[Debug] Replaced logic for detecting filesystem case sensitivity

### DIFF
--- a/src/Symfony/Component/Debug/DebugClassLoader.php
+++ b/src/Symfony/Component/Debug/DebugClassLoader.php
@@ -37,6 +37,7 @@ class DebugClassLoader
      * @param callable|object $classLoader
      *
      * @api
+     *
      * @deprecated since 2.5, passing an object is deprecated and support for it will be removed in 3.0
      */
     public function __construct($classLoader)
@@ -61,7 +62,6 @@ class DebugClassLoader
                     self::$caseCheck = 1;
                 } else {
                     // filesystem is not case sensitive AND realpath() fails to normalize case
-                    // this is _probably_ OX
                     self::$caseCheck = 2;
                 }
             }
@@ -81,7 +81,7 @@ class DebugClassLoader
     }
 
     /**
-     * Wraps all autoloaders
+     * Wraps all autoloaders.
      */
     public static function enable()
     {
@@ -128,7 +128,7 @@ class DebugClassLoader
     }
 
     /**
-     * Finds a file by class name
+     * Finds a file by class name.
      *
      * @param string $class A class name to resolve to file
      *

--- a/src/Symfony/Component/Debug/DebugClassLoader.php
+++ b/src/Symfony/Component/Debug/DebugClassLoader.php
@@ -52,7 +52,19 @@ class DebugClassLoader
         }
 
         if (!isset(self::$caseCheck)) {
-            self::$caseCheck = false !== stripos(PHP_OS, 'win') ? (false !== stripos(PHP_OS, 'darwin') ? 2 : 1) : 0;
+            if (!isset(self::$caseCheck)) {
+                if(!file_exists(strtolower(__FILE__))) {
+                    // filesystem is case sensitive
+                    self::$caseCheck = 0;
+                } elseif(realpath(strtolower(__FILE__)) === realpath(__FILE__)) {
+                    // filesystem is not case sensitive
+                    self::$caseCheck = 1;
+                } else {
+                    // filesystem is not case sensitive AND realpath() fails to normalize case
+                    // this is _probably_ OX
+                    self::$caseCheck = 2;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | master for features and deprecations / lowest applicable and maintained version otherwise |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

When I cloned the master branch onto a Virtualbox Vagrant OSX El Capitan host, Ubuntu Wily guest, the `Symfony\Component\Debug\Tests\DebugClassLoaderTest::testFileCaseMismatch` failed because 'Failed asserting that exception of type "\RuntimeException" is thrown'.

@WouterJ confirmed he got the same problem, and it's because Virtualbox shared folders aren't case sensitive, even when the guest is using a case sensitive filesystem. So I've replaced the logic that looked at the name of the operating system.

I ran the tests in the following environments:
- Virtualbox/Vagrant - OSX Host, Ubuntu guest
- Virtualbox/Vagrant - OSX Host, Windows guest
- OSX native
- Ubuntu native

NB - I _didn't_ run it on native Windows (because I don't have easy access to one).
