### PR TITLE
[Translation] Add support for fuzzy tags in PoFileLoader

### DIFF
--- a/src/Symfony/Component/Translation/Loader/PoFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/PoFileLoader.php
@@ -71,14 +71,20 @@ class PoFileLoader extends FileLoader
 
         $messages = array();
         $item = $defaults;
+        $flags = array();
 
         while ($line = fgets($stream)) {
             $line = trim($line);
 
             if ($line === '') {
                 // Whitespace indicated current item is done
-                $this->addMessage($messages, $item);
+                if (!in_array('fuzzy', $flags)) {
+                    $this->addMessage($messages, $item);
+                }
                 $item = $defaults;
+                $flags = array();
+            } elseif (substr($line, 0, 2) === '#,') {
+                $flags = array_map('trim', explode(',', substr($line, 2)));
             } elseif (substr($line, 0, 7) === 'msgid "') {
                 // We start a new msg so save previous
                 // TODO: this fails when comments or contexts are added
@@ -104,7 +110,9 @@ class PoFileLoader extends FileLoader
             }
         }
         // save last item
-        $this->addMessage($messages, $item);
+        if (!in_array('fuzzy', $flags)) {
+            $this->addMessage($messages, $item);
+        }
         fclose($stream);
 
         return $messages;

--- a/src/Symfony/Component/Translation/Tests/Loader/PoFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/PoFileLoaderTest.php
@@ -93,4 +93,16 @@ class PoFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('escaped "bar"', $messages['escaped "foo"']);
         $this->assertEquals('escaped "bar"|escaped "bars"', $messages['escaped "foos"']);
     }
+
+    public function testSkipFuzzyTranslations()
+    {
+        $loader = new PoFileLoader();
+        $resource = __DIR__.'/../fixtures/fuzzy-translations.po';
+        $catalogue = $loader->load($resource, 'en', 'domain1');
+
+        $messages = $catalogue->all('domain1');
+        $this->assertArrayHasKey('foo1', $messages);
+        $this->assertArrayNotHasKey('foo2', $messages);
+        $this->assertArrayHasKey('foo3', $messages);
+    }
 }

--- a/src/Symfony/Component/Translation/Tests/fixtures/fuzzy-translations.po
+++ b/src/Symfony/Component/Translation/Tests/fixtures/fuzzy-translations.po
@@ -1,0 +1,10 @@
+#, php-format
+msgid "foo1"
+msgstr "bar1"
+
+#, fuzzy, php-format
+msgid "foo2"
+msgstr "fuzzy bar2"
+
+msgid "foo3"
+msgstr "bar3"


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18161 |
| License | MIT |
| Doc PR | - |

The traditional gettext tools usually try to find similar strings when
updating translations. This results in some strings having a translation
but being marked as "fuzzy", even if the translation is not correct.

The expected result when a string is marked as fuzzy is that it should
not be used by the translation system. Using symfony, though, the
translations were used, which could result in "funny" messages being
displayed in the interface despite being often completely out of
context.

This commit discards messages in .po files that have a '#, fuzzy' flag.

This commit can (and imo should) be back-ported as-is to the 2.x branch.
