### PR TITLE
[2.7][WebProfilerBundle] Fix CORS ajax security issues

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -80,6 +80,20 @@
 
             requestStack = [],
 
+            extractHeaders = function(xhr, stackElement) {
+                // Here we avoid to call xhr.getResponseHeader in order to
+                // prevent polluting the console with CORS security errors
+                var allHeaders = xhr.getAllResponseHeaders();
+                var ret;
+
+                if (ret = allHeaders.match(/^x-debug-token:\s+(.*)$/im)) {
+                    stackElement.profile = ret[1];
+                }
+                if (ret = allHeaders.match(/^x-debug-token-link:\s+(.*)$/im)) {
+                    stackElement.profilerUrl = ret[1];
+                }
+            },
+
             renderAjaxRequests = function() {
                 var requestCounter = document.querySelectorAll('.sf-toolbar-ajax-requests');
                 if (!requestCounter.length) {
@@ -239,8 +253,8 @@
                                 stackElement.duration = new Date() - stackElement.start;
                                 stackElement.loading = false;
                                 stackElement.error = self.status < 200 || self.status >= 400;
-                                stackElement.profile = self.getResponseHeader("X-Debug-Token");
-                                stackElement.profilerUrl = self.getResponseHeader("X-Debug-Token-Link");
+
+                                extractHeaders(self, stackElement);
 
                                 Sfjs.renderAjaxRequests();
                             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

The WebProfiler toolbar monitors ajax requests. However, when using cross domain ajax requests, it triggers a security issues `Refused to get unsafe header "X-Debug-Token"` `Refused to get unsafe header "X-Debug-Token-Link"` because if the other app is not a Symfony App configured to expose these headers in CORS.

![image](https://cloud.githubusercontent.com/assets/137574/14225799/f462c09c-f8cf-11e5-925d-88be99945a92.png)

This fixes the issue. It adds a new configuration node to explicitly activate it on purpose.
