### PR TITLE
[Form] fix "prototype" not required when parent form is not required

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -55,7 +55,8 @@ class CollectionType extends AbstractType
         ));
 
         if ($form->getConfig()->hasAttribute('prototype')) {
-            $view->vars['prototype'] = $form->getConfig()->getAttribute('prototype')->createView($view);
+            $prototype = $form->getConfig()->getAttribute('prototype');
+            $view->vars['prototype'] = $prototype->setParent($form)->createView($view);
         }
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -221,4 +221,46 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertFalse($form->createView()->vars['required'], 'collection is not required');
         $this->assertFalse($form->createView()->vars['prototype']->vars['required'], '"prototype" should not be required');
     }
+
+    public function testPrototypeSetNotRequiredIfParentNotRequired()
+    {
+        $child = $this->factory->create('collection', array(), array(
+            'type' => 'file',
+            'allow_add' => true,
+            'prototype' => true,
+            'prototype_name' => '__test__',
+        ));
+
+        $parent = $this->factory->create('form', array(), array(
+            'required' => false,
+        ));
+
+        $child->setParent($parent);
+        $this->assertFalse($parent->createView()->vars['required'], 'Parent is not required');
+        $this->assertFalse($child->createView()->vars['required'], 'Child is not required');
+        $this->assertFalse($child->createView()->vars['prototype']->vars['required'], '"Prototype" should not be required');
+    }
+
+    public function testPrototypeNotOverrideRequiredByEntryOptionsInFavorOfParent()
+    {
+        $child = $this->factory->create('collection', array(), array(
+            'type' => 'file',
+            'allow_add' => true,
+            'prototype' => true,
+            'prototype_name' => '__test__',
+            'options' => array(
+                'required' => true,
+            ),
+        ));
+
+        $parent = $this->factory->create('form', array(), array(
+            'required' => false,
+        ));
+
+        $child->setParent($parent);
+
+        $this->assertFalse($parent->createView()->vars['required'], 'Parent is not required');
+        $this->assertFalse($child->createView()->vars['required'], 'Child is not required');
+        $this->assertFalse($child->createView()->vars['prototype']->vars['required'], '"Prototype" should not be required');
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.3+ |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18311 |
| License | MIT |
| Doc PR | ~ |
