### PR TITLE
[DependencyInjection] Fix a limitation of the PhpDumper

### DIFF
--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
@@ -71,7 +71,12 @@ class ProxyDumper implements DumperInterface
             $instantiation .= " \$this->services['$id'] =";
         }
 
-        $methodName = 'get'.Container::camelize($id).'Service';
+        if (func_num_args() >= 3) {
+            $methodName = func_get_arg(2);
+        } else {
+            @trigger_error(sprintf('You must use the third argument of %s to define the method to call to construct your service since version 3.1, not using it won\'t be supported in 4.0.', __METHOD__), E_USER_DEPRECATED);
+            $methodName = 'get'.Container::camelize($id).'Service';
+        }
         $proxyClass = $this->getProxyClassName($definition);
 
         $generatedClass = $this->generateProxyClass($definition);

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/ProxyDumperTest.php
@@ -60,6 +60,27 @@ class ProxyDumperTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testGetProxyFactoryCodeWithCustomMethod()
+    {
+        $definition = new Definition(__CLASS__);
+
+        $definition->setLazy(true);
+
+        $code = $this->dumper->getProxyFactoryCode($definition, 'foo', 'getFoo2Service');
+
+        $this->assertStringMatchesFormat(
+            '%wif ($lazyLoad) {%wreturn $this->services[\'foo\'] =%s'
+            .'SymfonyBridgeProxyManagerTestsLazyProxyPhpDumperProxyDumperTest_%s(%wfunction '
+            .'(&$wrappedInstance, \ProxyManager\Proxy\LazyLoadingInterface $proxy) {'
+            .'%w$wrappedInstance = $this->getFoo2Service(false);%w$proxy->setProxyInitializer(null);'
+            .'%wreturn true;%w}%w);%w}%w',
+           $code
+        );
+    }
+
+    /**
+     * @group legacy
+     */
     public function testGetProxyFactoryCode()
     {
         $definition = new Definition(__CLASS__);

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -58,8 +58,8 @@ class PhpDumper extends Dumper
     private $targetDirRegex;
     private $targetDirMaxMatches;
     private $docStar;
-    private $serviceIdToMethodNameMap = array();
-    private $usedMethodNames = array();
+    private $serviceIdToMethodNameMap;
+    private $usedMethodNames;
 
     /**
      * @var \Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\DumperInterface
@@ -108,6 +108,9 @@ class PhpDumper extends Dumper
             'namespace' => '',
             'debug' => true,
         ), $options);
+
+        $this->initializeMethodNamesMap($options['base_class']);
+
         $this->docStar = $options['debug'] ? '*' : '';
 
         if (!empty($options['file']) && is_dir($dir = dirname($options['file']))) {
@@ -1337,6 +1340,25 @@ EOF;
             }
 
             return sprintf('$this->get(\'%s\')', $id);
+        }
+    }
+
+    /**
+     * Initializes the method names map to avoid conflicts with the Container methods.
+     *
+     * @param string $class the container base class
+     */
+    private function initializeMethodNamesMap($class)
+    {
+        $this->serviceIdToMethodNameMap = array();
+        $this->usedMethodNames = array();
+
+        try {
+            $reflectionClass = new \ReflectionClass($class);
+            foreach ($reflectionClass->getMethods() as $method) {
+                $this->usedMethodNames[strtolower($method->getName())] = true;
+            }
+        } catch (\ReflectionException $e) {
         }
     }
 

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -58,6 +58,7 @@ class PhpDumper extends Dumper
     private $targetDirRegex;
     private $targetDirMaxMatches;
     private $docStar;
+    private $existingNames = array();
 
     /**
      * @var \Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\DumperInterface
@@ -1349,13 +1350,21 @@ EOF;
      */
     private function camelize($id)
     {
-        $name = Container::camelize($id);
-
-        if (!preg_match('/^[a-zA-Z0-9_\x7f-\xff]+$/', $name)) {
-            throw new InvalidArgumentException(sprintf('Service id "%s" cannot be converted to a valid PHP method name.', $id));
+        if (isset($this->existingNames[$id])) {
+            return $this->existingNames[$id];
         }
 
-        return $name;
+        $name = Container::camelize($id);
+        $uniqueName = $name = preg_replace('/[^a-zA-Z0-9_\x7f-\xff]/', '', $name);
+        $prefix = 1;
+
+        while (in_array($uniqueName, $this->existingNames)) {
+            ++$prefix;
+            $uniqueName = $name.$prefix;
+        }
+        $this->existingNames[$id] = $uniqueName;
+
+        return $uniqueName;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -58,7 +58,8 @@ class PhpDumper extends Dumper
     private $targetDirRegex;
     private $targetDirMaxMatches;
     private $docStar;
-    private $existingNames = array();
+    private $serviceIdToMethodNameMap = array();
+    private $usedMethodNames = array();
 
     /**
      * @var \Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\DumperInterface
@@ -1350,21 +1351,22 @@ EOF;
      */
     private function camelize($id)
     {
-        if (isset($this->existingNames[$id])) {
-            return $this->existingNames[$id];
+        if (isset($this->serviceIdToMethodNameMap[$id])) {
+            return $this->serviceIdToMethodNameMap[$id];
         }
 
         $name = Container::camelize($id);
-        $uniqueName = $name = preg_replace('/[^a-zA-Z0-9_\x7f-\xff]/', '', $name);
-        $prefix = 1;
+        $methodName = $name = preg_replace('/[^a-zA-Z0-9_\x7f-\xff]/', '', $name);
+        $suffix = 1;
 
-        while (in_array($uniqueName, $this->existingNames)) {
-            ++$prefix;
-            $uniqueName = $name.$prefix;
+        while (isset($this->usedMethodNames[$methodName])) {
+            ++$suffix;
+            $methodName = $name.$suffix;
         }
-        $this->existingNames[$id] = $uniqueName;
+        $this->serviceIdToMethodNameMap[$id] = $methodName;
+        $this->usedMethodNames[$methodName] = true;
 
-        return $uniqueName;
+        return $methodName;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -634,7 +634,7 @@ EOF;
      *$lazyInitializationDoc
      * $return
      */
-    {$visibility} function get{$this->camelize($id)}Service($lazyInitialization)
+    {$visibility} function {$this->generateMethodName($id)}($lazyInitialization)
     {
 
 EOF;
@@ -866,7 +866,7 @@ EOF;
         $code = "        \$this->methodMap = array(\n";
         ksort($definitions);
         foreach ($definitions as $id => $definition) {
-            $code .= '            '.var_export($id, true).' => '.var_export('get'.$this->camelize($id).'Service', true).",\n";
+            $code .= '            '.var_export($id, true).' => '.var_export($this->generateMethodName($id), true).",\n";
         }
 
         return $code."        );\n";
@@ -1349,22 +1349,24 @@ EOF;
      *
      * @throws InvalidArgumentException
      */
-    private function camelize($id)
+    private function generateMethodName($id)
     {
         if (isset($this->serviceIdToMethodNameMap[$id])) {
             return $this->serviceIdToMethodNameMap[$id];
         }
 
         $name = Container::camelize($id);
-        $methodName = $name = preg_replace('/[^a-zA-Z0-9_\x7f-\xff]/', '', $name);
+        $name = preg_replace('/[^a-zA-Z0-9_\x7f-\xff]/', '', $name);
+        $methodName = 'get'.$name.'Service';
         $suffix = 1;
 
-        while (isset($this->usedMethodNames[$methodName])) {
+        while (isset($this->usedMethodNames[strtolower($methodName)])) {
             ++$suffix;
-            $methodName = $name.$suffix;
+            $methodName = 'get'.$name.$suffix.'Service';
         }
+
         $this->serviceIdToMethodNameMap[$id] = $methodName;
-        $this->usedMethodNames[$methodName] = true;
+        $this->usedMethodNames[strtolower($methodName)] = true;
 
         return $methodName;
     }

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -630,6 +630,7 @@ EOF;
         // with proxies, for 5.3.3 compatibility, the getter must be public to be accessible to the initializer
         $isProxyCandidate = $this->getProxyDumper()->isProxyCandidate($definition);
         $visibility = $isProxyCandidate ? 'public' : 'protected';
+        $methodName = $this->generateMethodName($id);
         $code = <<<EOF
 
     /*{$this->docStar}
@@ -637,12 +638,12 @@ EOF;
      *$lazyInitializationDoc
      * $return
      */
-    {$visibility} function {$this->generateMethodName($id)}($lazyInitialization)
+    {$visibility} function {$methodName}($lazyInitialization)
     {
 
 EOF;
 
-        $code .= $isProxyCandidate ? $this->getProxyDumper()->getProxyFactoryCode($definition, $id) : '';
+        $code .= $isProxyCandidate ? $this->getProxyDumper()->getProxyFactoryCode($definition, $id, $methodName) : '';
 
         if ($definition->isSynthetic()) {
             $code .= sprintf("        throw new RuntimeException('You have requested a synthetic service (\"%s\"). The DIC does not know how to construct this service.');\n    }\n", $id);

--- a/src/Symfony/Component/DependencyInjection/LazyProxy/PhpDumper/DumperInterface.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/PhpDumper/DumperInterface.php
@@ -34,10 +34,11 @@ interface DumperInterface
      *
      * @param Definition $definition
      * @param string     $id         service identifier
+     * @param string     $methodName the method name to get the service, will be added to the interface in 4.0.
      *
      * @return string
      */
-    public function getProxyFactoryCode(Definition $definition, $id);
+    public function getProxyFactoryCode(Definition $definition, $id/**, $methodName = null */);
 
     /**
      * Generates the code for the lazy proxy.

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -158,6 +158,22 @@ class PhpDumperTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(method_exists($class, 'getFoobar2Service'));
     }
 
+    public function testConflictingMethodsWithParent()
+    {
+        $class = 'Symfony_DI_PhpDumper_Test_Conflicting_Method_With_Parent';
+        $container = new ContainerBuilder();
+        $container->register('bar', 'FooClass');
+        $container->register('foo_bar', 'FooClass');
+        $dumper = new PhpDumper($container);
+        eval('?>'.$dumper->dump(array(
+            'class' => $class,
+            'base_class' => 'Symfony\Component\DependencyInjection\Tests\Fixtures\containers\CustomContainer',
+        )));
+
+        $this->assertTrue(method_exists($class, 'getBar2Service'));
+        $this->assertTrue(method_exists($class, 'getFoobar2Service'));
+    }
+
     /**
      * @dataProvider provideInvalidFactories
      * @expectedException Symfony\Component\DependencyInjection\Exception\RuntimeException

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -132,16 +132,17 @@ class PhpDumperTest extends \PHPUnit_Framework_TestCase
         $this->assertStringEqualsFile(self::$fixturesPath.'/php/services19.php', $dumper->dump(), '->dump() dumps services with anonymous factories');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Service id "bar$" cannot be converted to a valid PHP method name.
-     */
-    public function testAddServiceInvalidServiceId()
+    public function testAddServiceIdWithUnsupportedCharacters()
     {
         $container = new ContainerBuilder();
         $container->register('bar$', 'FooClass');
+        $container->register('bar$!', 'FooClass');
         $dumper = new PhpDumper($container);
-        $dumper->dump();
+        eval('?>'.$dumper->dump(array('class' => 'Symfony_DI_PhpDumper_Test_Unsupported_Characters')));
+
+        $container = new \Symfony_DI_PhpDumper_Test_Unsupported_Characters();
+        $this->assertTrue(method_exists($container, 'getBarService'));
+        $this->assertTrue(method_exists($container, 'getBar2Service'));
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -134,15 +134,28 @@ class PhpDumperTest extends \PHPUnit_Framework_TestCase
 
     public function testAddServiceIdWithUnsupportedCharacters()
     {
+        $class = 'Symfony_DI_PhpDumper_Test_Unsupported_Characters';
         $container = new ContainerBuilder();
         $container->register('bar$', 'FooClass');
         $container->register('bar$!', 'FooClass');
         $dumper = new PhpDumper($container);
-        eval('?>'.$dumper->dump(array('class' => 'Symfony_DI_PhpDumper_Test_Unsupported_Characters')));
+        eval('?>'.$dumper->dump(array('class' => $class)));
 
-        $container = new \Symfony_DI_PhpDumper_Test_Unsupported_Characters();
-        $this->assertTrue(method_exists($container, 'getBarService'));
-        $this->assertTrue(method_exists($container, 'getBar2Service'));
+        $this->assertTrue(method_exists($class, 'getBarService'));
+        $this->assertTrue(method_exists($class, 'getBar2Service'));
+    }
+
+    public function testConflictingServiceIds()
+    {
+        $class = 'Symfony_DI_PhpDumper_Test_Conflicting_Service_Ids';
+        $container = new ContainerBuilder();
+        $container->register('foo_bar', 'FooClass');
+        $container->register('foobar', 'FooClass');
+        $dumper = new PhpDumper($container);
+        eval('?>'.$dumper->dump(array('class' => $class)));
+
+        $this->assertTrue(method_exists($class, 'getFooBarService'));
+        $this->assertTrue(method_exists($class, 'getFoobar2Service'));
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/CustomContainer.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/CustomContainer.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\containers;
+
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+
+class CustomContainer extends Container
+{
+    public function getBarService()
+    {
+    }
+
+    public function getFoobarService()
+    {
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/issues/17801 |
| License | MIT |
| Doc PR |  |

The `PhpDumper` cannot currently dump several services' id containing characters unsupported by php.
This PR tries to solve this issue by removing the unsupported characters and by sufixing their camelized association to avoid conflicts.
