### PR TITLE
[DependencyInjection] Make accessing environment variables in configuration more convenient.

### DIFF
--- a/src/Symfony/Component/Config/Definition/Builder/ExpressionNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ExpressionNodeDefinition.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Definition\Builder;
+
+use Symfony\Component\Config\Definition\ExpressionNode;
+
+/**
+ * This class provides a fluent interface for defining a node.
+ *
+ * @author Magnus Nordlander <magnus@fervo.se>
+ */
+class ExpressionNodeDefinition extends VariableNodeDefinition
+{
+    /**
+     * Instantiate a Node.
+     *
+     * @return VariableNode The node
+     */
+    protected function instantiateNode()
+    {
+        return new ExpressionNode($this->name, $this->parent);
+    }
+}

--- a/src/Symfony/Component/Config/Definition/Builder/NodeBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NodeBuilder.php
@@ -34,6 +34,7 @@ class NodeBuilder implements NodeParentInterface
             'float' => __NAMESPACE__.'\\FloatNodeDefinition',
             'array' => __NAMESPACE__.'\\ArrayNodeDefinition',
             'enum' => __NAMESPACE__.'\\EnumNodeDefinition',
+            'expression' => __NAMESPACE__.'\\ExpressionNodeDefinition',
         );
     }
 
@@ -133,6 +134,18 @@ class NodeBuilder implements NodeParentInterface
     public function variableNode($name)
     {
         return $this->node($name, 'variable');
+    }
+
+    /**
+     * Creates a child variable node.
+     *
+     * @param string $name The name of the node
+     *
+     * @return VariableNodeDefinition The builder of the child node
+     */
+    public function expressionNode($name)
+    {
+        return $this->node($name, 'expression');
     }
 
     /**

--- a/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
@@ -16,6 +16,7 @@ use Symfony\Component\Config\Definition\NodeInterface;
 use Symfony\Component\Config\Definition\ArrayNode;
 use Symfony\Component\Config\Definition\EnumNode;
 use Symfony\Component\Config\Definition\PrototypedArrayNode;
+use Symfony\Component\ExpressionLanguage\Expression;
 
 /**
  * Dumps a XML reference configuration for the given configuration/node instance.
@@ -118,6 +119,10 @@ class XmlReferenceDumper
 
                             case 'Symfony\Component\Config\Definition\EnumNode':
                                 $prototypeValue = implode('|', array_map('json_encode', $prototype->getValues()));
+                                break;
+
+                            case 'Symfony\Component\Config\Definition\ExpressionNode':
+                                $prototypeValue = 'expression';
                                 break;
 
                             default:
@@ -295,6 +300,10 @@ class XmlReferenceDumper
 
         if (empty($value)) {
             return '';
+        }
+
+        if ($value instanceof Expression) {
+            return (string) $value;
         }
 
         if (is_array($value)) {

--- a/src/Symfony/Component/Config/Definition/Dumper/YamlReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/YamlReferenceDumper.php
@@ -16,6 +16,7 @@ use Symfony\Component\Config\Definition\NodeInterface;
 use Symfony\Component\Config\Definition\ArrayNode;
 use Symfony\Component\Config\Definition\EnumNode;
 use Symfony\Component\Config\Definition\PrototypedArrayNode;
+use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\Yaml\Inline;
 
 /**
@@ -106,6 +107,8 @@ class YamlReferenceDumper
                     } elseif (!is_array($example)) {
                         $default = '[]';
                     }
+                } elseif ($default instanceof Expression) {
+                    $default = Inline::dump((string) $default);
                 } else {
                     $default = Inline::dump($default);
                 }

--- a/src/Symfony/Component/Config/Definition/ExpressionNode.php
+++ b/src/Symfony/Component/Config/Definition/ExpressionNode.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Definition;
+
+use Symfony\Component\Config\Definition\Exception\InvalidTypeException;
+use Symfony\Component\ExpressionLanguage\Expression;
+
+/**
+ * This node represents a Symfony Expression Language Expression.
+ *
+ * @author Magnus Nordlander <magnus@fervo.se>
+ */
+class ExpressionNode extends VariableNode
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function validateType($value)
+    {
+        if (null === $value) {
+            return;
+        }
+
+        if (!$value instanceof Expression) {
+            $e = new InvalidTypeException(sprintf('Invalid type for path "%s": expected Symfony\\Component\\ExpressionLanguage\\Expression , but got %s.', $this->getPath(), gettype($value)));
+
+            if ($hint = $this->getInfo()) {
+                $e->addHint($hint);
+            }
+            $e->setPath($this->getPath());
+
+            throw $e;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function preNormalize($value)
+    {
+        $value = parent::preNormalize($value);
+
+        return $this->transformToExpression($value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultValue()
+    {
+        $value = parent::getDefaultValue();
+
+        return $this->transformToExpression($value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function isValueEmpty($value)
+    {
+        return null === $value;
+    }
+
+    private function transformToExpression($value)
+    {
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if ($value instanceof Expression) {
+            return $value;
+        }
+
+        if (!class_exists(Expression::class)) {
+            throw new \RuntimeException('The Symfony Expression Language component must be installed to use expression nodes in configurations.');
+        }
+
+        return new Expression($value);
+    }
+}

--- a/src/Symfony/Component/Config/Tests/Definition/ExpressionNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ExpressionNodeTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Tests\Definition;
+
+use Symfony\Component\Config\Definition\ExpressionNode;
+use Symfony\Component\ExpressionLanguage\Expression;
+
+class ExpressionNodeTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider getValidValues
+     */
+    public function testNormalize($input, $output)
+    {
+        $node = new ExpressionNode('test');
+        $this->assertEquals($output, $node->normalize($input));
+    }
+
+    /**
+     * @dataProvider getValidValues
+     *
+     * @param bool $value
+     */
+    public function testValidNonEmptyValues($input, $output)
+    {
+        $node = new ExpressionNode('test');
+        $node->setAllowEmptyValue(false);
+
+        if (null !== $output) {
+            $this->assertEquals($output, $node->normalize($input));
+        }
+    }
+
+    public function getValidValues()
+    {
+        return array(
+            array(null, null),
+            array('', null),
+            array('foo', new Expression('foo')),
+            array(new Expression('bar'), new Expression('bar')),
+        );
+    }
+}

--- a/src/Symfony/Component/Config/composer.json
+++ b/src/Symfony/Component/Config/composer.json
@@ -20,7 +20,8 @@
         "symfony/filesystem": "~2.8|~3.0"
     },
     "suggest": {
-        "symfony/yaml": "To use the yaml reference dumper"
+        "symfony/yaml": "To use the yaml reference dumper",
+        "symfony/expression-language": "To use the expression node type"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Config\\": "" },

--- a/src/Symfony/Component/Config/composer.json
+++ b/src/Symfony/Component/Config/composer.json
@@ -19,6 +19,9 @@
         "php": ">=5.5.9",
         "symfony/filesystem": "~2.8|~3.0"
     },
+    "require-dev": {
+        "symfony/expression-language": "~2.8|~3.0"
+    },
     "suggest": {
         "symfony/yaml": "To use the yaml reference dumper",
         "symfony/expression-language": "To use the expression node type"

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection;
 
+use Symfony\Component\DependencyInjection\Exception\EnvironmentVariableNotFoundException;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
@@ -371,6 +372,23 @@ class Container implements ResettableContainerInterface
     public static function underscore($id)
     {
         return strtolower(preg_replace(array('/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'), array('\\1_\\2', '\\1_\\2'), str_replace('_', '.', $id)));
+    }
+
+    protected function getEnvironmentVariable($name, $default = null)
+    {
+        if (isset($_ENV[$name])) {
+            return $_ENV[$name];
+        }
+
+        if (false !== $value = getenv($name)) {
+            return $value;
+        }
+
+        if (2 > func_num_args()) {
+            throw new EnvironmentVariableNotFoundException($name);
+        }
+
+        return $default;
     }
 
     private function __clone()

--- a/src/Symfony/Component/DependencyInjection/Exception/EnvironmentVariableNotFoundException.php
+++ b/src/Symfony/Component/DependencyInjection/Exception/EnvironmentVariableNotFoundException.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Exception;
+
+/**
+ * This exception is thrown when an environment variable was not found.
+ *
+ * @author Magnus Nordlander <magnus@fervo.se>
+ */
+class EnvironmentVariableNotFoundException extends InvalidArgumentException
+{
+    public function __construct($name)
+    {
+        parent::__construct(sprintf('You have requested a non-existent environment variable "%s".', $name));
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/ExpressionLanguageProvider.php
+++ b/src/Symfony/Component/DependencyInjection/ExpressionLanguageProvider.php
@@ -19,6 +19,7 @@ use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
  *
  * To get a service, use service('request').
  * To get a parameter, use parameter('kernel.debug').
+ * To get an environment variable, use env('UID').
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
@@ -38,6 +39,20 @@ class ExpressionLanguageProvider implements ExpressionFunctionProviderInterface
             }, function (array $variables, $value) {
                 return $variables['container']->getParameter($value);
             }),
+
+            new ExpressionFunction('env', function ($arg, $default = null) {
+                if (2 > func_num_args()) {
+                    return sprintf('$this->getEnvironmentVariable(%s)', $arg);
+                }
+
+                return sprintf('$this->getEnvironmentVariable(%s, %s)', $arg, $default);
+            }, \Closure::bind(function (array $variables, $value, $default = null) {
+                if (3 > func_num_args()) {
+                    return $variables['container']->getEnvironmentVariable($value);
+                }
+
+                return $variables['container']->getEnvironmentVariable($value, $default);
+            }, null, Container::class)),
         );
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -442,14 +442,18 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateServiceWithExpression()
     {
+        putenv('SYMFONY_TEST_ENVIRONMENT_VAR=quux');
+
         $builder = new ContainerBuilder();
         $builder->setParameter('bar', 'bar');
         $builder->register('bar', 'BarClass');
-        $builder->register('foo', 'Bar\FooClass')->addArgument(array('foo' => new Expression('service("bar").foo ~ parameter("bar")')));
+        $builder->register('foo', 'Bar\FooClass')->addArgument(array('foo' => new Expression('service("bar").foo ~ parameter("bar") ~ env("SYMFONY_TEST_ENVIRONMENT_VAR")')));
 
         $builder->compile();
 
-        $this->assertEquals('foobar', $builder->get('foo')->arguments['foo']);
+        $this->assertEquals('foobarquux', $builder->get('foo')->arguments['foo']);
+
+        putenv('SYMFONY_TEST_ENVIRONMENT_VAR');
     }
 
     public function testResolveServices()

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -126,7 +126,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
         $sc = new ProjectServiceContainer();
         $sc->set('foo', $obj = new \stdClass());
-        $this->assertEquals(array('internal', 'bar', 'foo_bar', 'foo.baz', 'circular', 'throw_exception', 'throws_exception_on_service_configuration', 'service_container', 'foo'), $sc->getServiceIds(), '->getServiceIds() returns defined service ids by getXXXService() methods, followed by service ids defined by set()');
+        $this->assertEquals(array('internal', 'bar', 'foo_bar', 'foo.baz', 'env_dependent_one', 'env_dependent_two', 'circular', 'throw_exception', 'throws_exception_on_service_configuration', 'service_container', 'foo'), $sc->getServiceIds(), '->getServiceIds() returns defined service ids by getXXXService() methods, followed by service ids defined by set()');
     }
 
     public function testSet()
@@ -308,6 +308,52 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($clone->isPrivate());
     }
 
+    public function testEnvironmentVariablesFromGetenv()
+    {
+        $c = new ProjectServiceContainer();
+
+        unset($_ENV['SYMFONY_TEST_FOO_ONE']);
+        putenv('SYMFONY_TEST_FOO_ONE=foo');
+
+        $this->assertSame('foo', $c->get('env_dependent_one'));
+        putenv('SYMFONY_TEST_FOO_ONE');
+    }
+
+    public function testEnvironmentVariablesFromEnvGlobal()
+    {
+        $c = new ProjectServiceContainer();
+
+        putenv('SYMFONY_TEST_FOO_ONE');
+        $_ENV['SYMFONY_TEST_FOO_ONE'] = 'bar';
+
+        $this->assertSame('bar', $c->get('env_dependent_one'));
+        unset($_ENV['SYMFONY_TEST_FOO_ONE']);
+    }
+
+    /**
+     * @expectedException Symfony\Component\DependencyInjection\Exception\EnvironmentVariableNotFoundException
+     * @expectedExceptionMessage You have requested a non-existent environment variable "SYMFONY_TEST_FOO_ONE".
+     */
+    public function testEnvironmentVariablesThrowsWhenNotSetWithoutDefault()
+    {
+        $c = new ProjectServiceContainer();
+
+        unset($_ENV['SYMFONY_TEST_FOO_ONE']);
+        putenv('SYMFONY_TEST_FOO_ONE');
+
+        $c->get('env_dependent_one');
+    }
+
+    public function testEnvironmentVariablesReturnsDefaultWhenNotSet()
+    {
+        $c = new ProjectServiceContainer();
+
+        unset($_ENV['SYMFONY_TEST_FOO_TWO']);
+        putenv('SYMFONY_TEST_FOO_TWO');
+
+        $this->assertSame('xyzzy', $c->get('env_dependent_two'));
+    }
+
     /**
      * @group legacy
      * @requires function Symfony\Bridge\PhpUnit\ErrorAssert::assertDeprecationsAreTriggered
@@ -410,6 +456,16 @@ class ProjectServiceContainer extends Container
     protected function getFoo_BazService()
     {
         return $this->__foo_baz;
+    }
+
+    protected function getEnvDependentOneService()
+    {
+        return $this->getEnvironmentVariable('SYMFONY_TEST_FOO_ONE');
+    }
+
+    protected function getEnvDependentTwoService()
+    {
+        return $this->getEnvironmentVariable('SYMFONY_TEST_FOO_TWO', 'xyzzy');
     }
 
     protected function getCircularService()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

There have been several attempts to solve the issue of dynamic environment variables in Symfony (the issues are outlined in #10138, #7555). The latest stab at the issue that I am aware of was #16403, but that was closed as Fabien concluded that "a generic system is just not possible without rethinking the whole system", and that "another possibility is to only add support for some bundles like the DSN for the Doctrine bundle" (see https://github.com/symfony/symfony/pull/16403#issuecomment-156015119).

In order to make it easier on bundles to support allowing environment variables in their configuration, I propose adding an expression language function to get environment variables from service expressions, and a trait to more easily parse such an expression from the bundle extension.

This could easily be made in a separate bundle (see my own https://github.com/fervo/EnvironmentBundle), but I feel that adoption will be far higher if we do it in core. Using the trait, configuration with an environment variable is quite simple, something along the following line works brilliantly:

``` yaml
fervo_pubnub:
    publish_key: "@=env('PUBNUB_PUBLISH_KEY')"
    subscribe_key: "@=env('PUBNUB_SUBSCRIBE_KEY')"
```

If the extension uses the configuration values as service arguments verbatim, all it has to do is something like the following:

``` php
        $def = $container->getDefinition('fervo_pubnub');
        $def->replaceArgument(0, $this->resolve($config['publish_key']));
        $def->replaceArgument(1, $this->resolve($config['subscribe_key']));
```

It does require opt-in from all bundles wishing to use this, and for all configuration values it is used on, but I think that is the best way forward.
