### PR TITLE
[Cache] Introduce a NullAdapter to disable cache if needed

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/NullAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/NullAdapter.php
@@ -1,0 +1,157 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Adapter;
+
+use Psr\Cache\CacheItemInterface;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Symfony\Component\Cache\CacheItem;
+use Symfony\Component\Cache\Exception\InvalidArgumentException;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+class NullAdapter implements AdapterInterface, LoggerAwareInterface
+{
+    use LoggerAwareTrait;
+
+    private $createCacheItem;
+
+    public function __construct()
+    {
+        $this->createCacheItem = \Closure::bind(
+            function ($key, $value, $isHit) {
+                $item = new CacheItem();
+                $item->key = $key;
+                $item->value = $value;
+                $item->isHit = $isHit;
+                $item->defaultLifetime = 0;
+
+                return $item;
+            },
+            $this,
+            CacheItem::class
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItem($key)
+    {
+        $this->validateKey($key);
+
+        $f = $this->createCacheItem;
+
+        return $f($key, null, false);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItems(array $keys = array())
+    {
+        foreach ($keys as $key) {
+            $this->validateKey($key);
+        }
+
+        return $this->generateItems($keys);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasItem($key)
+    {
+        $this->validateKey($key);
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clear()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteItem($key)
+    {
+        $this->validateKey($key);
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteItems(array $keys)
+    {
+        foreach ($keys as $key) {
+            $this->validateKey($key);
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function save(CacheItemInterface $item)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function saveDeferred(CacheItemInterface $item)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function commit()
+    {
+        return false;
+    }
+
+    private function validateKey($key)
+    {
+        if (!is_string($key)) {
+            throw new InvalidArgumentException(sprintf('Cache key must be string, "%s" given', is_object($key) ? get_class($key) : gettype($key)));
+        }
+        if (!isset($key[0])) {
+            throw new InvalidArgumentException('Cache key length must be greater than zero');
+        }
+        if (isset($key[strcspn($key, '{}()/\@:')])) {
+            throw new InvalidArgumentException('Cache key contains reserved characters {}()/\@:');
+        }
+
+        return $key;
+    }
+
+    private function generateItems(array $keys)
+    {
+        $f = $this->createCacheItem;
+
+        foreach ($keys as $key) {
+            yield $key => $f($key, null, false);
+        }
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This NullAdapter is a way to disable cache in contexts where you have to provide a cache object. It's also useful for testing and development.
