### PR TITLE
[Serializer] Add ChainNameConverter

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG
  * added support for serializing objects that implement `DateTimeInterface`
  * added `AbstractObjectNormalizer` as a base class for normalizers that deal
    with objects
+ * added `ChainNameConverter` to process property names with multiple converters.
 
 2.7.0
 -----

--- a/src/Symfony/Component/Serializer/NameConverter/ChainNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/ChainNameConverter.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\NameConverter;
+
+/**
+ * ChainNameConverter allows to process a property name with multiple converters.
+ *
+ * @author Jérôme Gamez <jerome@gamez.name>
+ */
+class ChainNameConverter implements NameConverterInterface
+{
+    private $converters;
+
+    /**
+     * @param NameConverterInterface[] $converters A list of name converters.
+     */
+    public function __construct(array $converters = array())
+    {
+        $this->converters = $converters;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($propertyName)
+    {
+        foreach ($this->converters as $converter) {
+            $propertyName = $converter->normalize($propertyName);
+        }
+
+        return $propertyName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function denormalize($propertyName)
+    {
+        foreach ($this->converters as $converter) {
+            $propertyName = $converter->denormalize($propertyName);
+        }
+
+        return $propertyName;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/NameConverter/ChainNameConverterTest.php
+++ b/src/Symfony/Component/Serializer/Tests/NameConverter/ChainNameConverterTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\NameConverter;
+
+use Symfony\Component\Serializer\NameConverter\ChainNameConverter;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
+
+/**
+ * @author Jérôme Gamez <jerome@gamez.name>
+ */
+class ChainNameConverterTest extends \PHPUnit_Framework_TestCase
+{
+    protected $chainConverter;
+
+    protected $firstConverter;
+    protected $secondConverter;
+
+    protected function setUp()
+    {
+        $this->firstConverter = $this->getMock(NameConverterInterface::class);
+        $this->secondConverter = $this->getMock(NameConverterInterface::class);
+
+        $this->chainConverter = new ChainNameConverter(array($this->firstConverter, $this->secondConverter));
+    }
+
+    public function testNormalize()
+    {
+        $this->firstConverter->expects($this->once())->method('normalize')->with('one')->willReturn('two');
+        $this->secondConverter->expects($this->once())->method('normalize')->with('two')->willReturn('three');
+
+        $this->assertEquals('three', $this->chainConverter->normalize('one'));
+    }
+
+    public function testDenormalize()
+    {
+        $this->firstConverter->expects($this->once())->method('denormalize')->with('three')->willReturn('two');
+        $this->secondConverter->expects($this->once())->method('denormalize')->with('two')->willReturn('one');
+
+        $this->assertEquals('one', $this->chainConverter->denormalize('three'));
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | symfony/symfony-docs/pull/6374 |

The `ChainNameConverter` allows to process property names with multiple converters. This can be useful e.g. when you have to CamelCase underscored property names, and then need to rename them by custom rules.

My current use case is that I receive serialized data with (some, but not all) german snake cased property names (it's a 3rd party API :smile:) which I need to camelcase _and_ translate to english, so that e.g. a property named `ist_archiviert` would first be converted to `istArchiviert` and then translated into `isArchived` by a second converter. Properties that are already in english language would just be camelcased, and already valid property names would remain unchanged.

An usage example (with the `OrgPrefixNameConverter` from the docs):

``` php
use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
use Symfony\Component\Serializer\NameConverter\ChainNameConverter;

$camelCaseNameConverter = new CamelCaseToSnakeCaseNameConverter();
$orgPrefixNameConverter = new OrgPrefixNameConverter();

$nameConverter = new ChainNameConverter(array($camelCaseNameConverter, $orgPrefixNameConverter));
$normalizer = new ObjectNormalizer(null, $nameConverter);

:octocat: 
```
