### PR TITLE
[DomCrawler] Create a getter for baseHref

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -1088,4 +1088,14 @@ class Crawler implements \Countable, \IteratorAggregate
 
         return $crawler;
     }
+
+    /**
+     * Returns the base href value.
+     *
+     * @return string
+     */
+    public function getBaseHref()
+    {
+        return $this->baseHref;
+    }
 }

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -1097,6 +1097,13 @@ HTML;
         return new Crawler($dom, $uri);
     }
 
+    public function testGetBaseHref()
+    {
+        $baseHref = 'http://example.com/english';
+        $crawler = new Crawler(null, 'http://example.com/english/welcome', $baseHref);
+        $this->assertEquals($baseHref, $crawler->getBaseHref());
+    }
+
     protected function createTestXmlCrawler($uri = null)
     {
         $xml = '<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15584 |
| License | MIT |
| Doc PR | n/a |

As requested in #15584, I created a getter for `baseHref`. Happy Hack Day!
