### PR TITLE
Make Request::isFromTrustedProxy() public.

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1931,7 +1931,15 @@ class Request
         return new static($query, $request, $attributes, $cookies, $files, $server, $content);
     }
 
-    private function isFromTrustedProxy()
+    /**
+     * Indicates whether this request originated from a trusted proxy.
+     *
+     * This can be useful to determine whether or not to trust the
+     * contents of a proxy-specific header.
+     *
+     * @return bool true if the request came from a trusted proxy, false otherwise
+     */
+    public function isFromTrustedProxy()
     {
         return self::$trustedProxies && IpUtils::checkIp($this->server->get('REMOTE_ADDR'), self::$trustedProxies);
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

When adding custom headers to your proxy (in our particular case, a `X-Base-Url` header, but it could be anything), it is necessary to be able to tell whether the request came from a trusted proxy or not. Unfortunately, currently the `isFromTrustedProxy()` method is private, which means you'll need to subclass `Request` and add your own _differently named_ method just to be able to access this information.

This functionality is pretty straightforward, and I don't see a reason to keep this method private so this a trivial pull request to make it public (and it adds a comment so it'll show up in the API docs with proper documentation).
