### PR TITLE
[Serializer] Add deprecation notices

### DIFF
--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -40,7 +40,17 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
     protected $encoder;
     protected $decoder;
     protected $normalizers = array();
+
+    /**
+     * @deprecated since 2.3.37
+     * @see https://github.com/symfony/symfony/pull/17140
+     */
     protected $normalizerCache = array();
+
+    /**
+     * @deprecated since 2.3.37
+     * @see https://github.com/symfony/symfony/pull/17140
+     */
     protected $denormalizerCache = array();
 
     public function __construct(array $normalizers = array(), array $encoders = array())


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.3+ |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #17140 |
| License | MIT |
| Doc PR | none |

Since #17140 (de)normalizerCache are not used anymore and according to [this comment](https://github.com/symfony/symfony/pull/17140#discussion_r49429175) this should have been deprecated since then.
