### PR TITLE
Force profiler toolbar svg display

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -59,6 +59,7 @@
 .sf-toolbarreset svg,
 .sf-toolbarreset img {
     height: 20px;
+    display: inline-block;
 }
 
 .sf-toolbarreset .hide-button {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | - |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

When applying `display: block` on all svg of our website, we found that toolbar's svg were also impacted:

![capture du 2016-04-07 10-57-05](https://cloud.githubusercontent.com/assets/2021641/14345830/7d531388-fcaf-11e5-88ad-92f5522b4e98.png)

Just apply a default display on toolbar's svg fixes the issue.
