### PR TITLE
Fix leftover conflict marker in UPGRADE-3.0.md

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -403,7 +403,6 @@ UPGRADE FROM 2.x to 3.0
 
  * The `choice_list` option of `ChoiceType` was removed.
 
->>>>>>> 2.8
  * The option "precision" was renamed to "scale".
 
    Before:


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | 3.0 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? |  |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Presumably after resolving a merge conflict, a parasite line `>>>>>>> 2.8` was introduced as part of commit 67df429d99c1cf55227f8bb065f88872e5b3edeb:
- https://github.com/symfony/symfony/commit/67df429d99c1cf55227f8bb065f88872e5b3edeb#diff-0901ceb76939b17cd920bc69aa52d21fR406
- https://github.com/symfony/symfony/blame/67df429d99c1cf55227f8bb065f88872e5b3edeb/UPGRADE-3.0.md#L406

The present PR just deletes this line 406.
