### PR TITLE
[EventDispatcher] Try first if the event is Stopped

### DIFF
--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -155,10 +155,10 @@ class EventDispatcher implements EventDispatcherInterface
     protected function doDispatch($listeners, $eventName, Event $event)
     {
         foreach ($listeners as $listener) {
-            call_user_func($listener, $event);
             if ($event->isPropagationStopped()) {
                 break;
             }
+            call_user_func($listener, $event);
         }
     }
 

--- a/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
@@ -136,6 +136,10 @@ class TraceableEventDispatcher implements EventDispatcherInterface, TraceableEve
             $event = new Event();
         }
 
+        if (null !== $this->logger && $event->isPropagationStopped()) {
+            $this->logger->debug(sprintf('The "%s" event is already stopped. No listeners have been called.', $eventName));
+        }
+
         $eventId = ++$this->lastEventId;
 
         $this->preDispatch($eventName, $eventId, $event);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.3 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

If you trigger 2 events with the same instance of Event and if a listener in the first dispatch stop the propagation, then the very first listener of the second dispatch is called. It should not IMHO.
