### PR TITLE
[3.1] fix testing deprecation messages

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateNameParserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateNameParserTest.php
@@ -91,7 +91,9 @@ class TemplateNameParserTest extends TestCase
         $deprecations = array();
         set_error_handler(function ($type, $msg) use (&$deprecations) {
             if (E_USER_DEPRECATED !== $type) {
-                throw new \LogicException(sprintf('Unexpected error: "%s".', $msg));
+                restore_error_handler();
+
+                return call_user_func_array('PHPUnit_Util_ErrorHandler::handleError', func_get_args());
             }
 
             $deprecations[] = $msg;

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -519,12 +519,18 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
 
         $deprecations = array();
         set_error_handler(function ($type, $msg) use (&$deprecations) {
-            if (E_USER_DEPRECATED === $type) {
-                $deprecations[] = $msg;
+            if (E_USER_DEPRECATED !== $type) {
+                restore_error_handler();
+
+                return call_user_func_array('PHPUnit_Util_ErrorHandler::handleError', func_get_args());
             }
+
+            $deprecations[] = $msg;
         });
 
         $loader->load('legacy_invalid_alias_definition.xml');
+
+        restore_error_handler();
 
         $this->assertTrue($container->has('bar'));
 
@@ -532,7 +538,5 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('Using the attribute "class" is deprecated for alias definition "bar"', $deprecations[0]);
         $this->assertContains('Using the element "tag" is deprecated for alias definition "bar"', $deprecations[1]);
         $this->assertContains('Using the element "factory" is deprecated for alias definition "bar"', $deprecations[2]);
-
-        restore_error_handler();
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/EsiFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/EsiFragmentRendererTest.php
@@ -32,9 +32,13 @@ class EsiFragmentRendererTest extends \PHPUnit_Framework_TestCase
     {
         $deprecations = array();
         set_error_handler(function ($type, $message) use (&$deprecations) {
-            if (E_USER_DEPRECATED === $type) {
-                $deprecations[] = $message;
+            if (E_USER_DEPRECATED !== $type) {
+                restore_error_handler();
+
+                return call_user_func_array('PHPUnit_Util_ErrorHandler::handleError', func_get_args());
             }
+
+            $deprecations[] = $message;
         });
 
         $strategy = new EsiFragmentRenderer(new Esi(), $this->getInlineStrategy(true), new UriSigner('foo'));
@@ -45,10 +49,10 @@ class EsiFragmentRendererTest extends \PHPUnit_Framework_TestCase
 
         $strategy->render($reference, $request);
 
+        restore_error_handler();
+
         $this->assertCount(1, $deprecations);
         $this->assertContains('Passing objects as part of URI attributes to the ESI and SSI rendering strategies is deprecated', $deprecations[0]);
-
-        restore_error_handler();
     }
 
     public function testRender()

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -260,9 +260,13 @@ class InlineTest extends \PHPUnit_Framework_TestCase
     {
         $deprecations = array();
         set_error_handler(function ($type, $msg) use (&$deprecations) {
-            if (E_USER_DEPRECATED === $type) {
-                $deprecations[] = $msg;
+            if (E_USER_DEPRECATED !== $type) {
+                restore_error_handler();
+
+                return call_user_func_array('PHPUnit_Util_ErrorHandler::handleError', func_get_args());
             }
+
+            $deprecations[] = $msg;
         });
 
         Inline::parse('{ foo: %foo }');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
- always restore the previous error handler
- throw `LogicExcetion` when unexpected error type is triggered
