### PR TITLE
[Console] Correct time formatting.

### DIFF
--- a/src/Symfony/Component/Console/Helper/Helper.php
+++ b/src/Symfony/Component/Console/Helper/Helper.php
@@ -66,26 +66,28 @@ abstract class Helper implements HelperInterface
     {
         static $timeFormats = array(
             array(0, '< 1 sec'),
-            array(2, '1 sec'),
-            array(59, 'secs', 1),
+            array(1, '1 sec'),
+            array(2, 'secs', 1),
             array(60, '1 min'),
-            array(3600, 'mins', 60),
-            array(5400, '1 hr'),
-            array(86400, 'hrs', 3600),
-            array(129600, '1 day'),
-            array(604800, 'days', 86400),
+            array(120, 'mins', 60),
+            array(3600, '1 hr'),
+            array(7200, 'hrs', 3600),
+            array(86400, '1 day'),
+            array(172800, 'days', 86400),
         );
 
-        foreach ($timeFormats as $format) {
+        foreach ($timeFormats as $index => $format) {
             if ($secs >= $format[0]) {
-                continue;
-            }
+                if ((isset($timeFormats[$index + 1]) && $secs < $timeFormats[$index + 1][0])
+                    || $index == count($timeFormats) - 1
+                ) {
+                    if (2 == count($format)) {
+                        return $format[1];
+                    }
 
-            if (2 == count($format)) {
-                return $format[1];
+                    return floor($secs / $format[2]).' '.$format[1];
+                }
             }
-
-            return ceil($secs / $format[2]).' '.$format[1];
         }
     }
 

--- a/src/Symfony/Component/Console/Tests/Helper/HelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/HelperTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Helper;
+
+use Symfony\Component\Console\Helper\Helper;
+
+class HelperTest extends \PHPUnit_Framework_TestCase
+{
+    public function formatTimeProvider()
+    {
+        return array(
+            array(0,      '< 1 sec'),
+            array(1,      '1 sec'),
+            array(2,      '2 secs'),
+            array(59,     '59 secs'),
+            array(60,     '1 min'),
+            array(61,     '1 min'),
+            array(119,    '1 min'),
+            array(120,    '2 mins'),
+            array(121,    '2 mins'),
+            array(3599,   '59 mins'),
+            array(3600,   '1 hr'),
+            array(7199,   '1 hr'),
+            array(7200,   '2 hrs'),
+            array(7201,   '2 hrs'),
+            array(86399,  '23 hrs'),
+            array(86400,  '1 day'),
+            array(86401,  '1 day'),
+            array(172799, '1 day'),
+            array(172800, '2 days'),
+            array(172801, '2 days'),
+        );
+    }
+
+    /**
+     * @dataProvider formatTimeProvider
+     * @param int $secs
+     * @param string $expectedFormat
+     */
+    public function testFormatTime($secs, $expectedFormat)
+    {
+        $this->assertEquals($expectedFormat, Helper::formatTime($secs));
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Helper/HelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/HelperTest.php
@@ -43,7 +43,8 @@ class HelperTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider formatTimeProvider
-     * @param int $secs
+     *
+     * @param int    $secs
      * @param string $expectedFormat
      */
     public function testFormatTime($secs, $expectedFormat)

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -591,17 +591,17 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
             $this->generateOutput(
                 " \033[44;37m Starting the demo... fingers crossed  \033[0m\n".
                 '  0/15 '.$progress.str_repeat($empty, 26)."   0%\n".
-                " \xf0\x9f\x8f\x81  1 sec                          \033[44;37m 0 B \033[0m"
+                " \xf0\x9f\x8f\x81  < 1 sec                        \033[44;37m 0 B \033[0m"
             ).
             $this->generateOutput(
                 " \033[44;37m Looks good to me...                   \033[0m\n".
                 '  4/15 '.str_repeat($done, 7).$progress.str_repeat($empty, 19)."  26%\n".
-                " \xf0\x9f\x8f\x81  1 sec                       \033[41;37m 97 KiB \033[0m"
+                " \xf0\x9f\x8f\x81  < 1 sec                     \033[41;37m 97 KiB \033[0m"
             ).
             $this->generateOutput(
                 " \033[44;37m Thanks, bye                           \033[0m\n".
                 ' 15/15 '.str_repeat($done, 28)." 100%\n".
-                " \xf0\x9f\x8f\x81  1 sec                      \033[41;37m 195 KiB \033[0m"
+                " \xf0\x9f\x8f\x81  < 1 sec                    \033[41;37m 195 KiB \033[0m"
             ),
             stream_get_contents($output->getStream())
         );


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18420 |
| License | MIT |
| Doc PR |  |

The previous behavior caused dramatic jumps in the reported time instead of smoothly transitioning between time ranges.
Added tests around the new behavior and the transitions between seconds, minutes, and days.
