### PR TITLE
[Console] Add console.ERROR event and deprecate console.EXCEPTION

### DIFF
--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -11,6 +11,13 @@ Debug
 
  * The `ContextErrorException` class is deprecated. `\ErrorException` will be used instead in 4.0.
 
+Console
+-------
+
+ * The `console.exception` event and the related `ConsoleExceptionEvent` class
+   have been deprecated in favor of the `console.error` event and the `ConsoleErrorEvent`
+   class. The deprecated event and class will be removed in 4.0.
+
 DependencyInjection
 -------------------
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -12,6 +12,9 @@ Console
  * Setting unknown style options is not supported anymore and throws an
    exception.
 
+ * The `console.exception` event and the related `ConsoleExceptionEvent` class have
+   been removed in favor of the `console.error` event and the `ConsoleErrorEvent` class.
+
 Debug
 -----
 

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
 * added `ExceptionListener`
 * added `AddConsoleCommandPass` (originally in FrameworkBundle)
+* added console.error event to catch exceptions thrown by other listeners
+* deprecated console.exception event in favor of console.error
 
 3.2.0
 ------

--- a/src/Symfony/Component/Console/ConsoleEvents.php
+++ b/src/Symfony/Component/Console/ConsoleEvents.php
@@ -40,7 +40,8 @@ final class ConsoleEvents
     const TERMINATE = 'console.terminate';
 
     /**
-     * The EXCEPTION event occurs when an uncaught exception appears.
+     * The EXCEPTION event occurs when an uncaught exception appears
+     * while executing Command#run().
      *
      * This event allows you to deal with the exception or
      * to modify the thrown exception.
@@ -48,6 +49,21 @@ final class ConsoleEvents
      * @Event("Symfony\Component\Console\Event\ConsoleExceptionEvent")
      *
      * @var string
+     *
+     * @deprecated The console.exception event is deprecated since version 3.3 and will be removed in 4.0. Use the console.error event instead.
      */
     const EXCEPTION = 'console.exception';
+
+    /**
+     * The ERROR event occurs when an uncaught exception appears or
+     * a throwable error.
+     *
+     * This event allows you to deal with the exception/error or
+     * to modify the thrown exception.
+     *
+     * @Event("Symfony\Component\Console\Event\ConsoleErrorEvent")
+     *
+     * @var string
+     */
+    const ERROR = 'console.error';
 }

--- a/src/Symfony/Component/Console/Event/ConsoleErrorEvent.php
+++ b/src/Symfony/Component/Console/Event/ConsoleErrorEvent.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Event;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Debug\Exception\FatalThrowableError;
+
+/**
+ * Allows to handle throwables thrown while running a command.
+ *
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ */
+class ConsoleErrorEvent extends ConsoleExceptionEvent
+{
+    private $error;
+    private $handled = false;
+
+    public function __construct(Command $command, InputInterface $input, OutputInterface $output, $error, $exitCode)
+    {
+        if (!$error instanceof \Throwable && !$error instanceof \Exception) {
+            throw new InvalidArgumentException(sprintf('The error passed to ConsoleErrorEvent must be an instance of \Throwable or \Exception, "%s" was passed instead.', is_object($error) ? get_class($error) : gettype($error)));
+        }
+
+        $exception = $error;
+        if (!$error instanceof \Exception) {
+            $exception = new FatalThrowableError($error);
+        }
+        parent::__construct($command, $input, $output, $exception, $exitCode, false);
+
+        $this->error = $error;
+    }
+
+    /**
+     * Returns the thrown error/exception.
+     *
+     * @return \Throwable
+     */
+    public function getError()
+    {
+        return $this->error;
+    }
+
+    /**
+     * Replaces the thrown error/exception.
+     *
+     * @param \Throwable $error
+     */
+    public function setError($error)
+    {
+        if (!$error instanceof \Throwable && !$error instanceof \Exception) {
+            throw new InvalidArgumentException(sprintf('The error passed to ConsoleErrorEvent must be an instance of \Throwable or \Exception, "%s" was passed instead.', is_object($error) ? get_class($error) : gettype($error)));
+        }
+
+        $this->error = $error;
+    }
+
+    /**
+     * Marks the error/exception as handled.
+     *
+     * If it is not marked as handled, the error/exception will be displayed in
+     * the command output.
+     */
+    public function markErrorAsHandled()
+    {
+        $this->handled = true;
+    }
+
+    /**
+     * Whether the error/exception is handled by a listener or not.
+     *
+     * If it is not yet handled, the error/exception will be displayed in the
+     * command output.
+     *
+     * @return bool
+     */
+    public function isErrorHandled()
+    {
+        return $this->handled;
+    }
+
+    /**
+     * @deprecated Since version 3.3, to be removed in 4.0. Use getError() instead
+     */
+    public function getException()
+    {
+        @trigger_error(sprintf('The %s() method is deprecated since version 3.3 and will be removed in 4.0. Use ConsoleErrorEvent::getError() instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return parent::getException();
+    }
+
+    /**
+     * @deprecated Since version 3.3, to be removed in 4.0. Use setError() instead
+     */
+    public function setException(\Exception $exception)
+    {
+        @trigger_error(sprintf('The %s() method is deprecated since version 3.3 and will be removed in 4.0. Use ConsoleErrorEvent::setError() instead.', __METHOD__), E_USER_DEPRECATED);
+
+        parent::setException($exception);
+    }
+}

--- a/src/Symfony/Component/Console/Event/ConsoleEvent.php
+++ b/src/Symfony/Component/Console/Event/ConsoleEvent.php
@@ -28,7 +28,7 @@ class ConsoleEvent extends Event
     private $input;
     private $output;
 
-    public function __construct(Command $command, InputInterface $input, OutputInterface $output)
+    public function __construct(Command $command = null, InputInterface $input, OutputInterface $output)
     {
         $this->command = $command;
         $this->input = $input;
@@ -38,7 +38,7 @@ class ConsoleEvent extends Event
     /**
      * Gets the command that is executed.
      *
-     * @return Command A Command instance
+     * @return Command|null A Command instance
      */
     public function getCommand()
     {

--- a/src/Symfony/Component/Console/Event/ConsoleExceptionEvent.php
+++ b/src/Symfony/Component/Console/Event/ConsoleExceptionEvent.php
@@ -19,17 +19,24 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Allows to handle exception thrown in a command.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated ConsoleExceptionEvent is deprecated since version 3.3 and will be removed in 4.0. Use ConsoleErrorEvent instead.
  */
 class ConsoleExceptionEvent extends ConsoleEvent
 {
     private $exception;
     private $exitCode;
+    private $handled = false;
 
-    public function __construct(Command $command, InputInterface $input, OutputInterface $output, \Exception $exception, $exitCode)
+    public function __construct(Command $command, InputInterface $input, OutputInterface $output, \Exception $exception, $exitCode, $deprecation = true)
     {
+        if ($deprecation) {
+            @trigger_error(sprintf('The %s class is deprecated since version 3.3 and will be removed in 4.0. Use the ConsoleErrorEvent instead.', __CLASS__), E_USER_DEPRECATED);
+        }
+
         parent::__construct($command, $input, $output);
 
-        $this->setException($exception);
+        $this->exception = $exception;
         $this->exitCode = (int) $exitCode;
     }
 

--- a/src/Symfony/Component/Console/Event/ConsoleTerminateEvent.php
+++ b/src/Symfony/Component/Console/Event/ConsoleTerminateEvent.php
@@ -29,7 +29,7 @@ class ConsoleTerminateEvent extends ConsoleEvent
      */
     private $exitCode;
 
-    public function __construct(Command $command, InputInterface $input, OutputInterface $output, $exitCode)
+    public function __construct(Command $command = null, InputInterface $input, OutputInterface $output, $exitCode)
     {
         parent::__construct($command, $input, $output);
 

--- a/src/Symfony/Component/Console/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/Console/EventListener/ExceptionListener.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Console\EventListener;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Event\ConsoleEvent;
 use Symfony\Component\Console\ConsoleEvents;
-use Symfony\Component\Console\Event\ConsoleExceptionEvent;
+use Symfony\Component\Console\Event\ConsoleErrorEvent;
 use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -31,15 +31,15 @@ class ExceptionListener implements EventSubscriberInterface
         $this->logger = $logger;
     }
 
-    public function onConsoleException(ConsoleExceptionEvent $event)
+    public function onConsoleError(ConsoleErrorEvent $event)
     {
         if (null === $this->logger) {
             return;
         }
 
-        $exception = $event->getException();
+        $error = $event->getError();
 
-        $this->logger->error('Exception thrown while running command "{command}". Message: "{message}"', array('exception' => $exception, 'command' => $this->getInputString($event), 'message' => $exception->getMessage()));
+        $this->logger->error('Error thrown while running command "{command}". Message: "{message}"', array('error' => $error, 'command' => $this->getInputString($event), 'message' => $error->getMessage()));
     }
 
     public function onConsoleTerminate(ConsoleTerminateEvent $event)
@@ -60,7 +60,7 @@ class ExceptionListener implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return array(
-            ConsoleEvents::EXCEPTION => array('onConsoleException', -128),
+            ConsoleEvents::ERROR => array('onConsoleError', -128),
             ConsoleEvents::TERMINATE => array('onConsoleTerminate', -128),
         );
     }

--- a/src/Symfony/Component/Console/Tests/EventListener/ExceptionListenerTest.php
+++ b/src/Symfony/Component/Console/Tests/EventListener/ExceptionListenerTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Console\Tests\EventListener;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Event\ConsoleExceptionEvent;
+use Symfony\Component\Console\Event\ConsoleErrorEvent;
 use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 use Symfony\Component\Console\EventListener\ExceptionListener;
 use Symfony\Component\Console\Input\ArgvInput;
@@ -24,7 +24,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ExceptionListenerTest extends \PHPUnit_Framework_TestCase
 {
-    public function testOnConsoleException()
+    public function testOnConsoleError()
     {
         $exception = new \RuntimeException('An error occurred');
 
@@ -32,11 +32,11 @@ class ExceptionListenerTest extends \PHPUnit_Framework_TestCase
         $logger
             ->expects($this->once())
             ->method('error')
-            ->with('Exception thrown while running command "{command}". Message: "{message}"', array('exception' => $exception, 'command' => 'test:run --foo=baz buzz', 'message' => 'An error occurred'))
+            ->with('Error thrown while running command "{command}". Message: "{message}"', array('error' => $exception, 'command' => 'test:run --foo=baz buzz', 'message' => 'An error occurred'))
         ;
 
         $listener = new ExceptionListener($logger);
-        $listener->onConsoleException($this->getConsoleExceptionEvent($exception, new ArgvInput(array('console.php', 'test:run', '--foo=baz', 'buzz')), 1));
+        $listener->onConsoleError($this->getConsoleErrorEvent($exception, new ArgvInput(array('console.php', 'test:run', '--foo=baz', 'buzz')), 1));
     }
 
     public function testOnConsoleTerminateForNonZeroExitCodeWritesToLog()
@@ -68,7 +68,7 @@ class ExceptionListenerTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals(
             array(
-                'console.exception' => array('onConsoleException', -128),
+                'console.error' => array('onConsoleError', -128),
                 'console.terminate' => array('onConsoleTerminate', -128),
             ),
             ExceptionListener::getSubscribedEvents()
@@ -108,9 +108,9 @@ class ExceptionListenerTest extends \PHPUnit_Framework_TestCase
         return $this->getMockForAbstractClass(LoggerInterface::class);
     }
 
-    private function getConsoleExceptionEvent(\Exception $exception, InputInterface $input, $exitCode)
+    private function getConsoleErrorEvent(\Exception $exception, InputInterface $input, $exitCode)
     {
-        return new ConsoleExceptionEvent(new Command('test:run'), $input, $this->getOutput(), $exception, $exitCode);
+        return new ConsoleErrorEvent(new Command('test:run'), $input, $this->getOutput(), $exception, $exitCode);
     }
 
     private function getConsoleTerminateEvent(InputInterface $input, $exitCode)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | master |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | todo |
## The Problem

The current `console.EXCEPTION` event is only dispatched for exceptions during the execution of `Command#execute()`. All other exceptions (e.g. the ones thrown by listeners to events) are catched by the `try ... catch` loop in `Application#doRunCommand()`. This means that there is _no way to override exception handling_.
## The Solution

This PR adds a `console.ERROR` event which has the same scope as the default `try ... catch` loop. This allows to customize all exception handling.

In order to keep BC, a new event was created and `console.EXCEPTION` was deprecated.
