### PR TITLE
Don't send default cache header for 301 redirects

### DIFF
--- a/src/Symfony/Component/HttpFoundation/RedirectResponse.php
+++ b/src/Symfony/Component/HttpFoundation/RedirectResponse.php
@@ -41,6 +41,10 @@ class RedirectResponse extends Response
         if (!$this->isRedirect()) {
             throw new \InvalidArgumentException(sprintf('The HTTP status code is not a redirect ("%s" given).', $status));
         }
+
+        if (301 == $status && !array_key_exists('cache-control', $headers)) {
+            $this->headers->remove('cache-control');
+        }
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/RedirectResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RedirectResponseTest.php
@@ -80,4 +80,17 @@ class RedirectResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
         $this->assertEquals(301, $response->getStatusCode());
     }
+
+    public function testCacheHeaders()
+    {
+        $response = new RedirectResponse('foo.bar', 301);
+        $this->assertFalse($response->headers->hasCacheControlDirective('no-cache'));
+
+        $response = new RedirectResponse('foo.bar', 301, array('cache-control' => 'max-age=86400'));
+        $this->assertFalse($response->headers->hasCacheControlDirective('no-cache'));
+        $this->assertTrue($response->headers->hasCacheControlDirective('max-age'));
+
+        $response = new RedirectResponse('foo.bar', 302);
+        $this->assertTrue($response->headers->hasCacheControlDirective('no-cache'));
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17139 |
| License | MIT |
| Doc PR | see comments from https://github.com/symfony/symfony/issues/17139 |
