### PR TITLE
[Form] fixed BC break with pre selection of choices with `ChoiceType` and its children

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -261,7 +261,7 @@ class EntityTypeTest extends TypeTestCase
         $field->submit(null);
 
         $this->assertNull($field->getData());
-        $this->assertNull($field->getViewData());
+        $this->assertSame('', $field->getViewData(), 'View data is always a string');
     }
 
     public function testSubmitSingleNonExpandedNull()

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "symfony/stopwatch": "~2.2",
         "symfony/dependency-injection": "~2.2",
-        "symfony/form": "~2.7,>=2.7.1",
+        "symfony/form": "~2.7.12|~2.8.5",
         "symfony/http-kernel": "~2.2",
         "symfony/property-access": "~2.3",
         "symfony/security": "~2.2",

--- a/src/Symfony/Component/Form/Extension/Core/DataMapper/RadioListMapper.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataMapper/RadioListMapper.php
@@ -38,11 +38,13 @@ class RadioListMapper implements DataMapperInterface
     /**
      * {@inheritdoc}
      */
-    public function mapDataToForms($data, $radios)
+    public function mapDataToForms($choice, $radios)
     {
+        $valueMap = array_flip($this->choiceList->getValuesForChoices(array($choice)));
+
         foreach ($radios as $radio) {
             $value = $radio->getConfig()->getOption('value');
-            $radio->setData($value === $data ? true : false);
+            $radio->setData(isset($valueMap[$value]) ? true : false);
         }
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -143,14 +143,6 @@ class ChoiceType extends AbstractType
                         $event->setData(null);
                     }
                 });
-                // For radio lists, pre selection of the choice needs to pre set data
-                // with the string value so it can be matched in
-                // {@link \Symfony\Component\Form\Extension\Core\DataMapper\RadioListMapper::mapDataToForms()}
-                $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
-                    $choiceList = $event->getForm()->getConfig()->getOption('choice_list');
-                    $value = current($choiceList->getValuesForChoices(array($event->getData())));
-                    $event->setData((string) $value);
-                });
             }
         } elseif ($options['multiple']) {
             // <select> tag with "multiple" option

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -32,6 +32,12 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         'n/a' => '',
     );
 
+    private $booleanChoicesWithNull = array(
+        'Yes' => true,
+        'No' => false,
+        'n/a' => null,
+    );
+
     private $numericChoicesFlipped = array(
         0 => 'Bernhard',
         1 => 'Fabien',
@@ -183,6 +189,19 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertTrue($view->children[2]->vars['checked'], 'Empty value should be pre selected');
     }
 
+    public function testExpandedChoiceListWithBooleanAndNullValues()
+    {
+        $view = $this->factory->create('choice', null, array(
+            'choices' => $this->booleanChoicesWithNull,
+            'choices_as_values' => true,
+            'expanded' => true,
+        ))->createView();
+
+        $this->assertFalse($view->children[0]->vars['checked'], 'True value should not be pre selected');
+        $this->assertFalse($view->children[1]->vars['checked'], 'False value should not be pre selected');
+        $this->assertTrue($view->children[2]->vars['checked'], 'Empty value should be pre selected');
+    }
+
     public function testExpandedChoiceListWithScalarValuesAndFalseAsPreSetData()
     {
         $view = $this->factory->create('choice', false, array(
@@ -195,6 +214,19 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertSame('0', $view->vars['choices'][1]->value);
         $this->assertTrue($view->children[1]->vars['checked'], 'False value should be pre selected');
         $this->assertFalse($view->children[2]->vars['checked'], 'Empty value should not be pre selected');
+    }
+
+    public function testExpandedChoiceListWithBooleanAndNullValuesAndFalseAsPreSetData()
+    {
+        $view = $this->factory->create('choice', false, array(
+            'choices' => $this->booleanChoicesWithNull,
+            'choices_as_values' => true,
+            'expanded' => true,
+        ))->createView();
+
+        $this->assertFalse($view->children[0]->vars['checked'], 'True value should not be pre selected');
+        $this->assertTrue($view->children[1]->vars['checked'], 'False value should be pre selected');
+        $this->assertFalse($view->children[2]->vars['checked'], 'Null value should not be pre selected');
     }
 
     public function testPlaceholderPresentOnNonRequiredExpandedSingleChoice()
@@ -319,7 +351,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
         $view = $form->createView();
 
-        $this->assertSame('', $view->vars['value'], 'Value should be empty');
+        $this->assertSame('', $view->vars['value'], 'Value should be an empty string');
         $this->assertSame('1', $view->vars['choices'][0]->value);
         $this->assertSame('0', $view->vars['choices'][1]->value, 'Choice "false" should have "0" as value');
         $this->assertFalse($view->children[1]->vars['checked'], 'Choice "false" should not be selected');
@@ -940,8 +972,8 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $form->submit(null);
 
         $this->assertNull($form->getData());
-        $this->assertNull($form->getViewData());
-        $this->assertEmpty($form->getExtraData());
+        $this->assertSame('', $form->getViewData(), 'View data should always be a string');
+        $this->assertSame(array(), $form->getExtraData(), 'ChoiceType is compound when expanded, extra data should always be an array');
         $this->assertTrue($form->isSynchronized());
 
         $this->assertFalse($form[0]->getData());
@@ -972,8 +1004,8 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $form->submit(null);
 
         $this->assertNull($form->getData());
-        $this->assertNull($form->getViewData());
-        $this->assertEmpty($form->getExtraData());
+        $this->assertSame('', $form->getViewData(), 'View data should always be a string');
+        $this->assertSame(array(), $form->getExtraData(), 'ChoiceType is compound when expanded, extra data should always be an array');
         $this->assertTrue($form->isSynchronized());
     }
 
@@ -990,8 +1022,8 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $form->submit('');
 
         $this->assertNull($form->getData());
-        $this->assertNull($form->getViewData());
-        $this->assertEmpty($form->getExtraData());
+        $this->assertSame('', $form->getViewData(), 'View data should always be a string');
+        $this->assertSame(array(), $form->getExtraData(), 'ChoiceType is compound when expanded, extra data should always be an array');
         $this->assertTrue($form->isSynchronized());
 
         $this->assertFalse($form[0]->getData());
@@ -1022,8 +1054,8 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $form->submit('');
 
         $this->assertNull($form->getData());
-        $this->assertNull($form->getViewData());
-        $this->assertEmpty($form->getExtraData());
+        $this->assertSame('', $form->getViewData(), 'View data should always be a string');
+        $this->assertSame(array(), $form->getExtraData(), 'ChoiceType is compound when expanded, extra data should always be an array');
         $this->assertTrue($form->isSynchronized());
     }
 
@@ -1040,8 +1072,8 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $form->submit(false);
 
         $this->assertNull($form->getData());
-        $this->assertNull($form->getViewData());
-        $this->assertEmpty($form->getExtraData());
+        $this->assertSame('', $form->getViewData(), 'View data should always be a string');
+        $this->assertSame(array(), $form->getExtraData(), 'ChoiceType is compound when expanded, extra data should always be an array');
         $this->assertTrue($form->isSynchronized());
 
         $this->assertFalse($form[0]->getData());
@@ -1072,8 +1104,8 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $form->submit(false);
 
         $this->assertNull($form->getData());
-        $this->assertNull($form->getViewData());
-        $this->assertEmpty($form->getExtraData());
+        $this->assertSame('', $form->getViewData(), 'View data should always be a string');
+        $this->assertSame(array(), $form->getExtraData(), 'ChoiceType is compound when expanded, extra data should always be an array');
         $this->assertTrue($form->isSynchronized());
     }
 
@@ -1090,8 +1122,8 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $form->submit(null);
 
         $this->assertNull($form->getData());
-        $this->assertNull($form->getViewData());
-        $this->assertEmpty($form->getExtraData());
+        $this->assertSame('', $form->getViewData(), 'View data should always be a string');
+        $this->assertSame(array(), $form->getExtraData(), 'ChoiceType is compound when expanded, extra data should always be an array');
         $this->assertTrue($form->isSynchronized());
 
         $this->assertTrue($form['placeholder']->getData());
@@ -1124,8 +1156,8 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $form->submit(null);
 
         $this->assertNull($form->getData());
-        $this->assertNull($form->getViewData());
-        $this->assertEmpty($form->getExtraData());
+        $this->assertSame('', $form->getViewData(), 'View data should always be a string');
+        $this->assertSame(array(), $form->getExtraData(), 'ChoiceType is compound when expanded, extra data should always be an array');
         $this->assertTrue($form->isSynchronized());
     }
 
@@ -1142,8 +1174,8 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $form->submit('');
 
         $this->assertNull($form->getData());
-        $this->assertNull($form->getViewData());
-        $this->assertEmpty($form->getExtraData());
+        $this->assertSame('', $form->getViewData(), 'View data should always be a string');
+        $this->assertSame(array(), $form->getExtraData(), 'ChoiceType is compound when expanded, extra data should always be an array');
         $this->assertTrue($form->isSynchronized());
 
         $this->assertTrue($form['placeholder']->getData());
@@ -1176,8 +1208,8 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $form->submit('');
 
         $this->assertNull($form->getData());
-        $this->assertNull($form->getViewData());
-        $this->assertEmpty($form->getExtraData());
+        $this->assertSame('', $form->getViewData(), 'View data should always be a string');
+        $this->assertSame(array(), $form->getExtraData(), 'ChoiceType is compound when expanded, extra data should always be an array');
         $this->assertTrue($form->isSynchronized());
     }
 
@@ -1194,8 +1226,8 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $form->submit(false);
 
         $this->assertNull($form->getData());
-        $this->assertNull($form->getViewData());
-        $this->assertEmpty($form->getExtraData());
+        $this->assertSame('', $form->getViewData(), 'View data should always be a string');
+        $this->assertSame(array(), $form->getExtraData(), 'ChoiceType is compound when expanded, extra data should always be an array');
         $this->assertTrue($form->isSynchronized());
 
         $this->assertTrue($form['placeholder']->getData());
@@ -1228,8 +1260,8 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $form->submit(false);
 
         $this->assertNull($form->getData());
-        $this->assertNull($form->getViewData());
-        $this->assertEmpty($form->getExtraData());
+        $this->assertSame('', $form->getViewData(), 'View data should always be a string');
+        $this->assertSame(array(), $form->getExtraData(), 'ChoiceType is compound when expanded, extra data should always be an array');
         $this->assertTrue($form->isSynchronized());
     }
 
@@ -1247,7 +1279,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
         $form->submit('');
 
-        $this->assertNull($form->getData());
+        $this->assertSame('', $form->getData());
         $this->assertTrue($form->isSynchronized());
 
         $this->assertTrue($form[0]->getData());


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | 2.7+ |
| Bugfix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18173, #14712, #17789 |
| License | MIT |
| Doc PR | - |
- f7eea72 reverts BC break introduced in #17760
- 58e8ed0 fixes pre selection of choice with model values such as `false`, `null` or empty string without BC break.

`ChoiceType` now always use `ChoiceToValueTransformer` or `ChoicesToValuesTransformer` depending on `multiple` option.
Hence `CheckboxListMapper` and `RadioListMapper` don't handle the transformation anymore.
