### PR TITLE
[Console] Added support for the ability to define the full_name template parameter

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -31,6 +31,7 @@ class Command
 {
     private $application;
     private $name;
+    private $fullName;
     private $processTitle;
     private $aliases = array();
     private $definition;
@@ -60,6 +61,7 @@ class Command
         }
 
         $this->configure();
+        $this->setFullName(sprintf('%s %s', $_SERVER['PHP_SELF'], $this->getName()));
 
         if (!$this->name) {
             throw new LogicException(sprintf('The command defined in "%s" cannot have an empty name.', get_class($this)));
@@ -418,6 +420,20 @@ class Command
     }
 
     /**
+     * Sets the full name of the command.
+     *
+     * @param string $fullName The full command name
+     *
+     * @return Command The current instance
+     */
+    public function setFullName($fullName)
+    {
+        $this->fullName = $fullName;
+
+        return $this;
+    }
+
+    /**
      * Sets the process title of the command.
      *
      * This feature should be used only when creating a long process command,
@@ -503,6 +519,7 @@ class Command
     public function getProcessedHelp()
     {
         $name = $this->name;
+        $fullName = $this->fullName;
 
         $placeholders = array(
             '%command.name%',
@@ -510,7 +527,7 @@ class Command
         );
         $replacements = array(
             $name,
-            $_SERVER['PHP_SELF'].' '.$name,
+            $fullName,
         );
 
         return str_replace($placeholders, $replacements, $this->getHelp() ?: $this->getDescription());

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -31,7 +31,7 @@ class Command
 {
     private $application;
     private $name;
-    private $fullName;
+    private $fullNamePrefix;
     private $processTitle;
     private $aliases = array();
     private $definition;
@@ -61,7 +61,6 @@ class Command
         }
 
         $this->configure();
-        $this->setFullName(sprintf('%s %s', $_SERVER['PHP_SELF'], $this->getName()));
 
         if (!$this->name) {
             throw new LogicException(sprintf('The command defined in "%s" cannot have an empty name.', get_class($this)));
@@ -422,13 +421,13 @@ class Command
     /**
      * Sets the full name of the command.
      *
-     * @param string $fullName The full command name
+     * @param string $fullNamePrefix The full command name
      *
      * @return Command The current instance
      */
-    public function setFullName($fullName)
+    public function setFullNamePrefix($fullNamePrefix)
     {
-        $this->fullName = $fullName;
+        $this->fullNamePrefix = $fullNamePrefix;
 
         return $this;
     }
@@ -519,7 +518,7 @@ class Command
     public function getProcessedHelp()
     {
         $name = $this->name;
-        $fullName = $this->fullName;
+        $fullNamePrefix = $this->fullNamePrefix ?: $_SERVER['PHP_SELF'];
 
         $placeholders = array(
             '%command.name%',
@@ -527,7 +526,7 @@ class Command
         );
         $replacements = array(
             $name,
-            $fullName,
+            sprintf('%s %s', $fullNamePrefix, $name),
         );
 
         return str_replace($placeholders, $replacements, $this->getHelp() ?: $this->getDescription());

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -147,7 +147,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('description', $command->getProcessedHelp(), '->getProcessedHelp() falls back to the description');
 
         $command = new \TestCommand();
-        $command->setFullName(sprintf('custom %s', $command->getName()));
+        $command->setFullNamePrefix('custom');
         $command->setHelp('The %command.name% command does... Example: %command.full_name%.');
         $this->assertContains('Example: custom namespace:name.', $command->getProcessedHelp(), '->getProcessedHelp() uses predefined full_name');
     }

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -145,6 +145,11 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $command = new \TestCommand();
         $command->setHelp('');
         $this->assertContains('description', $command->getProcessedHelp(), '->getProcessedHelp() falls back to the description');
+
+        $command = new \TestCommand();
+        $command->setFullName(sprintf('custom %s', $command->getName()));
+        $command->setHelp('The %command.name% command does... Example: %command.full_name%.');
+        $this->assertContains('Example: custom namespace:name.', $command->getProcessedHelp(), '->getProcessedHelp() uses predefined full_name');
     }
 
     public function testGetSetAliases()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18524 |
| License | MIT |
| Doc PR | n/a |
