### PR TITLE
[LDAP] Check whether an entry attribute exists

### DIFF
--- a/src/Symfony/Component/Ldap/Entry.php
+++ b/src/Symfony/Component/Ldap/Entry.php
@@ -36,6 +36,18 @@ class Entry
     }
 
     /**
+     * Returns whether an attribute exists.
+     *
+     * @param $name string The name of the attribute
+     *
+     * @return bool
+     */
+    public function hasAttribute($name)
+    {
+        return isset($this->attributes[$name]);
+    }
+
+    /**
      * Returns a specific attribute's value.
      *
      * As LDAP can return multiple values for a single attribute,


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Currently a method exists for getting the value of an attribute. It would make the Entry class more complete to be able to simply test if an attribute exists in the entry.
