### PR TITLE
[Console] use ANSI escape sequences in ProgressBar overwrite method

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -40,7 +40,6 @@ class ProgressBar
     private $startTime;
     private $stepWidth;
     private $percent = 0.0;
-    private $lastMessagesLength = 0;
     private $formatLineCount;
     private $messages;
     private $overwrite = true;
@@ -472,7 +471,7 @@ class ProgressBar
             $this->setRealFormat($this->internalFormat ?: $this->determineBestFormat());
         }
 
-        $this->overwrite(str_repeat("\n", $this->formatLineCount));
+        $this->overwrite('');
     }
 
     /**
@@ -512,37 +511,22 @@ class ProgressBar
      */
     private function overwrite($message)
     {
-        $lines = explode("\n", $message);
-
-        // append whitespace to match the line's length
-        if (null !== $this->lastMessagesLength) {
-            foreach ($lines as $i => $line) {
-                if ($this->lastMessagesLength > Helper::strlenWithoutDecoration($this->output->getFormatter(), $line)) {
-                    $lines[$i] = str_pad($line, $this->lastMessagesLength, "\x20", STR_PAD_RIGHT);
-                }
-            }
-        }
-
         if ($this->overwrite) {
-            // move back to the beginning of the progress bar before redrawing it
+            // Move the cursor to the beginning of the line
             $this->output->write("\x0D");
+
+            // Erase the line
+            $this->output->write("\x1B[2K");
+
+            // Erase previous lines
+            if ($this->formatLineCount > 0) {
+                $this->output->write(str_repeat("\x1B[1A\x1B[2K", $this->formatLineCount));
+            }
         } elseif ($this->step > 0) {
-            // move to new line
             $this->output->writeln('');
         }
 
-        if ($this->formatLineCount) {
-            $this->output->write(sprintf("\033[%dA", $this->formatLineCount));
-        }
-        $this->output->write(implode("\n", $lines));
-
-        $this->lastMessagesLength = 0;
-        foreach ($lines as $line) {
-            $len = Helper::strlenWithoutDecoration($this->output->getFormatter(), $line);
-            if ($len > $this->lastMessagesLength) {
-                $this->lastMessagesLength = $len;
-            }
-        }
+        $this->output->write($message);
     }
 
     private function determineBestFormat()

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -13,8 +13,6 @@ namespace Symfony\Component\Console\Tests\Helper;
 
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Helper\Helper;
-use Symfony\Component\Console\Output\ConsoleOutput;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 
 /**

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Console\Tests\Helper;
 
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Helper\Helper;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 
 /**
@@ -233,7 +235,7 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
             $this->generateOutput('  0/50 [>---------------------------]   0%').
             $this->generateOutput('  0/50 [>---------------------------]   0%').
             $this->generateOutput('  1/50 [>---------------------------]   2%').
-            $this->generateOutput('  2/50 [=>--------------------------]     '),
+            $this->generateOutput('  2/50 [=>--------------------------]'),
             stream_get_contents($output->getStream())
         );
     }
@@ -356,7 +358,7 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             $this->generateOutput('  0/50 [>---------------------------]   0%').
             $this->generateOutput(' 25/50 [==============>-------------]  50%').
-            $this->generateOutput('                                          '),
+            $this->generateOutput(''),
             stream_get_contents($output->getStream())
         );
     }
@@ -554,9 +556,9 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
         rewind($output->getStream());
         $this->assertEquals(
             $this->generateOutput(">---------------------------\nfoobar").
-            $this->generateOutput("=========>------------------\nfoobar                      ").
-            $this->generateOutput("                            \n                            ").
-            $this->generateOutput("============================\nfoobar                      "),
+            $this->generateOutput("=========>------------------\nfoobar").
+            "\x0D\x1B[2K\x1B[1A\x1B[2K".
+            $this->generateOutput("============================\nfoobar"),
             stream_get_contents($output->getStream())
         );
     }
@@ -665,6 +667,6 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
     {
         $count = substr_count($expected, "\n");
 
-        return "\x0D".($count ? sprintf("\033[%dA", $count) : '').$expected;
+        return "\x0D\x1B[2K".($count ? str_repeat("\x1B[1A\x1B[2K", $count) : '').$expected;
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | maybe |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16957 |
| License | MIT |
| Doc PR |  |

Rewritten `overwrite` method in ProgressBar class to use ANSI escape sequences to erase lines.
This removes the need to store the last message length as it is not needed to fill the buffer with spaces anymore. As a plus it correctly resets the cursor position while clearing the output

If the output is not decorated the behavior has not been changed.
Could possibly cause a BC break if testing against the decorated emitted output as binary string
