### PR TITLE
[2.3][Form] Remove unnecessary attributes in form div layout

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -13,15 +13,22 @@
     <input type="{{ type }}" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %}/>
 {%- endblock form_widget_simple -%}
 
-{%- block form_widget_compound -%}
-    <div {{ block('widget_container_attributes') }}>
-        {%- if form.parent is empty -%}
-            {{ form_errors(form) }}
-        {%- endif -%}
-        {{- block('form_rows') -}}
-        {{- form_rest(form) -}}
-    </div>
-{%- endblock form_widget_compound -%}
+{% block form_widget_compound %}
+    {% spaceless %}
+        {% if form.parent is empty %}
+            <div>
+                {{ form_errors(form) }}
+                {{ block('form_rows') }}
+                {{ form_rest(form) }}
+            </div>
+        {% else %}
+            <div {{ block('widget_container_attributes') }}>
+                {{ block('form_rows') }}
+                {{ form_rest(form) }}
+            </div>
+        {% endif %}
+    {% endspaceless %}
+{% endblock form_widget_compound %}
 
 {%- block collection_widget -%}
     {% if prototype is defined %}

--- a/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
@@ -409,8 +409,6 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
                 /following-sibling::input[@type="hidden"][@id="name__token"]
             ]
             [count(.//input)=3]
-            [@id="my&id"]
-            [@class="my&class"]
     ]
     [@method="post"]
     [@action="http://example.com"]

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -92,11 +92,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
             'attr' => array('class' => 'my&class'),
         ), $vars));
 
-        $xpath = trim($xpath).'
-    [@id="my&id"]
-    [@class="my&class"]';
-
-        $this->assertMatchesXpath($html, $xpath);
+        $this->assertMatchesXpath($html, trim($xpath));
     }
 
     abstract protected function renderForm(FormView $view, array $vars = array());


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | 2.3 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/issues/7709 |
| License | MIT |
| Doc PR | https://www.w3.org/TR/WCAG20-TECHS/H93.html |

Having a non-unique `id` in a web page, does not comply with the standard developed by W3C.

I continued the development of this Pull Request : https://github.com/symfony/symfony/pull/10296

Done during the Virtual HackDay, made with Les Tilleuls, SensioLabs in the offices of Smile
