### PR TITLE
[DomCrawler] Fix adding HTML content containing a NULL character

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -183,6 +183,9 @@ class Crawler extends \SplObjectStorage
 
         restore_error_handler();
 
+        // Remove NULL characters to prevent DOMDocument::loadHTML() from stopping the document parsing
+        $content = str_replace("\x00", '', $content);
+
         if ('' !== trim($content)) {
             @$dom->loadHTML($content);
         }

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -137,6 +137,14 @@ EOF
         libxml_use_internal_errors($internalErrors);
     }
 
+    public function testAddHtmlContentWithNullCharacter()
+    {
+        $crawler = new Crawler();
+        $crawler->addHtmlContent("<html>\x00<div class=\"foo\"></html>", 'UTF-8');
+
+        $this->assertEquals('foo', $crawler->filterXPath('//div')->attr('class'));
+    }
+
     public function testAddXmlContent()
     {
         $crawler = new Crawler();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.3 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

When adding HTML content to the Crawler, if the string contains a null character (`0x00`) `DOMDocument::loadHTML()` method silently stops processing the document, only storing the nodes parsed up to that point.
