### PR TITLE
[ci] Skip dns-sensitive tests when DnsMock is not found

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
@@ -93,6 +93,7 @@ class EmailValidatorTest extends AbstractConstraintValidatorTest
 
     /**
      * @dataProvider getDnsChecks
+     * @requires function Symfony\Bridge\PhpUnit\DnsMock::withMockedHosts
      */
     public function testDnsChecks($type, $violation)
     {
@@ -126,6 +127,9 @@ class EmailValidatorTest extends AbstractConstraintValidatorTest
         );
     }
 
+    /**
+     * @requires function Symfony\Bridge\PhpUnit\DnsMock::withMockedHosts
+     */
     public function testHostnameIsProperlyParsed()
     {
         DnsMock::withMockedHosts(array('baz.com' => array(array('type' => 'MX'))));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.3 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18319 |
| License | MIT |
| Doc PR | - |
