### PR TITLE
[LDAP] Added search limit and time limit to LdapClient

### DIFF
--- a/src/Symfony/Component/Ldap/LdapClient.php
+++ b/src/Symfony/Component/Ldap/LdapClient.php
@@ -63,11 +63,15 @@ final class LdapClient implements LdapClientInterface
     /**
      * {@inheritdoc}
      */
-    public function find($dn, $query, $filter = '*')
+    public function find($dn, $query, $filter = '*', $maxItems = 0, $timeout = 0)
     {
         @trigger_error('The "find" method is deprecated since version 3.1 and will be removed in 4.0. Use the "query" method instead.', E_USER_DEPRECATED);
 
-        $query = $this->ldap->query($dn, $query, array('filter' => $filter));
+        $query = $this->ldap->query($dn, $query, array(
+            'filter' => $filter,
+            'maxItems' => $maxItems,
+            'timeout' => $timeout,
+        ));
         $entries = $query->execute();
         $result = array();
 

--- a/src/Symfony/Component/Ldap/LdapClientInterface.php
+++ b/src/Symfony/Component/Ldap/LdapClientInterface.php
@@ -26,11 +26,13 @@ interface LdapClientInterface extends LdapInterface
     /**
      * Find a username into ldap connection.
      *
-     * @param string $dn
-     * @param string $query
-     * @param mixed  $filter
+     * @param string  $dn
+     * @param string  $query
+     * @param mixed   $filter
+     * @param integer $maxItems
+     * @param integer $timeout
      *
      * @return array|null
      */
-    public function find($dn, $query, $filter = '*');
+    public function find($dn, $query, $filter = '*', $maxItems = 0, $timeout = 0);
 }

--- a/src/Symfony/Component/Ldap/Tests/LdapClientTest.php
+++ b/src/Symfony/Component/Ldap/Tests/LdapClientTest.php
@@ -94,7 +94,11 @@ class LdapClientTest extends \PHPUnit_Framework_TestCase
         $this->ldap
             ->expects($this->once())
             ->method('query')
-            ->with('dc=foo,dc=com', 'bar', array('filter' => 'baz'))
+            ->with('dc=foo,dc=com', 'bar', array(
+                'filter' => 'baz',
+                'maxItems' => 0,
+                'timeout' => 0,
+            ))
             ->willReturn($query)
         ;
 


### PR DESCRIPTION
Same as PR #18488, but on master branch (and fixed tests).

| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | maybe |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | (#18448 ?) |
| License | MIT |
| Doc PR | x |

I don't know if the change in the interface is a big BC break, because the Ldap component code is listed as beta until 3.1 and any existing function calls still work. 
