### PR TITLE
No Bootstrap markup is rendered for label set as false

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_horizontal_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_horizontal_layout.html.twig
@@ -25,13 +25,18 @@ col-sm-2
 {# Rows #}
 
 {% block form_row -%}
-    <div class="form-group{% if (not compound or force_error|default(false)) and not valid %} has-error{% endif %}">
-        {{- form_label(form) -}}
-        <div class="{{ block('form_group_class') }}">
-            {{- form_widget(form) -}}
-            {{- form_errors(form) -}}
+    {% set displayMarkup = form.children|length == 0 or form.vars.label is not same as(false) %}
+    {%- if displayMarkup -%}
+        <div class="form-group{% if (not compound or force_error|default(false)) and not valid %} has-error{% endif %}">
+            {{- form_label(form) -}}
+            <div class="{{ block('form_group_class') }}">
+    {%- endif -%}
+    {{- form_widget(form) -}}
+    {{- form_errors(form) -}}
+    {%- if displayMarkup -%}
+            </div>
         </div>
-{##}</div>
+    {%- endif -%}
 {%- endblock form_row %}
 
 {% block checkbox_row -%}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | - |
| Fixed tickets | #18474 |
| License | MIT |
| Doc PR | ~  |

When using horizontal Bootstrap forms and setting `'label' => false` for a custom form type the `form_row` renders an ugly markup
![screenshot 2016-04-11 13 48 25](https://cloud.githubusercontent.com/assets/165154/14426029/1c2a3baa-ffec-11e5-9e41-471866f78bcf.png)

This pr fixes that and make the form look like this
![screenshot 2016-04-11 13 45 05](https://cloud.githubusercontent.com/assets/165154/14425998/e8b029f6-ffeb-11e5-90d7-e6cc7d4b19b3.png)

``` php
// FooType
$builder
    ->add('test', 'text')
    ->add('foo', new BarType())
    ->add('foo2', new BarType(), ['label' => false])
;
```

``` php
// BarType
$builder->add('child', 'text');
```
