### PR TITLE
skipped dns-sensitive tests when DnsMock is not found (2.7)

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
@@ -194,6 +194,7 @@ class UrlValidatorTest extends AbstractConstraintValidatorTest
 
     /**
      * @dataProvider getCheckDns
+     * @requires function Symfony\Bridge\PhpUnit\DnsMock::withMockedHosts
      */
     public function testCheckDns($violation)
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.3 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18319 |
| License | MIT |
| Doc PR | - |
