### PR TITLE
[Form] remove useless copy in ChoiceType

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -420,7 +420,7 @@ class ChoiceType extends AbstractType
         $resolver->setAllowedTypes('choice_value', array('null', 'callable', 'string', 'Symfony\Component\PropertyAccess\PropertyPath'));
         $resolver->setAllowedTypes('choice_attr', array('null', 'array', 'callable', 'string', 'Symfony\Component\PropertyAccess\PropertyPath'));
         $resolver->setAllowedTypes('preferred_choices', array('array', '\Traversable', 'callable', 'string', 'Symfony\Component\PropertyAccess\PropertyPath'));
-        $resolver->setAllowedTypes('group_by', array('null', 'array', '\Traversable', 'callable', 'string', 'Symfony\Component\PropertyAccess\PropertyPath'));
+        $resolver->setAllowedTypes('group_by', array('null', 'callable', 'string', 'Symfony\Component\PropertyAccess\PropertyPath'));
     }
 
     /**
@@ -429,21 +429,6 @@ class ChoiceType extends AbstractType
     public function getName()
     {
         return 'choice';
-    }
-
-    private static function flipRecursive($choices, &$output = array())
-    {
-        foreach ($choices as $key => $value) {
-            if (is_array($value)) {
-                $output[$key] = array();
-                self::flipRecursive($value, $output[$key]);
-                continue;
-            }
-
-            $output[$value] = $key;
-        }
-
-        return $output;
     }
 
     /**
@@ -503,14 +488,6 @@ class ChoiceType extends AbstractType
 
     private function createChoiceListView(ChoiceListInterface $choiceList, array $options)
     {
-        // If no explicit grouping information is given, use the structural
-        // information from the "choices" option for creating groups
-        if (!$options['group_by'] && $options['choices']) {
-            $options['group_by'] = !$options['choices_as_values']
-                ? self::flipRecursive($options['choices'])
-                : $options['choices'];
-        }
-
         return $this->choiceListFactory->createView(
             $choiceList,
             $options['preferred_choices'],


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7+ |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | symfony/symfony-docs#6393 |

`ChoiceListFactoryInterface` expected `$groupBy` to be a callable or null, not an array ([ref](https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/Form/ChoiceList/Factory/ChoiceListFactoryInterface.php#L111)).

The factory defaults `groupBy` to `ChoiceListInterface::getStructuredValues()` ([ref](https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php#L122)).

Hence, the copy of the choices array and the recursive flip are useless and may be slowing down performances imho (especially with `EntityType`).
