### PR TITLE
[DX] [LDAP] Added default service name for the Security component's Ldap providers

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FormLoginLdapFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FormLoginLdapFactory.php
@@ -45,7 +45,7 @@ class FormLoginLdapFactory extends FormLoginFactory
 
         $node
             ->children()
-                ->scalarNode('service')->end()
+                ->scalarNode('service')->defaultValue('ldap')->end()
                 ->scalarNode('dn_string')->defaultValue('{username}')->end()
             ->end()
         ;

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpBasicLdapFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpBasicLdapFactory.php
@@ -55,7 +55,7 @@ class HttpBasicLdapFactory extends HttpBasicFactory
 
         $node
             ->children()
-                ->scalarNode('service')->end()
+                ->scalarNode('service')->defaultValue('ldap')->end()
                 ->scalarNode('dn_string')->defaultValue('{username}')->end()
             ->end()
         ;

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/UserProvider/LdapFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/UserProvider/LdapFactory.php
@@ -47,7 +47,7 @@ class LdapFactory implements UserProviderFactoryInterface
     {
         $node
             ->children()
-                ->scalarNode('service')->isRequired()->cannotBeEmpty()->end()
+                ->scalarNode('service')->isRequired()->cannotBeEmpty()->defaultValue('ldap')->end()
                 ->scalarNode('base_dn')->isRequired()->cannotBeEmpty()->end()
                 ->scalarNode('search_dn')->end()
                 ->scalarNode('search_password')->end()

--- a/src/Symfony/Component/Ldap/README.md
+++ b/src/Symfony/Component/Ldap/README.md
@@ -11,14 +11,10 @@ have been marked as internal as they still needed some work.
 Breaking changes were introduced in Symfony 3.1, so code relying on
 previous version of the component will break with this version.
 
-Documentation
--------------
-
-The documentation for the component can be found [online] [0].
-
 Resources
 ---------
 
+  * [Documentation](https://symfony.com/doc/current/components/filesystem/index.html)
   * [Contributing](https://symfony.com/doc/current/contributing/index.html)
   * [Report issues](https://github.com/symfony/symfony/issues) and
     [send Pull Requests](https://github.com/symfony/symfony/pulls)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This PR adds a default service name (`ldap`) for the Security component's Ldap factories (`LdapFactory`, `FormLoginLdapFactory` and `HttpBasicLdapFactory`.
