### PR TITLE
[Process] Turn getIterator() args to flags & add ITER_SKIP_OUT/ERR modes

### DIFF
--- a/src/Symfony/Component/Process/ProcessUtils.php
+++ b/src/Symfony/Component/Process/ProcessUtils.php
@@ -96,6 +96,9 @@ class ProcessUtils
             if (is_scalar($input)) {
                 return (string) $input;
             }
+            if ($input instanceof Process) {
+                return $input->getIterator($input::ITER_SKIP_ERR);
+            }
             if ($input instanceof \Iterator) {
                 return $input;
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8454 |
| License | MIT |
| Doc PR | - |

Targeted at 3.1
