### PR TITLE
[DependencyInjection] Make it easy to get a service from its FQCN

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Util/ServiceTypeHelper.php
+++ b/src/Symfony/Component/DependencyInjection/Util/ServiceTypeHelper.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Util;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\OutOfBoundsException;
+
+/**
+ * Help finding services corresponding to a type.
+ * Be aware that the map is constructed once, at the first call to {@link getOfType()}.
+ *
+ * @author Guilhem N <egetick@gmail.com>
+ */
+class ServiceTypeHelper
+{
+    private static $resolvedTypes = array();
+    private $container;
+    private $typeMap;
+
+    public function __construct(ContainerBuilder $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * Resolves services implementing a type.
+     *
+     * @param string $class
+     */
+    public function getOfType($class)
+    {
+        if (null === $this->typeMap) {
+            $this->populateAvailableTypes();
+        }
+
+        if (!isset($this->typeMap[$class])) {
+            return array();
+        }
+
+        return $this->typeMap[$class];
+    }
+
+    /**
+     * Resets the type map.
+     */
+    public function reset()
+    {
+        $this->typeMap = null;
+    }
+
+    /**
+     * Populates the list of available types.
+     */
+    private function populateAvailableTypes()
+    {
+        $this->typeMap = array();
+        foreach ($this->container->getDefinitions() as $id => $definition) {
+            $this->populateAvailableType($id, $definition);
+        }
+    }
+
+    /**
+     * Populates the list of available types for a given definition.
+     *
+     * @param string     $id
+     * @param Definition $definition
+     */
+    private function populateAvailableType($id, Definition $definition)
+    {
+        // Never use abstract services
+        if ($definition->isAbstract()) {
+            return;
+        }
+
+        $class = $this->container->getParameterBag()->resolveValue($definition->getClass());
+        if (!$class) {
+            return;
+        }
+
+        if (isset(self::$resolvedTypes[$class])) {
+            $types = self::$resolvedTypes[$class];
+        } else {
+            $types = array();
+            if ($interfaces = class_implements($class)) {
+                $types = $interfaces;
+            }
+
+            do {
+                $types[] = $class;
+            } while ($class = get_parent_class($class));
+
+            self::$resolvedTypes[$class] = $types;
+        }
+
+        foreach ($types as $type) {
+            if (!isset($this->typeMap[$type])) {
+                $this->typeMap[$type] = array();
+            }
+
+            $this->typeMap[$type][] = $id;
+        }
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/pull/18268 |
| License | MIT |
| Doc PR |  |

Alternative approach to https://github.com/symfony/symfony/pull/18268

This PR would allow people to use a new syntax to get their services by class name:

``` php
$container->getOfType(MyClass::class); // MyClass service, throws an exception if several services
$container->getAllOfType(Command::class); // All commands registered
```

This is particularly useful internally (I updated the `AutowiringPass` to show an example). We can also imagine automatically determine the service corresponding to a controller.
This could also be useful in third party bundles which could, for example, determine easily if a service already exists for a class (this is needed in `DunglasActionBundle`).

/cc @hason @Nicofuma @dunglas 
