### PR TITLE
[DomCrawler] Use XML_ELEMENT_NODE in nodeType check

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -455,7 +455,7 @@ class Crawler extends \SplObjectStorage
         $nodes = array();
 
         while ($node = $node->parentNode) {
-            if (1 === $node->nodeType) {
+            if (XML_ELEMENT_NODE === $node->nodeType) {
                 $nodes[] = $node;
             }
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.3+ |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Making use of the predefined dom constant `XML_ELEMENT_NODE` (which value is `1`) makes more sense while interpreting `parents()` it's functionality. See http://php.net/manual/en/dom.constants.php
