### PR TITLE
[Validator] In "strict" mode, email validator inaccurately claims certain valid emails are invalid

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -65,7 +65,7 @@ class EmailValidator extends ConstraintValidator
 
             $strictValidator = new \Egulias\EmailValidator\EmailValidator();
 
-            if (!$strictValidator->isValid($value, false, true)) {
+            if (!$strictValidator->isValid($value)) {
                 $this->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
                     ->addViolation();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | 2.5 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | potentially |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18156 |
| License | MIT |
| Doc PR | n/a |
