### PR TITLE
[FrameworkBundle] Deprecated form types as services

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Added `Controller::json` to simplify creating JSON responses when using the Serializer component
  * Deprecated absolute template paths support in the template name parser
+ * Deprecated services for core form types and core form type extensions without dependencies
 
 3.0.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
@@ -67,9 +67,11 @@
         </service>
         <service id="form.type.birthday" class="Symfony\Component\Form\Extension\Core\Type\BirthdayType">
             <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.checkbox" class="Symfony\Component\Form\Extension\Core\Type\CheckboxType">
             <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.choice" class="Symfony\Component\Form\Extension\Core\Type\ChoiceType">
             <tag name="form.type" />
@@ -77,84 +79,111 @@
         </service>
         <service id="form.type.collection" class="Symfony\Component\Form\Extension\Core\Type\CollectionType">
             <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.country" class="Symfony\Component\Form\Extension\Core\Type\CountryType">
             <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.date" class="Symfony\Component\Form\Extension\Core\Type\DateType">
             <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.datetime" class="Symfony\Component\Form\Extension\Core\Type\DateTimeType">
             <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.email" class="Symfony\Component\Form\Extension\Core\Type\EmailType">
             <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.file" class="Symfony\Component\Form\Extension\Core\Type\FileType">
             <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.hidden" class="Symfony\Component\Form\Extension\Core\Type\HiddenType">
             <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.integer" class="Symfony\Component\Form\Extension\Core\Type\IntegerType">
             <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.language" class="Symfony\Component\Form\Extension\Core\Type\LanguageType">
             <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.locale" class="Symfony\Component\Form\Extension\Core\Type\LocaleType">
             <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.money" class="Symfony\Component\Form\Extension\Core\Type\MoneyType">
             <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.number" class="Symfony\Component\Form\Extension\Core\Type\NumberType">
             <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.password" class="Symfony\Component\Form\Extension\Core\Type\PasswordType">
             <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.percent" class="Symfony\Component\Form\Extension\Core\Type\PercentType">
             <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.radio" class="Symfony\Component\Form\Extension\Core\Type\RadioType">
             <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.range" class="Symfony\Component\Form\Extension\Core\Type\RangeType">
             <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.repeated" class="Symfony\Component\Form\Extension\Core\Type\RepeatedType">
             <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.search" class="Symfony\Component\Form\Extension\Core\Type\SearchType">
             <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.textarea" class="Symfony\Component\Form\Extension\Core\Type\TextareaType">
             <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.text" class="Symfony\Component\Form\Extension\Core\Type\TextType">
             <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.time" class="Symfony\Component\Form\Extension\Core\Type\TimeType">
             <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.timezone" class="Symfony\Component\Form\Extension\Core\Type\TimezoneType">
             <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.url" class="Symfony\Component\Form\Extension\Core\Type\UrlType">
             <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.button" class="Symfony\Component\Form\Extension\Core\Type\ButtonType">
             <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.submit" class="Symfony\Component\Form\Extension\Core\Type\SubmitType">
             <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.reset" class="Symfony\Component\Form\Extension\Core\Type\ResetType">
             <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.currency" class="Symfony\Component\Form\Extension\Core\Type\CurrencyType">
             <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
 
         <!-- FormTypeHttpFoundationExtension -->
@@ -179,9 +208,11 @@
         </service>
         <service id="form.type_extension.repeated.validator" class="Symfony\Component\Form\Extension\Validator\Type\RepeatedTypeValidatorExtension">
             <tag name="form.type_extension" extended-type="Symfony\Component\Form\Extension\Core\Type\RepeatedType" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type_extension.submit.validator" class="Symfony\Component\Form\Extension\Validator\Type\SubmitTypeValidatorExtension">
             <tag name="form.type_extension" extended-type="Symfony\Component\Form\Extension\Core\Type\SubmitType" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
     </services>
 </container>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

These services are not used anymore and should be removed in 4.0 (ref #15079).
