### PR TITLE
[DomCrawler] Fix select option with empty value

### DIFF
--- a/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
@@ -259,7 +259,8 @@ class ChoiceFormField extends FormField
     {
         $option = array();
 
-        $defaultValue = (isset($node->nodeValue) && !empty($node->nodeValue)) ? $node->nodeValue : '1';
+        $defaultDefaultValue = 'select' === $this->node->nodeName ? '' : '1';
+        $defaultValue = (isset($node->nodeValue) && !empty($node->nodeValue)) ? $node->nodeValue : $defaultDefaultValue;
         $option['value'] = $node->hasAttribute('value') ? $node->getAttribute('value') : $defaultValue;
         $option['disabled'] = $node->hasAttribute('disabled');
 

--- a/src/Symfony/Component/DomCrawler/Tests/Field/ChoiceFormFieldTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Field/ChoiceFormFieldTest.php
@@ -336,6 +336,14 @@ class ChoiceFormFieldTest extends FormFieldTestCase
         $this->assertEquals('foo', $field->getValue(), '->select() changes the selected option');
     }
 
+    public function testSelectWithEmptyValue()
+    {
+        $node = $this->createSelectNodeWithEmptyOption(array('' => true, 'Female' => false, 'Male' => false));
+        $field = new ChoiceFormField($node);
+
+        $this->assertSame('', $field->getValue());
+    }
+
     protected function createSelectNode($options, $attributes = array(), $selectedAttrText = 'selected')
     {
         $document = new \DOMDocument();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.3+ |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no? |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

While using the Laravel's testing suite which makes use of the Symfony DOM Crawler (v3.0.2). I have been populating a form with a select which has a value which can be an empty value. 

For example, with this select you can choose your gender or leave it empty if you don't want to specify:

``` html
<select name="gender">
  <option selected></option>
  <option>Female</option>
  <option>Male</option>
</select>
```

When the `DomCrawler\Field::getValue()` is called I was expect to get the value `''` however I was actually getting `'on'`. This is caused by the [DomCrawler\Field::buildOptionValue()](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php#L262-L271) sets the default value to 'on' when there is no value which makes sense for ratios and checkboxes but not for select.

I have tracked this bug back to v2.3 but it is still present in v3, however, the default value was changed from '1' to 'on' in v2.5 which means that this patch will conflict when merging up the maintained versions.
