### PR TITLE
Fix logical OR in `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "paragonie/random_compat": "~1.0",
         "symfony/polyfill-apcu": "~1.1",
         "symfony/polyfill-mbstring": "~1.1",
-        "twig/twig": "~1.23|~2.0",
+        "twig/twig": "~1.23||~2.0",
         "psr/log": "~1.0"
     },
     "replace": {
@@ -73,7 +73,7 @@
         "monolog/monolog": "~1.3",
         "propel/propel1": "~1.6",
         "ircmaxell/password-compat": "~1.0",
-        "ocramius/proxy-manager": "~0.3.1|~1.0|~2.0"
+        "ocramius/proxy-manager": "~0.3.1||~1.0||~2.0"
     },
     "autoload": {
         "psr-0": { "Symfony\\": "src/" },


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | 2.3 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Composer version ranges states that logical ORs are represented by a double pipe
https://getcomposer.org/doc/articles/versions.md#range
