### PR TITLE
[phpunit] disable prophecy

### DIFF
--- a/phpunit
+++ b/phpunit
@@ -51,6 +51,7 @@ if (!file_exists("$PHPUNIT_DIR/phpunit-$PHPUNIT_VERSION/phpunit") || md5_file(__
     $zip->extractTo(getcwd());
     $zip->close();
     chdir("phpunit-$PHPUNIT_VERSION");
+    passthru("$COMPOSER remove --no-update phpspec/prophecy");
     passthru("$COMPOSER remove --no-update symfony/yaml");
     passthru("$COMPOSER require --dev --no-update symfony/phpunit-bridge \">=3.1@dev\"");
     passthru("$COMPOSER install --prefer-dist --no-progress --ansi", $exit);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.3 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Both Prophecy and Symfony require some phpdocumentor dependencies, but incompatible versions.
Since we don't use Prophecy, let's disable it.
phpunit-mock-objects is forced to v3.1.1 until we fix our test suite (see https://github.com/sebastianbergmann/phpunit-mock-objects/issues/299).
