### PR TITLE
FrameworkBundle: Client: getContainer(): fixed phpdoc

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Client.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Client.php
@@ -41,7 +41,7 @@ class Client extends BaseClient
     /**
      * Returns the container.
      *
-     * @return ContainerInterface
+     * @return ContainerInterface|null Returns null when the Kernel has been shutdown or not started yet
      */
     public function getContainer()
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | lowest applicable and maintained version |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

The kernel [might be shut down](https://github.com/symfony/symfony/blob/2.3/src/Symfony/Component/HttpKernel/Kernel.php#L164) and then the method will return null instead of a ContainerInterface object.

---

I've stumbled upon that when I was trying to do this in my [test](https://github.com/symfony/framework-bundle/blob/master/Test/WebTestCase.php):

``` php
    /**
     * @var Client|null
     */
    private static $client;

    public static function tearDownAfterClass()
    {
        $entityManager = $client->getContainer()
            ->get('doctrine')
            ->getManager();
        // remove entities created by tests
    }

    public function testWhatever()
    {
        self::$client = self::createClient();
        // entities are created
    }
```

`$client->getContainer()` has given me `null` while I was expecting the container, as the PHPDoc say I would. Unpleasant debugging and WTFing.
