### PR TITLE
Phpunit bridge replace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
         "symfony/locale": "self.version",
         "symfony/monolog-bridge": "self.version",
         "symfony/options-resolver": "self.version",
+        "symfony/phpunit-bridge": "self.version",
         "symfony/process": "self.version",
         "symfony/property-access": "self.version",
         "symfony/proxy-manager-bridge": "self.version",

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1181,7 +1181,7 @@ class ProcessTest extends \PHPUnit_Framework_TestCase
      * @dataProvider provideVariousIncrementals
      */
     public function testIncrementalOutputDoesNotRequireAnotherCall($stream, $method) {
-        $process = new Process(self::$phpBin.' -r '.escapeshellarg('$n = 0; while ($n < 3) { file_put_contents(\''.$stream.'\', $n, 1); $n++; usleep(1000); }'), null, null, null, null);
+        $process = $this->getProcess(self::$phpBin.' -r '.escapeshellarg('$n = 0; while ($n < 3) { file_put_contents(\''.$stream.'\', $n, 1); $n++; usleep(1000); }'), null, null, null, null);
         $process->start();
         $result = '';
         $limit = microtime(true) + 3;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes ? |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

Before I migrated to Sf 2.7+ (actually it was to 2.8), I had the dependency to `symfony/phpunit-bridge` in my `require-dev` dependencies in my composer file. Then, trying to use the brand new optimization from @nicolas-grekas in composer/composer#5174, I had some problem with conflicting classes name, because both `symfony/symfony` AND `symfony/phpunit-bridge` (which I actually forgot to remove while migrating to 2.8...) declared their classes.

So, saying that `symfony/symfony` also replaces `symfony/phpunit-bridge` is a logical step so that the package is not "installed" twice.
