### PR TITLE
[FrameworkBundle] Use Bundle#getPath() to load config files

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -989,7 +989,11 @@ class FrameworkExtension extends Extension
     }
 
     /**
-     * Gets the path of a given bundle using Bundle#getPath() when available.
+     * Gets the path of a given bundle using Bundle::getPath() when usable.
+     *
+     * WARNING:
+     * Calling this may cause a fatal error if the getPath method contains call(s)
+     * of constructor argument's methods, e.g. Bundle::$foo->bar() called in Bundle::getPath()
      *
      * @param string $fqcn The bundle FQCN
      *


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18563 |
| License | MIT |
| Doc PR | n/a |

This is the better workaround I found for now.
As proposed  by @WouterJ, it would be cleaner to move the whole logic in a compiler pass and use the bundle classes instance directly, but `$container->get('kernel')->getBundles()` is not accessible because the service is synthetic (tried within the SerializerPass for instance), same problem in the extension.
I would like to have your suggestions if you think that would be even better to use a compiler pass.

I've kept the reflection and used it to invoke the `getPath()` method of each bundle, rather than calling `dirname($reflection->getFilename())` and so totally ignore the `getPath()` method.
