### PR TITLE
[2.7][WebProfilerBunde] Give an absolute url in case the request occured from another domain

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
@@ -65,7 +65,7 @@ class WebDebugToolbarListener implements EventSubscriberInterface
             try {
                 $response->headers->set(
                     'X-Debug-Token-Link',
-                    $this->urlGenerator->generate('_profiler', array('token' => $response->headers->get('X-Debug-Token')))
+                    $this->urlGenerator->generate('_profiler', array('token' => $response->headers->get('X-Debug-Token')), UrlGeneratorInterface::ABSOLUTE_URL)
                 );
             } catch (\Exception $e) {
                 $response->headers->set('X-Debug-Error', get_class($e).': '.$e->getMessage());

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/EventListener/WebDebugToolbarListenerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/EventListener/WebDebugToolbarListenerTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class WebDebugToolbarListenerTest extends \PHPUnit_Framework_TestCase
 {
@@ -195,8 +196,8 @@ class WebDebugToolbarListenerTest extends \PHPUnit_Framework_TestCase
         $urlGenerator
             ->expects($this->once())
             ->method('generate')
-            ->with('_profiler', array('token' => 'xxxxxxxx'))
-            ->will($this->returnValue('/_profiler/xxxxxxxx'))
+            ->with('_profiler', array('token' => 'xxxxxxxx'), UrlGeneratorInterface::ABSOLUTE_URL)
+            ->will($this->returnValue('http://mydomain.com/_profiler/xxxxxxxx'))
         ;
 
         $event = new FilterResponseEvent($this->getKernelMock(), $this->getRequestMock(), HttpKernelInterface::MASTER_REQUEST, $response);
@@ -204,7 +205,7 @@ class WebDebugToolbarListenerTest extends \PHPUnit_Framework_TestCase
         $listener = new WebDebugToolbarListener($this->getTwigMock(), false, WebDebugToolbarListener::ENABLED, 'bottom', $urlGenerator);
         $listener->onKernelResponse($event);
 
-        $this->assertEquals('/_profiler/xxxxxxxx', $response->headers->get('X-Debug-Token-Link'));
+        $this->assertEquals('http://mydomain.com/_profiler/xxxxxxxx', $response->headers->get('X-Debug-Token-Link'));
     }
 
     public function testThrowingUrlGenerator()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This is related to #18413:

Using two symfony application ProjectA and MicroServiceB, if ProjectA issues XHR to MicroServiceB and both have the WebProfilerBundle enabled, then Ajax requests will be monitored in ProjectA. But - at the moment - it will try to look for profiles under ProjectA domain whereas data are stored on MicroServiceB domain.

This PR fixes this issue
