### PR TITLE
[2.7] fix mocks

### DIFF
--- a/phpunit
+++ b/phpunit
@@ -11,7 +11,7 @@
  */
 
 // Please update when phpunit needs to be reinstalled with fresh deps:
-// Cache-Id-Version: 2016-03-23 14:50 UTC
+// Cache-Id-Version: 2016-03-25 09:45 UTC
 
 use Symfony\Component\Process\ProcessUtils;
 

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ValidatorExtensionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator;
 
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
+use Symfony\Component\Validator\ValidatorInterface;
 
 class ValidatorExtensionTest extends \PHPUnit_Framework_TestCase
 {
@@ -38,9 +39,11 @@ class ValidatorExtensionTest extends \PHPUnit_Framework_TestCase
             ->method('addPropertyConstraint')
             ->with('children', $this->isInstanceOf('Symfony\Component\Validator\Constraints\Valid'));
 
-        $validator
-            ->expects($this->never())
-            ->method('getMetadataFactory');
+        if ($validator instanceof ValidatorInterface) {
+            $validator
+                ->expects($this->never())
+                ->method('getMetadataFactory');
+        }
 
         $extension = new ValidatorExtension($validator);
         $guesser = $extension->loadTypeGuesser();

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
@@ -55,7 +55,7 @@ class SwitchUserListenerTest extends \PHPUnit_Framework_TestCase
         $this->request->expects($this->any())->method('get')->with('_switch_user')->will($this->returnValue(null));
 
         $this->event->expects($this->never())->method('setResponse');
-        $this->securityContext->expects($this->never())->method('setToken');
+        $this->tokenStorage->expects($this->never())->method('setToken');
 
         $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager);
         $listener->handle($this->event);

--- a/src/Symfony/Component/Templating/Tests/DelegatingEngineTest.php
+++ b/src/Symfony/Component/Templating/Tests/DelegatingEngineTest.php
@@ -66,10 +66,7 @@ class DelegatingEngineTest extends \PHPUnit_Framework_TestCase
      */
     public function testStreamRequiresStreamingEngine()
     {
-        $engine = $this->getEngineMock('template.php', true);
-        $engine->expects($this->never())->method('stream');
-
-        $delegatingEngine = new DelegatingEngine(array($engine));
+        $delegatingEngine = new DelegatingEngine(array(new TestEngine()));
         $delegatingEngine->stream('template.php', array('foo' => 'bar'));
     }
 
@@ -154,4 +151,24 @@ class DelegatingEngineTest extends \PHPUnit_Framework_TestCase
 
 interface MyStreamingEngine extends StreamingEngineInterface, EngineInterface
 {
+}
+
+class TestEngine implements EngineInterface
+{
+    public function render($name, array $parameters = array())
+    {
+    }
+
+    public function exists($name)
+    {
+    }
+
+    public function supports($name)
+    {
+        return true;
+    }
+
+    public function stream()
+    {
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
- check for existance of `setMetadataFactory()` method (this is needed
  for tests run with deps=high as the method was removed in Symfony
  3.0)
- fix mock testing the `EngineInterface` as the `stream()` method cannot
  be mocked when it is does not exist in the mocked interface
