### PR TITLE
[HttpFoundation] Improve phpdoc

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -709,7 +709,7 @@ class Request
      * Order of precedence: PATH (routing placeholders or custom attributes), GET, BODY
      *
      * @param string $key     the key
-     * @param mixed  $default the default value
+     * @param mixed  $default the default value if the parameter key does not exist
      *
      * @return mixed
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master? |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Improve the phpdoc for the `$default` parameter of the `get()` method. It wasn't clear when the default value would be used (whether the key would not exist or the value was `null` or nullish).

The comment is now in sync with `Symfony\Component\HttpFoundation\ParameterBag::get()`.
