### PR TITLE
Add the kernel.controller_arguments event

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * added `Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface`
  * added `Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface` as argument to `HttpKernel`
  * added `Symfony\Component\HttpKernel\Controller\ArgumentResolver`
+ * added the `kernel.controller_arguments` event, triggered after controller arguments have been resolved
 
 3.0.0
 -----
@@ -22,8 +23,8 @@ CHANGELOG
  * removed `Symfony\Component\HttpKernel\EventListener\RouterListener::setRequest()`
  * removed `Symfony\Component\HttpKernel\EventListener\ProfilerListener::onKernelRequest()`
  * removed `Symfony\Component\HttpKernel\Fragment\FragmentHandler::setRequest()`
- * removed `Symfony\Component\HttpKernel\HttpCache\Esi::hasSurrogateEsiCapability()` 
- * removed `Symfony\Component\HttpKernel\HttpCache\Esi::addSurrogateEsiCapability()` 
+ * removed `Symfony\Component\HttpKernel\HttpCache\Esi::hasSurrogateEsiCapability()`
+ * removed `Symfony\Component\HttpKernel\HttpCache\Esi::addSurrogateEsiCapability()`
  * removed `Symfony\Component\HttpKernel\HttpCache\Esi::needsEsiParsing()`
  * removed `Symfony\Component\HttpKernel\HttpCache\HttpCache::getEsi()`
  * removed `Symfony\Component\HttpKernel\DependencyInjection\ContainerAwareHttpKernel`

--- a/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
@@ -61,7 +61,7 @@ class TraceableEventDispatcher extends BaseTraceableEventDispatcher
     protected function postDispatch($eventName, Event $event)
     {
         switch ($eventName) {
-            case KernelEvents::CONTROLLER:
+            case KernelEvents::CONTROLLER_ARGUMENTS:
                 $this->stopwatch->start('controller', 'section');
                 break;
             case KernelEvents::RESPONSE:

--- a/src/Symfony/Component/HttpKernel/Event/FilterControllerArgumentsEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/FilterControllerArgumentsEvent.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Event;
+
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Allows filtering of controller arguments.
+ *
+ * You can call getController() to retrieve the controller and getArguments
+ * to retrieve the current arguments. With setArguments() you can replace
+ * arguments that are used to call the controller.
+ *
+ * Arguments set in the event must be compatible with the signature of the
+ * controller.
+ *
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class FilterControllerArgumentsEvent extends FilterControllerEvent
+{
+    private $arguments;
+
+    public function __construct(HttpKernelInterface $kernel, callable $controller, array $arguments, Request $request, $requestType)
+    {
+        parent::__construct($kernel, $controller, $request, $requestType);
+
+        $this->arguments = $arguments;
+    }
+
+    /**
+     * @return array
+     */
+    public function getArguments()
+    {
+        return $this->arguments;
+    }
+
+    /**
+     * @param array $arguments
+     */
+    public function setArguments(array $arguments)
+    {
+        $this->arguments = $arguments;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Event/FilterControllerEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/FilterControllerEvent.php
@@ -53,8 +53,6 @@ class FilterControllerEvent extends KernelEvent
      * Sets a new controller.
      *
      * @param callable $controller
-     *
-     * @throws \LogicException
      */
     public function setController(callable $controller)
     {

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\HttpKernel;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface;
 use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
+use Symfony\Component\HttpKernel\Event\FilterControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
@@ -137,6 +138,11 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
 
         // controller arguments
         $arguments = $this->argumentResolver->getArguments($request, $controller);
+
+        $event = new FilterControllerArgumentsEvent($this, $controller, $arguments, $request, $type);
+        $this->dispatcher->dispatch(KernelEvents::CONTROLLER_ARGUMENTS, $event);
+        $controller = $event->getController();
+        $arguments = $event->getArguments();
 
         // call controller
         $response = call_user_func_array($controller, $arguments);

--- a/src/Symfony/Component/HttpKernel/KernelEvents.php
+++ b/src/Symfony/Component/HttpKernel/KernelEvents.php
@@ -77,6 +77,19 @@ final class KernelEvents
     const CONTROLLER = 'kernel.controller';
 
     /**
+     * The CONTROLLER_ARGUMENTS event occurs once controller arguments have been resolved.
+     *
+     * This event allows you to change the arguments that will be passed to
+     * the controller. The event listener method receives a
+     * Symfony\Component\HttpKernel\Event\FilterControllerArgumentsEvent instance.
+     *
+     * @Event
+     *
+     * @var string
+     */
+    const CONTROLLER_ARGUMENTS = 'kernel.controller_arguments';
+
+    /**
      * The RESPONSE event occurs once a response was created for
      * replying to a request.
      *

--- a/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
@@ -34,6 +34,7 @@ class TraceableEventDispatcherTest extends \PHPUnit_Framework_TestCase
             '__section__',
             'kernel.request',
             'kernel.controller',
+            'kernel.controller_arguments',
             'controller',
             'kernel.response',
             'kernel.terminate',


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18362 |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/6434 |

I'm not sure this can be integrated in 3.1 due to the feature freeze, but it would be great if it is, as it is a must-have to be able to make the `@Security` annotation compatible with the new argument resolver system (as we need to be able to run the security assertion after the resolving).

I made the arguments mutable here for consistency with `kernel.controller` (and @fabpot replied LGTM in the RFC when I suggested it).
