### PR TITLE
Missing symfony/dependency-injection dependency

### DIFF
--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
+        "symfony/dependency-injection": "~2.8|~3.0",
         "symfony/event-dispatcher": "~2.8|~3.0",
         "symfony/http-foundation": "~2.8|~3.0",
         "symfony/debug": "~2.8|~3.0",
@@ -28,7 +29,6 @@
         "symfony/config": "~2.8|~3.0",
         "symfony/console": "~2.8|~3.0",
         "symfony/css-selector": "~2.8|~3.0",
-        "symfony/dependency-injection": "~2.8|~3.0",
         "symfony/dom-crawler": "~2.8|~3.0",
         "symfony/expression-language": "~2.8|~3.0",
         "symfony/finder": "~2.8|~3.0",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | master |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | --- |
| License | MIT |
| Doc PR | --- |

The abstract class `DependencyInjection\Extension` extends `DependencyInjection\Extension\Extension`, so the dependency shouldn't be for development only.
