### PR TITLE
Replace iconv_*() uses by mb_*(), add mbstring polyfill when required

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Logger/DbalLogger.php
+++ b/src/Symfony/Bridge/Doctrine/Logger/DbalLogger.php
@@ -95,8 +95,8 @@ class DbalLogger implements SQLLogger
             }
 
             // detect if the too long string must be shorten
-            if (self::MAX_STRING_LENGTH < iconv_strlen($params[$index], 'UTF-8')) {
-                $params[$index] = iconv_substr($params[$index], 0, self::MAX_STRING_LENGTH - 6, 'UTF-8').' [...]';
+            if (self::MAX_STRING_LENGTH < mb_strlen($params[$index], 'UTF-8')) {
+                $params[$index] = mb_substr($params[$index], 0, self::MAX_STRING_LENGTH - 6, 'UTF-8').' [...]';
                 continue;
             }
         }

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": ">=5.3.9",
-        "doctrine/common": "~2.4"
+        "doctrine/common": "~2.4",
+        "symfony/polyfill-mbstring": "~1.0"
     },
     "require-dev": {
         "symfony/stopwatch": "~2.2|~3.0.0",

--- a/src/Symfony/Component/Validator/Constraints/LengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LengthValidator.php
@@ -40,12 +40,9 @@ class LengthValidator extends ConstraintValidator
 
         $stringValue = (string) $value;
 
-        if ('UTF8' === $charset = strtoupper($constraint->charset)) {
-            $charset = 'UTF-8'; // iconv on Windows requires "UTF-8" instead of "UTF8"
+        if (!$invalidCharset = !@mb_check_encoding($stringValue, $constraint->charset)) {
+            $length = mb_strlen($stringValue, $constraint->charset);
         }
-
-        $length = @iconv_strlen($stringValue, $charset);
-        $invalidCharset = false === $length;
 
         if ($invalidCharset) {
             if ($this->context instanceof ExecutionContextInterface) {

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.9",
+        "symfony/polyfill-mbstring": "~1.0",
         "symfony/translation": "~2.4|~3.0.0"
     },
     "require-dev": {

--- a/src/Symfony/Component/VarDumper/Cloner/VarCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/VarCloner.php
@@ -102,12 +102,12 @@ class VarCloner extends AbstractCloner
                             } else {
                                 $stub->value = $v;
                             }
-                        } elseif (0 <= $maxString && isset($v[1 + ($maxString >> 2)]) && 0 < $cut = iconv_strlen($v, 'UTF-8') - $maxString) {
+                        } elseif (0 <= $maxString && isset($v[1 + ($maxString >> 2)]) && 0 < $cut = mb_strlen($v, 'UTF-8') - $maxString) {
                             $stub = new Stub();
                             $stub->type = Stub::TYPE_STRING;
                             $stub->class = Stub::STRING_UTF8;
                             $stub->cut = $cut;
-                            $stub->value = iconv_substr($v, 0, $maxString, 'UTF-8');
+                            $stub->value = mb_substr($v, 0, $maxString, 'UTF-8');
                         }
                         break;
 

--- a/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
@@ -169,7 +169,7 @@ class CliDumper extends AbstractDumper
             $this->dumpLine($cursor->depth, true);
         } else {
             $attr = array(
-                'length' => 0 <= $cut ? iconv_strlen($str, 'UTF-8') + $cut : 0,
+                'length' => 0 <= $cut ? mb_strlen($str, 'UTF-8') + $cut : 0,
                 'binary' => $bin,
             );
             $str = explode("\n", $str);
@@ -195,8 +195,8 @@ class CliDumper extends AbstractDumper
                 if ($i < $m) {
                     $str .= "\n";
                 }
-                if (0 < $this->maxStringWidth && $this->maxStringWidth < $len = iconv_strlen($str, 'UTF-8')) {
-                    $str = iconv_substr($str, 0, $this->maxStringWidth, 'UTF-8');
+                if (0 < $this->maxStringWidth && $this->maxStringWidth < $len = mb_strlen($str, 'UTF-8')) {
+                    $str = mb_substr($str, 0, $this->maxStringWidth, 'UTF-8');
                     $lineCut = $len - $this->maxStringWidth;
                 }
                 if ($m && 0 < $cursor->depth) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18539 |
| License | MIT |
| Doc PR | - |

Looks like `iconv_*()` functions can be really slow (see #18539).
