### PR TITLE
[Security][CSRF] Double Submit Cookies CSRF prevention strategy

### DIFF
--- a/src/Symfony/Component/Security/Core/Exception/UnexpectedValueException.php
+++ b/src/Symfony/Component/Security/Core/Exception/UnexpectedValueException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Exception;
+
+/**
+ * Base UnexpectedValueException for the Security component.
+ *
+ * @author Oliver Hoff <oliver@hofff.com>
+ */
+class UnexpectedValueException extends \UnexpectedValueException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/AbstractTokenStorageProxy.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/AbstractTokenStorageProxy.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Csrf\TokenStorage;
+
+/**
+ * Forwards calls to another TokenStorageInterface
+ *
+ * @author Oliver Hoff <oliver@hofff.com>
+ */
+abstract class AbstractTokenStorageProxy implements TokenStorageInterface
+{
+    /**
+     * {@inheritDoc}
+     * @see \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface::getToken()
+     */
+    public function getToken($tokenId)
+    {
+        return $this->getProxiedTokenStorage()->getToken($tokenId);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface::setToken()
+     */
+    public function setToken($tokenId, $token)
+    {
+        // TODO interface declares return void, use return stmt or not?
+        $this->getProxiedTokenStorage()->setToken($tokenId, $token);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface::removeToken()
+     */
+    public function removeToken($tokenId)
+    {
+        return $this->getProxiedTokenStorage()->removeToken($tokenId);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface::hasToken()
+     */
+    public function hasToken($tokenId)
+    {
+        return $this->getProxiedTokenStorage()->hasToken($tokenId);
+    }
+
+    /**
+     * @return TokenStorageInterface
+     */
+    abstract protected function getProxiedTokenStorage();
+}

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/AbstractTokenStorageProxy.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/AbstractTokenStorageProxy.php
@@ -12,14 +12,15 @@
 namespace Symfony\Component\Security\Csrf\TokenStorage;
 
 /**
- * Forwards calls to another TokenStorageInterface
+ * Forwards calls to another TokenStorageInterface.
  *
  * @author Oliver Hoff <oliver@hofff.com>
  */
 abstract class AbstractTokenStorageProxy implements TokenStorageInterface
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
+     *
      * @see \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface::getToken()
      */
     public function getToken($tokenId)
@@ -28,7 +29,8 @@ abstract class AbstractTokenStorageProxy implements TokenStorageInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
+     *
      * @see \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface::setToken()
      */
     public function setToken($tokenId, $token)
@@ -38,7 +40,8 @@ abstract class AbstractTokenStorageProxy implements TokenStorageInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
+     *
      * @see \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface::removeToken()
      */
     public function removeToken($tokenId)
@@ -47,7 +50,8 @@ abstract class AbstractTokenStorageProxy implements TokenStorageInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
+     *
      * @see \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface::hasToken()
      */
     public function hasToken($tokenId)

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/AbstractTokenStorageProxy.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/AbstractTokenStorageProxy.php
@@ -20,8 +20,6 @@ abstract class AbstractTokenStorageProxy implements TokenStorageInterface
 {
     /**
      * {@inheritdoc}
-     *
-     * @see \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface::getToken()
      */
     public function getToken($tokenId)
     {
@@ -30,8 +28,6 @@ abstract class AbstractTokenStorageProxy implements TokenStorageInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @see \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface::setToken()
      */
     public function setToken($tokenId, $token)
     {
@@ -41,8 +37,6 @@ abstract class AbstractTokenStorageProxy implements TokenStorageInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @see \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface::removeToken()
      */
     public function removeToken($tokenId)
     {
@@ -51,8 +45,6 @@ abstract class AbstractTokenStorageProxy implements TokenStorageInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @see \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface::hasToken()
      */
     public function hasToken($tokenId)
     {

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/CookieTokenStorage.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/CookieTokenStorage.php
@@ -52,8 +52,6 @@ class CookieTokenStorage implements TokenStorageInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @see \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface::getToken()
      */
     public function getToken($tokenId)
     {
@@ -68,8 +66,6 @@ class CookieTokenStorage implements TokenStorageInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @see \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface::hasToken()
      */
     public function hasToken($tokenId)
     {
@@ -78,8 +74,6 @@ class CookieTokenStorage implements TokenStorageInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @see \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface::setToken()
      */
     public function setToken($tokenId, $token)
     {
@@ -94,8 +88,6 @@ class CookieTokenStorage implements TokenStorageInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @see \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface::removeToken()
      */
     public function removeToken($tokenId)
     {

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/CookieTokenStorage.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/CookieTokenStorage.php
@@ -1,0 +1,165 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Csrf\TokenStorage;
+
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\Security\Csrf\Exception\TokenNotFoundException;
+
+/**
+ * Accesses tokens in a set of cookies. A changeset records edits made to
+ * tokens. The changeset can be retrieved as a list of cookies to be used in a
+ * response's headers to "persist" the changes.
+ *
+ * @author Oliver Hoff <oliver@hofff.com>
+ */
+class CookieTokenStorage implements TokenStorageInterface
+{
+    /**
+     * @var array
+     */
+    private $transientTokens;
+
+    /**
+     * @var ParameterBag
+     */
+    private $cookies;
+
+    /**
+     * @var boolean
+     */
+    private $secure;
+
+    /**
+     * @param ParameterBag $cookies
+     * @param boolean $secure
+     */
+    public function __construct(ParameterBag $cookies, $secure)
+    {
+        $this->transientTokens = [];
+        $this->cookies = $cookies;
+        $this->secure = (bool) $secure;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface::getToken()
+     */
+    public function getToken($tokenId)
+    {
+        $token = $this->resolveToken($tokenId);
+
+        if (!strlen($token)) {
+            throw new TokenNotFoundException;
+        }
+
+        return $token;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface::hasToken()
+     */
+    public function hasToken($tokenId)
+    {
+        return strlen($this->resolveToken($tokenId)) > 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface::setToken()
+     */
+    public function setToken($tokenId, $token)
+    {
+        if (!strlen($token)) {
+            throw new \InvalidArgumentException('Empty tokens are not allowed');
+        }
+
+        $this->updateToken($tokenId, $token);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface::removeToken()
+     */
+    public function removeToken($tokenId)
+    {
+        $token = $this->resolveToken($tokenId);
+
+        $this->updateToken($tokenId, '');
+
+        return strlen($token) ? $token : null;
+    }
+
+    /**
+     * @return array
+     */
+    public function createCookies()
+    {
+        $cookies = [];
+
+        foreach ($this->transientTokens as $tokenId => $token) {
+            // FIXME empty tokens are handled by the http foundations cookie class
+            // and are recognized as a "delete" cookie
+            // the problem is the that the value of deleted cookies get set to
+            // the string "deleted" and not the empty string
+
+            // TODO http only?
+            $name = $this->generateCookieName($tokenId);
+            $cookies[] = new Cookie($name, $token, 0, null, null, $this->secure, true);
+        }
+
+        return $cookies;
+    }
+
+    /**
+     * @param string $tokenId
+     * @return string
+     */
+    protected function resolveToken($tokenId)
+    {
+        if (isset($this->transientTokens[$tokenId])) {
+            return $this->transientTokens[$tokenId];
+        }
+
+        $name = $this->generateCookieName($tokenId);
+
+        return $this->cookies->get($name, '');
+    }
+
+    /**
+     * @param string $tokenId
+     * @param string $token
+     * @return void
+     */
+    protected function updateToken($tokenId, $token)
+    {
+        $token = (string) $token;
+        $name = $this->generateCookieName($tokenId);
+
+        if ($token === $this->cookies->get($name, '')) {
+            unset($this->transientTokens[$tokenId]);
+        } else {
+            $this->transientTokens[$tokenId] = $token;
+        }
+    }
+
+    /**
+     *
+     * @param string $tokenId
+     * @return string
+     */
+    protected function generateCookieName($tokenId)
+    {
+        return sprintf('_csrf/%s/%s', $this->secure ? 'insecure' : 'secure', $tokenId);
+    }
+}

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/CookieTokenStorage.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/CookieTokenStorage.php
@@ -75,7 +75,7 @@ class CookieTokenStorage implements TokenStorageInterface
         $this->cookies = self::parseCookieHeader($cookies);
         $this->secure = (bool) $secure;
         $this->secret = (string) $secret;
-        $this->ttl = $ttl === null ? 60 * 60 : (int) $ttl;
+        $this->ttl = null === $ttl ? 60 * 60 : (int) $ttl;
 
         if ('' === $this->secret) {
             throw new InvalidArgumentException('Secret must be a non-empty string');
@@ -151,7 +151,7 @@ class CookieTokenStorage implements TokenStorageInterface
                 }
             }
 
-            if ($token !== '') {
+            if ('' !== $token) {
                 $cookies[] = $this->createCookie($tokenId, $token);
             }
         }

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/CookieTokenStorage.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/CookieTokenStorage.php
@@ -36,13 +36,13 @@ class CookieTokenStorage implements TokenStorageInterface
     private $cookies;
 
     /**
-     * @var boolean
+     * @var bool
      */
     private $secure;
 
     /**
      * @param ParameterBag $cookies
-     * @param boolean $secure
+     * @param bool         $secure
      */
     public function __construct(ParameterBag $cookies, $secure)
     {
@@ -51,7 +51,8 @@ class CookieTokenStorage implements TokenStorageInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
+     *
      * @see \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface::getToken()
      */
     public function getToken($tokenId)
@@ -66,7 +67,8 @@ class CookieTokenStorage implements TokenStorageInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
+     *
      * @see \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface::hasToken()
      */
     public function hasToken($tokenId)
@@ -75,7 +77,8 @@ class CookieTokenStorage implements TokenStorageInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
+     *
      * @see \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface::setToken()
      */
     public function setToken($tokenId, $token)
@@ -90,7 +93,8 @@ class CookieTokenStorage implements TokenStorageInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
+     *
      * @see \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface::removeToken()
      */
     public function removeToken($tokenId)
@@ -107,7 +111,7 @@ class CookieTokenStorage implements TokenStorageInterface
      */
     public function createCookies()
     {
-        $cookies = [];
+        $cookies = array();
 
         foreach ($this->transientTokens as $tokenId => $token) {
             // FIXME empty tokens are handled by the http foundations cookie class
@@ -124,6 +128,7 @@ class CookieTokenStorage implements TokenStorageInterface
 
     /**
      * @param string $tokenId
+     *
      * @return string
      */
     protected function resolveToken($tokenId)
@@ -140,7 +145,6 @@ class CookieTokenStorage implements TokenStorageInterface
     /**
      * @param string $tokenId
      * @param string $token
-     * @return void
      */
     protected function updateToken($tokenId, $token)
     {
@@ -154,8 +158,8 @@ class CookieTokenStorage implements TokenStorageInterface
     }
 
     /**
-     *
      * @param string $tokenId
+     *
      * @return string
      */
     protected function generateCookieName($tokenId)

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/CookieTokenStorageFactory.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/CookieTokenStorageFactory.php
@@ -38,7 +38,7 @@ class CookieTokenStorageFactory implements TokenStorageFactoryInterface
     public function __construct($secret, $ttl = null)
     {
         $this->secret = (string) $secret;
-        $this->ttl = $ttl === null ? 60 * 60 : (int) $ttl;
+        $this->ttl = null === $ttl ? 60 * 60 : (int) $ttl;
 
         if ('' === $this->secret) {
             throw new InvalidArgumentException('Secret must be a non-empty string');

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/CookieTokenStorageFactory.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/CookieTokenStorageFactory.php
@@ -22,8 +22,6 @@ class CookieTokenStorageFactory implements TokenStorageFactoryInterface
 {
     /**
      * {@inheritdoc}
-     *
-     * @see \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageFactoryInterface::createTokenStorage()
      */
     public function createTokenStorage(Request $request)
     {

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/CookieTokenStorageFactory.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/CookieTokenStorageFactory.php
@@ -54,6 +54,6 @@ class CookieTokenStorageFactory implements TokenStorageFactoryInterface
      */
     public function createTokenStorage(Request $request)
     {
-        return new CookieTokenStorage($request->cookies, $request->isSecure(), $this->secret, $this->ttl);
+        return new CookieTokenStorage($request->headers->get('Cookie'), $request->isSecure(), $this->secret, $this->ttl);
     }
 }

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/CookieTokenStorageFactory.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/CookieTokenStorageFactory.php
@@ -21,10 +21,12 @@ use Symfony\Component\HttpFoundation\Request;
 class CookieTokenStorageFactory implements TokenStorageFactoryInterface
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
+     *
      * @see \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageFactoryInterface::createTokenStorage()
      */
-    public function createTokenStorage(Request $request) {
+    public function createTokenStorage(Request $request)
+    {
         return new CookieTokenStorage($request->cookies, $request->isSecure());
     }
 }

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/CookieTokenStorageFactory.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/CookieTokenStorageFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Csrf\TokenStorage;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Creates CSRF token storages based on the requests cookies.
+ *
+ * @author Oliver Hoff <oliver@hofff.com>
+ */
+class CookieTokenStorageFactory implements TokenStorageFactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     * @see \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageFactoryInterface::createTokenStorage()
+     */
+    public function createTokenStorage(Request $request) {
+        return new CookieTokenStorage($request->cookies, $request->isSecure());
+    }
+}

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/CookieTokenStorageFactory.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/CookieTokenStorageFactory.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Csrf\TokenStorage;
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\InvalidArgumentException;
 
 /**
  * Creates CSRF token storages based on the requests cookies.
@@ -21,10 +22,38 @@ use Symfony\Component\HttpFoundation\Request;
 class CookieTokenStorageFactory implements TokenStorageFactoryInterface
 {
     /**
+     * @var string
+     */
+    private $secret;
+
+    /**
+     * @var int
+     */
+    private $ttl;
+
+    /**
+     * @param string $secret
+     * @param int    $ttl
+     */
+    public function __construct($secret, $ttl = null)
+    {
+        $this->secret = (string) $secret;
+        $this->ttl = $ttl === null ? 60 * 60 : (int) $ttl;
+
+        if ('' === $this->secret) {
+            throw new InvalidArgumentException('Secret must be a non-empty string');
+        }
+
+        if ($this->ttl < 60) {
+            throw new InvalidArgumentException('TTL must be an integer greater than or equal to 60');
+        }
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function createTokenStorage(Request $request)
     {
-        return new CookieTokenStorage($request->cookies, $request->isSecure());
+        return new CookieTokenStorage($request->cookies, $request->isSecure(), $this->secret, $this->ttl);
     }
 }

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/CookieTokenStorageListener.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/CookieTokenStorageListener.php
@@ -41,7 +41,6 @@ class CookieTokenStorageListener
 
     /**
      * @param FilterResponseEvent $event
-     * @return void
      */
     public function onKernelResponse(FilterResponseEvent $event)
     {

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/CookieTokenStorageListener.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/CookieTokenStorageListener.php
@@ -29,6 +29,11 @@ class CookieTokenStorageListener implements EventSubscriberInterface
     /**
      * @var string
      */
+    const DEFAULT_TOKEN_STORAGE_KEY = '_csrf_token_storage';
+
+    /**
+     * @var string
+     */
     private $tokenStorageKey;
 
     /**
@@ -36,9 +41,7 @@ class CookieTokenStorageListener implements EventSubscriberInterface
      */
     public function __construct($tokenStorageKey = null)
     {
-        // TODO should this class get its own DEFAULT_TOKEN_STORAGE_KEY constant?
-        // if no, where should the sole constant be put?
-        $this->tokenStorageKey = $tokenStorageKey === null ? RequestStackTokenStorage::DEFAULT_TOKEN_STORAGE_KEY : $tokenStorageKey;
+        $this->tokenStorageKey = null === $tokenStorageKey ? self::DEFAULT_TOKEN_STORAGE_KEY : $tokenStorageKey;
     }
 
     /**

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/CookieTokenStorageListener.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/CookieTokenStorageListener.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Security\Csrf\TokenStorage;
 
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * Checks the request's attributes for a CookieTokenStorage instance. If one is
@@ -22,7 +24,7 @@ use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
  *
  * @author Oliver Hoff <oliver@hofff.com>
  */
-class CookieTokenStorageListener
+class CookieTokenStorageListener implements EventSubscriberInterface
 {
     /**
      * @var string
@@ -53,5 +55,15 @@ class CookieTokenStorageListener
         foreach ($storage->createCookies() as $cookie) {
             $headers->setCookie($cookie);
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::RESPONSE => array(array('onKernelResponse', 0)),
+        );
     }
 }

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/CookieTokenStorageListener.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/CookieTokenStorageListener.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Csrf\TokenStorage;
+
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+
+/**
+ * Checks the request's attributes for a CookieTokenStorage instance. If one is
+ * found, the cookies representing the storage's changeset are appended to the
+ * response headers.
+ *
+ * TODO where to put this class?
+ *
+ * @author Oliver Hoff <oliver@hofff.com>
+ */
+class CookieTokenStorageListener
+{
+    /**
+     * @var string
+     */
+    private $tokenStorageKey;
+
+    /**
+     * @param string|null $tokenStorageKey
+     */
+    public function __construct($tokenStorageKey = null)
+    {
+        // TODO should this class get its own DEFAULT_TOKEN_STORAGE_KEY constant?
+        // if no, where should the sole constant be put?
+        $this->tokenStorageKey = $tokenStorageKey === null ? RequestStackTokenStorage::DEFAULT_TOKEN_STORAGE_KEY : $tokenStorageKey;
+    }
+
+    /**
+     * @param FilterResponseEvent $event
+     * @return void
+     */
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+        $storage = $event->getRequest()->attributes->get($this->tokenStorageKey);
+        if (!$storage instanceof CookieTokenStorage) {
+            return;
+        }
+
+        $headers = $event->getResponse()->headers;
+        foreach ($storage->createCookies() as $cookie) {
+            $headers->setCookie($cookie);
+        }
+    }
+}

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/RequestStackTokenStorage.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/RequestStackTokenStorage.php
@@ -45,9 +45,9 @@ class RequestStackTokenStorage extends AbstractTokenStorageProxy
     private $tokenStorageKey;
 
     /**
-     * @param RequestStack $requestStack
+     * @param RequestStack                 $requestStack
      * @param TokenStorageFactoryInterface $factory
-     * @param string|null $tokenStorageKey
+     * @param string|null                  $tokenStorageKey
      */
     public function __construct(
         RequestStack $requestStack,
@@ -60,7 +60,8 @@ class RequestStackTokenStorage extends AbstractTokenStorageProxy
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
+     *
      * @see \Symfony\Component\Security\Csrf\TokenStorage\AbstractTokenStorageProxy::getProxiedTokenStorage()
      */
     public function getProxiedTokenStorage()
@@ -90,5 +91,4 @@ class RequestStackTokenStorage extends AbstractTokenStorageProxy
 
         return $storage;
     }
-
 }

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/RequestStackTokenStorage.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/RequestStackTokenStorage.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Csrf\TokenStorage;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Forwards token storage calls to a token storage stored in the master
+ * request's attributes. If the attributes don't hold a token storage yet, one
+ * is created and set into the attributes.
+ *
+ * @author Oliver Hoff <oliver@hofff.com>
+ */
+class RequestStackTokenStorage extends AbstractTokenStorageProxy
+{
+    /**
+     * @var string
+     */
+    const DEFAULT_TOKEN_STORAGE_KEY = '_csrf_token_storage';
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var TokenStorageFactoryInterface
+     */
+    private $factory;
+
+    /**
+     * @var string
+     */
+    private $tokenStorageKey;
+
+    /**
+     * @param RequestStack $requestStack
+     * @param TokenStorageFactoryInterface $factory
+     * @param string|null $tokenStorageKey
+     */
+    public function __construct(
+        RequestStack $requestStack,
+        TokenStorageFactoryInterface $factory,
+        $tokenStorageKey = null
+    ) {
+        $this->requestStack = $requestStack;
+        $this->factory = $factory;
+        $this->tokenStorageKey = $tokenStorageKey === null ? self::DEFAULT_TOKEN_STORAGE_KEY : $tokenStorageKey;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Symfony\Component\Security\Csrf\TokenStorage\AbstractTokenStorageProxy::getProxiedTokenStorage()
+     */
+    public function getProxiedTokenStorage()
+    {
+        // TODO use master or current request?
+        $request = $this->requestStack->getMasterRequest();
+
+        if (!$request) {
+            throw new \RuntimeException('Not in a request context');
+        }
+
+        $storage = $request->attributes->get($this->tokenStorageKey);
+
+        // TODO what if storage is set and not an instance of TokenStorageInterface?
+        // error out? overwrite?
+        if (!$storage instanceof TokenStorageInterface) {
+            $storage = $this->factory->createTokenStorage($request);
+            $request->attributes->set($this->tokenStorageKey, $storage);
+        }
+
+        return $storage;
+    }
+
+}

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/RequestStackTokenStorage.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/RequestStackTokenStorage.php
@@ -61,8 +61,6 @@ class RequestStackTokenStorage extends AbstractTokenStorageProxy
 
     /**
      * {@inheritdoc}
-     *
-     * @see \Symfony\Component\Security\Csrf\TokenStorage\AbstractTokenStorageProxy::getProxiedTokenStorage()
      */
     public function getProxiedTokenStorage()
     {

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/RequestStackTokenStorage.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/RequestStackTokenStorage.php
@@ -49,11 +49,8 @@ class RequestStackTokenStorage extends AbstractTokenStorageProxy
      * @param TokenStorageFactoryInterface $factory
      * @param string|null                  $tokenStorageKey
      */
-    public function __construct(
-        RequestStack $requestStack,
-        TokenStorageFactoryInterface $factory,
-        $tokenStorageKey = null
-    ) {
+    public function __construct(RequestStack $requestStack, TokenStorageFactoryInterface $factory, $tokenStorageKey = null)
+    {
         $this->requestStack = $requestStack;
         $this->factory = $factory;
         $this->tokenStorageKey = $tokenStorageKey === null ? self::DEFAULT_TOKEN_STORAGE_KEY : $tokenStorageKey;
@@ -64,7 +61,6 @@ class RequestStackTokenStorage extends AbstractTokenStorageProxy
      */
     public function getProxiedTokenStorage()
     {
-        // TODO use master or current request?
         $request = $this->requestStack->getMasterRequest();
 
         if (!$request) {
@@ -77,11 +73,8 @@ class RequestStackTokenStorage extends AbstractTokenStorageProxy
             return $storage;
         }
 
-        if ($storage !== null) {
-            throw new UnexpectedValueException(sprintf(
-                'Expected null or an instance of "Symfony\\Component\\Security\\Csrf\\TokenStorage\\TokenStorageInterface", got "%s"',
-                is_object($storage) ? get_class($storage) : gettype($storage)
-            ));
+        if (null !== $storage) {
+            throw new UnexpectedValueException(sprintf('Expected null or an implementation of "%s", got "%s"', TokenStorageInterface::class, is_object($storage) ? get_class($storage) : gettype($storage)));
         }
 
         $storage = $this->factory->createTokenStorage($request);

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/SessionTokenStorageFactory.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/SessionTokenStorageFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Csrf\TokenStorage;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Creates CSRF token storages based on the requests session.
+ *
+ * @author Oliver Hoff <oliver@hofff.com>
+ */
+class SessionTokenStorageFactory implements TokenStorageFactoryInterface
+{
+    /**
+     * @var string
+     */
+    private $namespace;
+
+    /**
+     * @param string $namespace The namespace under which the token is stored in the session
+     */
+    public function __construct($namespace = null)
+    {
+        $this->namespace = $namespace === null ? SessionTokenStorage::SESSION_NAMESPACE : $namespace;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageFactoryInterface::createTokenStorage()
+     */
+    public function createTokenStorage(Request $request) {
+        $session = $request->getSession();
+        if (!$session) {
+            throw new \RuntimeException('Request has no session');
+        }
+
+        return new SessionTokenStorage($session, $this->namespace);
+    }
+}

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/SessionTokenStorageFactory.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/SessionTokenStorageFactory.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Csrf\TokenStorage;
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\RuntimeException;
 
 /**
  * Creates CSRF token storages based on the requests session.
@@ -30,7 +31,7 @@ class SessionTokenStorageFactory implements TokenStorageFactoryInterface
      */
     public function __construct($namespace = null)
     {
-        $this->namespace = $namespace === null ? SessionTokenStorage::SESSION_NAMESPACE : $namespace;
+        $this->namespace = $namespace === null ? SessionTokenStorage::SESSION_NAMESPACE : (string) $namespace;
     }
 
     /**
@@ -40,7 +41,7 @@ class SessionTokenStorageFactory implements TokenStorageFactoryInterface
     public function createTokenStorage(Request $request) {
         $session = $request->getSession();
         if (!$session) {
-            throw new \RuntimeException('Request has no session');
+            throw new RuntimeException('Request has no session');
         }
 
         return new SessionTokenStorage($session, $this->namespace);

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/SessionTokenStorageFactory.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/SessionTokenStorageFactory.php
@@ -35,10 +35,12 @@ class SessionTokenStorageFactory implements TokenStorageFactoryInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
+     *
      * @see \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageFactoryInterface::createTokenStorage()
      */
-    public function createTokenStorage(Request $request) {
+    public function createTokenStorage(Request $request)
+    {
         $session = $request->getSession();
         if (!$session) {
             throw new RuntimeException('Request has no session');

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/SessionTokenStorageFactory.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/SessionTokenStorageFactory.php
@@ -36,8 +36,6 @@ class SessionTokenStorageFactory implements TokenStorageFactoryInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @see \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageFactoryInterface::createTokenStorage()
      */
     public function createTokenStorage(Request $request)
     {

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/SessionTokenStorageFactory.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/SessionTokenStorageFactory.php
@@ -27,11 +27,18 @@ class SessionTokenStorageFactory implements TokenStorageFactoryInterface
     private $namespace;
 
     /**
-     * @param string $namespace The namespace under which the token is stored in the session
+     * @var string
      */
-    public function __construct($namespace = null)
+    private $secureNamespace;
+
+    /**
+     * @param string $namespace       The namespace under which tokens are stored in the session
+     * @param string $secureNamespace The namespace under which tokens are stored in the session for secure connections
+     */
+    public function __construct($namespace = null, $secureNamespace = null)
     {
         $this->namespace = $namespace === null ? SessionTokenStorage::SESSION_NAMESPACE : (string) $namespace;
+        $this->secureNamespace = $secureNamespace === null ? $this->namespace : (string) $secureNamespace;
     }
 
     /**
@@ -44,6 +51,8 @@ class SessionTokenStorageFactory implements TokenStorageFactoryInterface
             throw new RuntimeException('Request has no session');
         }
 
-        return new SessionTokenStorage($session, $this->namespace);
+        $namespace = $request->isSecure() ? $this->secureNamespace : $this->namespace;
+
+        return new SessionTokenStorage($session, $namespace);
     }
 }

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/TokenStorageFactoryInterface.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/TokenStorageFactoryInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Csrf\TokenStorage;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Creates CSRF token storages.
+ *
+ * @author Oliver Hoff <oliver@hofff.com>
+ */
+interface TokenStorageFactoryInterface
+{
+    /**
+     * Creates a new token storage for the given request.
+     *
+     * @param Request $request
+     * @return TokenStorageInterface
+     */
+    public function createTokenStorage(Request $request);
+}

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/TokenStorageFactoryInterface.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/TokenStorageFactoryInterface.php
@@ -24,6 +24,7 @@ interface TokenStorageFactoryInterface
      * Creates a new token storage for the given request.
      *
      * @param Request $request
+     *
      * @return TokenStorageInterface
      */
     public function createTokenStorage(Request $request);

--- a/src/Symfony/Component/Security/Csrf/composer.json
+++ b/src/Symfony/Component/Security/Csrf/composer.json
@@ -25,7 +25,7 @@
         "symfony/http-foundation": "~2.8|~3.0"
     },
     "suggest": {
-        "symfony/http-foundation": "For using the class SessionTokenStorage."
+        "symfony/http-foundation": "For using SessionTokenStorage, CookieTokenStorage or RequestStackTokenStorage."
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Security\\Csrf\\": "" },


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? |  |
| Fixed tickets | #18313 #13464 |
| License | MIT |
- cookie token storage managing csrf tokens stored inside cookies
  (prerequisite for "double submit cookies" csrf prevention strategy)
- kernel response event listener add the cookie headers of the cookie
  token storage to request responses
- token storage factory interface to create token storages based on
  requests
- session token storage factory using the requests session to create a
  session token storage
- cookie token storage factory using the requests cookies to create a
  cookie token storage
- request stack token storage managing and using token storages inside
  master request's attributes

assistance on the **TODO**s and **FIXME**s as well as some general feedback is very welcome
