### PR TITLE
Set $followRedirects default value false

### DIFF
--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -38,7 +38,7 @@ abstract class Client
     protected $crawler;
     protected $insulated = false;
     protected $redirect;
-    protected $followRedirects = true;
+    protected $followRedirects = false;
 
     private $maxRedirects = -1;
     private $redirectCount = 0;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

When $followRedirects is true,  $maxRedirects is -1, and the request return 301 again,  That don't throw Exception!  Program will cashed with segmentation fault!
