### PR TITLE
Autowiring the concrete class too - consistent with behavior of other services

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -48,6 +48,7 @@
 
         <service id="service_container" synthetic="true">
             <autowiring-type>Symfony\Component\DependencyInjection\ContainerInterface</autowiring-type>
+            <autowiring-type>Symfony\Component\DependencyInjection\Container</autowiring-type>
         </service>
 
         <service id="kernel" synthetic="true" />


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | 2.8 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18132 |
| License | MIT |
| Doc PR | n/a |

This follows #17261. Without this, if you use the concrete class `Container`, it doesn't autowire, so it creates a _new_ one. That is certainly not what the end-user wants, and it's a serious WTF :). We can talk all day long about not injecting the container and type-hinting interfaces, but this is needed to be consistent with how all the other services in the container work and to avoid this odd behavior.

Thanks!
