### PR TITLE
[Routing][UrlMatcher] Add '!' as prefix for a host to exclude this host from route

### DIFF
--- a/src/Symfony/Component/Routing/CompiledRoute.php
+++ b/src/Symfony/Component/Routing/CompiledRoute.php
@@ -39,11 +39,11 @@ class CompiledRoute implements \Serializable
      * @param array       $hostTokens    Host tokens
      * @param array       $hostVariables An array of host variables
      * @param array       $variables     An array of variables (variables defined in the path and in the host patterns)
-     * @param boolean     $hostExcluded  A boolean used to exclude the host
+     * @param bool        $hostExcluded  A boolean used to exclude the host
      */
     public function __construct($staticPrefix, $regex, array $tokens, array $pathVariables, $hostRegex = null, array $hostTokens = array(), array $hostVariables = array(), array $variables = array(), $hostExcluded = false)
     {
-        $this->staticPrefix = (string)$staticPrefix;
+        $this->staticPrefix = (string) $staticPrefix;
         $this->regex = $regex;
         $this->tokens = $tokens;
         $this->pathVariables = $pathVariables;
@@ -51,7 +51,7 @@ class CompiledRoute implements \Serializable
         $this->hostTokens = $hostTokens;
         $this->hostVariables = $hostVariables;
         $this->variables = $variables;
-        $this->hostExcluded = (bool)$hostExcluded;
+        $this->hostExcluded = (bool) $hostExcluded;
     }
 
     /**
@@ -172,7 +172,7 @@ class CompiledRoute implements \Serializable
     /**
      * Returns true if the host is excluded.
      *
-     * @return boolean The status
+     * @return bool The status
      */
     public function isHostExcluded()
     {

--- a/src/Symfony/Component/Routing/CompiledRoute.php
+++ b/src/Symfony/Component/Routing/CompiledRoute.php
@@ -86,7 +86,7 @@ class CompiledRoute implements \Serializable
         $this->hostRegex = $data['host_regex'];
         $this->hostTokens = $data['host_tokens'];
         $this->hostVariables = $data['host_vars'];
-        $this->hostExcluded = $data['host_excluded'];
+        $this->hostExcluded = !isset($data['host_excluded']) ? false : $data['host_excluded'];
     }
 
     /**

--- a/src/Symfony/Component/Routing/CompiledRoute.php
+++ b/src/Symfony/Component/Routing/CompiledRoute.php
@@ -26,6 +26,7 @@ class CompiledRoute implements \Serializable
     private $hostVariables;
     private $hostRegex;
     private $hostTokens;
+    private $hostExcluded;
 
     /**
      * Constructor.
@@ -38,10 +39,11 @@ class CompiledRoute implements \Serializable
      * @param array       $hostTokens    Host tokens
      * @param array       $hostVariables An array of host variables
      * @param array       $variables     An array of variables (variables defined in the path and in the host patterns)
+     * @param boolean     $hostExcluded  A boolean used to exclude the host
      */
-    public function __construct($staticPrefix, $regex, array $tokens, array $pathVariables, $hostRegex = null, array $hostTokens = array(), array $hostVariables = array(), array $variables = array())
+    public function __construct($staticPrefix, $regex, array $tokens, array $pathVariables, $hostRegex = null, array $hostTokens = array(), array $hostVariables = array(), array $variables = array(), $hostExcluded = false)
     {
-        $this->staticPrefix = (string) $staticPrefix;
+        $this->staticPrefix = (string)$staticPrefix;
         $this->regex = $regex;
         $this->tokens = $tokens;
         $this->pathVariables = $pathVariables;
@@ -49,6 +51,7 @@ class CompiledRoute implements \Serializable
         $this->hostTokens = $hostTokens;
         $this->hostVariables = $hostVariables;
         $this->variables = $variables;
+        $this->hostExcluded = (bool)$hostExcluded;
     }
 
     /**
@@ -65,6 +68,7 @@ class CompiledRoute implements \Serializable
             'host_regex' => $this->hostRegex,
             'host_tokens' => $this->hostTokens,
             'host_vars' => $this->hostVariables,
+            'host_excluded' => $this->hostExcluded,
         ));
     }
 
@@ -82,6 +86,7 @@ class CompiledRoute implements \Serializable
         $this->hostRegex = $data['host_regex'];
         $this->hostTokens = $data['host_tokens'];
         $this->hostVariables = $data['host_vars'];
+        $this->hostExcluded = $data['host_excluded'];
     }
 
     /**
@@ -162,5 +167,15 @@ class CompiledRoute implements \Serializable
     public function getHostVariables()
     {
         return $this->hostVariables;
+    }
+
+    /**
+     * Returns true if the host is excluded.
+     *
+     * @return boolean The status
+     */
+    public function isHostExcluded()
+    {
+        return $this->hostExcluded;
     }
 }

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Routing\Matcher;
 
+use Symfony\Component\Routing\CompiledRoute;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\RouteCollection;
@@ -142,8 +143,20 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
                 continue;
             }
 
+
             $hostMatches = array();
-            if ($compiledRoute->getHostRegex() && !preg_match($compiledRoute->getHostRegex(), $this->context->getHost(), $hostMatches)) {
+            $hostDontMatch = $compiledRoute->getHostRegex() && !preg_match($compiledRoute->getHostRegex(), $this->context->getHost(), $hostMatches);
+
+
+            /**
+             * Checks if it is an other host than the one excluded.
+             */
+            if ($compiledRoute->isHostExcluded() && $compiledRoute->getHostRegex()) {
+                $hostDontMatch = !$hostDontMatch;
+            }
+
+
+            if (true === $hostDontMatch) {
                 continue;
             }
 

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Routing\Matcher;
 
-use Symfony\Component\Routing\CompiledRoute;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\RouteCollection;
@@ -143,18 +142,15 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
                 continue;
             }
 
-
             $hostMatches = array();
             $hostDontMatch = $compiledRoute->getHostRegex() && !preg_match($compiledRoute->getHostRegex(), $this->context->getHost(), $hostMatches);
 
-
-            /**
+            /*
              * Checks if it is an other host than the one excluded.
              */
             if ($compiledRoute->isHostExcluded() && $compiledRoute->getHostRegex()) {
                 $hostDontMatch = !$hostDontMatch;
             }
-
 
             if (true === $hostDontMatch) {
                 continue;

--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -88,8 +88,7 @@ class RouteCompiler implements RouteCompilerInterface
         $pos = 0;
         $defaultSeparator = $isHost ? '.' : '/';
 
-
-        /**
+        /*
          * Checks if the host is excluded from route.
          */
         if (true === $isHost) {
@@ -99,7 +98,6 @@ class RouteCompiler implements RouteCompilerInterface
                 $pattern = substr($pattern, 1);
             }
         }
-
 
         // Match all variables enclosed in "{}" and iterate over them. But we only want to match the innermost variable
         // in case of nested "{}", e.g. {foo{bar}}. This in ensured because \w does not match "{" or "}" itself.
@@ -127,7 +125,7 @@ class RouteCompiler implements RouteCompilerInterface
 
             $regexp = $route->getRequirement($varName);
             if (null === $regexp) {
-                $followingPattern = (string)substr($pattern, $pos);
+                $followingPattern = (string) substr($pattern, $pos);
                 // Find the next static character after the variable that functions as a separator. By default, this separator and '/'
                 // are disallowed for the variable. This default requirement makes sure that optional variables can be matched at all
                 // and that the generating-matching-combination of URLs unambiguous, i.e. the params used for generating the URL are
@@ -178,12 +176,11 @@ class RouteCompiler implements RouteCompilerInterface
             $regexp .= self::computeRegexp($tokens, $i, $firstOptional);
         }
 
-
         $returnArray = array(
             'staticPrefix' => 'text' === $tokens[0][0] ? $tokens[0][1] : '',
-            'regex' => self::REGEX_DELIMITER . '^' . $regexp . '$' . self::REGEX_DELIMITER . 's' . ($isHost ? 'i' : ''),
+            'regex' => self::REGEX_DELIMITER.'^'.$regexp.'$'.self::REGEX_DELIMITER.'s'.($isHost ? 'i' : ''),
             'tokens' => array_reverse($tokens),
-            'variables' => $variables
+            'variables' => $variables,
         );
 
         if (true === $isHost) {

--- a/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
@@ -165,11 +165,11 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
     {
         $collection = new RouteCollection();
         $chars = '!"$%éà &\'()*+,./:;<=>@ABCDEFGHIJKLMNOPQRSTUVWXYZ\\[]^_`abcdefghijklmnopqrstuvwxyz{|}~-';
-        $collection->add('foo', new Route('/{foo}/bar', array(), array('foo' => '[' . preg_quote($chars) . ']+')));
+        $collection->add('foo', new Route('/{foo}/bar', array(), array('foo' => '['.preg_quote($chars).']+')));
 
         $matcher = new UrlMatcher($collection, new RequestContext());
-        $this->assertEquals(array('_route' => 'foo', 'foo' => $chars), $matcher->match('/' . rawurlencode($chars) . '/bar'));
-        $this->assertEquals(array('_route' => 'foo', 'foo' => $chars), $matcher->match('/' . strtr($chars, array('%' => '%25')) . '/bar'));
+        $this->assertEquals(array('_route' => 'foo', 'foo' => $chars), $matcher->match('/'.rawurlencode($chars).'/bar'));
+        $this->assertEquals(array('_route' => 'foo', 'foo' => $chars), $matcher->match('/'.strtr($chars, array('%' => '%25')).'/bar'));
     }
 
     public function testMatchWithDotMetacharacterInRequirements()
@@ -178,7 +178,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $collection->add('foo', new Route('/{foo}/bar', array(), array('foo' => '.+')));
 
         $matcher = new UrlMatcher($collection, new RequestContext());
-        $this->assertEquals(array('_route' => 'foo', 'foo' => "\n"), $matcher->match('/' . urlencode("\n") . '/bar'), 'linefeed character is matched');
+        $this->assertEquals(array('_route' => 'foo', 'foo' => "\n"), $matcher->match('/'.urlencode("\n").'/bar'), 'linefeed character is matched');
     }
 
     public function testMatchOverriddenRoute()
@@ -396,7 +396,6 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $matcher->match('/foo/bar');
     }
 
-
     public function testWithExcludedHost()
     {
         $coll = new RouteCollection();
@@ -405,7 +404,6 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $matcher = new UrlMatcher($coll, new RequestContext('', 'GET', 'example.net'));
         $this->assertEquals(array('_route' => 'foo'), $matcher->match('/foo'));
     }
-
 
     /**
      * @expectedException \Symfony\Component\Routing\Exception\ResourceNotFoundException
@@ -431,8 +429,6 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $matcher = new UrlMatcher($coll, new RequestContext('', 'GET', 'subdomain.example.com'));
         $this->assertEquals(array('foo' => 'bar', '_route' => 'foo'), $matcher->match('/foo/bar'));
     }
-
-
 
     /**
      * @expectedException \Symfony\Component\Routing\Exception\ResourceNotFoundException

--- a/src/Symfony/Component/Routing/Tests/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteTest.php
@@ -233,6 +233,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $route->setHost('{locale}.example.net');
         $route->compile();
 
+
         $this->assertEquals($route, $unserialized);
         $this->assertNotSame($route, $unserialized);
     }

--- a/src/Symfony/Component/Routing/Tests/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteTest.php
@@ -233,7 +233,6 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $route->setHost('{locale}.example.net');
         $route->compile();
 
-
         $this->assertEquals($route, $unserialized);
         $this->assertNotSame($route, $unserialized);
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | None |
| License | MIT |
| Doc PR | TODO |

For example:

```

site:
    resource: "@SiteBundle/Controller/"
    type:     annotation
    prefix:   /
    host: !example.com

```

http://example.net will have access to '/' , but http://example.com will respond with 404.
