### PR TITLE
[PropertyAccess] Allow brackets for properties and dots for array indexes

### DIFF
--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -113,7 +113,7 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchIndexException
+     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
      */
     public function testGetValueThrowsExceptionIfNotArrayAccess()
     {
@@ -228,7 +228,7 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchIndexException
+     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
      */
     public function testSetValueThrowsExceptionIfNotArrayAccess()
     {
@@ -526,5 +526,19 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
 
         $this->propertyAccessor->setValue($object, 'date', $date);
         $this->assertSame($date, $object->getDate());
+    }
+
+    public function testSetPropertyOnArray()
+    {
+        $array = array();
+        $this->propertyAccessor->setValue($array, 'foo', 'bar');
+        $this->assertSame(array('foo' => 'bar'), $array);
+    }
+
+    public function testSetIndexOnObject()
+    {
+        $object = (object) array('foo' => 123);
+        $this->propertyAccessor->setValue($object, '[foo]', 'bar');
+        $this->assertSame('bar', $object->foo);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

I'm wondering why we currently do not allow `[foo]` to access properties foo of objects, and `foo` for array keys. Here is a PR removing this limitation.
WDYT?

(We could also add a third argument to control strict vs loose behavior if this can't be accepted as is.)
