### PR TITLE
[WebProfilerBundle] Fixed error from unset twig variable

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -50,21 +50,21 @@
                 </span>
             </div>
 
-            {% if 'n/a' != collector.appname %}
+            {% if 'n/a' is not same as(collector.appname) %}
                 <div class="sf-toolbar-info-piece">
                     <b>Kernel name</b>
                     <span>{{ collector.appname }}</span>
                 </div>
             {% endif %}
 
-            {% if 'n/a' != collector.env %}
+            {% if 'n/a' is not same as(collector.env) %}
                 <div class="sf-toolbar-info-piece">
                     <b>Environment</b>
                     <span>{{ collector.env }}</span>
                 </div>
             {% endif %}
 
-            {% if 'n/a' != collector.debug %}
+            {% if 'n/a' is not same as(collector.debug) %}
                 <div class="sf-toolbar-info-piece">
                     <b>Debug</b>
                     <span class="sf-toolbar-status sf-toolbar-status-{{ collector.debug ? 'green' : 'red' }}">{{ collector.debug ? 'enabled' : 'disabled' }}</span>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -67,7 +67,7 @@
             {% if 'n/a' != collector.debug %}
                 <div class="sf-toolbar-info-piece">
                     <b>Debug</b>
-                    <span class="{{ debug_status_class }}">{{ collector.debug ? 'enabled' : 'disabled' }}</span>
+                    <span class="sf-toolbar-status sf-toolbar-status-{{ collector.debug ? 'green' : 'red' }}">{{ collector.debug ? 'enabled' : 'disabled' }}</span>
                 </div>
             {% endif %}
         </div>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Minor bug, fixes error from twig variable which was removed in 2.8
Here was where it was originally set https://github.com/symfony/symfony/blob/2.7/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig#L69

Replaced with expected class name
