### PR TITLE
[Cache] Restrict flushes to namespace scopes

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/ApcuAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ApcuAdapter.php
@@ -50,7 +50,9 @@ class ApcuAdapter extends AbstractAdapter
      */
     protected function doClear($namespace)
     {
-        return apcu_clear_cache();
+        return isset($namespace[0]) && class_exists('APCuIterator', false)
+            ? apcu_delete(new \APCuIterator(sprintf('/^%s/', preg_quote($namespace, '/')), APC_ITER_KEY))
+            : apcu_clear_cache();
     }
 
     /**

--- a/src/Symfony/Component/Cache/Adapter/DoctrineAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/DoctrineAdapter.php
@@ -22,8 +22,9 @@ class DoctrineAdapter extends AbstractAdapter
 
     public function __construct(CacheProvider $provider, $defaultLifetime = 0, $namespace = '')
     {
-        parent::__construct($namespace, $defaultLifetime);
+        parent::__construct('', $defaultLifetime);
         $this->provider = $provider;
+        $provider->setNamespace($namespace);
     }
 
     /**
@@ -47,7 +48,11 @@ class DoctrineAdapter extends AbstractAdapter
      */
     protected function doClear($namespace)
     {
-        return $this->provider->flushAll();
+        $namespace = $this->provider->getNamespace();
+
+        return isset($namespace[0])
+            ? $this->provider->deleteAll()
+            : $this->provider->flushAll();
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Instead of flushing all cache namespaces all the time, we can flush only the keys in the namespace.
