### PR TITLE
[FrameworkBundle] Return the invokable service if its name is the class name

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerResolver.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerResolver.php
@@ -78,7 +78,11 @@ class ControllerResolver extends BaseControllerResolver
      */
     protected function instantiateController($class)
     {
-        $controller = parent::instantiateController($class);
+        if ($this->container->has($class)) {
+            $controller = $this->container->get($class);
+        } else {
+            $controller = parent::instantiateController($class);
+        }
 
         if ($controller instanceof ContainerAwareInterface) {
             $controller->setContainer($this->container);

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerResolver.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerResolver.php
@@ -79,10 +79,10 @@ class ControllerResolver extends BaseControllerResolver
     protected function instantiateController($class)
     {
         if ($this->container->has($class)) {
-            $controller = $this->container->get($class);
-        } else {
-            $controller = parent::instantiateController($class);
+            return $this->container->get($class);
         }
+
+        $controller = parent::instantiateController($class);
 
         if ($controller instanceof ContainerAwareInterface) {
             $controller->setContainer($this->container);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerResolverTest.php
@@ -87,6 +87,8 @@ class ControllerResolverTest extends BaseControllerResolverTest
 
     public function testGetControllerInvokableService()
     {
+        $invokableController = new InvokableController('bar');
+
         $container = $this->createMockContainer();
         $container->expects($this->once())
             ->method('has')
@@ -96,7 +98,7 @@ class ControllerResolverTest extends BaseControllerResolverTest
         $container->expects($this->once())
             ->method('get')
             ->with('foo')
-            ->will($this->returnValue($this))
+            ->will($this->returnValue($invokableController))
         ;
 
         $resolver = $this->createControllerResolver(null, null, $container);
@@ -105,7 +107,33 @@ class ControllerResolverTest extends BaseControllerResolverTest
 
         $controller = $resolver->getController($request);
 
-        $this->assertInstanceOf(get_class($this), $controller);
+        $this->assertEquals($invokableController, $controller);
+    }
+
+    public function testGetControllerInvokableServiceWithClassNameAsName()
+    {
+        $invokableController = new InvokableController('bar');
+        $className = __NAMESPACE__.'\InvokableController';
+
+        $container = $this->createMockContainer();
+        $container->expects($this->once())
+            ->method('has')
+            ->with($className)
+            ->will($this->returnValue(true))
+        ;
+        $container->expects($this->once())
+            ->method('get')
+            ->with($className)
+            ->will($this->returnValue($invokableController))
+        ;
+
+        $resolver = $this->createControllerResolver(null, null, $container);
+        $request = Request::create('/');
+        $request->attributes->set('_controller', $className);
+
+        $controller = $resolver->getController($request);
+
+        $this->assertEquals($invokableController, $controller);
     }
 
     /**
@@ -171,6 +199,17 @@ class ContainerAwareController implements ContainerAwareInterface
     }
 
     public function testAction()
+    {
+    }
+
+    public function __invoke()
+    {
+    }
+}
+
+class InvokableController
+{
+    public function __construct($bar) // mandatory argument to prevent automatic instantiation
     {
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

 if a service is invokable and has the same name than its class name, the controller resolver of FrameworkBundle doesn't retrieve the service and tries to construct a new instance of the class instead.

This is a very rare edge case, but this fix is useful for dunglas/DunglasActionBundle#36: referencing auto-registered controllers following the ADR style in YAML and XML routing files will be more intuitive. 

Currently: `defaults:  { _controller: 'Your\Action\FQN:__invoke' }`, after this fix: `defaults:  { _controller: 'Your\Action\FQN' }`.

This PR also fix a currently useless test.
