### PR TITLE
[Cache] Add DoctrineProvider, for using PSR-6 pools in Doctrine Cache

### DIFF
--- a/src/Symfony/Component/Cache/DoctrineProvider.php
+++ b/src/Symfony/Component/Cache/DoctrineProvider.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache;
+
+use Doctrine\Common\Cache\CacheProvider;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class DoctrineProvider extends CacheProvider
+{
+    private $pool;
+
+    public function __construct(CacheItemPoolInterface $pool)
+    {
+        $this->pool = $pool;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doFetch($id)
+    {
+        $item = $this->pool->getItem(rawurlencode($id));
+
+        return $item->isHit() ? $item->get() : false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doContains($id)
+    {
+        return $this->pool->hasItem(rawurlencode($id));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doSave($id, $data, $lifeTime = 0)
+    {
+        $item = $this->pool->getItem(rawurlencode($id));
+
+        if (0 < $lifeTime) {
+            $item->expiresAfter($lifeTime);
+        }
+
+        return $this->pool->save($item->set($data));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doDelete($id)
+    {
+        return $this->pool->deleteItem(rawurlencode($id));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doFlush()
+    {
+        $this->pool->clear();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doGetStats()
+    {
+    }
+}

--- a/src/Symfony/Component/Cache/Tests/DoctrineProviderTest.php
+++ b/src/Symfony/Component/Cache/Tests/DoctrineProviderTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests;
+
+use Doctrine\Common\Cache\CacheProvider;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\DoctrineProvider;
+
+class DoctrineProviderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testProvider()
+    {
+        $pool = new ArrayAdapter();
+        $cache = new DoctrineProvider($pool);
+
+        $this->assertInstanceOf(CacheProvider::class, $cache);
+
+        $key = '{}()/\@:';
+
+        $this->assertTrue($cache->delete($key));
+        $this->assertFalse($cache->contains($key));
+
+        $this->assertTrue($cache->save($key, 'bar'));
+        $this->assertTrue($cache->contains($key));
+        $this->assertSame('bar', $cache->fetch($key));
+
+        $this->assertTrue($cache->delete($key));
+        $this->assertFalse($cache->fetch($key));
+        $this->assertTrue($cache->save($key, 'bar'));
+
+        $cache->flushAll();
+        $this->assertFalse($cache->fetch($key));
+        $this->assertFalse($cache->contains($key));
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This would allow cache pool configuration as usual (see #17290) before injecting the resulting doctrine cache provider anywhere such an interface is required.
