### PR TITLE
[Routing] Don't needlessly execute strtr's as they are fairly expensive

### DIFF
--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -76,6 +76,11 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
     );
 
     /**
+     * @var string This regexp matches all characters that are not or should not be encoded by rawurlencode (see list in array above).
+     */
+    protected $urlEncodingSkipRegexp = '#[^-.~a-zA-Z0-9_/@:;,=+!*|]#';
+
+    /**
      * Constructor.
      *
      * @param RouteCollection      $routes  A RouteCollection instance
@@ -182,19 +187,21 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
 
         if ('' === $url) {
             $url = '/';
+        } else if (preg_match($this->urlEncodingSkipRegexp, $url)) {
+            // the contexts base URL is already encoded (see Symfony\Component\HttpFoundation\Request)
+            $url = strtr(rawurlencode($url), $this->decodedChars);
         }
-
-        // the contexts base URL is already encoded (see Symfony\Component\HttpFoundation\Request)
-        $url = strtr(rawurlencode($url), $this->decodedChars);
 
         // the path segments "." and ".." are interpreted as relative reference when resolving a URI; see http://tools.ietf.org/html/rfc3986#section-3.3
         // so we need to encode them as they are not used for this purpose here
         // otherwise we would generate a URI that, when followed by a user agent (e.g. browser), does not match this route
-        $url = strtr($url, array('/../' => '/%2E%2E/', '/./' => '/%2E/'));
-        if ('/..' === substr($url, -3)) {
-            $url = substr($url, 0, -2).'%2E%2E';
-        } elseif ('/.' === substr($url, -2)) {
-            $url = substr($url, 0, -1).'%2E';
+        if(false !== strpos($url, '/.')) {
+            $url = strtr($url, array('/../' => '/%2E%2E/', '/./' => '/%2E/'));
+            if ('/..' === substr($url, -3)) {
+                $url = substr($url, 0, -2).'%2E%2E';
+            } elseif ('/.' === substr($url, -2)) {
+                $url = substr($url, 0, -1).'%2E';
+            }
         }
 
         $schemeAuthority = '';
@@ -268,7 +275,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
         if ($extra && $query = http_build_query($extra, '', '&')) {
             // "/" and "?" can be left decoded for better user experience, see
             // http://tools.ietf.org/html/rfc3986#section-3.4
-            $url .= '?'.strtr($query, array('%2F' => '/'));
+            $url .= '?'.(false === strpos($query, '%2F') ? $query : strtr($query, array('%2F' => '/')));
         }
 
         return $url;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 (based on Tobion's patch for #18227) |
| Bug fix? | refactoring |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | it should |
| Fixed tickets | based on research for ticket  #18106 |
| License | MIT |
| Doc PR |  |

Prior to making ticket #18106, I was actually trying to improve the performance of the routing's UrlGenerator. I initially created a fairly complex alternative, but found out a large part of the improved performance could be achieved by a few trivial changes.
In my tests the runtime of 'doGenerate' was spent largely in two 'strtr'-calls. I.e. preventing those from being executed saved a relatively large part of its runtime.

Based on an assumption that it is fairly uncommon to actually _need_ that combined rawurlencode+strtr-decode and it being even more uncommon to have /.. or /. in a generated url, I made those encoding-steps conditional.

When generating the same url 500 times, the runtime of the full generate-call would drop from around 37-45ms to around 17-27ms depending on how complex the specified url is. Even when the rawurlencode is necessary in a url, it is still unlikely that it also contains /.. or /., so the preg_match and strpos should rarely increase the total time.

Note, this is on a system running php 5.6 with xdebug enabled, so the numbers may be a bit inflated.
