### PR TITLE
Fix copy-paste in PHPDoc comment text

### DIFF
--- a/src/Symfony/Component/Form/DataTransformerInterface.php
+++ b/src/Symfony/Component/Form/DataTransformerInterface.php
@@ -58,7 +58,7 @@ interface DataTransformerInterface
      *
      * This method must be able to deal with empty values. Usually this will
      * be an empty string, but depending on your implementation other empty
-     * values are possible as well (such as empty strings). The reasoning behind
+     * values are possible as well (such as NULL). The reasoning behind
      * this is that value transformers must be chainable. If the
      * reverseTransform() method of the first value transformer outputs an
      * empty string, the second value transformer must be able to process that


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.3+ (actually all branches from 2.0) |
| License | MIT |

In http://api.symfony.com/2.3/Symfony/Component/Form/DataTransformerInterface.html, compare the documentation (_emphasis_ mine) respectively for `transform` and for `reverseTransform`:

> Usually this will be _NULL_, but […] other empty values are possible as well (such as _empty strings_).
> Usually this will be _an empty string_, but […] other empty values are possible as well (such as _empty strings_).

This PR corrects the repetition in the latter, giving symmetry:

> Usually this will be _NULL_, but […] other empty values are possible as well (such as _empty strings_).
> Usually this will be _an empty string_, but […] other empty values are possible as well (such as _NULL_).

_Note:_ For now I just changed `empty strings` to `NULL`, which is 9 characters shorter, should I also reformat the affected comment paragraph so that this line and the subsequent ones fill up to 80 columns (as was the case before the change, and is for `transform`)?
