### PR TITLE
[Browserkit][Form][Tests] Add submitWithAdditionalValues() method in Symfony\Component\BrowserK…

### DIFF
--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -263,6 +263,31 @@ abstract class Client
     }
 
     /**
+     * Submits a form with additional values.
+     *
+     * @param Form  $form             A Form instance
+     * @param array $values           An array of form field values
+     * @param array $additionalValues An array of additional field values
+     *
+     * @return Crawler
+     */
+    public function submitWithAdditionalValues(Form $form, array $values = array(), array $additionalValues = array())
+    {
+        $form->setValues($values);
+
+        $values = $form->getPhpValues();
+
+        if (!empty($additionalValues)) {
+            $values = array_merge(
+                $values,
+                $form->convertFieldsToArray($additionalValues)
+            );
+        }
+
+        return $this->request($form->getMethod(), $form->getUri(), $values, $form->getPhpFiles());
+    }
+
+    /**
      * Calls a URI.
      *
      * @param string $method        The request method

--- a/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
@@ -286,6 +286,52 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://www.example.com/foo', $client->getRequest()->getUri(), '->submit() submit forms');
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Unreachable field "foo"
+     */
+    public function testSubmitMissingField()
+    {
+        $client = new TestClient();
+        $client->setNextResponse(new Response('<html><form action="/foo"><input type="submit" /></form></html>'));
+        $crawler = $client->request('GET', 'http://www.example.com/foo/foobar');
+
+        $client->submit($crawler->filter('input')->form(), array('foo[0]' => 'bar'));
+    }
+
+    /**
+     * Submit the same data that in testSubmitMissingField() but
+     * without triggering an Exception.
+     */
+    public function testSubmitWithAdditionalValues()
+    {
+        $client = new TestClient();
+        $client->setNextResponse(new Response('<html><form action="/foo"><input type="submit" /></form></html>'));
+        $crawler = $client->request('GET', 'http://www.example.com/foo/foobar');
+
+        $additionalValues = array('foo[0]' => 'bar');
+        // The field "foo[0]" will be converted to an array "foo => 0".
+        $expectedParameters = array('foo' => array('0' => 'bar'));
+
+        $client->submitWithAdditionalValues($crawler->filter('input')->form(), array(), $additionalValues);
+
+        $this->assertEquals('http://www.example.com/foo', $client->getRequest()->getUri(), '->submit() submit forms');
+        $this->assertEquals($expectedParameters, $client->getRequest()->getParameters(), 'parameters have not been added');
+
+        // Add an element to an existing collection.
+        $client->setNextResponse(new Response('<html><form action="/foo" method="post"><input type="text" name="foo[0][name]" value="foo" /><input type="text" name="foo[1][name]" value="bar" /><input type="submit" /></form></html>'));
+        $crawler = $client->request('GET', 'http://www.example.com/foo/foobar');
+
+        $additionalValues = array('foo[2][name]' => 'foobar');
+        $expectedParameters = array('foo' => array('2' => array('name' => 'foobar')));
+
+        $form = $crawler->filter('input[type=submit]')->form();
+        $client->submitWithAdditionalValues($form, $form->getPhpValues(), $additionalValues);
+
+        $this->assertEquals('http://www.example.com/foo', $client->getRequest()->getUri(), '->submit() submit forms');
+        $this->assertEquals($expectedParameters, $client->getRequest()->getParameters(), 'parameters have not been added');
+    }
+
     public function testSubmitPreserveAuth()
     {
         $client = new TestClient(array('PHP_AUTH_USER' => 'foo', 'PHP_AUTH_PW' => 'bar'));

--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -130,17 +130,16 @@ class Form extends Link implements \ArrayAccess
     }
 
     /**
-     * Gets the field values as PHP.
-     *
      * This method converts fields with the array notation
      * (like foo[bar] to arrays) like PHP does.
      *
      * @return array An array of field values.
      */
-    public function getPhpValues()
+    public function convertFieldsToArray($fields)
     {
         $values = array();
-        foreach ($this->getValues() as $name => $value) {
+
+        foreach ($fields as $name => $value) {
             $qs = http_build_query(array($name => $value), '', '&');
             if (!empty($qs)) {
                 parse_str($qs, $expandedValue);
@@ -150,6 +149,16 @@ class Form extends Link implements \ArrayAccess
         }
 
         return $values;
+    }
+
+    /**
+     * Gets the field values as PHP.
+     *
+     * @return array An array of field values.
+     */
+    public function getPhpValues()
+    {
+        return $this->convertFieldsToArray($this->getValues());
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #3824, #4124 |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/6403 |

This PR adds a `submitWithAdditionalValues()` method which you can use in order to submit a form with additional data during tests.

For example, when you have a `CollectionType` with the `'allow_add' => true,` option, you can't change the values with `$form[FIELD_NAME][…] = 'foo'`, it triggers an error.

With the `submitWithAdditionalValues()` method you can add some fields to the request:

``` php
    $client->submitWithAdditionalValues(
        $crawler->filter('input')->form(),
        array(),
        // New values:
        array('foo[0]' => 'bar'),
    );
```

Where `array('foo[0]' => 'bar'),` is an array which values won't be checked (Symfony won't check if the field exist).
