### PR TITLE
[FrameworkBundle] Fallback to default cache system in production for validation

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -468,7 +468,7 @@ class Configuration implements ConfigurationInterface
                     ->info('validation configuration')
                     ->canBeEnabled()
                     ->children()
-                        ->scalarNode('cache')->end()
+                        ->scalarNode('cache')->defaultValue('validator.mapping.cache.symfony')->end()
                         ->booleanNode('enable_annotations')->defaultFalse()->end()
                         ->arrayNode('static_method')
                             ->defaultValue(array('loadValidatorMetadata'))

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -71,6 +71,9 @@ class FrameworkExtension extends Extension
         // Property access is used by both the Form and the Validator component
         $loader->load('property_access.xml');
 
+        // Load Cache configuration first as it is used by other components
+        $loader->load('cache_pools.xml');
+
         $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
 
@@ -781,7 +784,7 @@ class FrameworkExtension extends Extension
             }
         }
 
-        if (isset($config['cache'])) {
+        if (!$container->getParameter('kernel.debug')) {
             $container->setParameter(
                 'validator.mapping.cache.prefix',
                 'validator_'.$this->getKernelRootHash($container)
@@ -1019,8 +1022,6 @@ class FrameworkExtension extends Extension
 
     private function registerCacheConfiguration(array $config, ContainerBuilder $container, XmlFileLoader $loader)
     {
-        $loader->load('cache_pools.xml');
-
         foreach ($config['pools'] as $name => $poolConfig) {
             $poolDefinition = new DefinitionDecorator($poolConfig['adapter']);
             $poolDefinition->setPublic($poolConfig['public']);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache_pools.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache_pools.xml
@@ -21,6 +21,10 @@
             <tag name="cache.pool" clearer="cache.default_pools_clearer" />
         </service>
 
+        <service id="cache.pool.validator" parent="cache.adapter.local" public="false">
+            <tag name="cache.pool" clearer="cache.default_pools_clearer" />
+        </service>
+
         <service id="cache.adapter.apcu" class="Symfony\Component\Cache\Adapter\ApcuAdapter" abstract="true">
             <argument /> <!-- namespace -->
             <argument /> <!-- default lifetime -->

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
@@ -28,6 +28,10 @@
 
         <service id="validator.mapping.class_metadata_factory" alias="validator" public="false" />
 
+        <service id="validator.mapping.cache.symfony" class="Symfony\Component\Validator\Mapping\Cache\Psr6Cache" public="false">
+            <argument type="service" id="cache.pool.validator" />
+        </service>
+
         <service id="validator.mapping.cache.doctrine.apc" class="Symfony\Component\Validator\Mapping\Cache\DoctrineCache" public="false">
             <argument type="service">
                 <service class="Doctrine\Common\Cache\ApcCache">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/CachePoolPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/CachePoolPassTest.php
@@ -41,7 +41,7 @@ class CachePoolPassTest extends \PHPUnit_Framework_TestCase
 
         $this->cachePoolPass->process($container);
 
-        $this->assertSame('yRnzIIVLvL', $cachePool->getArgument(0));
+        $this->assertSame('VcRIZlUhEv', $cachePool->getArgument(0));
     }
 
     public function testArgsAreReplaced()
@@ -61,7 +61,7 @@ class CachePoolPassTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(Reference::class, $cachePool->getArgument(0));
         $this->assertSame('foobar', (string) $cachePool->getArgument(0));
-        $this->assertSame('yRnzIIVLvL', $cachePool->getArgument(1));
+        $this->assertSame('VcRIZlUhEv', $cachePool->getArgument(1));
         $this->assertSame(3, $cachePool->getArgument(2));
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -211,6 +211,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 'static_method' => array('loadValidatorMetadata'),
                 'translation_domain' => 'validators',
                 'strict_email' => false,
+                'cache' => 'validator.mapping.cache.symfony',
             ),
             'annotations' => array(
                 'cache' => 'file',

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -48,7 +48,7 @@
         "symfony/expression-language": "~2.8|~3.0",
         "symfony/process": "~2.8|~3.0",
         "symfony/serializer": "~2.8|^3.0",
-        "symfony/validator": "~2.8|~3.0",
+        "symfony/validator": "~3.1",
         "symfony/yaml": "~2.8|~3.0",
         "symfony/property-info": "~2.8|~3.0",
         "phpdocumentor/reflection-docblock": "^3.0",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | WIP |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This PR proposes a default fallback to filesystem cache for some services if the APC cache is not enabled in production. In other words, if the following part of `config_prod.yml` file is not uncommented, the filesystem will be used:

``` yaml
#framework:
#    validation:
#        cache: validator.mapping.cache.doctrine.apc
#    serializer:
#        cache: serializer.mapping.cache.doctrine.apc
#
# ... other services
```
