### PR TITLE
[PropertyAccess] Remove most ref mismatches to improve perf

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyPath.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPath.php
@@ -91,7 +91,7 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
         $remaining = $propertyPath;
 
         // first element is evaluated differently - no leading dot for properties
-        $pattern = '/^(([^\.\[]+)|\[([^\]]+)\])(.*)/';
+        $pattern = '/^(([^\.\[]++)|\[([^\]]++)\])(.*)/';
 
         while (preg_match($pattern, $remaining, $matches)) {
             if ('' !== $matches[2]) {
@@ -106,7 +106,7 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
 
             $position += strlen($matches[1]);
             $remaining = $matches[4];
-            $pattern = '/^(\.(\w+)|\[([^\]]+)\])(.*)/';
+            $pattern = '/^(\.(\w++)|\[([^\]]++)\])(.*)/';
         }
 
         if ('' !== $remaining) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.3 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This PR is for PHP5 where ref mismatches is a perf pain: it removes all ref mismatches along the "getValue" path, and keeps only the required ones on the "setValue" path. 
