### PR TITLE
Using class name resolution as scalar via "class" keyword (PHP 5.5+)

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -44,7 +44,7 @@ class UniqueEntityValidator extends ConstraintValidator
     public function validate($entity, Constraint $constraint)
     {
         if (!$constraint instanceof UniqueEntity) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\UniqueEntity');
+            throw new UnexpectedTypeException($constraint, UniqueEntity::class);
         }
 
         if (!is_array($constraint->fields) && !is_string($constraint->fields)) {

--- a/src/Symfony/Component/Config/Definition/Builder/NodeBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NodeBuilder.php
@@ -27,13 +27,13 @@ class NodeBuilder implements NodeParentInterface
     public function __construct()
     {
         $this->nodeMapping = array(
-            'variable' => __NAMESPACE__.'\\VariableNodeDefinition',
-            'scalar' => __NAMESPACE__.'\\ScalarNodeDefinition',
-            'boolean' => __NAMESPACE__.'\\BooleanNodeDefinition',
-            'integer' => __NAMESPACE__.'\\IntegerNodeDefinition',
-            'float' => __NAMESPACE__.'\\FloatNodeDefinition',
-            'array' => __NAMESPACE__.'\\ArrayNodeDefinition',
-            'enum' => __NAMESPACE__.'\\EnumNodeDefinition',
+            'variable' => VariableNodeDefinition::class,
+            'scalar' => ScalarNodeDefinition::class,
+            'boolean' => BooleanNodeDefinition::class,
+            'integer' => IntegerNodeDefinition::class,
+            'float' => FloatNodeDefinition::class,
+            'array' => ArrayNodeDefinition::class,
+            'enum' => EnumNodeDefinition::class,
         );
     }
 

--- a/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
+++ b/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
@@ -47,7 +47,7 @@ class XmlUtilsTest extends \PHPUnit_Framework_TestCase
             $this->assertContains('XSD file or callable', $e->getMessage());
         }
 
-        $mock = $this->getMock(__NAMESPACE__.'\Validator');
+        $mock = $this->getMock(Validator::class);
         $mock->expects($this->exactly(2))->method('validate')->will($this->onConsecutiveCalls(false, true));
 
         try {

--- a/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
@@ -140,7 +140,7 @@ class DebugClassLoaderTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('Can only be run on case insensitive filesystems');
         }
 
-        class_exists(__NAMESPACE__.'\Fixtures\CaseMismatch', true);
+        class_exists(Fixtures\CaseMismatch::class, true);
     }
 
     /**
@@ -148,17 +148,17 @@ class DebugClassLoaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testPsr4CaseMismatch()
     {
-        class_exists(__NAMESPACE__.'\Fixtures\Psr4CaseMismatch', true);
+        class_exists(Fixtures\Psr4CaseMismatch::class, true);
     }
 
     public function testNotPsr0()
     {
-        $this->assertTrue(class_exists(__NAMESPACE__.'\Fixtures\NotPSR0', true));
+        $this->assertTrue(class_exists(Fixtures\NotPSR0::class, true));
     }
 
     public function testNotPsr0Bis()
     {
-        $this->assertTrue(class_exists(__NAMESPACE__.'\Fixtures\NotPSR0bis', true));
+        $this->assertTrue(class_exists(Fixtures\NotPSR0bis::class, true));
     }
 
     public function testClassAlias()

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -24,8 +24,8 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('foo', __NAMESPACE__.'\Foo');
-        $barDefinition = $container->register('bar', __NAMESPACE__.'\Bar');
+        $container->register('foo', Foo::class);
+        $barDefinition = $container->register('bar', Bar::class);
         $barDefinition->setAutowired(true);
 
         $pass = new AutowirePass();
@@ -39,8 +39,8 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('b', __NAMESPACE__.'\B');
-        $cDefinition = $container->register('c', __NAMESPACE__.'\C');
+        $container->register('b', B::class);
+        $cDefinition = $container->register('c', C::class);
         $cDefinition->setAutowired(true);
 
         $pass = new AutowirePass();
@@ -54,8 +54,8 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('f', __NAMESPACE__.'\F');
-        $gDefinition = $container->register('g', __NAMESPACE__.'\G');
+        $container->register('f', F::class);
+        $gDefinition = $container->register('g', G::class);
         $gDefinition->setAutowired(true);
 
         $pass = new AutowirePass();
@@ -71,9 +71,9 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('b', __NAMESPACE__.'\B');
-        $container->register('f', __NAMESPACE__.'\F');
-        $hDefinition = $container->register('h', __NAMESPACE__.'\H')->addArgument(new Reference('b'));
+        $container->register('b', B::class);
+        $container->register('f', F::class);
+        $hDefinition = $container->register('h', H::class)->addArgument(new Reference('b'));
         $hDefinition->setAutowired(true);
 
         $pass = new AutowirePass();
@@ -88,9 +88,9 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('b', __NAMESPACE__.'\B');
-        $container->register('f', __NAMESPACE__.'\F');
-        $hDefinition = $container->register('h', __NAMESPACE__.'\H')->addArgument('')->addArgument('');
+        $container->register('b', B::class);
+        $container->register('f', F::class);
+        $hDefinition = $container->register('h', H::class)->addArgument('')->addArgument('');
         $hDefinition->setAutowired(true);
 
         $pass = new AutowirePass();
@@ -109,10 +109,10 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('c1', __NAMESPACE__.'\CollisionA');
-        $container->register('c2', __NAMESPACE__.'\CollisionB');
-        $container->register('c3', __NAMESPACE__.'\CollisionB');
-        $aDefinition = $container->register('a', __NAMESPACE__.'\CannotBeAutowired');
+        $container->register('c1', CollisionA::class);
+        $container->register('c2', CollisionB::class);
+        $container->register('c3', CollisionB::class);
+        $aDefinition = $container->register('a', CannotBeAutowired::class);
         $aDefinition->setAutowired(true);
 
         $pass = new AutowirePass();
@@ -127,9 +127,9 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('a1', __NAMESPACE__.'\Foo');
-        $container->register('a2', __NAMESPACE__.'\Foo');
-        $aDefinition = $container->register('a', __NAMESPACE__.'\NotGuessableArgument');
+        $container->register('a1', Foo::class);
+        $container->register('a2', Foo::class);
+        $aDefinition = $container->register('a', NotGuessableArgument::class);
         $aDefinition->setAutowired(true);
 
         $pass = new AutowirePass();
@@ -144,9 +144,9 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('a1', __NAMESPACE__.'\B');
-        $container->register('a2', __NAMESPACE__.'\B');
-        $aDefinition = $container->register('a', __NAMESPACE__.'\NotGuessableArgumentForSubclass');
+        $container->register('a1', B::class);
+        $container->register('a2', B::class);
+        $aDefinition = $container->register('a', NotGuessableArgumentForSubclass::class);
         $aDefinition->setAutowired(true);
 
         $pass = new AutowirePass();
@@ -172,9 +172,9 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('a1', __NAMESPACE__.'\Foo');
-        $container->register('a2', __NAMESPACE__.'\Foo')->addAutowiringType(__NAMESPACE__.'\Foo');
-        $aDefinition = $container->register('a', __NAMESPACE__.'\NotGuessableArgument');
+        $container->register('a1', Foo::class);
+        $container->register('a2', Foo::class)->addAutowiringType(Foo::class);
+        $aDefinition = $container->register('a', NotGuessableArgument::class);
         $aDefinition->setAutowired(true);
 
         $pass = new AutowirePass();
@@ -188,9 +188,9 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('c1', __NAMESPACE__.'\CollisionA');
-        $container->register('c2', __NAMESPACE__.'\CollisionB')->addAutowiringType(__NAMESPACE__.'\CollisionInterface');
-        $aDefinition = $container->register('a', __NAMESPACE__.'\CannotBeAutowired');
+        $container->register('c1', CollisionA::class);
+        $container->register('c2', CollisionB::class)->addAutowiringType(CollisionInterface::class);
+        $aDefinition = $container->register('a', CannotBeAutowired::class);
         $aDefinition->setAutowired(true);
 
         $pass = new AutowirePass();
@@ -204,7 +204,7 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
     {
         $container = new ContainerBuilder();
 
-        $coopTilleulsDefinition = $container->register('coop_tilleuls', __NAMESPACE__.'\LesTilleuls');
+        $coopTilleulsDefinition = $container->register('coop_tilleuls', LesTilleuls::class);
         $coopTilleulsDefinition->setAutowired(true);
 
         $pass = new AutowirePass();
@@ -214,22 +214,22 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('autowired.symfony\component\dependencyinjection\tests\compiler\dunglas', $container->getDefinition('coop_tilleuls')->getArgument(0));
 
         $dunglasDefinition = $container->getDefinition('autowired.symfony\component\dependencyinjection\tests\compiler\dunglas');
-        $this->assertEquals(__NAMESPACE__.'\Dunglas', $dunglasDefinition->getClass());
+        $this->assertEquals(Dunglas::class, $dunglasDefinition->getClass());
         $this->assertFalse($dunglasDefinition->isPublic());
         $this->assertCount(1, $dunglasDefinition->getArguments());
         $this->assertEquals('autowired.symfony\component\dependencyinjection\tests\compiler\lille', $dunglasDefinition->getArgument(0));
 
         $lilleDefinition = $container->getDefinition('autowired.symfony\component\dependencyinjection\tests\compiler\lille');
-        $this->assertEquals(__NAMESPACE__.'\Lille', $lilleDefinition->getClass());
+        $this->assertEquals(Lille::class, $lilleDefinition->getClass());
     }
 
     public function testResolveParameter()
     {
         $container = new ContainerBuilder();
 
-        $container->setParameter('class_name', __NAMESPACE__.'\Foo');
+        $container->setParameter('class_name', Foo::class);
         $container->register('foo', '%class_name%');
-        $barDefinition = $container->register('bar', __NAMESPACE__.'\Bar');
+        $barDefinition = $container->register('bar', Bar::class);
         $barDefinition->setAutowired(true);
 
         $pass = new AutowirePass();
@@ -242,9 +242,9 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('a', __NAMESPACE__.'\A');
-        $container->register('foo', __NAMESPACE__.'\Foo');
-        $optDefinition = $container->register('opt', __NAMESPACE__.'\OptionalParameter');
+        $container->register('a', A::class);
+        $container->register('foo', Foo::class);
+        $optDefinition = $container->register('opt', OptionalParameter::class);
         $optDefinition->setAutowired(true);
 
         $pass = new AutowirePass();
@@ -260,8 +260,8 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('foo', __NAMESPACE__.'\Foo');
-        $container->register('bar', __NAMESPACE__.'\Bar');
+        $container->register('foo', Foo::class);
+        $container->register('bar', Bar::class);
 
         $pass = new AutowirePass();
         $pass->process($container);
@@ -277,7 +277,7 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
     {
         $container = new ContainerBuilder();
 
-        $aDefinition = $container->register('a', __NAMESPACE__.'\BadTypeHintedArgument');
+        $aDefinition = $container->register('a', BadTypeHintedArgument::class);
         $aDefinition->setAutowired(true);
 
         $pass = new AutowirePass();
@@ -288,9 +288,9 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('abstract_foo', __NAMESPACE__.'\Foo')->setAbstract(true);
-        $container->register('foo', __NAMESPACE__.'\Foo');
-        $container->register('bar', __NAMESPACE__.'\Bar')->setAutowired(true);
+        $container->register('abstract_foo', Foo::class)->setAbstract(true);
+        $container->register('foo', Foo::class);
+        $container->register('bar', Bar::class)->setAutowired(true);
 
         $pass = new AutowirePass();
         $pass->process($container);
@@ -303,10 +303,10 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('foo', __NAMESPACE__.'\Foo');
-        $container->register('a', __NAMESPACE__.'\A');
-        $container->register('dunglas', __NAMESPACE__.'\Dunglas');
-        $container->register('multiple', __NAMESPACE__.'\MultipleArguments')
+        $container->register('foo', Foo::class);
+        $container->register('a', A::class);
+        $container->register('dunglas', Dunglas::class);
+        $container->register('multiple', MultipleArguments::class)
             ->setAutowired(true)
             // set the 2nd (index 1) argument only: autowire the first and third
             // args are: A, Foo, Dunglas
@@ -336,9 +336,9 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('a', __NAMESPACE__.'\A');
-        $container->register('dunglas', __NAMESPACE__.'\Dunglas');
-        $container->register('arg_no_type_hint', __NAMESPACE__.'\MultipleArguments')
+        $container->register('a', A::class);
+        $container->register('dunglas', Dunglas::class);
+        $container->register('arg_no_type_hint', MultipleArguments::class)
             ->setAutowired(true);
 
         $pass = new AutowirePass();
@@ -355,9 +355,9 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('a', __NAMESPACE__.'\A');
-        $container->register('lille', __NAMESPACE__.'\Lille');
-        $container->register('not_really_optional_scalar', __NAMESPACE__.'\MultipleArgumentsOptionalScalarNotReallyOptional')
+        $container->register('a', A::class);
+        $container->register('lille', Lille::class);
+        $container->register('not_really_optional_scalar', MultipleArgumentsOptionalScalarNotReallyOptional::class)
             ->setAutowired(true);
 
         $pass = new AutowirePass();
@@ -368,9 +368,9 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('a', __NAMESPACE__.'\A');
-        $container->register('lille', __NAMESPACE__.'\Lille');
-        $container->register('with_optional_scalar', __NAMESPACE__.'\MultipleArgumentsOptionalScalar')
+        $container->register('a', A::class);
+        $container->register('lille', Lille::class);
+        $container->register('with_optional_scalar', MultipleArgumentsOptionalScalar::class)
             ->setAutowired(true);
 
         $pass = new AutowirePass();
@@ -392,9 +392,9 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('a', __NAMESPACE__.'\A');
-        $container->register('lille', __NAMESPACE__.'\Lille');
-        $container->register('with_optional_scalar_last', __NAMESPACE__.'\MultipleArgumentsOptionalScalarLast')
+        $container->register('a', A::class);
+        $container->register('lille', Lille::class);
+        $container->register('with_optional_scalar_last', MultipleArgumentsOptionalScalarLast::class)
             ->setAutowired(true);
 
         $pass = new AutowirePass();

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -721,8 +721,8 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('a', __NAMESPACE__.'\A');
-        $bDefinition = $container->register('b', __NAMESPACE__.'\B');
+        $container->register('a', A::class);
+        $bDefinition = $container->register('b', B::class);
         $bDefinition->setAutowired(true);
 
         $container->compile();

--- a/src/Symfony/Component/Form/Extension/Core/Type/BirthdayType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/BirthdayType.php
@@ -31,7 +31,7 @@ class BirthdayType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\DateType';
+        return DateType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -415,12 +415,12 @@ class ChoiceType extends AbstractType
         );
 
         if ($options['multiple']) {
-            $choiceType = __NAMESPACE__.'\CheckboxType';
+            $choiceType = CheckboxType::class;
             // The user can check 0 or more checkboxes. If required
             // is true, he is required to check all of them.
             $choiceOpts['required'] = false;
         } else {
-            $choiceType = __NAMESPACE__.'\RadioType';
+            $choiceType = RadioType::class;
         }
 
         $builder->add($name, $choiceType, $choiceOpts);

--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -93,7 +93,7 @@ class CollectionType extends AbstractType
             'prototype' => true,
             'prototype_data' => null,
             'prototype_name' => '__name__',
-            'entry_type' => __NAMESPACE__.'\TextType',
+            'entry_type' => TextType::class,
             'entry_options' => array(),
             'delete_empty' => false,
         ));

--- a/src/Symfony/Component/Form/Extension/Core/Type/CountryType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CountryType.php
@@ -33,7 +33,7 @@ class CountryType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\ChoiceType';
+        return ChoiceType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/CurrencyType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CurrencyType.php
@@ -33,7 +33,7 @@ class CurrencyType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\ChoiceType';
+        return ChoiceType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -161,8 +161,8 @@ class DateTimeType extends AbstractType
                         'time' => $timeParts,
                     )),
                 )))
-                ->add('date', __NAMESPACE__.'\DateType', $dateOptions)
-                ->add('time', __NAMESPACE__.'\TimeType', $timeOptions)
+                ->add('date', DateType::class, $dateOptions)
+                ->add('time', TimeType::class, $timeOptions)
             ;
         }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/EmailType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/EmailType.php
@@ -20,7 +20,7 @@ class EmailType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\TextType';
+        return TextType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/LanguageType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/LanguageType.php
@@ -33,7 +33,7 @@ class LanguageType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\ChoiceType';
+        return ChoiceType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/LocaleType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/LocaleType.php
@@ -33,7 +33,7 @@ class LocaleType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\ChoiceType';
+        return ChoiceType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/PasswordType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/PasswordType.php
@@ -44,7 +44,7 @@ class PasswordType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\TextType';
+        return TextType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/RadioType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/RadioType.php
@@ -20,7 +20,7 @@ class RadioType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\CheckboxType';
+        return CheckboxType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/RangeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/RangeType.php
@@ -20,7 +20,7 @@ class RangeType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\TextType';
+        return TextType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/RepeatedType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/RepeatedType.php
@@ -47,7 +47,7 @@ class RepeatedType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
-            'type' => __NAMESPACE__.'\TextType',
+            'type' => TextType::class,
             'options' => array(),
             'first_options' => array(),
             'second_options' => array(),

--- a/src/Symfony/Component/Form/Extension/Core/Type/ResetType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ResetType.php
@@ -26,7 +26,7 @@ class ResetType extends AbstractType implements ButtonTypeInterface
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\ButtonType';
+        return ButtonType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/SearchType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/SearchType.php
@@ -20,7 +20,7 @@ class SearchType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\TextType';
+        return TextType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/SubmitType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/SubmitType.php
@@ -33,7 +33,7 @@ class SubmitType extends AbstractType implements SubmitButtonTypeInterface
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\ButtonType';
+        return ButtonType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/TextareaType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TextareaType.php
@@ -30,7 +30,7 @@ class TextareaType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\TextType';
+        return TextType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
@@ -39,7 +39,7 @@ class TimezoneType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\ChoiceType';
+        return ChoiceType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/UrlType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/UrlType.php
@@ -43,7 +43,7 @@ class UrlType extends AbstractType
      */
     public function getParent()
     {
-        return __NAMESPACE__.'\TextType';
+        return TextType::class;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -28,7 +28,7 @@ class FormValidator extends ConstraintValidator
     public function validate($form, Constraint $constraint)
     {
         if (!$constraint instanceof Form) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Form');
+            throw new UnexpectedTypeException($constraint, Form::class);
         }
 
         if (!$form instanceof FormInterface) {

--- a/src/Symfony/Component/Form/Tests/Fixtures/FooSubType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/FooSubType.php
@@ -17,6 +17,6 @@ class FooSubType extends AbstractType
 {
     public function getParent()
     {
-        return __NAMESPACE__.'\FooType';
+        return FooType::class;
     }
 }

--- a/src/Symfony/Component/Form/Tests/Fixtures/FooTypeBarExtension.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/FooTypeBarExtension.php
@@ -30,6 +30,6 @@ class FooTypeBarExtension extends AbstractTypeExtension
 
     public function getExtendedType()
     {
-        return __NAMESPACE__.'\FooType';
+        return FooType::class;
     }
 }

--- a/src/Symfony/Component/Form/Tests/Fixtures/FooTypeBazExtension.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/FooTypeBazExtension.php
@@ -23,6 +23,6 @@ class FooTypeBazExtension extends AbstractTypeExtension
 
     public function getExtendedType()
     {
-        return __NAMESPACE__.'\FooType';
+        return FooType::class;
     }
 }

--- a/src/Symfony/Component/Form/Tests/ResolvedFormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/ResolvedFormTypeTest.php
@@ -347,12 +347,12 @@ class ResolvedFormTypeTest extends \PHPUnit_Framework_TestCase
     public function provideTypeClassBlockPrefixTuples()
     {
         return array(
-            array(__NAMESPACE__.'\Fixtures\FooType', 'foo'),
-            array(__NAMESPACE__.'\Fixtures\Foo', 'foo'),
-            array(__NAMESPACE__.'\Fixtures\Type', 'type'),
-            array(__NAMESPACE__.'\Fixtures\FooBarHTMLType', 'foo_bar_html'),
-            array(__NAMESPACE__.'\Fixtures\Foo1Bar2Type', 'foo1_bar2'),
-            array(__NAMESPACE__.'\Fixtures\FBooType', 'f_boo'),
+            array(Fixtures\FooType::class, 'foo'),
+            array(Fixtures\Foo::class, 'foo'),
+            array(Fixtures\Type::class, 'type'),
+            array(Fixtures\FooBarHTMLType::class, 'foo_bar_html'),
+            array(Fixtures\Foo1Bar2Type::class, 'foo1_bar2'),
+            array(Fixtures\FBooType::class, 'f_boo'),
         );
     }
 

--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -242,7 +242,7 @@ class SimpleFormTest extends AbstractFormTest
 
     public function testEmptyIfEmptyCountable()
     {
-        $this->form = new Form(new FormConfigBuilder('name', __NAMESPACE__.'\SimpleFormTest_Countable', $this->dispatcher));
+        $this->form = new Form(new FormConfigBuilder('name', SimpleFormTest_Countable::class, $this->dispatcher));
 
         $this->form->setData(new SimpleFormTest_Countable(0));
 
@@ -251,7 +251,7 @@ class SimpleFormTest extends AbstractFormTest
 
     public function testNotEmptyIfFilledCountable()
     {
-        $this->form = new Form(new FormConfigBuilder('name', __NAMESPACE__.'\SimpleFormTest_Countable', $this->dispatcher));
+        $this->form = new Form(new FormConfigBuilder('name', SimpleFormTest_Countable::class, $this->dispatcher));
 
         $this->form->setData(new SimpleFormTest_Countable(1));
 
@@ -260,7 +260,7 @@ class SimpleFormTest extends AbstractFormTest
 
     public function testEmptyIfEmptyTraversable()
     {
-        $this->form = new Form(new FormConfigBuilder('name', __NAMESPACE__.'\SimpleFormTest_Traversable', $this->dispatcher));
+        $this->form = new Form(new FormConfigBuilder('name', SimpleFormTest_Traversable::class, $this->dispatcher));
 
         $this->form->setData(new SimpleFormTest_Traversable(0));
 
@@ -269,7 +269,7 @@ class SimpleFormTest extends AbstractFormTest
 
     public function testNotEmptyIfFilledTraversable()
     {
-        $this->form = new Form(new FormConfigBuilder('name', __NAMESPACE__.'\SimpleFormTest_Traversable', $this->dispatcher));
+        $this->form = new Form(new FormConfigBuilder('name', SimpleFormTest_Traversable::class, $this->dispatcher));
 
         $this->form->setData(new SimpleFormTest_Traversable(1));
 

--- a/src/Symfony/Component/Process/ProcessBuilder.php
+++ b/src/Symfony/Component/Process/ProcessBuilder.php
@@ -265,7 +265,7 @@ class ProcessBuilder
         $options = $this->options;
 
         $arguments = array_merge($this->prefix, $this->arguments);
-        $script = implode(' ', array_map(array(__NAMESPACE__.'\\ProcessUtils', 'escapeArgument'), $arguments));
+        $script = implode(' ', array_map(array(ProcessUtils::class, 'escapeArgument'), $arguments));
 
         if ($this->inheritEnv) {
             $env = array_replace($_ENV, $_SERVER, $this->env);

--- a/src/Symfony/Component/Security/Core/Validator/Constraints/UserPasswordValidator.php
+++ b/src/Symfony/Component/Security/Core/Validator/Constraints/UserPasswordValidator.php
@@ -36,7 +36,7 @@ class UserPasswordValidator extends ConstraintValidator
     public function validate($password, Constraint $constraint)
     {
         if (!$constraint instanceof UserPassword) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\UserPassword');
+            throw new UnexpectedTypeException($constraint, UserPassword::class);
         }
 
         $user = $this->tokenStorage->getToken()->getUser();

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
@@ -50,7 +50,7 @@ class ArrayDenormalizerTest extends \PHPUnit_Framework_TestCase
                 array('foo' => 'one', 'bar' => 'two'),
                 array('foo' => 'three', 'bar' => 'four'),
             ),
-            __NAMESPACE__.'\ArrayDummy[]'
+            ArrayDummy::class.'[]'
         );
 
         $this->assertEquals(
@@ -66,7 +66,7 @@ class ArrayDenormalizerTest extends \PHPUnit_Framework_TestCase
     {
         $this->serializer->expects($this->once())
             ->method('supportsDenormalization')
-            ->with($this->anything(), __NAMESPACE__.'\ArrayDummy', $this->anything())
+            ->with($this->anything(), ArrayDummy::class, $this->anything())
             ->will($this->returnValue(true));
 
         $this->assertTrue(
@@ -75,7 +75,7 @@ class ArrayDenormalizerTest extends \PHPUnit_Framework_TestCase
                     array('foo' => 'one', 'bar' => 'two'),
                     array('foo' => 'three', 'bar' => 'four'),
                 ),
-                __NAMESPACE__.'\ArrayDummy[]'
+                ArrayDummy::class.'[]'
             )
         );
     }
@@ -102,7 +102,7 @@ class ArrayDenormalizerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(
             $this->denormalizer->supportsDenormalization(
                 array('foo' => 'one', 'bar' => 'two'),
-                __NAMESPACE__.'\ArrayDummy'
+                ArrayDummy::class
             )
         );
     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -37,7 +37,7 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->serializer = $this->getMock(__NAMESPACE__.'\SerializerNormalizer');
+        $this->serializer = $this->getMock(SerializerNormalizer::class);
         $this->normalizer = new GetSetMethodNormalizer();
         $this->normalizer->setSerializer($this->serializer);
     }
@@ -82,7 +82,7 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
     {
         $obj = $this->normalizer->denormalize(
             array('foo' => 'foo', 'bar' => 'bar', 'baz' => true, 'fooBar' => 'foobar'),
-            __NAMESPACE__.'\GetSetDummy',
+            GetSetDummy::class,
             'any'
         );
         $this->assertEquals('foo', $obj->getFoo());
@@ -96,21 +96,21 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
         $data->foo = 'foo';
         $data->bar = 'bar';
         $data->fooBar = 'foobar';
-        $obj = $this->normalizer->denormalize($data, __NAMESPACE__.'\GetSetDummy', 'any');
+        $obj = $this->normalizer->denormalize($data, GetSetDummy::class, 'any');
         $this->assertEquals('foo', $obj->getFoo());
         $this->assertEquals('bar', $obj->getBar());
     }
 
     public function testDenormalizeNull()
     {
-        $this->assertEquals(new GetSetDummy(), $this->normalizer->denormalize(null, __NAMESPACE__.'\GetSetDummy'));
+        $this->assertEquals(new GetSetDummy(), $this->normalizer->denormalize(null, GetSetDummy::class));
     }
 
     public function testConstructorDenormalize()
     {
         $obj = $this->normalizer->denormalize(
             array('foo' => 'foo', 'bar' => 'bar', 'baz' => true, 'fooBar' => 'foobar'),
-            __NAMESPACE__.'\GetConstructorDummy', 'any');
+            GetConstructorDummy::class, 'any');
         $this->assertEquals('foo', $obj->getFoo());
         $this->assertEquals('bar', $obj->getBar());
         $this->assertTrue($obj->isBaz());
@@ -120,7 +120,7 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
     {
         $obj = $this->normalizer->denormalize(
             array('foo' => 'foo', 'bar' => null, 'baz' => true),
-            __NAMESPACE__.'\GetConstructorDummy', 'any');
+            GetConstructorDummy::class, 'any');
         $this->assertEquals('foo', $obj->getFoo());
         $this->assertNull($obj->getBar());
         $this->assertTrue($obj->isBaz());
@@ -130,7 +130,7 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
     {
         $obj = $this->normalizer->denormalize(
             array('foo' => 'test', 'baz' => array(1, 2, 3)),
-            __NAMESPACE__.'\GetConstructorOptionalArgsDummy', 'any');
+            GetConstructorOptionalArgsDummy::class, 'any');
         $this->assertEquals('test', $obj->getFoo());
         $this->assertEquals(array(), $obj->getBar());
         $this->assertEquals(array(1, 2, 3), $obj->getBaz());
@@ -140,7 +140,7 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
     {
         $obj = $this->normalizer->denormalize(
             array('bar' => 'test'),
-            __NAMESPACE__.'\GetConstructorArgsWithDefaultValueDummy', 'any');
+            GetConstructorArgsWithDefaultValueDummy::class, 'any');
         $this->assertEquals(array(), $obj->getFoo());
         $this->assertEquals('test', $obj->getBar());
     }
@@ -174,14 +174,14 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
         $data->bar = 'bar';
         $data->baz = true;
         $data->fooBar = 'foobar';
-        $obj = $this->normalizer->denormalize($data, __NAMESPACE__.'\GetConstructorDummy', 'any');
+        $obj = $this->normalizer->denormalize($data, GetConstructorDummy::class, 'any');
         $this->assertEquals('foo', $obj->getFoo());
         $this->assertEquals('bar', $obj->getBar());
     }
 
     public function testConstructorWArgWithPrivateMutator()
     {
-        $obj = $this->normalizer->denormalize(array('foo' => 'bar'), __NAMESPACE__.'\ObjectConstructorArgsWithPrivateMutatorDummy', 'any');
+        $obj = $this->normalizer->denormalize(array('foo' => 'bar'), ObjectConstructorArgsWithPrivateMutatorDummy::class, 'any');
         $this->assertEquals('bar', $obj->getFoo());
     }
 
@@ -454,7 +454,7 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
 
         $obj = $this->normalizer->denormalize(
             array('bar' => 'bar'),
-            __NAMESPACE__.'\GetSetDummy',
+            GetSetDummy::class,
             null,
             array(GetSetMethodNormalizer::OBJECT_TO_POPULATE => $dummy)
         );
@@ -468,13 +468,13 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals(
             new GetSetDummy(),
-            $this->normalizer->denormalize(array('non_existing' => true), __NAMESPACE__.'\GetSetDummy')
+            $this->normalizer->denormalize(array('non_existing' => true), GetSetDummy::class)
         );
     }
 
     public function testDenormalizeShouldNotSetStaticAttribute()
     {
-        $obj = $this->normalizer->denormalize(array('staticObject' => true), __NAMESPACE__.'\GetSetDummy');
+        $obj = $this->normalizer->denormalize(array('staticObject' => true), GetSetDummy::class);
 
         $this->assertEquals(new GetSetDummy(), $obj);
         $this->assertNull(GetSetDummy::getStaticObject());
@@ -492,7 +492,7 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
 
     public function testPrivateSetter()
     {
-        $obj = $this->normalizer->denormalize(array('foo' => 'foobar'), __NAMESPACE__.'\ObjectWithPrivateSetterDummy');
+        $obj = $this->normalizer->denormalize(array('foo' => 'foobar'), ObjectWithPrivateSetterDummy::class);
         $this->assertEquals('bar', $obj->getFoo());
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -40,7 +40,7 @@ class ObjectNormalizerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->serializer = $this->getMock(__NAMESPACE__.'\ObjectSerializerNormalizer');
+        $this->serializer = $this->getMock(ObjectSerializerNormalizer::class);
         $this->normalizer = new ObjectNormalizer();
         $this->normalizer->setSerializer($this->serializer);
     }
@@ -79,7 +79,7 @@ class ObjectNormalizerTest extends \PHPUnit_Framework_TestCase
     {
         $obj = $this->normalizer->denormalize(
             array('foo' => 'foo', 'bar' => 'bar', 'baz' => true, 'fooBar' => 'foobar'),
-            __NAMESPACE__.'\ObjectDummy',
+            ObjectDummy::class,
             'any'
         );
         $this->assertEquals('foo', $obj->getFoo());
@@ -93,21 +93,21 @@ class ObjectNormalizerTest extends \PHPUnit_Framework_TestCase
         $data->foo = 'foo';
         $data->bar = 'bar';
         $data->fooBar = 'foobar';
-        $obj = $this->normalizer->denormalize($data, __NAMESPACE__.'\ObjectDummy', 'any');
+        $obj = $this->normalizer->denormalize($data, ObjectDummy::class, 'any');
         $this->assertEquals('foo', $obj->getFoo());
         $this->assertEquals('bar', $obj->bar);
     }
 
     public function testDenormalizeNull()
     {
-        $this->assertEquals(new ObjectDummy(), $this->normalizer->denormalize(null, __NAMESPACE__.'\ObjectDummy'));
+        $this->assertEquals(new ObjectDummy(), $this->normalizer->denormalize(null, ObjectDummy::class));
     }
 
     public function testConstructorDenormalize()
     {
         $obj = $this->normalizer->denormalize(
             array('foo' => 'foo', 'bar' => 'bar', 'baz' => true, 'fooBar' => 'foobar'),
-            __NAMESPACE__.'\ObjectConstructorDummy', 'any');
+            ObjectConstructorDummy::class, 'any');
         $this->assertEquals('foo', $obj->getFoo());
         $this->assertEquals('bar', $obj->bar);
         $this->assertTrue($obj->isBaz());
@@ -117,7 +117,7 @@ class ObjectNormalizerTest extends \PHPUnit_Framework_TestCase
     {
         $obj = $this->normalizer->denormalize(
             array('foo' => 'foo', 'bar' => null, 'baz' => true),
-            __NAMESPACE__.'\ObjectConstructorDummy', 'any');
+            ObjectConstructorDummy::class, 'any');
         $this->assertEquals('foo', $obj->getFoo());
         $this->assertNull($obj->bar);
         $this->assertTrue($obj->isBaz());
@@ -127,7 +127,7 @@ class ObjectNormalizerTest extends \PHPUnit_Framework_TestCase
     {
         $obj = $this->normalizer->denormalize(
             array('foo' => 'test', 'baz' => array(1, 2, 3)),
-            __NAMESPACE__.'\ObjectConstructorOptionalArgsDummy', 'any');
+            ObjectConstructorOptionalArgsDummy::class, 'any');
         $this->assertEquals('test', $obj->getFoo());
         $this->assertEquals(array(), $obj->bar);
         $this->assertEquals(array(1, 2, 3), $obj->getBaz());
@@ -137,7 +137,7 @@ class ObjectNormalizerTest extends \PHPUnit_Framework_TestCase
     {
         $obj = $this->normalizer->denormalize(
             array('bar' => 'test'),
-            __NAMESPACE__.'\ObjectConstructorArgsWithDefaultValueDummy', 'any');
+            ObjectConstructorArgsWithDefaultValueDummy::class, 'any');
         $this->assertEquals(array(), $obj->getFoo());
         $this->assertEquals('test', $obj->getBar());
     }
@@ -149,7 +149,7 @@ class ObjectNormalizerTest extends \PHPUnit_Framework_TestCase
         $data->bar = 'bar';
         $data->baz = true;
         $data->fooBar = 'foobar';
-        $obj = $this->normalizer->denormalize($data, __NAMESPACE__.'\ObjectConstructorDummy', 'any');
+        $obj = $this->normalizer->denormalize($data, ObjectConstructorDummy::class, 'any');
         $this->assertEquals('foo', $obj->getFoo());
         $this->assertEquals('bar', $obj->bar);
     }
@@ -433,7 +433,7 @@ class ObjectNormalizerTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals(
             new ObjectDummy(),
-            $this->normalizer->denormalize(array('non_existing' => true), __NAMESPACE__.'\ObjectDummy')
+            $this->normalizer->denormalize(array('non_existing' => true), ObjectDummy::class)
         );
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -57,7 +57,7 @@ class PropertyNormalizerTest extends \PHPUnit_Framework_TestCase
     {
         $obj = $this->normalizer->denormalize(
             array('foo' => 'foo', 'bar' => 'bar'),
-            __NAMESPACE__.'\PropertyDummy',
+            PropertyDummy::class,
             'any'
         );
         $this->assertEquals('foo', $obj->foo);
@@ -68,7 +68,7 @@ class PropertyNormalizerTest extends \PHPUnit_Framework_TestCase
     {
         $obj = $this->normalizer->denormalize(
             array('foo' => 'foo', 'bar' => 'bar'),
-            __NAMESPACE__.'\PropertyConstructorDummy',
+            PropertyConstructorDummy::class,
             'any'
         );
         $this->assertEquals('foo', $obj->getFoo());
@@ -79,7 +79,7 @@ class PropertyNormalizerTest extends \PHPUnit_Framework_TestCase
     {
         $obj = $this->normalizer->denormalize(
             array('foo' => null, 'bar' => 'bar'),
-            __NAMESPACE__.'\PropertyConstructorDummy', '
+            PropertyConstructorDummy::class, '
             any'
         );
         $this->assertNull($obj->getFoo());
@@ -335,13 +335,13 @@ class PropertyNormalizerTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals(
             new PropertyDummy(),
-            $this->normalizer->denormalize(array('non_existing' => true), __NAMESPACE__.'\PropertyDummy')
+            $this->normalizer->denormalize(array('non_existing' => true), PropertyDummy::class)
         );
     }
 
     public function testDenormalizeShouldIgnoreStaticProperty()
     {
-        $obj = $this->normalizer->denormalize(array('outOfScope' => true), __NAMESPACE__.'\PropertyDummy');
+        $obj = $this->normalizer->denormalize(array('outOfScope' => true), PropertyDummy::class);
 
         $this->assertEquals(new PropertyDummy(), $obj);
         $this->assertEquals('out_of_scope', PropertyDummy::$outOfScope);

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -288,7 +288,7 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertTrue(
-            $serializer->supportsDenormalization(array(), __NAMESPACE__.'\Model[]', 'json')
+            $serializer->supportsDenormalization(array(), Model::class.'[]', 'json')
         );
     }
 

--- a/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
@@ -29,7 +29,7 @@ abstract class AbstractComparisonValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof AbstractComparison) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\AbstractComparison');
+            throw new UnexpectedTypeException($constraint, AbstractComparison::class);
         }
 
         if (null === $value) {

--- a/src/Symfony/Component/Validator/Constraints/AllValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AllValidator.php
@@ -26,7 +26,7 @@ class AllValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof All) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\All');
+            throw new UnexpectedTypeException($constraint, All::class);
         }
 
         if (null === $value) {

--- a/src/Symfony/Component/Validator/Constraints/BlankValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/BlankValidator.php
@@ -26,7 +26,7 @@ class BlankValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Blank) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Blank');
+            throw new UnexpectedTypeException($constraint, Blank::class);
         }
 
         if ('' !== $value && null !== $value) {

--- a/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
@@ -29,7 +29,7 @@ class CallbackValidator extends ConstraintValidator
     public function validate($object, Constraint $constraint)
     {
         if (!$constraint instanceof Callback) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Callback');
+            throw new UnexpectedTypeException($constraint, Callback::class);
         }
 
         $method = $constraint->callback;

--- a/src/Symfony/Component/Validator/Constraints/CardSchemeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CardSchemeValidator.php
@@ -91,7 +91,7 @@ class CardSchemeValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof CardScheme) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\CardScheme');
+            throw new UnexpectedTypeException($constraint, CardScheme::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
@@ -31,7 +31,7 @@ class ChoiceValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Choice) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Choice');
+            throw new UnexpectedTypeException($constraint, Choice::class);
         }
 
         if (!is_array($constraint->choices) && !$constraint->callback) {

--- a/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
@@ -26,7 +26,7 @@ class CollectionValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Collection) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Collection');
+            throw new UnexpectedTypeException($constraint, Collection::class);
         }
 
         if (null === $value) {

--- a/src/Symfony/Component/Validator/Constraints/CountryValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CountryValidator.php
@@ -29,7 +29,7 @@ class CountryValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Country) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Country');
+            throw new UnexpectedTypeException($constraint, Country::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/CurrencyValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CurrencyValidator.php
@@ -30,7 +30,7 @@ class CurrencyValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Currency) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Currency');
+            throw new UnexpectedTypeException($constraint, Currency::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
@@ -31,7 +31,7 @@ class DateTimeValidator extends DateValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof DateTime) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\DateTime');
+            throw new UnexpectedTypeException($constraint, DateTime::class);
         }
 
         if (null === $value || '' === $value || $value instanceof \DateTime) {

--- a/src/Symfony/Component/Validator/Constraints/DateValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateValidator.php
@@ -44,7 +44,7 @@ class DateValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Date) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Date');
+            throw new UnexpectedTypeException($constraint, Date::class);
         }
 
         if (null === $value || '' === $value || $value instanceof \DateTime) {

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -37,7 +37,7 @@ class EmailValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Email) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Email');
+            throw new UnexpectedTypeException($constraint, Email::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/ExpressionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionValidator.php
@@ -39,7 +39,7 @@ class ExpressionValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Expression) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Expression');
+            throw new UnexpectedTypeException($constraint, Expression::class);
         }
 
         $variables = array();

--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -41,7 +41,7 @@ class FileValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof File) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\File');
+            throw new UnexpectedTypeException($constraint, File::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/IbanValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IbanValidator.php
@@ -142,7 +142,7 @@ class IbanValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Iban) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Iban');
+            throw new UnexpectedTypeException($constraint, Iban::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/ImageValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ImageValidator.php
@@ -30,7 +30,7 @@ class ImageValidator extends FileValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Image) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Image');
+            throw new UnexpectedTypeException($constraint, Image::class);
         }
 
         $violations = count($this->context->getViolations());

--- a/src/Symfony/Component/Validator/Constraints/IpValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IpValidator.php
@@ -29,7 +29,7 @@ class IpValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Ip) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Ip');
+            throw new UnexpectedTypeException($constraint, Ip::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/IsFalseValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IsFalseValidator.php
@@ -26,7 +26,7 @@ class IsFalseValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof IsFalse) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\IsFalse');
+            throw new UnexpectedTypeException($constraint, IsFalse::class);
         }
 
         if (null === $value || false === $value || 0 === $value || '0' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/IsNullValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IsNullValidator.php
@@ -26,7 +26,7 @@ class IsNullValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof IsNull) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\IsNull');
+            throw new UnexpectedTypeException($constraint, IsNull::class);
         }
 
         if (null !== $value) {

--- a/src/Symfony/Component/Validator/Constraints/IsTrueValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IsTrueValidator.php
@@ -26,7 +26,7 @@ class IsTrueValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof IsTrue) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\IsTrue');
+            throw new UnexpectedTypeException($constraint, IsTrue::class);
         }
 
         if (null === $value) {

--- a/src/Symfony/Component/Validator/Constraints/IsbnValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IsbnValidator.php
@@ -32,7 +32,7 @@ class IsbnValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Isbn) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Isbn');
+            throw new UnexpectedTypeException($constraint, Isbn::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/IssnValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IssnValidator.php
@@ -31,7 +31,7 @@ class IssnValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Issn) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Issn');
+            throw new UnexpectedTypeException($constraint, Issn::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/LanguageValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LanguageValidator.php
@@ -29,7 +29,7 @@ class LanguageValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Language) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Language');
+            throw new UnexpectedTypeException($constraint, Language::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/LengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LengthValidator.php
@@ -26,7 +26,7 @@ class LengthValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Length) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Length');
+            throw new UnexpectedTypeException($constraint, Length::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/LocaleValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LocaleValidator.php
@@ -29,7 +29,7 @@ class LocaleValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Locale) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Locale');
+            throw new UnexpectedTypeException($constraint, Locale::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/LuhnValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LuhnValidator.php
@@ -40,7 +40,7 @@ class LuhnValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Luhn) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Luhn');
+            throw new UnexpectedTypeException($constraint, Luhn::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
@@ -26,7 +26,7 @@ class NotBlankValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof NotBlank) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\NotBlank');
+            throw new UnexpectedTypeException($constraint, NotBlank::class);
         }
 
         if (false === $value || (empty($value) && '0' != $value)) {

--- a/src/Symfony/Component/Validator/Constraints/NotNullValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotNullValidator.php
@@ -26,7 +26,7 @@ class NotNullValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof NotNull) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\NotNull');
+            throw new UnexpectedTypeException($constraint, NotNull::class);
         }
 
         if (null === $value) {

--- a/src/Symfony/Component/Validator/Constraints/RangeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/RangeValidator.php
@@ -26,7 +26,7 @@ class RangeValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Range) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Range');
+            throw new UnexpectedTypeException($constraint, Range::class);
         }
 
         if (null === $value) {

--- a/src/Symfony/Component/Validator/Constraints/RegexValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/RegexValidator.php
@@ -29,7 +29,7 @@ class RegexValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Regex) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Regex');
+            throw new UnexpectedTypeException($constraint, Regex::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/TimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TimeValidator.php
@@ -44,7 +44,7 @@ class TimeValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Time) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Time');
+            throw new UnexpectedTypeException($constraint, Time::class);
         }
 
         if (null === $value || '' === $value || $value instanceof \DateTime) {

--- a/src/Symfony/Component/Validator/Constraints/TypeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TypeValidator.php
@@ -26,7 +26,7 @@ class TypeValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Type) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Type');
+            throw new UnexpectedTypeException($constraint, Type::class);
         }
 
         if (null === $value) {

--- a/src/Symfony/Component/Validator/Constraints/UrlValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UrlValidator.php
@@ -42,7 +42,7 @@ class UrlValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Url) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Url');
+            throw new UnexpectedTypeException($constraint, Url::class);
         }
 
         if (null === $value) {

--- a/src/Symfony/Component/Validator/Tests/Constraints/EqualToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EqualToValidatorTest.php
@@ -62,7 +62,7 @@ class EqualToValidatorTest extends AbstractComparisonValidatorTestCase
             array(new \DateTime('2001-01-01'), 'Jan 1, 2001, 12:00 AM', new \DateTime('2000-01-01'), 'Jan 1, 2000, 12:00 AM', 'DateTime'),
             array(new \DateTime('2001-01-01'), 'Jan 1, 2001, 12:00 AM', '2000-01-01', 'Jan 1, 2000, 12:00 AM', 'DateTime'),
             array(new \DateTime('2001-01-01 UTC'), 'Jan 1, 2001, 12:00 AM', '2000-01-01 UTC', 'Jan 1, 2000, 12:00 AM', 'DateTime'),
-            array(new ComparisonTest_Class(4), '4', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'),
+            array(new ComparisonTest_Class(4), '4', new ComparisonTest_Class(5), '5', ComparisonTest_Class::class),
         );
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorTest.php
@@ -64,8 +64,8 @@ class GreaterThanValidatorTest extends AbstractComparisonValidatorTestCase
             array(new \DateTime('2000/01/01'), 'Jan 1, 2000, 12:00 AM', '2000/01/01', 'Jan 1, 2000, 12:00 AM', 'DateTime'),
             array(new \DateTime('2000/01/01 UTC'), 'Jan 1, 2000, 12:00 AM', '2005/01/01 UTC', 'Jan 1, 2005, 12:00 AM', 'DateTime'),
             array(new \DateTime('2000/01/01 UTC'), 'Jan 1, 2000, 12:00 AM', '2000/01/01 UTC', 'Jan 1, 2000, 12:00 AM', 'DateTime'),
-            array(new ComparisonTest_Class(4), '4', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'),
-            array(new ComparisonTest_Class(5), '5', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'),
+            array(new ComparisonTest_Class(4), '4', new ComparisonTest_Class(5), '5', ComparisonTest_Class::class),
+            array(new ComparisonTest_Class(5), '5', new ComparisonTest_Class(5), '5', ComparisonTest_Class::class),
             array('22', '"22"', '333', '"333"', 'string'),
             array('22', '"22"', '22', '"22"', 'string'),
         );

--- a/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToValidatorTest.php
@@ -80,7 +80,7 @@ class IdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
             array('22', '"22"', '333', '"333"', 'string'),
             array(new \DateTime('2001-01-01'), 'Jan 1, 2001, 12:00 AM', new \DateTime('2001-01-01'), 'Jan 1, 2001, 12:00 AM', 'DateTime'),
             array(new \DateTime('2001-01-01'), 'Jan 1, 2001, 12:00 AM', new \DateTime('1999-01-01'), 'Jan 1, 1999, 12:00 AM', 'DateTime'),
-            array(new ComparisonTest_Class(4), '4', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'),
+            array(new ComparisonTest_Class(4), '4', new ComparisonTest_Class(5), '5', ComparisonTest_Class::class),
         );
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorTest.php
@@ -66,7 +66,7 @@ class LessThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
             array(new \DateTime('2010-01-01'), 'Jan 1, 2010, 12:00 AM', new \DateTime('2000-01-01'), 'Jan 1, 2000, 12:00 AM', 'DateTime'),
             array(new \DateTime('2010-01-01'), 'Jan 1, 2010, 12:00 AM', '2000-01-01', 'Jan 1, 2000, 12:00 AM', 'DateTime'),
             array(new \DateTime('2010-01-01 UTC'), 'Jan 1, 2010, 12:00 AM', '2000-01-01 UTC', 'Jan 1, 2000, 12:00 AM', 'DateTime'),
-            array(new ComparisonTest_Class(5), '5', new ComparisonTest_Class(4), '4', __NAMESPACE__.'\ComparisonTest_Class'),
+            array(new ComparisonTest_Class(5), '5', new ComparisonTest_Class(4), '4', ComparisonTest_Class::class),
             array('c', '"c"', 'b', '"b"', 'string'),
         );
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorTest.php
@@ -64,8 +64,8 @@ class LessThanValidatorTest extends AbstractComparisonValidatorTestCase
             array(new \DateTime('2000-01-01'), 'Jan 1, 2000, 12:00 AM', '2000-01-01', 'Jan 1, 2000, 12:00 AM', 'DateTime'),
             array(new \DateTime('2010-01-01 UTC'), 'Jan 1, 2010, 12:00 AM', '2000-01-01 UTC', 'Jan 1, 2000, 12:00 AM', 'DateTime'),
             array(new \DateTime('2000-01-01 UTC'), 'Jan 1, 2000, 12:00 AM', '2000-01-01 UTC', 'Jan 1, 2000, 12:00 AM', 'DateTime'),
-            array(new ComparisonTest_Class(5), '5', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'),
-            array(new ComparisonTest_Class(6), '6', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'),
+            array(new ComparisonTest_Class(5), '5', new ComparisonTest_Class(5), '5', ComparisonTest_Class::class),
+            array(new ComparisonTest_Class(6), '6', new ComparisonTest_Class(5), '5', ComparisonTest_Class::class),
             array('333', '"333"', '22', '"22"', 'string'),
         );
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToValidatorTest.php
@@ -62,7 +62,7 @@ class NotEqualToValidatorTest extends AbstractComparisonValidatorTestCase
             array(new \DateTime('2000-01-01'), 'Jan 1, 2000, 12:00 AM', new \DateTime('2000-01-01'), 'Jan 1, 2000, 12:00 AM', 'DateTime'),
             array(new \DateTime('2000-01-01'), 'Jan 1, 2000, 12:00 AM', '2000-01-01', 'Jan 1, 2000, 12:00 AM', 'DateTime'),
             array(new \DateTime('2000-01-01 UTC'), 'Jan 1, 2000, 12:00 AM', '2000-01-01 UTC', 'Jan 1, 2000, 12:00 AM', 'DateTime'),
-            array(new ComparisonTest_Class(5), '5', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'),
+            array(new ComparisonTest_Class(5), '5', new ComparisonTest_Class(5), '5', ComparisonTest_Class::class),
         );
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToValidatorTest.php
@@ -78,7 +78,7 @@ class NotIdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
             array(3, '3', 3, '3', 'integer'),
             array('a', '"a"', 'a', '"a"', 'string'),
             array($date, 'Jan 1, 2000, 12:00 AM', $date, 'Jan 1, 2000, 12:00 AM', 'DateTime'),
-            array($object, '2', $object, '2', __NAMESPACE__.'\ComparisonTest_Class'),
+            array($object, '2', $object, '2', ComparisonTest_Class::class),
         );
 
         return $comparisons;

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/StaticMethodLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/StaticMethodLoaderTest.php
@@ -32,7 +32,7 @@ class StaticMethodLoaderTest extends \PHPUnit_Framework_TestCase
     public function testLoadClassMetadataReturnsTrueIfSuccessful()
     {
         $loader = new StaticMethodLoader('loadMetadata');
-        $metadata = new ClassMetadata(__NAMESPACE__.'\StaticLoaderEntity');
+        $metadata = new ClassMetadata(StaticLoaderEntity::class);
 
         $this->assertTrue($loader->loadClassMetadata($metadata));
     }
@@ -48,7 +48,7 @@ class StaticMethodLoaderTest extends \PHPUnit_Framework_TestCase
     public function testLoadClassMetadata()
     {
         $loader = new StaticMethodLoader('loadMetadata');
-        $metadata = new ClassMetadata(__NAMESPACE__.'\StaticLoaderEntity');
+        $metadata = new ClassMetadata(StaticLoaderEntity::class);
 
         $loader->loadClassMetadata($metadata);
 
@@ -58,12 +58,12 @@ class StaticMethodLoaderTest extends \PHPUnit_Framework_TestCase
     public function testLoadClassMetadataDoesNotRepeatLoadWithParentClasses()
     {
         $loader = new StaticMethodLoader('loadMetadata');
-        $metadata = new ClassMetadata(__NAMESPACE__.'\StaticLoaderDocument');
+        $metadata = new ClassMetadata(StaticLoaderDocument::class);
         $loader->loadClassMetadata($metadata);
         $this->assertCount(0, $metadata->getConstraints());
 
         $loader = new StaticMethodLoader('loadMetadata');
-        $metadata = new ClassMetadata(__NAMESPACE__.'\BaseStaticLoaderDocument');
+        $metadata = new ClassMetadata(BaseStaticLoaderDocument::class);
         $loader->loadClassMetadata($metadata);
         $this->assertCount(1, $metadata->getConstraints());
     }
@@ -71,7 +71,7 @@ class StaticMethodLoaderTest extends \PHPUnit_Framework_TestCase
     public function testLoadClassMetadataIgnoresInterfaces()
     {
         $loader = new StaticMethodLoader('loadMetadata');
-        $metadata = new ClassMetadata(__NAMESPACE__.'\StaticLoaderInterface');
+        $metadata = new ClassMetadata(StaticLoaderInterface::class);
 
         $loader->loadClassMetadata($metadata);
 
@@ -81,7 +81,7 @@ class StaticMethodLoaderTest extends \PHPUnit_Framework_TestCase
     public function testLoadClassMetadataInAbstractClasses()
     {
         $loader = new StaticMethodLoader('loadMetadata');
-        $metadata = new ClassMetadata(__NAMESPACE__.'\AbstractStaticLoader');
+        $metadata = new ClassMetadata(AbstractStaticLoader::class);
 
         $loader->loadClassMetadata($metadata);
 
@@ -94,7 +94,7 @@ class StaticMethodLoaderTest extends \PHPUnit_Framework_TestCase
         // strict standards error
         error_reporting(0);
 
-        $metadata = new ClassMetadata(__NAMESPACE__.'\AbstractStaticMethodLoader');
+        $metadata = new ClassMetadata(AbstractStaticMethodLoader::class);
 
         $loader = new StaticMethodLoader('loadMetadata');
         $loader->loadClassMetadata($metadata);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Since Symfony 3.0's minimum required version of PHP is >= 5.5, the codebase can now take advantage of the `ClassName::class` syntax - https://wiki.php.net/rfc/class_name_scalars.  This will result in visually-cleaner code, since the cumbersome `__NAMESPACE__.'\ClassNameAsAString'` concatenations will no longer be necessary.  It will also enable modern IDEs to perform more comprehensive static code analysis (ie. a "Find Usages" command run against a given class will now display all of its `::class` usages).
