### PR TITLE
[DependencyInjection] Resolve anonymous inline services as DefinitionDecorator

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -59,8 +59,8 @@ class PassConfig
 
         $this->removingPasses = array(
             new RemovePrivateAliasesPass(),
-            new RemoveAbstractDefinitionsPass(),
             new ReplaceAliasByActualDefinitionPass(),
+            new RemoveAbstractDefinitionsPass(),
             new RepeatedPass(array(
                 new AnalyzeServiceReferencesPass(),
                 new InlineServiceDefinitionsPass(),
@@ -103,8 +103,7 @@ class PassConfig
             throw new InvalidArgumentException(sprintf('Invalid type "%s".', $type));
         }
 
-        $passes = &$this->$property;
-        $passes[] = $pass;
+        $this->{$property}[] = $pass;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -233,10 +233,10 @@ class XmlFileLoader extends FileLoader
         if (false !== $nodes = $xml->xpath('//container:argument[@type="service"][not(@id)]|//container:property[@type="service"][not(@id)]')) {
             foreach ($nodes as $node) {
                 // give it a unique name
-                $node['id'] = sprintf('%s_%d', md5($file), ++$count);
+                $node['parent'] = sprintf('%s_%d', md5($file), ++$count);
 
-                $definitions[(string) $node['id']] = array($node->service, $file, false);
-                $node->service['id'] = (string) $node['id'];
+                $definitions[(string) $node['parent']] = array($node->service, $file, false);
+                $node->service['id'] = (string) $node['parent'];
             }
         }
 

--- a/src/Symfony/Component/DependencyInjection/SimpleXMLElement.php
+++ b/src/Symfony/Component/DependencyInjection/SimpleXMLElement.php
@@ -62,6 +62,11 @@ class SimpleXMLElement extends \SimpleXMLElement
 
             switch ($arg['type']) {
                 case 'service':
+                    if (!isset($arg['id'])) {
+                        $arguments[$key] = new DefinitionDecorator((string) $arg['parent']);
+                        break;
+                    }
+
                     $invalidBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE;
                     if (isset($arg['on-invalid']) && 'ignore' == $arg['on-invalid']) {
                         $invalidBehavior = ContainerInterface::IGNORE_ON_INVALID_REFERENCE;

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -707,6 +707,21 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array($second, $first), $configs);
     }
 
+    public function testAbstractAlias()
+    {
+        $container = new ContainerBuilder();
+
+        $abstract = new Definition('AbstractClass');
+        $abstract->setAbstract(true);
+
+        $container->setDefinition('abstract_service', $abstract);
+        $container->setAlias('abstract_alias', 'abstract_service');
+
+        $container->compile();
+
+        $this->assertSame('abstract_service', (string) $container->getAlias('abstract_alias'));
+    }
+
     public function testLazyLoadedService()
     {
         $loader = new ClosureLoader($container = new ContainerBuilder());

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services5.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services5.xml
@@ -14,8 +14,11 @@
         </service>
       </argument>
       <property name="p" type="service">
-        <service class="BazClass" />
+        <service class="BuzClass" />
       </property>
+    </service>
+    <service class="BizClass">
+        <tag name="biz_tag" />
     </service>
   </services>
 </container>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.3 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Because anonymous inline services should no be shared when using a DefinitionDecorator on a service that uses them.
