### PR TITLE
[Logging] Add support for Firefox (43+) in ChromePhpHandler

### DIFF
--- a/src/Symfony/Bridge/Monolog/Handler/ChromePhpHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/ChromePhpHandler.php
@@ -42,7 +42,7 @@ class ChromePhpHandler extends BaseChromePhpHandler
             return;
         }
 
-        if (!preg_match('{\bChrome/\d+[\.\d+]*\b}', $event->getRequest()->headers->get('User-Agent'))) {
+        if (!preg_match('{\b(?:Chrome/\d+(?:\.\d+)*|Firefox/(?:4[3-9]|[5-9]\d|\d{3,})(?:\.\d)*)\b}', $event->getRequest()->headers->get('User-Agent'))) {
             $this->sendHeaders = false;
             $this->headers = array();
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.3 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

Firefox added support for Chrome Logger a while back in [version 43](https://www.mozilla.org/en-US/firefox/43.0/releasenotes/).
Support for Firefox was added in the ChromePHPHandler of [Monolog 1.18.0](https://github.com/Seldaek/monolog/issues/721), although its not mentioned in the changelog.

This PR is basically just to replace the originally copied regular expression, [with this new one](https://github.com/Seldaek/monolog/commit/fa96f6aa8f49706df6bfa0929609ed8b3345d94b).

There should be no BC breakage, even though users may be using Monolog versions between 1.11 and 1.18. Monolog's ChromePHPHandler only got minor touch ups and its protocol (and thus output) remained the same.
This fix in fact also adds support for Firefox 43+ to older Monolog's when using the Symfony-version of that handler (which they should be using), since the Symfony-version of ChromePhpHandler completely overwrites the 'headersAccepted'-check of Monolog.
