### PR TITLE
[Bridge][Twig] Optionally pass dumper into DumpExtension

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/DumpExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/DumpExtension.php
@@ -23,10 +23,12 @@ use Symfony\Component\VarDumper\Dumper\HtmlDumper;
 class DumpExtension extends \Twig_Extension
 {
     private $cloner;
+    private $dumper;
 
-    public function __construct(ClonerInterface $cloner)
+    public function __construct(ClonerInterface $cloner, HtmlDumper $dumper = null)
     {
         $this->cloner = $cloner;
+        $this->dumper = $dumper ?: new HtmlDumper();
     }
 
     public function getFunctions()
@@ -67,11 +69,14 @@ class DumpExtension extends \Twig_Extension
         }
 
         $dump = fopen('php://memory', 'r+b');
-        $dumper = new HtmlDumper($dump);
+        $prevOutput = $this->dumper->setOutput($dump);
 
         foreach ($vars as $value) {
-            $dumper->dump($this->cloner->cloneVar($value));
+            $this->dumper->dump($this->cloner->cloneVar($value));
         }
+
+        $this->dumper->setOutput($prevOutput);
+
         rewind($dump);
 
         return stream_get_contents($dump);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

Allow the dumper to be passed into `DumpExtension` constructor. This allows a different dumper to be used or even just `HtmlDumper` with a non-default configuration, such as different styles.

Note: The dumper's output is ignored.
