### PR TITLE
[FrameworkBundle] Add file helper to Controller

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -139,8 +139,6 @@ abstract class Controller implements ContainerAwareInterface
      */
     protected function file($file, $fileName = null, $disposition = ResponseHeaderBag::DISPOSITION_ATTACHMENT)
     {
-        $deleteFileAfterSend = false;
-
         if (!is_string($file) && !$file instanceof File) {
             throw new \InvalidArgumentException(sprint('The "%s" method expects first argument to be a string or an instance of "%s"', __METHOD__, File::class));
         }
@@ -151,10 +149,6 @@ abstract class Controller implements ContainerAwareInterface
 
         $response = new BinaryFileResponse($file);
         $mimeType = $file->getMimeType();
-
-        if (true === $deleteFileAfterSend) {
-            $response->deleteFileAfterSend($deleteFileAfterSend);
-        }
 
         $response->headers->set('Content-Type', $mimeType);
         $disposition = $response->headers->makeDisposition($disposition, $fileName === null ? $file->getFileName() : $fileName);

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -129,7 +129,7 @@ abstract class Controller implements ContainerAwareInterface
     /**
      * Returns a BinaryFileResponse object with original or customized file name and disposition header.
      *
-     * @param File|string $file        File object, path to file or string with content to be sent as response
+     * @param File|string $file        File object or path to file to be sent as response
      * @param string|null $fileName    File name to be sent to response or null (will use original file name)
      * @param string      $disposition Disposition of response ("attachment" is default, other type is "inline")
      *
@@ -145,7 +145,7 @@ abstract class Controller implements ContainerAwareInterface
             throw new \InvalidArgumentException(sprint('The "%s" method expects first argument to be a string or an instance of "%s"', __METHOD__, File::class));
         }
 
-        if (is_string($file) && file_exists($file)) {
+        if (!$file instanceof File) {
             $file = new File($file);
         }
 
@@ -180,16 +180,6 @@ abstract class Controller implements ContainerAwareInterface
 
         if (true === $deleteFileAfterSend) {
             $response->deleteFileAfterSend($deleteFileAfterSend);
-        }
-
-        if (null === $disposition) {
-            $disposition = ResponseHeaderBag::DISPOSITION_ATTACHMENT;
-        }
-
-        if(!in_array($disposition, array(ResponseHeaderBag::DISPOSITION_INLINE, ResponseHeaderBag::DISPOSITION_ATTACHMENT), true)) {
-            throw new \LogicException(
-                sprintf('You can\'t use disposition "%s". Use "attachment" or "inline".', $disposition)
-            );
         }
 
         $response->headers->set('Content-Type', $mimeType);

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -131,7 +131,7 @@ abstract class Controller implements ContainerAwareInterface
      *
      * @param File|string $file        File object, path to file or string with content to be sent as response
      * @param string|null $fileName    File name to be sent to response or null (will use original file name)
-     * @param string      $disposition Disposition of response (attachment is default, other type is inline)
+     * @param string      $disposition Disposition of response ("attachment" is default, other type is "inline")
      *
      * @return BinaryFileResponse
      *
@@ -141,8 +141,8 @@ abstract class Controller implements ContainerAwareInterface
     {
         $deleteFileAfterSend = false;
 
-        if (!is_string($file) && false === ($file instanceof File)) {
-            throw new \InvalidArgumentException('Only File object and string can be passed to file helper.');
+        if (!is_string($file) && !$file instanceof File) {
+            throw new \InvalidArgumentException(sprint('The "%s" method expects first argument to be a string or an instance of "%s"', __METHOD__, File::class));
         }
 
         if (is_string($file) && file_exists($file)) {
@@ -171,14 +171,15 @@ abstract class Controller implements ContainerAwareInterface
             $file = new File($tmpPath);
         }
 
-        if ($file->isReadable()) {
-            $response = new BinaryFileResponse($file);
-            $mimeType = $file->getMimeType();
-            if (true === $deleteFileAfterSend) {
-                $response->deleteFileAfterSend($deleteFileAfterSend);
-            }
-        } else {
+        if (!$file->isReadable()) {
             throw new \RuntimeException(sprintf('"%s" is not readable.', $file->getPath()));
+        }
+
+        $response = new BinaryFileResponse($file);
+        $mimeType = $file->getMimeType();
+
+        if (true === $deleteFileAfterSend) {
+            $response->deleteFileAfterSend($deleteFileAfterSend);
         }
 
         if (null === $disposition) {

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -146,7 +146,7 @@ abstract class Controller implements ContainerAwareInterface
             $file = new File($file);
         }
 
-        // Test if is content in string is given
+        // Test if content in string is given
         if (is_string($file)) {
             if (empty($file)) {
                 throw new \InvalidArgumentException('File content can\'t be empty.');

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -137,12 +137,9 @@ abstract class Controller implements ContainerAwareInterface
      */
     protected function file($file, $fileName = null, $disposition = ResponseHeaderBag::DISPOSITION_ATTACHMENT)
     {
-        if (!$file instanceof File) {
-            $file = new File($file);
-        }
-
-        $response = new BinaryFileResponse($file, 200, ['Content-type' => $file->getMimeType()]);
-        $disposition = $response->headers->makeDisposition($disposition, $fileName === null ? $file->getFileName() : $fileName);
+        $response = new BinaryFileResponse($file);
+        $response->headers->set('Content-type', $response->getFile()->getMimeType());
+        $disposition = $response->headers->makeDisposition($disposition, $fileName === null ? $response->getFile()->getFilename() : $fileName);
 //        $response->setContentDisposition($disposition, $fileName === null ? $file->getFileName() : $fileName);
         $response->headers->set('Content-Disposition', $disposition);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -134,8 +134,6 @@ abstract class Controller implements ContainerAwareInterface
      * @param string      $disposition Disposition of response ("attachment" is default, other type is "inline")
      *
      * @return BinaryFileResponse
-     *
-     * @throws \LogicException|\InvalidArgumentException|\RuntimeException
      */
     protected function file($file, $fileName = null, $disposition = ResponseHeaderBag::DISPOSITION_ATTACHMENT)
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -202,7 +202,7 @@ abstract class Controller implements ContainerAwareInterface
             $fileName === null ? $file->getFileName() : $fileName
         );
         $response->headers->set('Content-Disposition', $disposition);
-        
+
         return $response;
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -149,32 +149,6 @@ abstract class Controller implements ContainerAwareInterface
             $file = new File($file);
         }
 
-        if (is_string($file)) {
-            if ('' === $file) {
-                throw new \InvalidArgumentException('File content can\'t be empty.');
-            }
-
-            if (empty($fileName)) {
-                throw new \InvalidArgumentException('File name can\'t be empty.');
-            }
-            $cacheDir = $this->container->get('kernel')->getCacheDir();
-            $tmpName = md5($fileName);
-            $tmpPath = $cacheDir.DIRECTORY_SEPARATOR.$tmpName;
-
-            try {
-                file_put_contents($tmpPath, $file);
-            } catch (\Exception $e) {
-                throw new \RuntimeException(sprintf('Temporary file "%s" couldn\'t be created.', $tmpPath), 0, $e);
-            }
-
-            $deleteFileAfterSend = true;
-            $file = new File($tmpPath);
-        }
-
-        if (!$file->isReadable()) {
-            throw new \RuntimeException(sprintf('"%s" is not readable.', $file->getPath()));
-        }
-
         $response = new BinaryFileResponse($file);
         $mimeType = $file->getMimeType();
 
@@ -183,10 +157,7 @@ abstract class Controller implements ContainerAwareInterface
         }
 
         $response->headers->set('Content-Type', $mimeType);
-        $disposition = $response->headers->makeDisposition(
-            $disposition,
-            $fileName === null ? $file->getFileName() : $fileName
-        );
+        $disposition = $response->headers->makeDisposition($disposition, $fileName === null ? $file->getFileName() : $fileName);
         $response->headers->set('Content-Disposition', $disposition);
 
         return $response;

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -142,7 +142,7 @@ abstract class Controller implements ContainerAwareInterface
         }
 
         $response = new BinaryFileResponse($file, 200, ['Content-type' => $file->getMimeType()]);
-        $disposition = $response->headers->makeDisposition($disposition, $fileName === null ? $file->getFileName() : $fileName);
+        $response->setContentDisposition($disposition, $fileName === null ? $file->getFileName() : $fileName);
         $response->headers->set('Content-Disposition', $disposition);
 
         return $response;

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -145,10 +145,7 @@ abstract class Controller implements ContainerAwareInterface
             $file = new File($file);
         }
 
-        $response = new BinaryFileResponse($file);
-        $mimeType = $file->getMimeType();
-
-        $response->headers->set('Content-Type', $mimeType);
+        $response = new BinaryFileResponse($file, 200, ['Content-type' => $file->getMimeType()]);
         $disposition = $response->headers->makeDisposition($disposition, $fileName === null ? $file->getFileName() : $fileName);
         $response->headers->set('Content-Disposition', $disposition);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -145,12 +145,10 @@ abstract class Controller implements ContainerAwareInterface
             throw new \InvalidArgumentException('Only File object and string can be passed to file helper.');
         }
 
-        // Test if path to file is given
         if (is_string($file) && file_exists($file)) {
             $file = new File($file);
         }
 
-        // Test if content in string is given
         if (is_string($file)) {
             if ('' === $file) {
                 throw new \InvalidArgumentException('File content can\'t be empty.');

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -142,7 +142,8 @@ abstract class Controller implements ContainerAwareInterface
         }
 
         $response = new BinaryFileResponse($file, 200, ['Content-type' => $file->getMimeType()]);
-        $response->setContentDisposition($disposition, $fileName === null ? $file->getFileName() : $fileName);
+        $disposition = $response->headers->makeDisposition($disposition, $fileName === null ? $file->getFileName() : $fileName);
+//        $response->setContentDisposition($disposition, $fileName === null ? $file->getFileName() : $fileName);
         $response->headers->set('Content-Disposition', $disposition);
 
         return $response;

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -137,10 +137,6 @@ abstract class Controller implements ContainerAwareInterface
      */
     protected function file($file, $fileName = null, $disposition = ResponseHeaderBag::DISPOSITION_ATTACHMENT)
     {
-        if (!is_string($file) && !$file instanceof File) {
-            throw new \InvalidArgumentException(sprintf('The "%s" method expects first argument to be a string or an instance of "%s"', __METHOD__, File::class));
-        }
-
         if (!$file instanceof File) {
             $file = new File($file);
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -144,7 +144,7 @@ abstract class Controller implements ContainerAwareInterface
         if (!is_string($file) && false === ($file instanceof File)) {
             throw new \InvalidArgumentException('Only File object and string can be passed to file helper.');
         }
-        
+
         // Test if path to file is given
         if (is_string($file) && file_exists($file)) {
             $file = new File($file);

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -165,7 +165,7 @@ abstract class Controller implements ContainerAwareInterface
             );
         }
 
-        if($disposition === null) {
+        if ($disposition === null) {
             $disposition = ResponseHeaderBag::DISPOSITION_ATTACHMENT;
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -138,10 +138,7 @@ abstract class Controller implements ContainerAwareInterface
     protected function file($file, $fileName = null, $disposition = ResponseHeaderBag::DISPOSITION_ATTACHMENT)
     {
         $response = new BinaryFileResponse($file);
-        $response->headers->set('Content-type', $response->getFile()->getMimeType());
-        $disposition = $response->headers->makeDisposition($disposition, $fileName === null ? $response->getFile()->getFilename() : $fileName);
-//        $response->setContentDisposition($disposition, $fileName === null ? $file->getFileName() : $fileName);
-        $response->headers->set('Content-Disposition', $disposition);
+        $response->setContentDisposition($disposition, $fileName === null ? $response->getFile()->getFileName() : $fileName);
 
         return $response;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -138,7 +138,7 @@ abstract class Controller implements ContainerAwareInterface
     protected function file($file, $fileName = null, $disposition = ResponseHeaderBag::DISPOSITION_ATTACHMENT)
     {
         if (!is_string($file) && !$file instanceof File) {
-            throw new \InvalidArgumentException(sprint('The "%s" method expects first argument to be a string or an instance of "%s"', __METHOD__, File::class));
+            throw new \InvalidArgumentException(sprintf('The "%s" method expects first argument to be a string or an instance of "%s"', __METHOD__, File::class));
         }
 
         if (!$file instanceof File) {

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -129,7 +129,7 @@ abstract class Controller implements ContainerAwareInterface
     /**
      * Returns a BinaryFileResponse object with original or customized file name and disposition header.
      *
-     * @param File|string $file        File object (or string with content) to be sent as response
+     * @param File|string $file        File object, path to file or string with content to be sent as response
      * @param null        $fileName    File name to be sent to response or null (will use original file name)
      * @param string      $disposition Disposition of response (attachment is default, other type is inline)
      *
@@ -140,10 +140,18 @@ abstract class Controller implements ContainerAwareInterface
     protected function file($file, $fileName = null, $disposition = ResponseHeaderBag::DISPOSITION_ATTACHMENT)
     {
         $deleteFileAfterSend = false;
+
+        // Test if path to file is given
+        if (is_string($file) && file_exists($file)) {
+            $file = new File($file);
+        }
+
+        // Test if is content in string is given
         if (is_string($file)) {
             if (empty($file)) {
                 throw new \InvalidArgumentException('File content can\'t be empty.');
             }
+
             if (empty($fileName)) {
                 throw new \InvalidArgumentException('File name can\'t be empty.');
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTest.php
@@ -224,7 +224,6 @@ class ControllerTest extends TestCase
 
         /* @var BinaryFileResponse $response */
         $response = $controller->file(new File(__FILE__));
-
         $this->assertInstanceOf(BinaryFileResponse::class, $response);
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('text/x-php', $response->headers->get('content-type'));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTest.php
@@ -230,7 +230,7 @@ class ControllerTest extends TestCase
             $this->assertSame('text/x-php', $response->headers->get('content-type'));
         }
         $this->assertContains(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $response->headers->get('content-disposition'));
-        $this->assertContains(pathinfo(__FILE__, PATHINFO_BASENAME), $response->headers->get('content-disposition'));
+        $this->assertContains(basename(__FILE__), $response->headers->get('content-disposition'));
     }
 
     public function testFileAsInline()
@@ -248,7 +248,7 @@ class ControllerTest extends TestCase
             $this->assertSame('text/x-php', $response->headers->get('content-type'));
         }
         $this->assertContains(ResponseHeaderBag::DISPOSITION_INLINE, $response->headers->get('content-disposition'));
-        $this->assertContains(pathinfo(__FILE__, PATHINFO_BASENAME), $response->headers->get('content-disposition'));
+        $this->assertContains(basename(__FILE__), $response->headers->get('content-disposition'));
     }
 
     public function testFileWithOwnFileName()
@@ -302,7 +302,7 @@ class ControllerTest extends TestCase
             $this->assertSame('text/x-php', $response->headers->get('content-type'));
         }
         $this->assertContains(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $response->headers->get('content-disposition'));
-        $this->assertContains(pathinfo(__FILE__, PATHINFO_BASENAME), $response->headers->get('content-disposition'));
+        $this->assertContains(basename(__FILE__), $response->headers->get('content-disposition'));
     }
 
     public function testFileFromPathWithCustomizedFileName()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTest.php
@@ -226,7 +226,9 @@ class ControllerTest extends TestCase
         $response = $controller->file(new File(__FILE__));
         $this->assertInstanceOf(BinaryFileResponse::class, $response);
         $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame('text/x-php', $response->headers->get('content-type'));
+        if ($response->headers->get('content-type')) {
+            $this->assertSame('text/x-php', $response->headers->get('content-type'));
+        }
         $this->assertContains(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $response->headers->get('content-disposition'));
         $this->assertContains(pathinfo(__FILE__, PATHINFO_BASENAME), $response->headers->get('content-disposition'));
     }
@@ -242,7 +244,9 @@ class ControllerTest extends TestCase
 
         $this->assertInstanceOf(BinaryFileResponse::class, $response);
         $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame('text/x-php', $response->headers->get('content-type'));
+        if ($response->headers->get('content-type')) {
+            $this->assertSame('text/x-php', $response->headers->get('content-type'));
+        }
         $this->assertContains(ResponseHeaderBag::DISPOSITION_INLINE, $response->headers->get('content-disposition'));
         $this->assertContains(pathinfo(__FILE__, PATHINFO_BASENAME), $response->headers->get('content-disposition'));
     }
@@ -259,7 +263,9 @@ class ControllerTest extends TestCase
 
         $this->assertInstanceOf(BinaryFileResponse::class, $response);
         $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame('text/x-php', $response->headers->get('content-type'));
+        if ($response->headers->get('content-type')) {
+            $this->assertSame('text/x-php', $response->headers->get('content-type'));
+        }
         $this->assertContains(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $response->headers->get('content-disposition'));
         $this->assertContains($fileName, $response->headers->get('content-disposition'));
     }
@@ -276,7 +282,9 @@ class ControllerTest extends TestCase
 
         $this->assertInstanceOf(BinaryFileResponse::class, $response);
         $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame('text/x-php', $response->headers->get('content-type'));
+        if ($response->headers->get('content-type')) {
+            $this->assertSame('text/x-php', $response->headers->get('content-type'));
+        }
         $this->assertContains(ResponseHeaderBag::DISPOSITION_INLINE, $response->headers->get('content-disposition'));
         $this->assertContains($fileName, $response->headers->get('content-disposition'));
     }
@@ -290,7 +298,9 @@ class ControllerTest extends TestCase
 
         $this->assertInstanceOf(BinaryFileResponse::class, $response);
         $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame('text/x-php', $response->headers->get('content-type'));
+        if ($response->headers->get('content-type')) {
+            $this->assertSame('text/x-php', $response->headers->get('content-type'));
+        }
         $this->assertContains(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $response->headers->get('content-disposition'));
         $this->assertContains(pathinfo(__FILE__, PATHINFO_BASENAME), $response->headers->get('content-disposition'));
     }
@@ -304,7 +314,9 @@ class ControllerTest extends TestCase
 
         $this->assertInstanceOf(BinaryFileResponse::class, $response);
         $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame('text/x-php', $response->headers->get('content-type'));
+        if ($response->headers->get('content-type')) {
+            $this->assertSame('text/x-php', $response->headers->get('content-type'));
+        }
         $this->assertContains(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $response->headers->get('content-disposition'));
         $this->assertContains('test.php', $response->headers->get('content-disposition'));
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTest.php
@@ -215,7 +215,7 @@ class ControllerTest extends TestCase
     public function testFile()
     {
         $controller = new TestController();
-        /** @var BinaryFileResponse $response */
+        /* @var BinaryFileResponse $response */
         $response = $controller->file(new File(__FILE__));
 
         $this->assertInstanceOf(BinaryFileResponse::class, $response);
@@ -228,7 +228,7 @@ class ControllerTest extends TestCase
     public function testFileAsInline()
     {
         $controller = new TestController();
-        /** @var BinaryFileResponse $response */
+        /* @var BinaryFileResponse $response */
         $response = $controller->file(new File(__FILE__), null, ResponseHeaderBag::DISPOSITION_INLINE);
 
         $this->assertInstanceOf(BinaryFileResponse::class, $response);
@@ -241,7 +241,7 @@ class ControllerTest extends TestCase
     public function testFileWithOwnFileName()
     {
         $controller = new TestController();
-        /** @var BinaryFileResponse $response */
+        /* @var BinaryFileResponse $response */
         $fileName = 'test.php';
         $response = $controller->file(new File(__FILE__), $fileName);
 
@@ -255,7 +255,7 @@ class ControllerTest extends TestCase
     public function testFileWithOwnFileNameAsInline()
     {
         $controller = new TestController();
-        /** @var BinaryFileResponse $response */
+        /* @var BinaryFileResponse $response */
         $fileName = 'test.php';
         $response = $controller->file(new File(__FILE__), $fileName, ResponseHeaderBag::DISPOSITION_INLINE);
 
@@ -269,7 +269,7 @@ class ControllerTest extends TestCase
     public function testFileFromString()
     {
         $controller = new TestController();
-        /** @var BinaryFileResponse $response */
+        /* @var BinaryFileResponse $response */
         $fileName = 'test.txt';
         $content = 'This is my testing file';
         $response = $controller->file($content, $fileName, ResponseHeaderBag::DISPOSITION_ATTACHMENT, 'text/plain');
@@ -284,7 +284,7 @@ class ControllerTest extends TestCase
     public function testFileFromStringWithoutFileName()
     {
         $controller = new TestController();
-        /** @var BinaryFileResponse $response */
+        /* @var BinaryFileResponse $response */
         $fileName = '';
         $content = 'This is my testing file';
         $this->setExpectedException(\InvalidArgumentException::class);
@@ -294,7 +294,7 @@ class ControllerTest extends TestCase
     public function testFileFromStringWithoutContent()
     {
         $controller = new TestController();
-        /** @var BinaryFileResponse $response */
+        /* @var BinaryFileResponse $response */
         $fileName = 'test.txt';
         $content = '';
         $this->setExpectedException(\InvalidArgumentException::class);
@@ -304,7 +304,7 @@ class ControllerTest extends TestCase
     public function testFileFromStringWithoutSpecifiedMimeType()
     {
         $controller = new TestController();
-        /** @var BinaryFileResponse $response */
+        /* @var BinaryFileResponse $response */
         $fileName = 'test.txt';
         $content = 'This is my testing file';
         $this->setExpectedException(\InvalidArgumentException::class);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTest.php
@@ -310,6 +310,17 @@ class ControllerTest extends TestCase
         $this->assertContains('test.php', $response->headers->get('content-disposition'));
     }
 
+    /**
+     * @expectedException \Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException
+     */
+    public function testFileWhichDoesNotExist()
+    {
+        $controller = new TestController();
+
+        /* @var BinaryFileResponse $response */
+        $response = $controller->file('some-file.txt', 'test.php');
+    }
+
     public function testIsGranted()
     {
         $authorizationChecker = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTest.php
@@ -226,8 +226,8 @@ class ControllerTest extends TestCase
         $response = $controller->file(new File(__FILE__));
 
         $this->assertInstanceOf(BinaryFileResponse::class, $response);
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('text/x-php', $response->headers->get('content-type'));
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('text/x-php', $response->headers->get('content-type'));
         $this->assertContains(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $response->headers->get('content-disposition'));
         $this->assertContains(pathinfo(__FILE__, PATHINFO_BASENAME), $response->headers->get('content-disposition'));
     }
@@ -242,8 +242,8 @@ class ControllerTest extends TestCase
         $response = $controller->file(new File(__FILE__), null, ResponseHeaderBag::DISPOSITION_INLINE);
 
         $this->assertInstanceOf(BinaryFileResponse::class, $response);
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('text/x-php', $response->headers->get('content-type'));
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('text/x-php', $response->headers->get('content-type'));
         $this->assertContains(ResponseHeaderBag::DISPOSITION_INLINE, $response->headers->get('content-disposition'));
         $this->assertContains(pathinfo(__FILE__, PATHINFO_BASENAME), $response->headers->get('content-disposition'));
     }
@@ -259,8 +259,8 @@ class ControllerTest extends TestCase
         $response = $controller->file(new File(__FILE__), $fileName);
 
         $this->assertInstanceOf(BinaryFileResponse::class, $response);
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('text/x-php', $response->headers->get('content-type'));
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('text/x-php', $response->headers->get('content-type'));
         $this->assertContains(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $response->headers->get('content-disposition'));
         $this->assertContains($fileName, $response->headers->get('content-disposition'));
     }
@@ -276,8 +276,8 @@ class ControllerTest extends TestCase
         $response = $controller->file(new File(__FILE__), $fileName, ResponseHeaderBag::DISPOSITION_INLINE);
 
         $this->assertInstanceOf(BinaryFileResponse::class, $response);
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('text/x-php', $response->headers->get('content-type'));
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('text/x-php', $response->headers->get('content-type'));
         $this->assertContains(ResponseHeaderBag::DISPOSITION_INLINE, $response->headers->get('content-disposition'));
         $this->assertContains($fileName, $response->headers->get('content-disposition'));
     }
@@ -301,8 +301,8 @@ class ControllerTest extends TestCase
         $response->sendContent();
 
         $this->assertInstanceOf(Response::class, $response);
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('text/plain', $response->headers->get('content-type'));
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('text/plain', $response->headers->get('content-type'));
         $this->assertContains(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $response->headers->get('content-disposition'));
         $this->assertContains($fileName, $response->headers->get('content-disposition'));
         $this->assertFileNotExists(sys_get_temp_dir().DIRECTORY_SEPARATOR.md5($fileName));
@@ -342,8 +342,8 @@ class ControllerTest extends TestCase
         $response = $controller->file(__FILE__);
 
         $this->assertInstanceOf(BinaryFileResponse::class, $response);
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('text/x-php', $response->headers->get('content-type'));
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('text/x-php', $response->headers->get('content-type'));
         $this->assertContains(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $response->headers->get('content-disposition'));
         $this->assertContains(pathinfo(__FILE__, PATHINFO_BASENAME), $response->headers->get('content-disposition'));
     }
@@ -356,8 +356,8 @@ class ControllerTest extends TestCase
         $response = $controller->file(__FILE__, 'test.php');
 
         $this->assertInstanceOf(BinaryFileResponse::class, $response);
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('text/x-php', $response->headers->get('content-type'));
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('text/x-php', $response->headers->get('content-type'));
         $this->assertContains(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $response->headers->get('content-disposition'));
         $this->assertContains('test.php', $response->headers->get('content-disposition'));
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTest.php
@@ -282,58 +282,6 @@ class ControllerTest extends TestCase
         $this->assertContains($fileName, $response->headers->get('content-disposition'));
     }
 
-    public function testFileFromString()
-    {
-        $kernel = $this->getMock('Symfony\Component\HttpKernel\KernelInterface');
-        $kernel->expects($this->at(0))->method('getCacheDir')->will($this->returnValue(sys_get_temp_dir()));
-
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $container->expects($this->at(0))->method('get')->will($this->returnValue($kernel));
-
-        $controller = new TestController();
-        $controller->setContainer($container);
-
-        /* @var BinaryFileResponse $response */
-        $fileName = 'test.txt';
-        $tmpName = md5($fileName);
-        $content = 'This is my testing file';
-        $response = $controller->file($content, $fileName, ResponseHeaderBag::DISPOSITION_ATTACHMENT, 'text/plain');
-        $response->sendContent();
-
-        $this->assertInstanceOf(Response::class, $response);
-        $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame('text/plain', $response->headers->get('content-type'));
-        $this->assertContains(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $response->headers->get('content-disposition'));
-        $this->assertContains($fileName, $response->headers->get('content-disposition'));
-        $this->assertFileNotExists(sys_get_temp_dir().DIRECTORY_SEPARATOR.md5($fileName));
-    }
-
-    public function testFileFromStringWithoutFileName()
-    {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $controller = new TestController();
-        $controller->setContainer($container);
-
-        /* @var BinaryFileResponse $response */
-        $fileName = '';
-        $content = 'This is my testing file';
-        $this->setExpectedException(\InvalidArgumentException::class);
-        $controller->file($content, $fileName, ResponseHeaderBag::DISPOSITION_ATTACHMENT, 'text/plain');
-    }
-
-    public function testFileFromStringWithoutContent()
-    {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $controller = new TestController();
-        $controller->setContainer($container);
-
-        /* @var BinaryFileResponse $response */
-        $fileName = 'test.txt';
-        $content = '';
-        $this->setExpectedException(\InvalidArgumentException::class);
-        $controller->file($content, $fileName, ResponseHeaderBag::DISPOSITION_ATTACHMENT, 'text/plain');
-    }
-
     public function testFileFromPath()
     {
         $controller = new TestController();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTest.php
@@ -334,6 +334,34 @@ class ControllerTest extends TestCase
         $controller->file($content, $fileName, ResponseHeaderBag::DISPOSITION_ATTACHMENT, 'text/plain');
     }
 
+    public function testFileFromPath()
+    {
+        $controller = new TestController();
+
+        /* @var BinaryFileResponse $response */
+        $response = $controller->file(__FILE__);
+
+        $this->assertInstanceOf(BinaryFileResponse::class, $response);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('text/x-php', $response->headers->get('content-type'));
+        $this->assertContains(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $response->headers->get('content-disposition'));
+        $this->assertContains(pathinfo(__FILE__, PATHINFO_BASENAME), $response->headers->get('content-disposition'));
+    }
+
+    public function testFileFromPathWithCustomizedFileName()
+    {
+        $controller = new TestController();
+
+        /* @var BinaryFileResponse $response */
+        $response = $controller->file(__FILE__, 'test.php');
+
+        $this->assertInstanceOf(BinaryFileResponse::class, $response);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('text/x-php', $response->headers->get('content-type'));
+        $this->assertContains(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $response->headers->get('content-disposition'));
+        $this->assertContains('test.php', $response->headers->get('content-disposition'));
+    }
+
     public function testIsGranted()
     {
         $authorizationChecker = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/6454 |

I think it would be more "sexy" to serve files from controller easier (like `json()` helper does).

**This Controller helper allows user to serve files to Response in these ways:**
- pass `Symfony\Component\HttpFoundation\File` (or `Symfony\Component\HttpFoundation\UploadedFile`) instance
- [REMOVED] provide content as `string` and specify file name (mime type will be auto recognized)
- provide path to file (you are still able to specify other than original file name)

**Examples**

```
return $this->file($uploadedFile);
// ...or...
return $this->file('/path/to/my/picture.jpg');
```
