### PR TITLE
[Form] added `CallbackChoiceLoader` and refactored ChoiceType's children

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.2.0
+-----
+
+ * added `CallbackChoiceLoader`
+
 3.1.0
 -----
 

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * added `CallbackChoiceLoader`
+ * implemented `ChoiceLoaderInterface` in children of `ChoiceType`
 
 3.1.0
 -----

--- a/src/Symfony/Component/Form/ChoiceList/Loader/CallbackChoiceLoader.php
+++ b/src/Symfony/Component/Form/ChoiceList/Loader/CallbackChoiceLoader.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\ChoiceList\Loader;
+
+use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
+
+/**
+ * Loads an {@link ArrayChoiceList} instance from a callable returning an array of choices.
+ *
+ * @author Jules Pietri <jules@heahprod.com>
+ */
+class CallbackChoiceLoader implements ChoiceLoaderInterface
+{
+    private $callback;
+
+    /**
+     * The loaded choice list.
+     *
+     * @var ArrayChoiceList
+     */
+    private $choiceList;
+
+    /**
+     * @param callable $callback The callable returning an array of choices
+     */
+    public function __construct(callable $callback)
+    {
+        $this->callback = $callback;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadChoiceList($value = null)
+    {
+        if (null !== $this->choiceList) {
+            return $this->choiceList;
+        }
+
+        return $this->choiceList = new ArrayChoiceList(call_user_func($this->callback), $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadChoicesForValues(array $values, $value = null)
+    {
+        // Optimize
+        if (empty($values)) {
+            return array();
+        }
+
+        return $this->loadChoiceList($value)->getChoicesForValues($values);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadValuesForChoices(array $choices, $value = null)
+    {
+        // Optimize
+        if (empty($choices)) {
+            return array();
+        }
+
+        return $this->loadChoiceList($value)->getValuesForChoices($choices);
+    }
+}

--- a/src/Symfony/Component/Form/Extension/Core/Type/CountryType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CountryType.php
@@ -12,18 +12,31 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
+use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\Intl\Intl;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class CountryType extends AbstractType
+class CountryType extends AbstractType implements ChoiceLoaderInterface
 {
+    /**
+     * Country loaded choice list.
+     *
+     * The choices are lazy loaded and generated from the Intl component.
+     *
+     * {@link \Symfony\Component\Intl\Intl::getRegionBundle()}.
+     *
+     * @var ArrayChoiceList
+     */
+    private $choiceList;
+
     /**
      * {@inheritdoc}
      */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
-            'choices' => array_flip(Intl::getRegionBundle()->getCountryNames()),
+            'choice_loader' => $this,
             'choice_translation_domain' => false,
         ));
     }
@@ -42,5 +55,53 @@ class CountryType extends AbstractType
     public function getBlockPrefix()
     {
         return 'country';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadChoiceList($value = null)
+    {
+        if (null !== $this->choiceList) {
+            return $this->choiceList;
+        }
+
+        return $this->choiceList = new ArrayChoiceList(array_flip(Intl::getRegionBundle()->getCountryNames()), $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadChoicesForValues(array $values, $value = null)
+    {
+        // Optimize
+        if (empty($values)) {
+            return array();
+        }
+
+        // If no callable is set, values are the same as choices
+        if (null === $value) {
+            return $values;
+        }
+
+        return $this->loadChoiceList($value)->getChoicesForValues($values);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadValuesForChoices(array $choices, $value = null)
+    {
+        // Optimize
+        if (empty($choices)) {
+            return array();
+        }
+
+        // If no callable is set, choices are the same as values
+        if (null === $value) {
+            return $choices;
+        }
+
+        return $this->loadChoiceList($value)->getValuesForChoices($choices);
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/Type/CurrencyType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CurrencyType.php
@@ -12,18 +12,31 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
+use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\Intl\Intl;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class CurrencyType extends AbstractType
+class CurrencyType extends AbstractType implements ChoiceLoaderInterface
 {
+    /**
+     * Currency loaded choice list.
+     *
+     * The choices are lazy loaded and generated from the Intl component.
+     *
+     * {@link \Symfony\Component\Intl\Intl::getCurrencyBundle()}.
+     *
+     * @var ArrayChoiceList
+     */
+    private $choiceList;
+
     /**
      * {@inheritdoc}
      */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
-            'choices' => array_flip(Intl::getCurrencyBundle()->getCurrencyNames()),
+            'choice_loader' => $this,
             'choice_translation_domain' => false,
         ));
     }
@@ -42,5 +55,53 @@ class CurrencyType extends AbstractType
     public function getBlockPrefix()
     {
         return 'currency';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadChoiceList($value = null)
+    {
+        if (null !== $this->choiceList) {
+            return $this->choiceList;
+        }
+
+        return $this->choiceList = new ArrayChoiceList(array_flip(Intl::getCurrencyBundle()->getCurrencyNames()), $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadChoicesForValues(array $values, $value = null)
+    {
+        // Optimize
+        if (empty($values)) {
+            return array();
+        }
+
+        // If no callable is set, values are the same as choices
+        if (null === $value) {
+            return $values;
+        }
+
+        return $this->loadChoiceList($value)->getChoicesForValues($values);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadValuesForChoices(array $choices, $value = null)
+    {
+        // Optimize
+        if (empty($choices)) {
+            return array();
+        }
+
+        // If no callable is set, choices are the same as values
+        if (null === $value) {
+            return $choices;
+        }
+
+        return $this->loadChoiceList($value)->getValuesForChoices($choices);
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/Type/LanguageType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/LanguageType.php
@@ -12,18 +12,31 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
+use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\Intl\Intl;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class LanguageType extends AbstractType
+class LanguageType extends AbstractType implements ChoiceLoaderInterface
 {
+    /**
+     * Language loaded choice list.
+     *
+     * The choices are lazy loaded and generated from the Intl component.
+     *
+     * {@link \Symfony\Component\Intl\Intl::getLanguageBundle()}.
+     *
+     * @var ArrayChoiceList
+     */
+    private $choiceList;
+
     /**
      * {@inheritdoc}
      */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
-            'choices' => array_flip(Intl::getLanguageBundle()->getLanguageNames()),
+            'choice_loader' => $this,
             'choice_translation_domain' => false,
         ));
     }
@@ -42,5 +55,53 @@ class LanguageType extends AbstractType
     public function getBlockPrefix()
     {
         return 'language';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadChoiceList($value = null)
+    {
+        if (null !== $this->choiceList) {
+            return $this->choiceList;
+        }
+
+        return $this->choiceList = new ArrayChoiceList(array_flip(Intl::getLanguageBundle()->getLanguageNames()), $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadChoicesForValues(array $values, $value = null)
+    {
+        // Optimize
+        if (empty($values)) {
+            return array();
+        }
+
+        // If no callable is set, values are the same as choices
+        if (null === $value) {
+            return $values;
+        }
+
+        return $this->loadChoiceList($value)->getChoicesForValues($values);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadValuesForChoices(array $choices, $value = null)
+    {
+        // Optimize
+        if (empty($choices)) {
+            return array();
+        }
+
+        // If no callable is set, choices are the same as values
+        if (null === $value) {
+            return $choices;
+        }
+
+        return $this->loadChoiceList($value)->getValuesForChoices($choices);
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/Type/LocaleType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/LocaleType.php
@@ -12,18 +12,31 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
+use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\Intl\Intl;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class LocaleType extends AbstractType
+class LocaleType extends AbstractType implements ChoiceLoaderInterface
 {
+    /**
+     * Locale loaded choice list.
+     *
+     * The choices are lazy loaded and generated from the Intl component.
+     *
+     * {@link \Symfony\Component\Intl\Intl::getLocaleBundle()}.
+     *
+     * @var ArrayChoiceList
+     */
+    private $choiceList;
+
     /**
      * {@inheritdoc}
      */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
-            'choices' => array_flip(Intl::getLocaleBundle()->getLocaleNames()),
+            'choice_loader' => $this,
             'choice_translation_domain' => false,
         ));
     }
@@ -42,5 +55,53 @@ class LocaleType extends AbstractType
     public function getBlockPrefix()
     {
         return 'locale';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadChoiceList($value = null)
+    {
+        if (null !== $this->choiceList) {
+            return $this->choiceList;
+        }
+
+        return $this->choiceList = new ArrayChoiceList(array_flip(Intl::getLocaleBundle()->getLocaleNames()), $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadChoicesForValues(array $values, $value = null)
+    {
+        // Optimize
+        if (empty($values)) {
+            return array();
+        }
+
+        // If no callable is set, values are the same as choices
+        if (null === $value) {
+            return $values;
+        }
+
+        return $this->loadChoiceList($value)->getChoicesForValues($values);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadValuesForChoices(array $choices, $value = null)
+    {
+        // Optimize
+        if (empty($choices)) {
+            return array();
+        }
+
+        // If no callable is set, choices are the same as values
+        if (null === $value) {
+            return $choices;
+        }
+
+        return $this->loadChoiceList($value)->getValuesForChoices($choices);
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
@@ -12,16 +12,20 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
+use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class TimezoneType extends AbstractType
+class TimezoneType extends AbstractType implements ChoiceLoaderInterface
 {
     /**
-     * Stores the available timezone choices.
+     * Timezone loaded choice list.
      *
-     * @var array
+     * The choices are generated from the ICU function \DateTimeZone::listIdentifiers().
+     *
+     * @var ArrayChoiceList
      */
-    private static $timezones;
+    private $choiceList;
 
     /**
      * {@inheritdoc}
@@ -29,7 +33,7 @@ class TimezoneType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
-            'choices' => self::getTimezones(),
+            'choice_loader' => $this,
             'choice_translation_domain' => false,
         ));
     }
@@ -51,38 +55,79 @@ class TimezoneType extends AbstractType
     }
 
     /**
-     * Returns the timezone choices.
-     *
-     * The choices are generated from the ICU function
-     * \DateTimeZone::listIdentifiers(). They are cached during a single request,
-     * so multiple timezone fields on the same page don't lead to unnecessary
-     * overhead.
+     * {@inheritdoc}
+     */
+    public function loadChoiceList($value = null)
+    {
+        if (null !== $this->choiceList) {
+            return $this->choiceList;
+        }
+
+        return $this->choiceList = new ArrayChoiceList($this->getTimezones(), $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadChoicesForValues(array $values, $value = null)
+    {
+        // Optimize
+        if (empty($values)) {
+            return array();
+        }
+
+        // If no callable is set, values are the same as choices
+        if (null === $value) {
+            return $values;
+        }
+
+        return $this->loadChoiceList($value)->getChoicesForValues($values);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadValuesForChoices(array $choices, $value = null)
+    {
+        // Optimize
+        if (empty($choices)) {
+            return array();
+        }
+
+        // If no callable is set, choices are the same as values
+        if (null === $value) {
+            return $choices;
+        }
+
+        return $this->loadChoiceList($value)->getValuesForChoices($choices);
+    }
+
+    /**
+     * Returns a normalized array of timezone choices.
      *
      * @return array The timezone choices
      */
     private static function getTimezones()
     {
-        if (null === self::$timezones) {
-            self::$timezones = array();
+        $timezones = array();
 
-            foreach (\DateTimeZone::listIdentifiers() as $timezone) {
-                $parts = explode('/', $timezone);
+        foreach (\DateTimeZone::listIdentifiers() as $timezone) {
+            $parts = explode('/', $timezone);
 
-                if (count($parts) > 2) {
-                    $region = $parts[0];
-                    $name = $parts[1].' - '.$parts[2];
-                } elseif (count($parts) > 1) {
-                    $region = $parts[0];
-                    $name = $parts[1];
-                } else {
-                    $region = 'Other';
-                    $name = $parts[0];
-                }
-
-                self::$timezones[$region][str_replace('_', ' ', $name)] = $timezone;
+            if (count($parts) > 2) {
+                $region = $parts[0];
+                $name = $parts[1].' - '.$parts[2];
+            } elseif (count($parts) > 1) {
+                $region = $parts[0];
+                $name = $parts[1];
+            } else {
+                $region = 'Other';
+                $name = $parts[0];
             }
+
+            $timezones[$region][str_replace('_', ' ', $name)] = $timezone;
         }
 
-        return self::$timezones;
+        return $timezones;
     }
 }

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Loader/CallbackChoiceLoaderTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Loader/CallbackChoiceLoaderTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\ChoiceList\Loader;
+
+use Symfony\Component\Form\ChoiceList\LazyChoiceList;
+use Symfony\Component\Form\ChoiceList\Loader\CallbackChoiceLoader;
+
+/**
+ * @author Jules Pietri <jules@heahprod.com>
+ */
+class CallbackChoiceLoaderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Symfony\Component\Form\ChoiceList\Loader\CallbackChoiceLoader
+     */
+    static private $loader;
+
+    /**
+     * @var callable
+     */
+    static private $value;
+
+    /**
+     * @var array
+     */
+    static private $choices;
+
+    /**
+     * @var string[]
+     */
+    static private $choiceValues;
+
+    /**
+     * @var \Symfony\Component\Form\ChoiceList\LazyChoiceList
+     */
+    static private $lazyChoiceList;
+
+    static public function setUpBeforeClass()
+    {
+        self::$loader = new CallbackChoiceLoader(function() {
+            return self::$choices;
+        });
+        self::$value = function ($choice) {
+            return isset($choice->value) ? $choice->value : null;
+        };
+        self::$choices = array(
+            (object) array('value' => 'choice_one'),
+            (object) array('value' => 'choice_two'),
+        );
+        self::$choiceValues = array('choice_one', 'choice_two');
+        self::$lazyChoiceList = new LazyChoiceList(self::$loader, self::$value);
+    }
+
+    public function testLoadChoiceList()
+    {
+        $this->assertInstanceOf('\Symfony\Component\Form\ChoiceList\ChoiceListInterface', self::$loader->loadChoiceList(self::$value));
+    }
+
+    public function testLoadChoiceListOnlyOnce()
+    {
+        $loadedChoiceList = self::$loader->loadChoiceList(self::$value);
+
+        $this->assertSame($loadedChoiceList, self::$loader->loadChoiceList(self::$value));
+    }
+
+    public function testLoadChoicesForValuesLoadsChoiceListOnFirstCall()
+    {
+        $this->assertSame(
+            self::$loader->loadChoicesForValues(self::$choiceValues, self::$value),
+            self::$lazyChoiceList->getChoicesForValues(self::$choiceValues),
+            'Choice list should not be reloaded.'
+        );
+    }
+
+    public function testLoadValuesForChoicesLoadsChoiceListOnFirstCall()
+    {
+        $this->assertSame(
+            self::$loader->loadValuesForChoices(self::$choices, self::$value),
+            self::$lazyChoiceList->getValuesForChoices(self::$choices),
+            'Choice list should not be reloaded.'
+        );
+    }
+
+    static public function tearDownAfterClass()
+    {
+        self::$loader = null;
+        self::$value = null;
+        self::$choices = array();
+        self::$choiceValues = array();
+        self::$lazyChoiceList = null;
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | todo |
# Todo
- [ ] Address a doc PR
- [x] Update CHANGELOG
# Changes
- 39e937f added `CallbackChoiceLoader` to lazy load choices with a simple callable.
- 995dc56 refactored `CountryType`, `CurrencyType`, `LanguageType`, `LocaleType` and `TimezoneType` for better performance by implementing `ChoiceLoaderInterface` for lazy loading.
# Usage

``` php
use Symfony\Component\Form\ChoiceList\Loader\CallbackChoiceLoader;
use Symfony\Component\Form\Extension\Core\Type\ChoiceType;

$builder->add('constants', ChoiceType::class, array(
    'choice_loader' => new CallbackChoiceLoader(function() {
            return StaticClass::getConstants();
    },
));
```
