### PR TITLE
[Security] Deprecate onAuthenticationSuccess()

### DIFF
--- a/src/Symfony/Component/Security/Guard/Authenticator/AbstractFormLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Guard/Authenticator/AbstractFormLoginAuthenticator.php
@@ -41,7 +41,7 @@ abstract class AbstractFormLoginAuthenticator extends AbstractGuardAuthenticator
      * login page directly), this returns the URL the user should be redirected
      * to after logging in successfully (e.g. your homepage).
      *
-     * @deprecated Implement onAuthenticationFailure() instead of needing this function.
+     * @deprecated Implement onAuthenticationSuccess() instead of needing this function.
      *
      * @return string
      */
@@ -79,7 +79,7 @@ abstract class AbstractFormLoginAuthenticator extends AbstractGuardAuthenticator
     {
         @trigger_error(sprintf('The AbstractFormLoginAuthenticator::onAuthenticationSuccess() implementation was deprecated in Symfony 3.1 and will be removed in Symfony 4.0. You should implement this method yourself in %s and remove getDefaultSuccessRedirectUrl().', get_class($this)), E_USER_DEPRECATED);
 
-        // if the user hit a secure page and start() was called, this was
+        // if the user hits a secure page and start() was called, this was
         // the URL they were on, and probably where you want to redirect to
         $targetPath = $this->getTargetPath($request->getSession(), $providerKey);
 

--- a/src/Symfony/Component/Security/Guard/Authenticator/AbstractFormLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Guard/Authenticator/AbstractFormLoginAuthenticator.php
@@ -36,21 +36,6 @@ abstract class AbstractFormLoginAuthenticator extends AbstractGuardAuthenticator
     abstract protected function getLoginUrl();
 
     /**
-     * The user will be redirected to the secure page they originally tried
-     * to access. But if no such page exists (i.e. the user went to the
-     * login page directly), this returns the URL the user should be redirected
-     * to after logging in successfully (e.g. your homepage).
-     *
-     * @deprecated Implement onAuthenticationSuccess() instead of needing this function.
-     *
-     * @return string
-     */
-    protected function getDefaultSuccessRedirectUrl()
-    {
-        throw new \Exception(sprintf('You must implement onAuthenticationSuccess() or getDefaultSuccessRedirectURL() in %s.', get_class($this)));
-    }
-
-    /**
      * Override to change what happens after a bad username/password is submitted.
      *
      * @param Request                 $request
@@ -78,6 +63,10 @@ abstract class AbstractFormLoginAuthenticator extends AbstractGuardAuthenticator
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey)
     {
         @trigger_error(sprintf('The AbstractFormLoginAuthenticator::onAuthenticationSuccess() implementation was deprecated in Symfony 3.1 and will be removed in Symfony 4.0. You should implement this method yourself in %s and remove getDefaultSuccessRedirectUrl().', get_class($this)), E_USER_DEPRECATED);
+
+        if (!method_exists($this, 'getDefaultSuccessRedirectUrl')) {
+            throw new \Exception(sprintf('You must implement onAuthenticationSuccess() or getDefaultSuccessRedirectURL() in %s.', get_class($this)));
+        }
 
         // if the user hits a secure page and start() was called, this was
         // the URL they were on, and probably where you want to redirect to

--- a/src/Symfony/Component/Security/Guard/Authenticator/AbstractFormLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Guard/Authenticator/AbstractFormLoginAuthenticator.php
@@ -41,9 +41,14 @@ abstract class AbstractFormLoginAuthenticator extends AbstractGuardAuthenticator
      * login page directly), this returns the URL the user should be redirected
      * to after logging in successfully (e.g. your homepage).
      *
+     * @deprecated Implement onAuthenticationFailure() instead of needing this function.
+     *
      * @return string
      */
-    abstract protected function getDefaultSuccessRedirectUrl();
+    protected function getDefaultSuccessRedirectUrl()
+    {
+        throw new \Exception(sprintf('You must implement onAuthenticationSuccess() or getDefaultSuccessRedirectURL() in %s.', get_class($this)));
+    }
 
     /**
      * Override to change what happens after a bad username/password is submitted.
@@ -72,6 +77,8 @@ abstract class AbstractFormLoginAuthenticator extends AbstractGuardAuthenticator
      */
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey)
     {
+        @trigger_error(sprintf('The AbstractFormLoginAuthenticator::onAuthenticationSuccess() implementation was deprecated in Symfony 3.1 and will be removed in Symfony 4.0. You should implement this method yourself in %s and remove getDefaultSuccessRedirectUrl().', get_class($this)), E_USER_DEPRECATED);
+
         // if the user hit a secure page and start() was called, this was
         // the URL they were on, and probably where you want to redirect to
         $targetPath = $this->getTargetPath($request->getSession(), $providerKey);

--- a/src/Symfony/Component/Security/Guard/Tests/Authenticator/AbstractFormLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/Authenticator/AbstractFormLoginAuthenticatorTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Guard\Authenticator\AbstractFormLoginAuthenticator;
+
 class AbstractFormLoginAuthenticatorTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/src/Symfony/Component/Security/Guard/Tests/Authenticator/AbstractFormLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/Authenticator/AbstractFormLoginAuthenticatorTest.php
@@ -34,10 +34,7 @@ class AbstractFormLoginAuthenticatorTest extends \PHPUnit_Framework_TestCase
             'provider_key'
         );
 
-        $this->assertEquals(
-            '/default_url',
-            $actualResponse->getTargetUrl()
-        );
+        $this->assertEquals('/default_url', $actualResponse->getTargetUrl());
     }
 }
 
@@ -64,4 +61,3 @@ class LegacyFormLoginAuthenticator extends AbstractFormLoginAuthenticator
     {
     }
 }
-

--- a/src/Symfony/Component/Security/Guard/Tests/Authenticator/AbstractFormLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/Authenticator/AbstractFormLoginAuthenticatorTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Guard\Tests\Authenticator;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Guard\Authenticator\AbstractFormLoginAuthenticator;
+class AbstractFormLoginAuthenticatorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @group legacy
+     */
+    public function testLegacyWithLoginUrl()
+    {
+        $request = new Request();
+        $request->setSession($this->getMock('Symfony\Component\HttpFoundation\Session\Session'));
+
+        $authenticator = new LegacyFormLoginAuthenticator();
+        /** @var RedirectResponse $actualResponse */
+        $actualResponse = $authenticator->onAuthenticationSuccess(
+            $request,
+            $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface'),
+            'provider_key'
+        );
+
+        $this->assertEquals(
+            '/default_url',
+            $actualResponse->getTargetUrl()
+        );
+    }
+}
+
+class LegacyFormLoginAuthenticator extends AbstractFormLoginAuthenticator
+{
+    protected function getDefaultSuccessRedirectUrl()
+    {
+        return '/default_url';
+    }
+
+    protected function getLoginUrl()
+    {
+    }
+
+    public function getCredentials(Request $request)
+    {
+    }
+
+    public function getUser($credentials, UserProviderInterface $userProvider)
+    {
+    }
+
+    public function checkCredentials($credentials, UserInterface $user)
+    {
+    }
+}
+


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | master |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #18027 |
| License | MIT |
| Doc PR | not yet - the existing feature is not currently documented |

Because of the new `TargetPathTrait`, implementing `onAuthenticationSuccess` yourself is quite easy. I think we should just remove it. This also will fix #18027.

Thanks!
