### PR TITLE
Fixed a redundant check in DefaultValueResolver

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/DefaultValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/DefaultValueResolver.php
@@ -27,7 +27,7 @@ final class DefaultValueResolver implements ArgumentValueResolverInterface
      */
     public function supports(Request $request, ArgumentMetadata $argument)
     {
-        return $argument->hasDefaultValue() && !$request->attributes->has($argument->getName());
+        return $argument->hasDefaultValue();
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

In #18308 I have introduced a `DefaultValueResolver`. When writing documentation, I was planning on adding the code as an example and I noticed it did a check in the request attributes. A default value value should always be injected, whether the request has it or not. In case the request _does_ have the value, it would've already been added and thus never reach the default resolver. 

Thus as this is never called in the default and configured flows and should not change the default value behavior, I'm removing this.
