### PR TITLE
[EventDispatcher] Event interface

### DIFF
--- a/src/Symfony/Component/EventDispatcher/CHANGELOG.md
+++ b/src/Symfony/Component/EventDispatcher/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 3.1.0
 -----
 
- * added EventInterface
+ * [BC BREAK] added EventInterface
  
 3.0.0
 -----

--- a/src/Symfony/Component/EventDispatcher/CHANGELOG.md
+++ b/src/Symfony/Component/EventDispatcher/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.1.0
+-----
+
+ * added EventInterface
+ 
 3.0.0
 -----
 

--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\EventDispatcher\Debug;
 
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\Stopwatch\Stopwatch;
@@ -118,7 +119,7 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
     /**
      * {@inheritdoc}
      */
-    public function dispatch($eventName, Event $event = null)
+    public function dispatch($eventName, EventInterface $event = null)
     {
         if (null === $event) {
             $event = new Event();
@@ -215,20 +216,20 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
     /**
      * Called before dispatching the event.
      *
-     * @param string $eventName The event name
-     * @param Event  $event     The event
+     * @param string     $eventName The event name
+     * @param EventInterface $event The event
      */
-    protected function preDispatch($eventName, Event $event)
+    protected function preDispatch($eventName, EventInterface $event)
     {
     }
 
     /**
      * Called after dispatching the event.
      *
-     * @param string $eventName The event name
-     * @param Event  $event     The event
+     * @param string      $eventName The event name
+     * @param EventInterface  $event The event
      */
-    protected function postDispatch($eventName, Event $event)
+    protected function postDispatch($eventName, EventInterface $event)
     {
     }
 

--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -216,8 +216,8 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
     /**
      * Called before dispatching the event.
      *
-     * @param string     $eventName The event name
-     * @param EventInterface $event The event
+     * @param string         $eventName The event name
+     * @param EventInterface $event     The event
      */
     protected function preDispatch($eventName, EventInterface $event)
     {
@@ -226,8 +226,8 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
     /**
      * Called after dispatching the event.
      *
-     * @param string      $eventName The event name
-     * @param EventInterface  $event The event
+     * @param string         $eventName The event name
+     * @param EventInterface $event     The event
      */
     protected function postDispatch($eventName, EventInterface $event)
     {

--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -216,20 +216,20 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
     /**
      * Called before dispatching the event.
      *
-     * @param string         $eventName The event name
-     * @param EventInterface $event     The event
+     * @param string $eventName The event name
+     * @param Event      $event The event
      */
-    protected function preDispatch($eventName, EventInterface $event)
+    protected function preDispatch($eventName, Event $event)
     {
     }
 
     /**
      * Called after dispatching the event.
      *
-     * @param string         $eventName The event name
-     * @param EventInterface $event     The event
+     * @param string $eventName The event name
+     * @param Event      $event The event
      */
-    protected function postDispatch($eventName, EventInterface $event)
+    protected function postDispatch($eventName, Event $event)
     {
     }
 

--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -217,7 +217,7 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
      * Called before dispatching the event.
      *
      * @param string $eventName The event name
-     * @param Event      $event The event
+     * @param Event  $event     The event
      */
     protected function preDispatch($eventName, Event $event)
     {
@@ -227,7 +227,7 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
      * Called after dispatching the event.
      *
      * @param string $eventName The event name
-     * @param Event      $event The event
+     * @param Event  $event     The event
      */
     protected function postDispatch($eventName, Event $event)
     {

--- a/src/Symfony/Component/EventDispatcher/Debug/WrappedListener.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/WrappedListener.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\EventDispatcher\Debug;
 
+use Symfony\Component\EventDispatcher\EventInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
-use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -52,7 +52,7 @@ class WrappedListener
         return $this->stoppedPropagation;
     }
 
-    public function __invoke(Event $event, $eventName, EventDispatcherInterface $dispatcher)
+    public function __invoke(EventInterface $event, $eventName, EventDispatcherInterface $dispatcher)
     {
         $this->called = true;
 

--- a/src/Symfony/Component/EventDispatcher/Event.php
+++ b/src/Symfony/Component/EventDispatcher/Event.php
@@ -24,8 +24,9 @@ namespace Symfony\Component\EventDispatcher;
  * @author Jonathan Wage <jonwage@gmail.com>
  * @author Roman Borschel <roman@code-factory.org>
  * @author Bernhard Schussek <bschussek@gmail.com>
+ * @author Tomasz Świacko-Świackiewicz <tomasz.swiacko.swiackiewicz@gmail.com>
  */
-class Event
+class Event implements EventInterface
 {
     /**
      * @var bool Whether no further event listeners should be triggered
@@ -33,11 +34,7 @@ class Event
     private $propagationStopped = false;
 
     /**
-     * Returns whether further event listeners should be triggered.
-     *
-     * @see Event::stopPropagation()
-     *
-     * @return bool Whether propagation was already stopped for this event.
+     * {@inheritdoc}
      */
     public function isPropagationStopped()
     {
@@ -45,11 +42,7 @@ class Event
     }
 
     /**
-     * Stops the propagation of the event to further event listeners.
-     *
-     * If multiple event listeners are connected to the same event, no
-     * further event listener will be triggered once any trigger calls
-     * stopPropagation().
+     * {@inheritdoc}
      */
     public function stopPropagation()
     {

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -161,9 +161,9 @@ class EventDispatcher implements EventDispatcherInterface
      * This method can be overridden to add functionality that is executed
      * for each listener.
      *
-     * @param callable[] $listeners The event listeners.
-     * @param string     $eventName The name of the event to dispatch.
-     * @param EventInterface $event The event object to pass to the event handlers/listeners.
+     * @param callable[]     $listeners The event listeners.
+     * @param string         $eventName The name of the event to dispatch.
+     * @param EventInterface $event     The event object to pass to the event handlers/listeners.
      */
     protected function doDispatch($listeners, $eventName, EventInterface $event)
     {

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -33,7 +33,7 @@ class EventDispatcher implements EventDispatcherInterface
     /**
      * {@inheritdoc}
      */
-    public function dispatch($eventName, Event $event = null)
+    public function dispatch($eventName, EventInterface $event = null)
     {
         if (null === $event) {
             $event = new Event();
@@ -163,9 +163,9 @@ class EventDispatcher implements EventDispatcherInterface
      *
      * @param callable[] $listeners The event listeners.
      * @param string     $eventName The name of the event to dispatch.
-     * @param Event      $event     The event object to pass to the event handlers/listeners.
+     * @param EventInterface $event The event object to pass to the event handlers/listeners.
      */
-    protected function doDispatch($listeners, $eventName, Event $event)
+    protected function doDispatch($listeners, $eventName, EventInterface $event)
     {
         foreach ($listeners as $listener) {
             call_user_func($listener, $event, $eventName, $this);

--- a/src/Symfony/Component/EventDispatcher/EventDispatcherInterface.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcherInterface.php
@@ -23,15 +23,15 @@ interface EventDispatcherInterface
     /**
      * Dispatches an event to all registered listeners.
      *
-     * @param string $eventName The name of the event to dispatch. The name of
-     *                          the event is the name of the method that is
-     *                          invoked on listeners.
-     * @param Event  $event     The event to pass to the event handlers/listeners.
-     *                          If not supplied, an empty Event instance is created.
+     * @param string     $eventName The name of the event to dispatch. The name of
+     *                              the event is the name of the method that is
+     *                              invoked on listeners.
+     * @param EventInterface $event The event to pass to the event handlers/listeners.
+     *                              If not supplied, an empty Event instance is created.
      *
-     * @return Event
+     * @return EventInterface
      */
-    public function dispatch($eventName, Event $event = null);
+    public function dispatch($eventName, EventInterface $event = null);
 
     /**
      * Adds an event listener that listens on the specified events.

--- a/src/Symfony/Component/EventDispatcher/EventDispatcherInterface.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcherInterface.php
@@ -23,11 +23,11 @@ interface EventDispatcherInterface
     /**
      * Dispatches an event to all registered listeners.
      *
-     * @param string     $eventName The name of the event to dispatch. The name of
-     *                              the event is the name of the method that is
-     *                              invoked on listeners.
-     * @param EventInterface $event The event to pass to the event handlers/listeners.
-     *                              If not supplied, an empty Event instance is created.
+     * @param string         $eventName The name of the event to dispatch. The name of
+     *                                  the event is the name of the method that is
+     *                                  invoked on listeners.
+     * @param EventInterface $event     The event to pass to the event handlers/listeners.
+     *                                  If not supplied, an empty Event instance is created.
      *
      * @return EventInterface
      */

--- a/src/Symfony/Component/EventDispatcher/EventInterface.php
+++ b/src/Symfony/Component/EventDispatcher/EventInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher;
+
+/**
+ * The EventInterface is the base interface for classes containing event data.
+ *
+ * You can call the method stopPropagation() to abort the execution of
+ * further listeners in your event listener.
+ *
+ * @author Tomasz Świacko-Świackiewicz <tomasz.swiacko.swiackiewicz@gmail.com>
+ */
+interface EventInterface
+{
+    /**
+     * Returns whether further event listeners should be triggered.
+     *
+     * @see EventInterface::stopPropagation()
+     *
+     * @return bool Whether propagation was already stopped for this event.
+     */
+    public function isPropagationStopped();
+
+    /**
+     * Stops the propagation of the event to further event listeners.
+     *
+     * If multiple event listeners are connected to the same event, no
+     * further event listener will be triggered once any trigger calls
+     * stopPropagation().
+     */
+    public function stopPropagation();
+}

--- a/src/Symfony/Component/EventDispatcher/ImmutableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/ImmutableEventDispatcher.php
@@ -38,7 +38,7 @@ class ImmutableEventDispatcher implements EventDispatcherInterface
     /**
      * {@inheritdoc}
      */
-    public function dispatch($eventName, Event $event = null)
+    public function dispatch($eventName, EventInterface $event = null)
     {
         return $this->dispatcher->dispatch($eventName, $event);
     }

--- a/src/Symfony/Component/EventDispatcher/Tests/AbstractEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/AbstractEventDispatcherTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\EventDispatcher\Tests;
 
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 abstract class AbstractEventDispatcherTest extends \PHPUnit_Framework_TestCase
@@ -317,12 +318,12 @@ class TestEventListener
 
     /* Listener methods */
 
-    public function preFoo(Event $e)
+    public function preFoo(EventInterface $e)
     {
         $this->preFooInvoked = true;
     }
 
-    public function postFoo(Event $e)
+    public function postFoo(EventInterface $e)
     {
         $this->postFooInvoked = true;
 
@@ -335,7 +336,7 @@ class TestWithDispatcher
     public $name;
     public $dispatcher;
 
-    public function foo(Event $e, $name, $dispatcher)
+    public function foo(EventInterface $e, $name, $dispatcher)
     {
         $this->name = $name;
         $this->dispatcher = $dispatcher;

--- a/src/Symfony/Component/EventDispatcher/Tests/ContainerAwareEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/ContainerAwareEventDispatcherTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\EventDispatcher\Tests;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher;
 use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\EventInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class ContainerAwareEventDispatcherTest extends AbstractEventDispatcherTest
@@ -177,7 +178,7 @@ class ContainerAwareEventDispatcherTest extends AbstractEventDispatcherTest
 
 class Service
 {
-    public function onEvent(Event $e)
+    public function onEvent(EventInterface $e)
     {
     }
 }
@@ -193,15 +194,15 @@ class SubscriberService implements EventSubscriberInterface
         );
     }
 
-    public function onEvent(Event $e)
+    public function onEvent(EventInterface $e)
     {
     }
 
-    public function onEventWithPriority(Event $e)
+    public function onEventWithPriority(EventInterface $e)
     {
     }
 
-    public function onEventNested(Event $e)
+    public function onEventNested(EventInterface $e)
     {
     }
 }

--- a/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\EventDispatcher\Tests\Debug;
 
 use Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\Event;
@@ -108,11 +109,11 @@ class TraceableEventDispatcherTest extends \PHPUnit_Framework_TestCase
     {
         $tdispatcher = null;
         $dispatcher = new TraceableEventDispatcher(new EventDispatcher(), new Stopwatch());
-        $dispatcher->addListener('foo', function (Event $event, $eventName, $dispatcher) use (&$tdispatcher) {
+        $dispatcher->addListener('foo', function (EventInterface $event, $eventName, $dispatcher) use (&$tdispatcher) {
             $tdispatcher = $dispatcher;
             $dispatcher->dispatch('bar');
         });
-        $dispatcher->addListener('bar', function (Event $event) {});
+        $dispatcher->addListener('bar', function (EventInterface $event) {});
         $dispatcher->dispatch('foo');
         $this->assertSame($dispatcher, $tdispatcher);
         $this->assertCount(2, $dispatcher->getCalledListeners());
@@ -139,7 +140,7 @@ class TraceableEventDispatcherTest extends \PHPUnit_Framework_TestCase
 
         $dispatcher = new EventDispatcher();
         $tdispatcher = new TraceableEventDispatcher($dispatcher, new Stopwatch(), $logger);
-        $tdispatcher->addListener('foo', $listener1 = function (Event $event) { $event->stopPropagation(); });
+        $tdispatcher->addListener('foo', $listener1 = function (EventInterface $event) { $event->stopPropagation(); });
         $tdispatcher->addListener('foo', $listener2 = function () {});
 
         $logger->expects($this->at(0))->method('debug')->with('Notified event "{event}" to listener "{listener}".', array('event' => 'foo', 'listener' => 'closure'));
@@ -181,10 +182,10 @@ class TraceableEventDispatcherTest extends \PHPUnit_Framework_TestCase
     {
         $nestedCall = false;
         $dispatcher = new TraceableEventDispatcher(new EventDispatcher(), new Stopwatch());
-        $dispatcher->addListener('foo', function (Event $e) use ($dispatcher) {
+        $dispatcher->addListener('foo', function (EventInterface $e) use ($dispatcher) {
             $dispatcher->dispatch('bar', $e);
         });
-        $dispatcher->addListener('bar', function (Event $e) use (&$nestedCall) {
+        $dispatcher->addListener('bar', function (EventInterface $e) use (&$nestedCall) {
             $nestedCall = true;
         });
 

--- a/src/Symfony/Component/EventDispatcher/Tests/EventTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/EventTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\EventDispatcher\Event;
 class EventTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var \Symfony\Component\EventDispatcher\Event
+     * @var \Symfony\Component\EventDispatcher\EventInterface
      */
     protected $event;
 

--- a/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
@@ -12,8 +12,8 @@
 namespace Symfony\Component\HttpKernel\Debug;
 
 use Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher as BaseTraceableEventDispatcher;
-use Symfony\Component\EventDispatcher\EventInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\EventDispatcher\Event;
 
 /**
  * Collects some data about event listeners.
@@ -27,7 +27,7 @@ class TraceableEventDispatcher extends BaseTraceableEventDispatcher
     /**
      * {@inheritdoc}
      */
-    protected function preDispatch($eventName, EventInterface $event)
+    protected function preDispatch($eventName, Event $event)
     {
         switch ($eventName) {
             case KernelEvents::REQUEST:
@@ -58,7 +58,7 @@ class TraceableEventDispatcher extends BaseTraceableEventDispatcher
     /**
      * {@inheritdoc}
      */
-    protected function postDispatch($eventName, EventInterface $event)
+    protected function postDispatch($eventName, Event $event)
     {
         switch ($eventName) {
             case KernelEvents::CONTROLLER:

--- a/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
@@ -12,8 +12,8 @@
 namespace Symfony\Component\HttpKernel\Debug;
 
 use Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher as BaseTraceableEventDispatcher;
+use Symfony\Component\EventDispatcher\EventInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\EventDispatcher\Event;
 
 /**
  * Collects some data about event listeners.
@@ -27,7 +27,7 @@ class TraceableEventDispatcher extends BaseTraceableEventDispatcher
     /**
      * {@inheritdoc}
      */
-    protected function preDispatch($eventName, Event $event)
+    protected function preDispatch($eventName, EventInterface $event)
     {
         switch ($eventName) {
             case KernelEvents::REQUEST:
@@ -58,7 +58,7 @@ class TraceableEventDispatcher extends BaseTraceableEventDispatcher
     /**
      * {@inheritdoc}
      */
-    protected function postDispatch($eventName, Event $event)
+    protected function postDispatch($eventName, EventInterface $event)
     {
         switch ($eventName) {
             case KernelEvents::CONTROLLER:


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

Current EventDispatcherInterface is tight coupled with Event class. More flexible solution  - passing EventInterface (instead of Event class) in EventDispatcherInterface::dispatch() method. Event class will implement EventInterface.
