### PR TITLE
[FrameworkBundle] Fallback to default cache system in production for serializer

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -513,7 +513,7 @@ class Configuration implements ConfigurationInterface
                     ->canBeEnabled()
                     ->children()
                         ->booleanNode('enable_annotations')->defaultFalse()->end()
-                        ->scalarNode('cache')->end()
+                        ->scalarNode('cache')->defaultValue('serializer.mapping.cache.symfony')->end()
                         ->scalarNode('name_converter')->end()
                     ->end()
                 ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -982,7 +982,7 @@ class FrameworkExtension extends Extension
 
         $chainLoader->replaceArgument(0, $serializerLoaders);
 
-        if (isset($config['cache']) && $config['cache']) {
+        if (!$container->getParameter('kernel.debug')) {
             $container->setParameter(
                 'serializer.mapping.cache.prefix',
                 'serializer_'.$this->getKernelRootHash($container)

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache_pools.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache_pools.xml
@@ -25,6 +25,10 @@
             <tag name="cache.pool" clearer="cache.default_pools_clearer" />
         </service>
 
+        <service id="cache.pool.serializer" parent="cache.adapter.local" public="false">
+            <tag name="cache.pool" clearer="cache.default_pools_clearer" />
+        </service>
+
         <service id="cache.adapter.apcu" class="Symfony\Component\Cache\Adapter\ApcuAdapter" abstract="true">
             <argument /> <!-- namespace -->
             <argument /> <!-- default lifetime -->

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
@@ -38,6 +38,10 @@
         </service>
 
         <!-- Cache -->
+        <service id="serializer.mapping.cache.symfony" class="Symfony\Component\Cache\DoctrineProvider" public="false">
+            <argument type="service" id="cache.pool.serializer" />
+        </service>
+
         <service id="serializer.mapping.cache.apc" class="Doctrine\Common\Cache\ApcCache" public="false">
             <call method="setNamespace">
                 <argument>%serializer.mapping.cache.prefix%</argument>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -221,6 +221,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             'serializer' => array(
                 'enabled' => false,
                 'enable_annotations' => false,
+                'cache' => 'serializer.mapping.cache.symfony',
             ),
             'property_access' => array(
                 'magic_call' => false,


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

In the same idea as https://github.com/symfony/symfony/pull/18544, this PR proposes a default fallback to filesystem cache for the serializer if the APC cache is not enabled in production. In other words, if the following part of `config_prod.yml` file is not uncommented, the filesystem will be used:

``` yaml
#framework:
#    serializer:
#        cache: serializer.mapping.cache.doctrine.apc
```
