### PR TITLE
[FrameworkBundle] Use SymfonyStyle in AbstractConfigCommand

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
@@ -27,6 +27,7 @@ abstract class AbstractConfigCommand extends ContainerDebugCommand
 {
     protected function listBundles($output)
     {
+        $title = 'Available registered bundles with their extension alias if available';
         $headers = array('Bundle name', 'Extension alias');
         $rows = array();
 
@@ -41,9 +42,10 @@ abstract class AbstractConfigCommand extends ContainerDebugCommand
         }
 
         if ($output instanceof StyleInterface) {
+            $output->title($title);
             $output->table($headers, $rows);
         } else {
-            $output->writeln('Available registered bundles with their extension alias if available:');
+            $output->writeln($title);
             $table = new Table($output);
             $table->setHeaders($headers)->setRows($rows)->render($output);
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
@@ -56,12 +56,10 @@ EOF
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $io = new SymfonyStyle($input, $output);
-        $name = $input->getArgument('name');
 
-        if (empty($name)) {
-            $io->comment('Provide the name of a bundle as the first argument of this command to dump its configuration.');
-            $io->newLine();
-            $this->listBundles($output);
+        if (null === $name = $input->getArgument('name')) {
+            $this->listBundles($io);
+            $io->comment('Provide the name of a bundle as the first argument of this command to dump its configuration. (e.g. <comment>debug:config FrameworkBundle</comment>)');
 
             return;
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
@@ -68,12 +68,10 @@ EOF
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $io = new SymfonyStyle($input, $output);
-        $name = $input->getArgument('name');
 
-        if (empty($name)) {
-            $io->comment('Provide the name of a bundle as the first argument of this command to dump its default configuration.');
-            $io->newLine();
-            $this->listBundles($output);
+        if (null === $name = $input->getArgument('name')) {
+            $this->listBundles($io);
+            $io->comment('Provide the name of a bundle as the first argument of this command to dump its default configuration. (e.g. <comment>config:dump-reference FrameworkBundle</comment>)');
 
             return;
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Before:
![screen shot 2016-04-10 at 18 12 56](https://cloud.githubusercontent.com/assets/1104667/14411548/ab040a32-ff4b-11e5-878d-7e6acb257750.png)
After:
![screen shot 2016-04-10 at 18 11 57](https://cloud.githubusercontent.com/assets/1104667/14411553/be16e022-ff4b-11e5-838e-5fa2ad46133b.png)
