### PR TITLE
[DependencyInjection] Automatic registration of FQCN services

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
@@ -16,6 +16,7 @@ use Symfony\Bundle\WebProfilerBundle\DependencyInjection\WebProfilerExtension;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\AmbiguousServiceException;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 
@@ -34,6 +35,10 @@ class WebProfilerExtensionTest extends TestCase
             try {
                 $container->get($id);
             } catch (\Exception $e) {
+                if ($e instanceof AmbiguousServiceException) {
+                    continue;
+                }
+
                 $errors[$id] = $e->getMessage();
             }
         }

--- a/src/Symfony/Component/DependencyInjection/AmbiguousDefinition.php
+++ b/src/Symfony/Component/DependencyInjection/AmbiguousDefinition.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection;
+
+class AmbiguousDefinition extends Definition
+{
+    private $services;
+
+    public function __construct($class, array $services)
+    {
+        parent::__construct($class, [$class, $services]);
+        $this->setFactory([AmbiguousService::class, 'throwException']);
+        $this->services = $services;
+    }
+
+    public function getServices()
+    {
+        return $this->services;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/AmbiguousService.php
+++ b/src/Symfony/Component/DependencyInjection/AmbiguousService.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Exception\AmbiguousServiceException;
+
+class AmbiguousService
+{
+    static public function throwException($class, $services)
+    {
+        throw new AmbiguousServiceException($class, $services);
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckAmbiguousReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckAmbiguousReferencesPass.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\AmbiguousDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\AmbiguousReferenceException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @author Martin Hasoň <martin.hason@gmail.com>
+ */
+class CheckAmbiguousReferencesPass implements CompilerPassInterface
+{
+    /** @var ContainerBuilder */
+    private $container;
+
+    public function process(ContainerBuilder $container)
+    {
+        $this->container = $container;
+        foreach ($container->getDefinitions() as $id => $definition) {
+            $this->processArguments($id, $definition->getArguments());
+            $this->processArguments($id, $definition->getMethodCalls());
+            $this->processArguments($id, $definition->getProperties());
+            $this->processFactory($id, $definition->getFactory());
+        }
+    }
+
+    private function processArguments($id, array $arguments)
+    {
+        foreach ($arguments as $argument) {
+            $definition = $argument;
+
+            if (is_array($argument)) {
+                $this->processArguments($id, $argument);
+            } elseif ($argument instanceof Reference) {
+                try {
+                    $definition = $this->container->findDefinition((string) $argument);
+                } catch (ServiceNotFoundException $e) {
+                    continue;
+                }
+            }
+
+            if ($definition instanceof AmbiguousDefinition) {
+                throw new AmbiguousReferenceException($definition->getClass(), $id, $definition->getServices());
+            }
+        }
+    }
+
+    private function processFactory($factory)
+    {
+        if (null === $factory || !is_array($factory) || !$factory[0] instanceof Reference) {
+            return;
+        }
+
+        $definition = $this->container->findDefinition($id = (string) $factory[0]);
+
+        if ($definition instanceof AmbiguousDefinition) {
+            throw new AmbiguousReferenceException($definition->getClass(), $id, $definition->getServices());
+        }
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -48,6 +48,7 @@ class PassConfig
             new DecoratorServicePass(),
             new ResolveParameterPlaceHoldersPass(),
             new CheckDefinitionValidityPass(),
+            new RegisterClassNamedServicesPass(),
             new ResolveReferencesToAliasesPass(),
             new ResolveInvalidReferencesPass(),
             new AutowirePass(),
@@ -57,6 +58,7 @@ class PassConfig
         );
 
         $this->removingPasses = array(
+            new CheckAmbiguousReferencesPass(),
             new RemovePrivateAliasesPass(),
             new RemoveAbstractDefinitionsPass(),
             new ReplaceAliasByActualDefinitionPass(),

--- a/src/Symfony/Component/DependencyInjection/Compiler/RegisterClassNamedServicesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RegisterClassNamedServicesPass.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\AmbiguousDefinition;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * @author Martin Hasoň <martin.hason@gmail.com>
+ */
+class RegisterClassNamedServicesPass implements CompilerPassInterface
+{
+    private $container;
+    private $types;
+    private $definedTypes;
+    private $reflectionClasses = array();
+
+    public function process(ContainerBuilder $container)
+    {
+        $this->container = $container;
+        $this->types = array();
+        $this->definedTypes = array();
+
+        //$this->populateAvailableTypes('service_container', new Definition(Container::class));
+
+        foreach ($container->getDefinitions() as $id => $definition) {
+            $this->populateAvailableTypes($id, $definition);
+        }
+
+        foreach ($this->types as $type => $services) {
+            $this->registerService($type, $services);
+        }
+
+        $this->container = null;
+        $this->types = array();
+        $this->definedTypes = array();
+        $this->reflectionClasses = array();
+    }
+
+    private function populateAvailableTypes($id, Definition $definition)
+    {
+        if ($definition->isAbstract()) {
+            return;
+        }
+
+        if (!$reflectionClass = $this->getReflectionClass($id, $definition)) {
+            return;
+        }
+
+        foreach ($definition->getAutowiringTypes() as $type) {
+            $this->definedTypes[$type] = true;
+            $this->set($type, $id);
+        }
+
+        foreach ($reflectionClass->getInterfaces() as $interfaceClass) {
+            $this->set($interfaceClass->name, $id);
+        }
+
+        do {
+            $this->set($reflectionClass->name, $id);
+        } while ($reflectionClass = $reflectionClass->getParentClass());
+    }
+
+    private function getReflectionClass($id, Definition $definition)
+    {
+        if (isset($this->reflectionClasses[$id])) {
+            return $this->reflectionClasses[$id];
+        }
+
+        if (!$class = $definition->getClass()) {
+            return;
+        }
+
+        $class = $this->container->getParameterBag()->resolveValue($class);
+
+        try {
+            return $this->reflectionClasses[$id] = new \ReflectionClass($class);
+        } catch (\ReflectionException $reflectionException) {
+            return;
+        }
+    }
+
+    private function set($type, $id)
+    {
+        if (isset($this->definedTypes[$type])) {
+            return;
+        }
+
+        $this->types[$type][] = $id;
+    }
+
+    private function registerService($type, array $services)
+    {
+        if (1 === count($services)) {
+            $service = reset($services);
+            //$public = 'service_container' === $service ?: $this->container->getDefinition($service)->isPublic();
+            $public = $this->container->getDefinition($service)->isPublic();
+            $this->container->setAlias($type, new Alias($service, $public));
+        } else {
+            $this->container->setDefinition($type, new AmbiguousDefinition($type, $services));
+        }
+    }
+}
+

--- a/src/Symfony/Component/DependencyInjection/Exception/AmbiguousReferenceException.php
+++ b/src/Symfony/Component/DependencyInjection/Exception/AmbiguousReferenceException.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Exception;
+
+class AmbiguousReferenceException extends InvalidArgumentException
+{
+    public function __construct($type, $service, $services)
+    {
+        parent::__construct(sprintf('Ambiguous services for class "%s". You should use concrete service name instead of class: "%s"', $type, implode('", "', $services)));
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Exception/AmbiguousServiceException.php
+++ b/src/Symfony/Component/DependencyInjection/Exception/AmbiguousServiceException.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Exception;
+
+class AmbiguousServiceException extends RuntimeException
+{
+    public function __construct($type, $services)
+    {
+        parent::__construct(sprintf('Ambiguous services for class "%s". You should use concrete service name instead of class: "%s"', $type, implode('", "', $services)));
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckAmbiguousReferencePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckAmbiguousReferencePassTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class CheckAmbiguousReferencePassTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var ContainerBuilder */
+    private $container;
+
+    protected function setUp()
+    {
+        $this->container = new ContainerBuilder();
+        require_once __DIR__.'/../Fixtures/includes/classes2.php';
+    }
+
+    /**
+     * @expectedException Symfony\Component\DependencyInjection\Exception\AmbiguousReferenceException
+     * @expectedExceptionMessage Ambiguous services for class "Symfony\Component\DependencyInjection\Tests\Compiler\ClassNamedServices\E". You should use concrete service name instead of class: "foo", "bar"
+     */
+    public function testThrowExceptionForAmbiguousDefinitionInArguments()
+    {
+        $container = $this->container;
+        $container->register('foo', ClassNamedServices\E::class);
+        $container->register('bar', ClassNamedServices\E::class);
+
+        $definition = $container->register('baz', ClassNamedServices\A::class);
+        $definition->setArguments(array(new Reference(ClassNamedServices\E::class)));
+
+        $container->compile();
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterClassNamedServicesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterClassNamedServicesPassTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Compiler;
+
+use Symfony\Component\DependencyInjection\AmbiguousDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class RegisterClassNamedServicesPassTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var ContainerBuilder */
+    private $container;
+
+    protected function setUp()
+    {
+        $this->container = new ContainerBuilder();
+        require_once __DIR__.'/../Fixtures/includes/classes2.php';
+    }
+
+    public function testRegisterFqcnServices()
+    {
+        $container = $this->container;
+        $container->register('foo', ClassNamedServices\A::class);
+        $container->compile();
+
+        $serviceIds = $container->getServiceIds();
+        $classes = array_map('strtolower', array(
+            ClassNamedServices\IA::class,
+            ClassNamedServices\IB::class,
+            ClassNamedServices\IC::class,
+            ClassNamedServices\A::class,
+            ClassNamedServices\B::class,
+            ClassNamedServices\C::class,
+        ));
+
+        foreach ($classes as $class) {
+            $this->assertContains($class, $serviceIds);
+        }
+    }
+
+    public function testRegisterFqcnServicesAsAliases()
+    {
+        $container = $this->container;
+        $container->register('foo', ClassNamedServices\A::class);
+        $container->compile();
+
+        $this->assertTrue($container->hasAlias(ClassNamedServices\A::class));
+        $this->assertTrue($container->hasAlias(ClassNamedServices\IC::class));
+        $this->assertEquals($container->findDefinition(ClassNamedServices\B::class), $container->findDefinition(ClassNamedServices\IC::class));
+    }
+
+    public function testNotRegisterForPrivateServices()
+    {
+        $container = $this->container;
+        $definition = $container->register('bar', ClassNamedServices\E::class);
+        $definition->setPublic(false);
+
+        $definition = $container->register('foo', ClassNamedServices\A::class);
+        $definition->setArguments(array(new Reference(ClassNamedServices\E::class)));
+        $container->compile();
+
+        $this->assertFalse($container->hasAlias(ClassNamedServices\E::class));
+        $this->assertInstanceOf(Definition::class, $container->getDefinition('foo')->getArgument(0));
+    }
+
+    public function testRegisterAmbiguousDefinition()
+    {
+        $container = $this->container;
+        $container->register('foo', ClassNamedServices\E::class);
+        $container->register('bar', ClassNamedServices\E::class);
+
+        $container->compile();
+
+        $this->assertInstanceOf(AmbiguousDefinition::class, $container->getDefinition(ClassNamedServices\E::class));
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services13.dot
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services13.dot
@@ -4,7 +4,7 @@ digraph sc {
   edge [fontsize="9" fontname="Arial" color="grey" arrowhead="open" arrowsize="0.5"];
 
   node_foo [label="foo\nFooClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
-  node_bar [label="bar\nBarClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
+  node_bar [label="bar (barclass)\nBarClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_service_container [label="service_container\nSymfony\\Component\\DependencyInjection\\ContainerBuilder\n", shape=record, fillcolor="#9999ff", style="filled"];
   node_foo -> node_bar [label="" style="filled"];
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/classes2.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/classes2.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Compiler\ClassNamedServices;
+
+interface IA {
+}
+
+interface IC
+{
+}
+
+interface IB extends IC
+{
+}
+
+class C implements IB
+{
+}
+
+class B extends C
+{
+}
+
+class A extends B implements IA
+{
+}
+
+class E
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10.php
@@ -29,8 +29,9 @@ class ProjectServiceContainer extends Container
         $this->methodMap = array(
             'test' => 'getTestService',
         );
-
-        $this->aliases = array();
+        $this->aliases = array(
+            'stdclass' => 'test',
+        );
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services12.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services12.php
@@ -33,8 +33,9 @@ class ProjectServiceContainer extends Container
         $this->methodMap = array(
             'test' => 'getTestService',
         );
-
-        $this->aliases = array();
+        $this->aliases = array(
+            'stdclass' => 'test',
+        );
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -28,6 +28,7 @@ class ProjectServiceContainer extends Container
         $this->services = array();
         $this->methodMap = array(
             'bar' => 'getBarService',
+            'bar\\fooclass' => 'getBar_FooclassService',
             'baz' => 'getBazService',
             'configured_service' => 'getConfiguredServiceService',
             'decorator_service' => 'getDecoratorServiceService',
@@ -42,10 +43,12 @@ class ProjectServiceContainer extends Container
             'new_factory_service' => 'getNewFactoryServiceService',
             'request' => 'getRequestService',
             'service_from_static_method' => 'getServiceFromStaticMethodService',
+            'stdclass' => 'getStdclassService',
         );
         $this->aliases = array(
             'alias_for_alias' => 'foo',
             'alias_for_foo' => 'foo',
+            'bazclass' => 'foo.baz',
             'decorated' => 'decorator_service_with_name',
         );
     }
@@ -75,6 +78,19 @@ class ProjectServiceContainer extends Container
         $a->configure($instance);
 
         return $instance;
+    }
+
+    /**
+     * Gets the 'bar\fooclass' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return \Bar\FooClass A Bar\FooClass instance.
+     */
+    protected function getBar_FooclassService()
+    {
+        return $this->services['bar\fooclass'] = \Symfony\Component\DependencyInjection\AmbiguousService::throwException('Bar\\FooClass', array(0 => 'foo', 1 => 'bar', 2 => 'foo_bar', 3 => 'method_call1', 4 => 'service_from_static_method'));
     }
 
     /**
@@ -308,6 +324,19 @@ class ProjectServiceContainer extends Container
     protected function getServiceFromStaticMethodService()
     {
         return $this->services['service_from_static_method'] = \Bar\FooClass::getInstance();
+    }
+
+    /**
+     * Gets the 'stdclass' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return \stdClass A stdClass instance.
+     */
+    protected function getStdclassService()
+    {
+        return $this->services['stdclass'] = \Symfony\Component\DependencyInjection\AmbiguousService::throwException('stdClass', array(0 => 'configured_service', 1 => 'decorator_service', 2 => 'decorator_service_with_name', 3 => 'deprecated_service', 4 => 'decorator_service.inner'));
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

All services can be accessed by FQCN, the same concept as for form types:

``` yaml
# routing.yml
index:
  path: /
  defaults:
    _controller: 'AppBundle\Controller\MyController:index'
```

``` yaml
# services.yml
services:
  my_controller:
    class: AppBundle\Controller\MyController
    arguments:
      - '@Symfony\Bridge\Doctrine\RegistryInterface'
```

``` php
class OldController extends Controller
{
    public function indexAction()
    {
        $em = $this->get(RegistryInterface::class)->getManager();
    }
}
```
