### PR TITLE
[WebProfilerBundle] Added table-layout property to AJAX toolbar css

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -293,6 +293,7 @@
     color: #F5F5F5;
 }
 .sf-toolbar-ajax-requests {
+    table-layout: auto;
     width: 100%;
 }
 .sf-toolbar-ajax-requests td {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

When a page contains the following css:

``` css
table {
    table-layout: fixed;
}
```

Then the AJAX panel has broken table cell spacing.  All the cells are mostly on top of each other.

This patch fixes that situation by overriding the table-layout property for the AJAX panel.
