### PR TITLE
Update UPGRADE-3.0 with Voter::voteOnAttribute()

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -1075,7 +1075,7 @@ UPGRADE FROM 2.x to 3.0
    }
    ```
 
- * The `AbstractVoter::isGranted()` method have been replaced by `AbstractVoter::voteOnAttribute()`.
+ * The `AbstractVoter::isGranted()` method have been replaced by `Voter::voteOnAttribute()`.
 
    Before:
 
@@ -1094,7 +1094,7 @@ UPGRADE FROM 2.x to 3.0
    After:
 
    ```php
-   class MyVoter extends AbstractVoter
+   class MyVoter extends Voter
    {
        protected function voteOnAttribute($attribute, $object, TokenInterface $token)
        {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.0 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | n/a |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The instructions show that `AbstractVoter::isGranted()` has been replaced by `AbstractVoter::voteOnAttribute()`. Since AbstractVoter is removed it should be Voter::voteOnAttribute()
