### PR TITLE
[Routing] Only trigger deprecations when necessary

### DIFF
--- a/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
@@ -126,7 +126,7 @@ class YamlFileLoader extends FileLoader
         $methods = isset($config['methods']) ? $config['methods'] : array();
         $condition = isset($config['condition']) ? $config['condition'] : null;
 
-        if (isset($requirements['_method'])) {
+        if (isset($requirements['_method']) && !isset($requirements['methods'])) {
             if (0 === count($methods)) {
                 $methods = explode('|', $requirements['_method']);
             }
@@ -135,7 +135,7 @@ class YamlFileLoader extends FileLoader
             @trigger_error(sprintf('The "_method" requirement of route "%s" in file "%s" is deprecated since version 2.2 and will be removed in 3.0. Use the "methods" option instead.', $name, $path), E_USER_DEPRECATED);
         }
 
-        if (isset($requirements['_scheme'])) {
+        if (isset($requirements['_scheme']) && !isset($requirements['schemes'])) {
             if (0 === count($schemes)) {
                 $schemes = explode('|', $requirements['_scheme']);
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

It's really annoying to have deprecations when you're aware of a problem but you have to still support the old notation. So what do you think about only triggering deprecations when the `_method` requirement is used alone (without the new `methods` attribute) ?
