### PR TITLE
[Command] Fixed methodes comments as phpDoc syntax

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -202,7 +202,7 @@ class Command
      *
      * @return int The command exit code
      *
-     * @throws \Exception
+     * @throws ExceptionInterface
      *
      * @see setCode()
      * @see execute()
@@ -572,6 +572,8 @@ class Command
      * Add a command usage example.
      *
      * @param string $usage The usage, it'll be prefixed with the command name
+     *
+     * @return Command
      */
     public function addUsage($usage)
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | master |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Fix methodes comments (of Command) class as phpDoc syntax:
- replace "@throws \Exception" by "@throws ExceptionInterface" on "run" methode
- add "@return Command" to "addUsage" methode
