### PR TITLE
[2.3] fix mocks

### DIFF
--- a/phpunit
+++ b/phpunit
@@ -11,7 +11,7 @@
  */
 
 // Please update when phpunit needs to be reinstalled with fresh deps:
-// Cache-Id-Version: 2016-03-23 14:50 UTC
+// Cache-Id-Version: 2016-03-25 09:45 UTC
 
 use Symfony\Component\Process\ProcessUtils;
 

--- a/src/Symfony/Component/Security/Tests/Acl/Domain/ObjectIdentityTest.php
+++ b/src/Symfony/Component/Security/Tests/Acl/Domain/ObjectIdentityTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Tests\Acl\Domain
 {
     use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
+    use Symfony\Component\Security\Acl\Model\DomainObjectInterface;
 
     class ObjectIdentityTest extends \PHPUnit_Framework_TestCase
     {
@@ -34,17 +35,7 @@ namespace Symfony\Component\Security\Tests\Acl\Domain
 
         public function testFromDomainObjectPrefersInterfaceOverGetId()
         {
-            $domainObject = $this->getMock('Symfony\Component\Security\Acl\Model\DomainObjectInterface');
-            $domainObject
-                ->expects($this->once())
-                ->method('getObjectIdentifier')
-                ->will($this->returnValue('getObjectIdentifier()'))
-            ;
-            $domainObject
-                ->expects($this->never())
-                ->method('getId')
-                ->will($this->returnValue('getId()'))
-            ;
+            $domainObject = new DomainObjectImplementation();
 
             $id = ObjectIdentity::fromDomainObject($domainObject);
             $this->assertEquals('getObjectIdentifier()', $id->getIdentifier());
@@ -119,6 +110,19 @@ namespace Symfony\Component\Security\Tests\Acl\Domain
         public function getId()
         {
             return $this->id;
+        }
+    }
+
+    class DomainObjectImplementation implements DomainObjectInterface
+    {
+        public function getObjectIdentifier()
+        {
+            return 'getObjectIdentifier()';
+        }
+
+        public function getId()
+        {
+            return 'getId()';
         }
     }
 }

--- a/src/Symfony/Component/Security/Tests/Http/Firewall/SwitchUserListenerTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Firewall/SwitchUserListenerTest.php
@@ -53,7 +53,7 @@ class SwitchUserListenerTest extends \PHPUnit_Framework_TestCase
     {
         $this->request->expects($this->any())->method('get')->with('_switch_user')->will($this->returnValue(null));
 
-        $this->event->expects($this->never())->method('setResopnse');
+        $this->event->expects($this->never())->method('setResponse');
         $this->securityContext->expects($this->never())->method('setToken');
 
         $listener = new SwitchUserListener($this->securityContext, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.3 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
- fix a typo in a method name (`setResponse` instead of `seetResopnse`)
- fix mocking a method that is not part of the `DomainObjectInterface`
