### PR TITLE
Fixed the styles of the Symfony icon in the web debug toolbar

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Icon/symfony.svg
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Icon/symfony.svg
@@ -1,4 +1,4 @@
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="40" height="40" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
 <path fill="#AAAAAA" d="M12,0.9C5.8,0.9,0.9,5.8,0.9,12s5,11.1,11.1,11.1s11.1-5,11.1-11.1S18.2,0.9,12,0.9z M18.5,6.9
     c-0.6,0-0.9-0.3-0.9-0.8c0-0.2,0-0.4,0.2-0.6c0.1-0.3,0.2-0.3,0.2-0.4c0-0.3-0.5-0.4-0.6-0.4c-1.8,0.1-2.3,2.5-2.7,4.4l-0.2,1
     c1,0.2,1.8,0,2.2-0.3c0.6-0.4-0.2-0.7-0.1-1.2c0.1-0.3,0.5-0.5,0.7-0.6c0.5,0,0.7,0.5,0.7,0.9c0,0.7-1,1.8-3,1.8


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8+ |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
### Before

![symfony_icon_before](https://cloud.githubusercontent.com/assets/73419/14114615/d63240fc-f5d7-11e5-9cd2-b0a67077dbe7.png)
### After

![symfony_icon_after](https://cloud.githubusercontent.com/assets/73419/14114617/d95e7cc8-f5d7-11e5-8ff3-6e706b8c5de8.png)

---

@WhiteEagle88 the change from `24` to `40` was made in [this commit](https://github.com/symfony/symfony/commit/d120c08f8b72236460de5cbe95140b60358799c0) of yours to fix some problems with Microsoft Edge browser. Could you please check if this pull request breaks anything for you? Thanks!
