### PR TITLE
Forgotten use HttpFoundation\Request

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\WebProfilerBundle\Controller;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
 use Symfony\Component\Routing\Matcher\TraceableUrlMatcher;


### PR DESCRIPTION
Symfony 2.8.4-DEV

In function getTraces used "$traceRequest = Request::create", but class Request does not present in namespace Symfony\Bundle\WebProfilerBundle\Controller
