### PR TITLE
[Serializer] Remove dead code

### DIFF
--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -250,15 +250,6 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
             return $normalizer->denormalize($data, $class, $format, $context);
         }
 
-        foreach ($this->normalizers as $normalizer) {
-            if (
-                $normalizer instanceof DenormalizerInterface &&
-                $normalizer->supportsDenormalization($data, $class, $format)
-            ) {
-                return $normalizer->denormalize($data, $class, $format, $context);
-            }
-        }
-
         throw new UnexpectedValueException(sprintf('Could not denormalize object of type %s, no supporting normalizer found.', $class));
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7+ |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

The deleted lines are the exact equivalent of L249-251. It looks like this is due from a bad merged when the (de)normalization cache has been removed.
