### PR TITLE
[PropertyInfo] Support singular adder and remover

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -27,7 +27,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
     /**
      * @internal
      *
-     * @var string[]
+     * @var array[]
      */
     public static $mutatorPrefixes = array('add', 'remove', 'set');
 
@@ -317,11 +317,12 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
     private function getMutatorMethod($class, $property)
     {
         $ucProperty = ucfirst($property);
-        $names = $this->getSingulars($ucProperty);
+        $ucSingulars = (array) Inflector::singularize($ucProperty);
 
         foreach (self::$mutatorPrefixes as $prefix) {
+            $names = array($ucProperty);
             if (in_array($prefix, self::$arrayMutatorPrefixes)) {
-                array_unshift($names, $ucProperty);
+                $names = array_merge($names, $ucSingulars);
             }
 
             foreach ($names as $name) {
@@ -357,7 +358,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
             }
 
             foreach ($reflectionProperties as $reflectionProperty) {
-                foreach ($this->getSingulars($reflectionProperty->name) as $name) {
+                foreach ((array) Inflector::singularize($reflectionProperty->name) as $name) {
                     if ($name === lcfirst($matches[2])) {
                         return $reflectionProperty->name;
                     }
@@ -366,22 +367,5 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
 
             return $matches[2];
         }
-    }
-
-    /**
-     * Gets singulars of a word.
-     *
-     * @param string $plural
-     *
-     * @return array
-     */
-    private function getSingulars($plural)
-    {
-        $singulars = Inflector::singularize($plural);
-        if (is_string($singulars)) {
-            $singulars = array($singulars);
-        }
-
-        return $singulars;
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\PropertyInfo\Extractor;
 
-use Symfony\Component\PropertyAccess\StringUtil;
+use Symfony\Component\Inflector\Inflector;
 use Symfony\Component\PropertyInfo\PropertyAccessExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyListExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
@@ -317,15 +317,11 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
     private function getMutatorMethod($class, $property)
     {
         $ucProperty = ucfirst($property);
-        $singulars = $this->getSingulars($ucProperty);
+        $names = $this->getSingulars($ucProperty);
 
         foreach (self::$mutatorPrefixes as $prefix) {
-
-            if (null !== $singulars && in_array($prefix, self::$arrayMutatorPrefixes)) {
-                $names = $singulars;
-                $names[] = $ucProperty;
-            } else {
-                $names = array($ucProperty);
+            if (in_array($prefix, self::$arrayMutatorPrefixes)) {
+                array_unshift($names, $ucProperty);
             }
 
             foreach ($names as $name) {
@@ -377,15 +373,11 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
      *
      * @param string $plural
      *
-     * @return array|null Returns null if cannot guess.
+     * @return array
      */
     private function getSingulars($plural)
     {
-        if (!class_exists('Symfony\Component\PropertyAccess\StringUtil')) {
-            return;
-        }
-
-        $singulars = StringUtil::singularify($plural);
+        $singulars = Inflector::singularize($plural);
         if (is_string($singulars)) {
             $singulars = array($singulars);
         }

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -334,7 +334,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
                         return array($reflectionMethod, $prefix);
                     }
                 } catch (\ReflectionException $reflectionException) {
-                    // Try the next prefix if the method doesn't exist
+                    // Try the next one if method does not exist
                 }
             }
         }

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -359,7 +359,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
 
             foreach ($reflectionProperties as $reflectionProperty) {
                 foreach ((array) Inflector::singularize($reflectionProperty->name) as $name) {
-                    if ($name === lcfirst($matches[2])) {
+                    if (strtolower($name) === strtolower($matches[2])) {
                         return $reflectionProperty->name;
                     }
                 }

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -27,7 +27,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
     /**
      * @internal
      *
-     * @var array[]
+     * @var string[]
      */
     public static $mutatorPrefixes = array('add', 'remove', 'set');
 
@@ -41,7 +41,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
     /**
      * @internal
      *
-     * @var string[]
+     * @var array[]
      */
     public static $arrayMutatorPrefixes = array('add', 'remove');
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractors/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractors/ReflectionExtractorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\PropertyInfo\Tests\Extractor;
 
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\AdderRemoverDummy;
 use Symfony\Component\PropertyInfo\Type;
 
 /**
@@ -118,5 +119,12 @@ class ReflectionExtractorTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->extractor->isWritable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'd', array()));
         $this->assertTrue($this->extractor->isWritable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'e', array()));
         $this->assertTrue($this->extractor->isWritable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'f', array()));
+    }
+
+    public function testSingularize()
+    {
+        $this->assertTrue($this->extractor->isWritable(AdderRemoverDummy::class, 'analyses'));
+        $this->assertTrue($this->extractor->isWritable(AdderRemoverDummy::class, 'feet'));
+        $this->assertEquals(array('analyses', 'feet'), $this->extractor->getProperties(AdderRemoverDummy::class));
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/AdderRemoverDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/AdderRemoverDummy.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class AdderRemoverDummy
+{
+    private $analyses;
+    private $feet;
+
+    public function addAnalyse(Dummy $analyse)
+    {
+    }
+
+    public function removeFoot(Dummy $foot)
+    {
+    }
+}

--- a/src/Symfony/Component/PropertyInfo/composer.json
+++ b/src/Symfony/Component/PropertyInfo/composer.json
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "symfony/serializer": "~2.8|~3.0",
-        "symfony/property-acccess": "~2.8|~3.0",
+        "symfony/property-access": "~2.8|~3.0",
         "symfony/cache": "~3.1",
         "phpdocumentor/reflection-docblock": "^3.0",
         "doctrine/annotations": "~1.0"

--- a/src/Symfony/Component/PropertyInfo/composer.json
+++ b/src/Symfony/Component/PropertyInfo/composer.json
@@ -23,11 +23,11 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9"
+        "php": ">=5.5.9",
+        "symfony/inflector": "~3.1"
     },
     "require-dev": {
         "symfony/serializer": "~2.8|~3.0",
-        "symfony/property-access": "~2.8|~3.0",
         "symfony/cache": "~3.1",
         "phpdocumentor/reflection-docblock": "^3.0",
         "doctrine/annotations": "~1.0"
@@ -39,8 +39,7 @@
         "psr/cache-implementation": "To cache results",
         "symfony/doctrine-bridge": "To use Doctrine metadata",
         "phpdocumentor/reflection-docblock": "To use the PHPDoc",
-        "symfony/serializer": "To use Serializer metadata",
-        "symfony/property-access": "To detect singular adders and removers"
+        "symfony/serializer": "To use Serializer metadata"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\PropertyInfo\\": "" },

--- a/src/Symfony/Component/PropertyInfo/composer.json
+++ b/src/Symfony/Component/PropertyInfo/composer.json
@@ -27,6 +27,7 @@
     },
     "require-dev": {
         "symfony/serializer": "~2.8|~3.0",
+        "symfony/property-acccess": "~2.8|~3.0",
         "symfony/cache": "~3.1",
         "phpdocumentor/reflection-docblock": "^3.0",
         "doctrine/annotations": "~1.0"
@@ -38,7 +39,8 @@
         "psr/cache-implementation": "To cache results",
         "symfony/doctrine-bridge": "To use Doctrine metadata",
         "phpdocumentor/reflection-docblock": "To use the PHPDoc",
-        "symfony/serializer": "To use Serializer metadata"
+        "symfony/serializer": "To use Serializer metadata",
+        "symfony/property-access": "To detect singular adders and removers"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\PropertyInfo\\": "" },


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18166 |
| License | MIT |
| Doc PR | n/a |

Fix #18166 with only a soft dependency to the PropertyAccess component. If #18260 is accepted, this PR can be reworked to use this new component, in the meantime it fixes the problem with a soft dependency.

I don't now if it should be considered as a bug fix (and then merged in 2.8) or as a new feature. It's technically a bug fix but I'm not sure that introducing a new soft dependency is acceptable if older branches. What do you think @symfony/deciders?
