### PR TITLE
[Validator] EmailValidator cannot extract hostname if email contains multiple @ symbols

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -37,7 +37,7 @@ class EmailValidator extends ConstraintValidator
         $valid = filter_var($value, FILTER_VALIDATE_EMAIL);
 
         if ($valid) {
-            $host = substr($value, strpos($value, '@') + 1);
+            $host = substr(strrchr($value, '@'), 1);
 
             // Check for host DNS resource records
             if ($valid && $constraint->checkMX) {

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -37,7 +37,7 @@ class EmailValidator extends ConstraintValidator
         $valid = filter_var($value, FILTER_VALIDATE_EMAIL);
 
         if ($valid) {
-            $host = substr(strrchr($value, '@'), 1);
+            $host = substr($value, strrpos($value, '@') + 1);
 
             // Check for host DNS resource records
             if ($valid && $constraint->checkMX) {

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
@@ -125,4 +125,19 @@ class EmailValidatorTest extends AbstractConstraintValidatorTest
             array('AAAA', true),
         );
     }
+
+    public function testHostnameIsProperlyParsed()
+    {
+        DnsMock::withMockedHosts(array(
+            'baz.com' => array(array('type' => 'MX')),
+            '@bar"@baz.com' => array(array('type' => false)),
+        ));
+
+        $this->validator->validate(
+            '"foo@bar"@baz.com',
+            new Email(array('checkMX' => true))
+        );
+
+        $this->assertNoViolation();
+    }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
@@ -128,10 +128,7 @@ class EmailValidatorTest extends AbstractConstraintValidatorTest
 
     public function testHostnameIsProperlyParsed()
     {
-        DnsMock::withMockedHosts(array(
-            'baz.com' => array(array('type' => 'MX')),
-            '@bar"@baz.com' => array(array('type' => false)),
-        ));
+        DnsMock::withMockedHosts(array('baz.com' => array(array('type' => 'MX'))));
 
         $this->validator->validate(
             '"foo@bar"@baz.com',


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | 2.3 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18146 |
| License | MIT |
| Doc PR | n/a |
