### PR TITLE
[FrameworkBundle] Better output for user in ContainerDebugCommand

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -121,8 +121,14 @@ EOF
         $options['output'] = $io;
         $helper->describe($output, $object, $options);
 
-        if (!$input->getArgument('name') && $input->isInteractive()) {
-            $io->comment('To search for a specific service, re-run this command with a search term. (e.g. <comment>debug:container log</comment>)');
+        if (!$input->getArgument('name') && !$input->getOption('tag') && !$input->getOption('parameter') && $input->isInteractive()) {
+            if ($input->getOption('tags')) {
+                $io->comment('To search for a specific tag, re-run this command with a search term. (e.g. <comment>debug:container --tag=form.type</comment>)');
+            } elseif ($input->getOption('parameters')) {
+                $io->comment('To search for a specific parameter, re-run this command with a search term. (e.g. <comment>debug:container --parameter=kernel.debug</comment>)');
+            } else {
+                $io->comment('To search for a specific service, re-run this command with a search term. (e.g. <comment>debug:container log</comment>)');
+            }
         }
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.0 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Right now, the message `To search for a specific service, re-run this command with a search term. (e.g. debug:container log)` is displayed to the user whenever the command is being run. (Except when the search term is given).

But if a user runs e.g. `debug:container --parameters`. This message is out of scope since the user is looking for information about parameters, not services.

This PR will update the command to give better output to the user.

`debug:container`
Will keep current behaviour
`debug:container --parameters`
Will hint how to search for specific parameter
`debug:container --tags`
Will hint how to search for specific tag
