### PR TITLE
[HttpKernel] Renamed the argument resolver tag

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ControllerArgumentValueResolverPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ControllerArgumentValueResolverPass.php
@@ -29,7 +29,7 @@ class ControllerArgumentValueResolverPass implements CompilerPassInterface
         }
 
         $definition = $container->getDefinition('argument_resolver');
-        $argumentResolvers = $this->findAndSortTaggedServices('controller_argument.value_resolver', $container);
+        $argumentResolvers = $this->findAndSortTaggedServices('controller.argument_value_resolver', $container);
         $definition->replaceArgument(1, $argumentResolvers);
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
@@ -25,19 +25,19 @@
         </service>
 
         <service id="argument_resolver.request_attribute" class="Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestAttributeValueResolver" public="false">
-            <tag name="controller_argument.value_resolver" priority="100" />
+            <tag name="controller.argument_value_resolver" priority="100" />
         </service>
 
         <service id="argument_resolver.request" class="Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestValueResolver" public="false">
-            <tag name="controller_argument.value_resolver" priority="50" />
+            <tag name="controller.argument_value_resolver" priority="50" />
         </service>
 
         <service id="argument_resolver.default" class="Symfony\Component\HttpKernel\Controller\ArgumentResolver\DefaultValueResolver" public="false">
-            <tag name="controller_argument.value_resolver" priority="-100" />
+            <tag name="controller.argument_value_resolver" priority="-100" />
         </service>
 
         <service id="argument_resolver.variadic" class="Symfony\Component\HttpKernel\Controller\ArgumentResolver\VariadicValueResolver" public="false">
-            <tag name="controller_argument.value_resolver" priority="-150" />
+            <tag name="controller.argument_value_resolver" priority="-150" />
         </service>
 
         <service id="response_listener" class="Symfony\Component\HttpKernel\EventListener\ResponseListener">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ControllerArgumentValueResolverPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ControllerArgumentValueResolverPassTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
+
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ControllerArgumentValueResolverPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver;
+
+class ControllerArgumentValueResolverPassTest extends \PHPUnit_Framework_TestCase
+{
+    public function testServicesAreOrderedAccordingToPriority()
+    {
+        $services = array(
+            'n3' => array(array()),
+            'n1' => array(array('priority' => 200)),
+            'n2' => array(array('priority' => 100)),
+        );
+
+        $expected = array(
+            new Reference('n1'),
+            new Reference('n2'),
+            new Reference('n3'),
+        );
+
+        $definition = new Definition(ArgumentResolver::class, array(null, array()));
+        $container = new ContainerBuilder();
+        $container->setDefinition('argument_resolver', $definition);
+
+        foreach ($services as $id => list($tag)) {
+            $container->register($id)->addTag('controller.argument_value_resolver', $tag);
+        }
+
+        (new ControllerArgumentValueResolverPass())->process($container);
+        $this->assertEquals($expected, $definition->getArgument(1));
+    }
+
+    public function testReturningEmptyArrayWhenNoService()
+    {
+        $definition = new Definition(ArgumentResolver::class, array(null, array()));
+        $container = new ContainerBuilder();
+        $container->setDefinition('argument_resolver', $definition);
+
+        (new ControllerArgumentValueResolverPass())->process($container);
+        $this->assertEquals(array(), $definition->getArgument(1));
+    }
+
+    public function testNoArgumentResolver()
+    {
+        $container = new ContainerBuilder();
+
+        (new ControllerArgumentValueResolverPass())->process($container);
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | not if merged before 3.1 |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

Changed as discussed several times: https://github.com/symfony/symfony/pull/18510#issuecomment-208778875, https://github.com/symfony/symfony-docs/pull/6422#issuecomment-208453616.
