### PR TITLE
[Bridge\PhpUnit] Add "disabled" mode to SYMFONY_DEPRECATIONS_HELPER

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ services:
     - redis-server
 
 before_install:
+    - mkdir /tmp/slapd
+    - slapd -f src/Symfony/Component/Ldap/Tests/Fixtures/conf/slapd.conf -h ldap://localhost:3389 &
     # Matrix lines for intermediate PHP versions are skipped for pull requests
     - if [[ ! $deps && ! $TRAVIS_PHP_VERSION = ${MIN_PHP%.*} && $TRAVIS_PHP_VERSION != hhvm && $TRAVIS_PULL_REQUEST != false ]]; then deps=skip; fi;
     # A sigchild-enabled-PHP is used to test the Process component on the lowest PHP matrix line
@@ -57,9 +59,6 @@ before_install:
     - if [[ $deps != skip && $TRAVIS_REPO_SLUG = symfony/symfony ]]; then cp .composer/* ~/.composer/; composer global install; fi;
     - if [[ $deps != skip ]]; then ./phpunit install; fi;
     - export PHPUNIT=$(readlink -f ./phpunit)
-    - mkdir /tmp/slapd
-    - slapd -f src/Symfony/Component/Ldap/Tests/Fixtures/conf/slapd.conf -h ldap://localhost:3389 &
-    - sleep 3
     - ldapadd -h localhost:3389 -D cn=admin,dc=symfony,dc=com -w symfony -f src/Symfony/Component/Ldap/Tests/Fixtures/data/base.ldif
     - ldapadd -h localhost:3389 -D cn=admin,dc=symfony,dc=com -w symfony -f src/Symfony/Component/Ldap/Tests/Fixtures/data/fixtures.ldif
 

--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -19,6 +19,7 @@ namespace Symfony\Bridge\PhpUnit;
 class DeprecationErrorHandler
 {
     const MODE_WEAK = 'weak';
+    const MODE_DISABLED = 'disabled';
 
     private static $isRegistered = false;
 
@@ -67,11 +68,10 @@ class DeprecationErrorHandler
             'other' => array(),
         );
         $deprecationHandler = function ($type, $msg, $file, $line, $context) use (&$deprecations, $getMode) {
-            if (E_USER_DEPRECATED !== $type) {
+            if (E_USER_DEPRECATED !== $type || DeprecationErrorHandler::MODE_DISABLED === $mode = $getMode()) {
                 return \PHPUnit_Util_ErrorHandler::handleError($type, $msg, $file, $line, $context);
             }
 
-            $mode = $getMode();
             $trace = debug_backtrace(true);
             $group = 'other';
 

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/disabled.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/disabled.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test DeprecationErrorHandler in weak mode
+--FILE--
+<?php
+
+putenv('SYMFONY_DEPRECATIONS_HELPER=disabled');
+putenv('ANSICON');
+putenv('ConEmuANSI');
+putenv('TERM');
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = dirname($vendor);
+}
+define('PHPUNIT_COMPOSER_INSTALL', $vendor.'/vendor/autoload.php');
+require PHPUNIT_COMPOSER_INSTALL;
+require_once __DIR__.'/../../bootstrap.php';
+
+echo (int) set_error_handler('var_dump');
+echo (int) class_exists('Symfony\Bridge\PhpUnit\DeprecationErrorHandler', false);
+
+?>
+--EXPECTF--
+00

--- a/src/Symfony/Bridge/PhpUnit/Tests/DnsMockTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DnsMockTest.php
@@ -13,8 +13,6 @@ namespace Symfony\Bridge\PhpUnit\Tests;
 
 use Symfony\Bridge\PhpUnit\DnsMock;
 
-require_once __DIR__.'/../DnsMock.php';
-
 class DnsMockTest extends \PHPUnit_Framework_TestCase
 {
     protected function tearDown()

--- a/src/Symfony/Bridge/PhpUnit/bootstrap.php
+++ b/src/Symfony/Bridge/PhpUnit/bootstrap.php
@@ -24,4 +24,6 @@ if (!class_exists('Doctrine\Common\Annotations\AnnotationRegistry', false) && cl
     AnnotationRegistry::registerLoader('class_exists');
 }
 
-DeprecationErrorHandler::register(getenv('SYMFONY_DEPRECATIONS_HELPER'));
+if ('disabled' !== getenv('SYMFONY_DEPRECATIONS_HELPER')) {
+    DeprecationErrorHandler::register(getenv('SYMFONY_DEPRECATIONS_HELPER'));
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18222 |
| License | MIT |
| Doc PR | - |

See https://github.com/symfony/symfony/pull/18232/files?w=1

Because we keep adding features to the bridge, so that one could want some features but not the deprecations helper.
In weak mode, this PR also disables colors.
Fetching the SYMFONY_DEPRECATIONS_HELPER env var is also done lazily to workaround old phpunit versions affected by sebastianbergmann/phpunit#1216
