### PR TITLE
[FrameworkBundle][2.3] Add tests for the Controller class

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTest.php
@@ -39,4 +39,122 @@ class ControllerTest extends TestCase
         $response = $controller->forward('a_controller');
         $this->assertEquals('xml--fr', $response->getContent());
     }
+
+    public function testGenerateUrl()
+    {
+        $router = $this->getMock('Symfony\Component\Routing\RouterInterface');
+        $router->expects($this->once())->method('generate')->willReturn('/foo');
+
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container->expects($this->at(0))->method('get')->will($this->returnValue($router));
+
+        $controller = new Controller();
+        $controller->setContainer($container);
+
+        $this->assertEquals('/foo', $controller->generateUrl('foo'));
+    }
+
+    public function testRedirect()
+    {
+        $controller = new Controller();
+        $response = $controller->redirect('http://dunglas.fr', 301);
+
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertSame('http://dunglas.fr', $response->getTargetUrl());
+        $this->assertSame(301, $response->getStatusCode());
+    }
+
+    public function testRenderViewTemplating()
+    {
+        $templating = $this->getMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $templating->expects($this->once())->method('render')->willReturn('bar');
+
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container->expects($this->at(0))->method('get')->will($this->returnValue($templating));
+
+        $controller = new Controller();
+        $controller->setContainer($container);
+
+        $this->assertEquals('bar', $controller->renderView('foo'));
+    }
+
+    public function testRenderTemplating()
+    {
+        $templating = $this->getMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $templating->expects($this->once())->method('renderResponse')->willReturn(new Response('bar'));
+
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container->expects($this->at(0))->method('get')->will($this->returnValue($templating));
+
+        $controller = new Controller();
+        $controller->setContainer($container);
+
+        $this->assertEquals('bar', $controller->render('foo')->getContent());
+    }
+
+    public function testStreamTemplating()
+    {
+        $templating = $this->getMock('Symfony\Component\Routing\RouterInterface');
+
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container->expects($this->at(0))->method('get')->will($this->returnValue($templating));
+
+        $controller = new Controller();
+        $controller->setContainer($container);
+
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\StreamedResponse', $controller->stream('foo'));
+    }
+
+    public function testCreateNotFoundException()
+    {
+        $controller = new Controller();
+
+        $this->assertInstanceOf('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', $controller->createNotFoundException());
+    }
+
+    public function testCreateForm()
+    {
+        $form = $this->getMock('Symfony\Component\Form\FormInterface');
+
+        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory->expects($this->once())->method('create')->willReturn($form);
+
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container->expects($this->at(0))->method('get')->will($this->returnValue($formFactory));
+
+        $controller = new Controller();
+        $controller->setContainer($container);
+
+        $this->assertEquals($form, $controller->createForm('foo'));
+    }
+
+    public function testCreateFormBuilder()
+    {
+        $formBuilder = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
+
+        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory->expects($this->once())->method('createBuilder')->willReturn($formBuilder);
+
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container->expects($this->at(0))->method('get')->will($this->returnValue($formFactory));
+
+        $controller = new Controller();
+        $controller->setContainer($container);
+
+        $this->assertEquals($formBuilder, $controller->createFormBuilder('foo'));
+    }
+
+    public function testGetDoctrine()
+    {
+        $doctrine = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container->expects($this->at(0))->method('has')->will($this->returnValue(true));
+        $container->expects($this->at(1))->method('get')->will($this->returnValue($doctrine));
+
+        $controller = new Controller();
+        $controller->setContainer($container);
+
+        $this->assertEquals($doctrine, $controller->getDoctrine());
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.3 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Backport tests of #18193 to the `abstract` Controller.
