### PR TITLE
[FrameworkBundle] Deprecated form types as services

### DIFF
--- a/UPGRADE-3.1.md
+++ b/UPGRADE-3.1.md
@@ -25,6 +25,39 @@ FrameworkBundle
  * As it was never an officially supported feature, the support for absolute
    template paths has been deprecated and will be removed in Symfony 4.0.
 
+ * The following form types registered as services are deprecated since 3.1
+   and will be removed in 4.0; use their fully-qualified class name instead:
+
+    - `"form.type.birthday"`
+    - `"form.type.checkbox"`
+    - `"form.type.collection"`
+    - `"form.type.country"`
+    - `"form.type.currency"`
+    - `"form.type.date"`
+    - `"form.type.datetime"`
+    - `"form.type.email"`
+    - `"form.type.file"`
+    - `"form.type.hidden"`
+    - `"form.type.integer"`
+    - `"form.type.language"`
+    - `"form.type.locale"`
+    - `"form.type.money"`
+    - `"form.type.number"`
+    - `"form.type.password"`
+    - `"form.type.percent"`
+    - `"form.type.radio"`
+    - `"form.type.range"`
+    - `"form.type.repeated"`
+    - `"form.type.search"`
+    - `"form.type.textarea"`
+    - `"form.type.text"`
+    - `"form.type.time"`
+    - `"form.type.timezone"`
+    - `"form.type.url"`
+    - `"form.type.button"`
+    - `"form.type.submit"`
+    - `"form.type.reset"`
+
 HttpKernel
 ----------
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -13,8 +13,42 @@ Form
 ----
 
  * The `choices_as_values` option of the `ChoiceType` has been removed.
+
  * Support for data objects that implements both `Traversable` and
    `ArrayAccess` in `ResizeFormListener::preSubmit` method has been removed
+
+ * The following form types registered as services has been removed; use
+   their fully-qualified class name instead:
+
+    - `"form.type.birthday"`
+    - `"form.type.checkbox"`
+    - `"form.type.collection"`
+    - `"form.type.country"`
+    - `"form.type.currency"`
+    - `"form.type.date"`
+    - `"form.type.datetime"`
+    - `"form.type.email"`
+    - `"form.type.file"`
+    - `"form.type.hidden"`
+    - `"form.type.integer"`
+    - `"form.type.language"`
+    - `"form.type.locale"`
+    - `"form.type.money"`
+    - `"form.type.number"`
+    - `"form.type.password"`
+    - `"form.type.percent"`
+    - `"form.type.radio"`
+    - `"form.type.range"`
+    - `"form.type.repeated"`
+    - `"form.type.search"`
+    - `"form.type.textarea"`
+    - `"form.type.text"`
+    - `"form.type.time"`
+    - `"form.type.timezone"`
+    - `"form.type.url"`
+    - `"form.type.button"`
+    - `"form.type.submit"`
+    - `"form.type.reset"`
 
 FrameworkBundle
 ---------------

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Added `Controller::json` to simplify creating JSON responses when using the Serializer component
  * Deprecated absolute template paths support in the template name parser
+ * Deprecated using core form types without dependencies as services
 
 3.0.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
@@ -66,95 +66,95 @@
             <tag name="form.type" />
         </service>
         <service id="form.type.birthday" class="Symfony\Component\Form\Extension\Core\Type\BirthdayType">
-            <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.checkbox" class="Symfony\Component\Form\Extension\Core\Type\CheckboxType">
-            <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.choice" class="Symfony\Component\Form\Extension\Core\Type\ChoiceType">
             <tag name="form.type" />
             <argument type="service" id="form.choice_list_factory"/>
         </service>
         <service id="form.type.collection" class="Symfony\Component\Form\Extension\Core\Type\CollectionType">
-            <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.country" class="Symfony\Component\Form\Extension\Core\Type\CountryType">
-            <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.date" class="Symfony\Component\Form\Extension\Core\Type\DateType">
-            <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.datetime" class="Symfony\Component\Form\Extension\Core\Type\DateTimeType">
-            <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.email" class="Symfony\Component\Form\Extension\Core\Type\EmailType">
-            <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.file" class="Symfony\Component\Form\Extension\Core\Type\FileType">
-            <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.hidden" class="Symfony\Component\Form\Extension\Core\Type\HiddenType">
-            <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.integer" class="Symfony\Component\Form\Extension\Core\Type\IntegerType">
-            <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.language" class="Symfony\Component\Form\Extension\Core\Type\LanguageType">
-            <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.locale" class="Symfony\Component\Form\Extension\Core\Type\LocaleType">
-            <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.money" class="Symfony\Component\Form\Extension\Core\Type\MoneyType">
-            <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.number" class="Symfony\Component\Form\Extension\Core\Type\NumberType">
-            <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.password" class="Symfony\Component\Form\Extension\Core\Type\PasswordType">
-            <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.percent" class="Symfony\Component\Form\Extension\Core\Type\PercentType">
-            <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.radio" class="Symfony\Component\Form\Extension\Core\Type\RadioType">
-            <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.range" class="Symfony\Component\Form\Extension\Core\Type\RangeType">
-            <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.repeated" class="Symfony\Component\Form\Extension\Core\Type\RepeatedType">
-            <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.search" class="Symfony\Component\Form\Extension\Core\Type\SearchType">
-            <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.textarea" class="Symfony\Component\Form\Extension\Core\Type\TextareaType">
-            <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.text" class="Symfony\Component\Form\Extension\Core\Type\TextType">
-            <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.time" class="Symfony\Component\Form\Extension\Core\Type\TimeType">
-            <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.timezone" class="Symfony\Component\Form\Extension\Core\Type\TimezoneType">
-            <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.url" class="Symfony\Component\Form\Extension\Core\Type\UrlType">
-            <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.button" class="Symfony\Component\Form\Extension\Core\Type\ButtonType">
-            <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.submit" class="Symfony\Component\Form\Extension\Core\Type\SubmitType">
-            <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.reset" class="Symfony\Component\Form\Extension\Core\Type\ResetType">
-            <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
         <service id="form.type.currency" class="Symfony\Component\Form\Extension\Core\Type\CurrencyType">
-            <tag name="form.type" />
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0.</deprecated>
         </service>
 
         <!-- FormTypeHttpFoundationExtension -->


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

These services are needless in regard of #15079.
If they have no dependencies, whatever are the registered extensions, `FormTypeInterface` instances will be autoloaded by their FQCN.
