### PR TITLE
Removed 3.0.0 restriction for the Ldap component in the Security component

### DIFF
--- a/src/Symfony/Component/Security/Core/composer.json
+++ b/src/Symfony/Component/Security/Core/composer.json
@@ -24,7 +24,7 @@
         "symfony/event-dispatcher": "~2.8|~3.0",
         "symfony/expression-language": "~2.8|~3.0",
         "symfony/http-foundation": "~2.8|~3.0",
-        "symfony/ldap": "~2.8|~3.0.0",
+        "symfony/ldap": "~2.8|~3.0",
         "symfony/validator": "~2.8|~3.0",
         "psr/log": "~1.0"
     },

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -37,7 +37,7 @@
         "symfony/routing": "~2.8|~3.0",
         "symfony/validator": "~2.8|~3.0",
         "symfony/expression-language": "~2.8|~3.0",
-        "symfony/ldap": "~2.8|~3.0.0",
+        "symfony/ldap": "~2.8|~3.0",
         "psr/log": "~1.0"
     },
     "suggest": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.0 |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This ticket removes the restriction on version 3.0 of the Ldap component, as the component is now both backward and forward-compatible.

This PR is being made against the `3.0` branch and not in the `2.8` branch as it seems that all other dependencies rely on `~2.8|~3.0.0` for the `2.8` branch.

There will be a conflict with the `master` branch. The versions to use on the `master` branch is `~3.1` for both `composer.json` files, as the authentication provider and the user provider rely on the new interface, and the `LdapInterface::query()` method, instead of `LdapClientInterface::search()`, which is deprecated.
