### PR TITLE
[FrameworkBundle][2.8] Add tests for the Controller class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,8 +86,7 @@
         "monolog/monolog": "~1.11",
         "ocramius/proxy-manager": "~0.4|~1.0|~2.0",
         "egulias/email-validator": "~1.2",
-        "phpdocumentor/reflection": "^1.0.7",
-        "twig/twig": "~1.23|~2.0"
+        "phpdocumentor/reflection": "^1.0.7"
     },
     "conflict": {
         "phpdocumentor/reflection": "<1.0.7"

--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,8 @@
         "monolog/monolog": "~1.11",
         "ocramius/proxy-manager": "~0.4|~1.0|~2.0",
         "egulias/email-validator": "~1.2",
-        "phpdocumentor/reflection": "^1.0.7"
+        "phpdocumentor/reflection": "^1.0.7",
+        "twig/twig": "~1.23|~2.0"
     },
     "conflict": {
         "phpdocumentor/reflection": "<1.0.7"

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -49,7 +49,8 @@
         "symfony/validator": "~2.5|~3.0.0",
         "symfony/yaml": "~2.0,>=2.0.5|~3.0.0",
         "symfony/property-info": "~2.8|~3.0.0",
-        "phpdocumentor/reflection": "^1.0.7"
+        "phpdocumentor/reflection": "^1.0.7",
+        "twig/twig": "~1.23|~2.0"
     },
     "suggest": {
         "symfony/console": "For using the console commands",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Backport tests of #18193 to the `abstract` Controller.
