### PR TITLE
[DX][Finder] Add a simple way to get the first and last result of a Finder

### DIFF
--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -83,8 +83,8 @@ class Finder implements \IteratorAggregate, \Countable
     /**
      * Get the first element in the finder.
      *
-     * @return mixed Returns the first element in the Finder or `null`
-     *               if it is empty.
+     * @return SplFileInfo|null The first element in the Finder or `null`
+     *                          if it is empty.
      */
     public function first()
     {
@@ -94,8 +94,8 @@ class Finder implements \IteratorAggregate, \Countable
     /**
      * Get the last element in the Finder.
      *
-     * @return mixed Returns the last element in the Finder or `null`
-     *               if it is empty.
+     * @return SplFileInfo|null The last element in the Finder or `null`
+     *                          if it is empty.
      */
     public function last()
     {

--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -21,6 +21,7 @@ use Symfony\Component\Finder\Iterator\FilecontentFilterIterator;
 use Symfony\Component\Finder\Iterator\FilenameFilterIterator;
 use Symfony\Component\Finder\Iterator\SizeRangeFilterIterator;
 use Symfony\Component\Finder\Iterator\SortableIterator;
+use Symfony\Component\Finder\Iterator\FinderIterator;
 
 /**
  * Finder allows to build rules to find files and directories.
@@ -77,6 +78,28 @@ class Finder implements \IteratorAggregate, \Countable
     public static function create()
     {
         return new static();
+    }
+
+    /**
+     * Get the first element in the finder.
+     *
+     * @return mixed Returns the first element in the Finder or `null`
+     *               if it is empty.
+     */
+    public function first()
+    {
+        return $this->getIterator()->first();
+    }
+
+    /**
+     * Get the last element in the Finder.
+     *
+     * @return mixed Returns the last element in the Finder or `null`
+     *               if it is empty.
+     */
+    public function last()
+    {
+        return $this->getIterator()->last();
     }
 
     /**
@@ -568,10 +591,13 @@ class Finder implements \IteratorAggregate, \Countable
         }
 
         if (1 === count($this->dirs) && 0 === count($this->iterators)) {
-            return $this->searchInDirectory($this->dirs[0]);
+            $iterator = new FinderIterator();
+            $iterator->append($this->searchInDirectory($this->dirs[0]));
+
+            return $iterator;
         }
 
-        $iterator = new \AppendIterator();
+        $iterator = new FinderIterator();
         foreach ($this->dirs as $dir) {
             $iterator->append($this->searchInDirectory($dir));
         }

--- a/src/Symfony/Component/Finder/Iterator/FinderIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/FinderIterator.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Symfony\Component\Finder\Iterator;
 
 /**
@@ -18,7 +19,7 @@ class FinderIterator extends \AppendIterator
             return $element;
         }
 
-        return null;
+        return;
     }
 
     /**

--- a/src/Symfony/Component/Finder/Iterator/FinderIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/FinderIterator.php
@@ -14,9 +14,11 @@ class FinderIterator extends \AppendIterator
      */
     public function first()
     {
-        foreach ($this as $elem) {
-            return $elem;
+        foreach ($this as $element) {
+            return $element;
         }
+
+        return null;
     }
 
     /**
@@ -26,10 +28,8 @@ class FinderIterator extends \AppendIterator
      */
     public function last()
     {
-        foreach ($this as $elem) {
-            continue;
-        }
+        $elements = iterator_to_array($this);
 
-        return $elem;
+        return empty($elements) ? null : $elements[count($elements) - 1];
     }
 }

--- a/src/Symfony/Component/Finder/Iterator/FinderIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/FinderIterator.php
@@ -1,0 +1,35 @@
+<?php
+namespace Symfony\Component\Finder\Iterator;
+
+/**
+ * @author Ramon Kleiss <ramonkleiss@gmail.com>
+ * @author Royi Eltink
+ */
+class FinderIterator extends \AppendIterator
+{
+    /**
+     * Get the first element in the iterator.
+     *
+     * @return mixed
+     */
+    public function first()
+    {
+        foreach ($this as $elem) {
+            return $elem;
+        }
+    }
+
+    /**
+     * Get the last element in the iterator.
+     *
+     * @return mixed
+     */
+    public function last()
+    {
+        foreach ($this as $elem) {
+            continue;
+        }
+
+        return $elem;
+    }
+}

--- a/src/Symfony/Component/Finder/Iterator/FinderIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/FinderIterator.php
@@ -28,7 +28,7 @@ class FinderIterator extends \AppendIterator
      */
     public function last()
     {
-        $elements = iterator_to_array($this);
+        $elements = array_values(iterator_to_array($this));
 
         return empty($elements) ? null : $elements[count($elements) - 1];
     }

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -20,6 +20,22 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $this->assertInstanceOf('Symfony\Component\Finder\Finder', Finder::create());
     }
 
+    public function testGetFirstElement()
+    {
+        $finder = $this->buildFinder();
+        $finder->in(self::$tmpDir);
+
+        $this->assertEquals('foo', $finder->first()->getFileName());
+    }
+
+    public function testGetLastElement()
+    {
+        $finder = $this->buildFinder();
+        $finder->in(self::$tmpDir);
+
+        $this->assertEquals('toto', $finder->last()->getFileName());
+    }
+
     public function testDirectories()
     {
         $finder = $this->buildFinder();
@@ -309,6 +325,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
 
         $finder = $this->buildFinder();
         $this->assertEquals(2, iterator_count($finder->directories()->in(self::$tmpDir)), 'implements the \IteratorAggregate interface');
+        $this->assertInstanceOf('Symfony\Component\Finder\Iterator\FinderIterator', $finder->directories()->in(self::$tmpDir)->getIterator());
 
         $finder = $this->buildFinder();
         $a = iterator_to_array($finder->directories()->in(self::$tmpDir));

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -23,9 +23,9 @@ class FinderTest extends Iterator\RealIteratorTestCase
     public function testGetFirstElement()
     {
         $finder = $this->buildFinder();
-        $finder->in(self::$tmpDir);
+        $finder->in(self::$tmpDir)->files();
 
-        $this->assertEquals('foo', $finder->first()->getFileName());
+        $this->assertNotNull($finder->files()->first());
     }
 
     public function testGetLastElement()
@@ -33,7 +33,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $finder = $this->buildFinder();
         $finder->in(self::$tmpDir);
 
-        $this->assertEquals('toto', $finder->last()->getFileName());
+        $this->assertNotNull($finder->files()->last());
     }
 
     public function testDirectories()

--- a/src/Symfony/Component/Finder/Tests/Iterator/FinderIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/FinderIteratorTest.php
@@ -18,8 +18,22 @@ class FinderIteratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('a', $this->iterator->first());
     }
 
+    public function testReturnNullAsFirstWhenEmpty()
+    {
+        $iterator = new FinderIterator();
+
+        $this->assertNull($iterator->first());
+    }
+
     public function testLast()
     {
         $this->assertEquals('z', $this->iterator->last());
+    }
+
+    public function testReturnNullAsLastWhenEmpty()
+    {
+        $iterator = new FinderIterator();
+
+        $this->assertNull($iterator->last());
     }
 }

--- a/src/Symfony/Component/Finder/Tests/Iterator/FinderIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/FinderIteratorTest.php
@@ -36,4 +36,12 @@ class FinderIteratorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($iterator->last());
     }
+
+    public function testReturnLastWhenUsingHashTable()
+    {
+        $iterator = new FinderIterator();
+        $iterator->append(new \ArrayIterator(array('foo' => 'bar')));
+
+        $this->assertEquals('bar', $iterator->last());
+    }
 }

--- a/src/Symfony/Component/Finder/Tests/Iterator/FinderIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/FinderIteratorTest.php
@@ -1,0 +1,25 @@
+<?php
+namespace Symfony\Component\Finder\Tests\Iterator;
+
+use Symfony\Component\Finder\Iterator\FinderIterator;
+
+class FinderIteratorTest extends \PHPUnit_Framework_TestCase
+{
+    private $iterator;
+
+    public function setup()
+    {
+        $this->iterator = new FinderIterator();
+        $this->iterator->append(new \ArrayIterator(range('a', 'z')));
+    }
+
+    public function testFirst()
+    {
+        $this->assertEquals('a', $this->iterator->first());
+    }
+
+    public function testLast()
+    {
+        $this->assertEquals('z', $this->iterator->last());
+    }
+}

--- a/src/Symfony/Component/Finder/Tests/Iterator/FinderIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/FinderIteratorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Symfony\Component\Finder\Tests\Iterator;
 
 use Symfony\Component\Finder\Iterator\FinderIterator;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17991 |
| License | MIT |
| Doc PR | - |

This PR adds features to the Finder component. It allows you to get the first (and additionally) the last result in a Finder iterator. It should also close issue #17991.

Example:

``` php
$finder = new Finder();
$finder->files()->in(__DIR__)->first(); // The first file in the directory.
$finder->files()->in(__DIR__)->last(); // Obviously the last file in the directory.
```
