### PR TITLE
[FrameworkBundle][Serializer] Fix APC cache service name

### DIFF
--- a/UPGRADE-3.1.md
+++ b/UPGRADE-3.1.md
@@ -83,6 +83,11 @@ FrameworkBundle
     - `"form.type.submit"`
     - `"form.type.reset"`
 
+ * The service `serializer.mapping.cache.apc`  has been deprecated in favor of
+   `serializer.mapping.cache.doctrine.apc` to be consistent with the validator
+   cache service. If you are using `serializer.mapping.cache.apc`, use
+   `serializer.mapping.cache.doctrine.apc` instead.
+
 HttpKernel
 ----------
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -75,6 +75,9 @@ FrameworkBundle
     - `"form.type.submit"`
     - `"form.type.reset"`
 
+ * The service `serializer.mapping.cache.apc` has been removed; use
+   `serializer.mapping.cache.doctrine.apc` instead.
+
 HttpKernel
 ----------
 

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -7,7 +7,8 @@ CHANGELOG
  * Added `Controller::json` to simplify creating JSON responses when using the Serializer component
  * Deprecated absolute template paths support in the template name parser
  * Deprecated using core form types without dependencies as services
- * added `Symfony\Bundle\FrameworkBundle\DataCollector\RequestDataCollector`
+ * Added `Symfony\Bundle\FrameworkBundle\DataCollector\RequestDataCollector`
+ * Deprecated service `serializer.mapping.cache.apc` (use `serializer.mapping.cache.doctrine.apc` instead)
 
 3.0.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
@@ -38,10 +38,14 @@
         </service>
 
         <!-- Cache -->
-        <service id="serializer.mapping.cache.apc" class="Doctrine\Common\Cache\ApcCache" public="false">
+        <service id="serializer.mapping.cache.doctrine.apc" class="Doctrine\Common\Cache\ApcCache" public="false">
             <call method="setNamespace">
                 <argument>%serializer.mapping.cache.prefix%</argument>
             </call>
+        </service>
+
+        <service id="serializer.mapping.cache.apc" parent="serializer.mapping.cache.doctrine.apc">
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0. Use "serializer.mapping.cache.doctrine.apc" instead</deprecated>
         </service>
 
         <!-- Encoders -->


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master or 3.0 (not sure) |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

In the commit https://github.com/symfony/symfony-standard/commit/008055659c18182be62fc7d27166010630f2d0b0, we introduced in the standard edition the usage of `serializer.mapping.cache.doctrine.apc` instead of `serializer.mapping.cache.apc` in `config_prod.yml` comments.

Earlier, we introduced the validator equivalent modification (`validator.mapping.cache.doctrine.apc` instead of `validator.mapping.cache.apc`) but while we adapted the validator configuration in the FrameworkBundle in https://github.com/symfony/symfony/pull/16822, we did not adapt the FrameworkBundle configuration for the serializer.

I tested the current master of symfony-standard and it's indeed failing:

```
[Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]                                    
The service "serializer" has a dependency on a non-existent service "serializer.mapping.cache.doctrine.apc".
```

This PR renames the serializer APCu cache service name to fix this issue. However, I'm not sure when the validator cache service modification was merged and released so I'm not sure how this PR should handle this. Is this a bug? Or is this a new feature and we should trigger a depreciation but keep the service `serializer.mapping.cache.apc` usable?
