### PR TITLE
[FrameworkBundle] Upgrade notice for the Controller::json() method

### DIFF
--- a/UPGRADE-3.1.md
+++ b/UPGRADE-3.1.md
@@ -26,6 +26,11 @@ FrameworkBundle
  * As it was never an officially supported feature, the support for absolute
    template paths has been deprecated and will be removed in Symfony 4.0.
 
+ * The abstract `Controller` class now has a `json()` helper method that creates
+   a `JsonResponse`. If you have existing controllers extending `Controller`
+   that contain a method with this name, you need to rename that method to avoid
+   conflicts.
+
  * The following form types registered as services have been deprecated and
    will be removed in Symfony 4.0; use their fully-qualified class name instead:
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

PR #17642 added a `json()` method to the `Controller` class. This might break existing code extending the class. This PR adds a note about this to the UPGRADE-3.1 document.
