### PR TITLE
[Validator] Cache DNS record for repeat calls

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -67,6 +67,7 @@ class EmailValidator extends ConstraintValidator
         if (!isset($cache[$host])) {
             $cache[$host] = checkdnsrr($host, 'MX');
         }
+
         return $cache[$host];
     }
 

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -63,7 +63,7 @@ class EmailValidator extends ConstraintValidator
      */
     private function checkMX($host)
     {
-        static $cache = [];
+        static $cache = array();
         if (!isset($cache[$host])) {
             $cache[$host] = checkdnsrr($host, 'MX');
         }

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -63,7 +63,11 @@ class EmailValidator extends ConstraintValidator
      */
     private function checkMX($host)
     {
-        return checkdnsrr($host, 'MX');
+        static $cache = [];
+        if (!isset($cache[$host])) {
+            $cache[$host] = checkdnsrr($host, 'MX');
+        }
+        return $cache[$host];
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | 2.3 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

I noticed that if you have `checkMX` and `checkHost` it performs the same DNS record lookup twice. Since DNS requires a network call, it would be great if these were cached.
