### PR TITLE
[Security] Normalize "symfony/security-acl" dependency versions across all composer.json files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "doctrine/common": "~2.4",
         "twig/twig": "~1.23|~2.0",
         "psr/log": "~1.0",
-        "symfony/security-acl": "~2.7",
+        "symfony/security-acl": "~2.7|~3.0.0",
         "symfony/polyfill-apcu": "~1.1",
         "symfony/polyfill-intl-icu": "~1.0",
         "symfony/polyfill-mbstring": "~1.0",

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.9",
-        "symfony/security-acl": "~2.7",
+        "symfony/security-acl": "~2.7|~3.0.0",
         "symfony/event-dispatcher": "~2.2|~3.0.0",
         "symfony/http-foundation": "~2.1|~3.0.0",
         "symfony/http-kernel": "~2.4|~3.0.0",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

There are some inconsistencies in the Symfony 2.8 `symfony/security-acl` dependency versions that would help downstream if we could just package `symfony/security-acl` 3.0.0 instead of having to package both versions 2.8.0 (for Symfony 2.8) and 3.0.0 (for Symfony 3.0).

```
$ git clone https://github.com/symfony/symfony.git
Cloning into 'symfony'...
cd remote: Counting objects: 319438, done.
nyReceiving objects:   4% (12778/319438), 2.06 MiB | 4.12 MiB/s   
4Receiving objects:  41% (130970/319438), 40.80 MiB | 7.86 MiB/s    
remote: Total 319438 (delta 0), reused 0 (delta 0), pack-reused 319437
Receiving objects: 100% (319438/319438), 68.46 MiB | 8.21 MiB/s, done.
Resolving deltas: 100% (204691/204691), done.
Checking connectivity... done.


$ cd symfony


$ git checkout v2.8.4
Previous HEAD position was 4e17cb2... Merge branch '2.8' into 3.0
HEAD is now at 9e14f9f... Merge branch '2.7' into 2.8


$ find . -name 'composer.json' | xargs grep 'symfony/security-acl'
./src/Symfony/Bundle/SecurityBundle/composer.json:        "symfony/security-acl": "~2.7|~3.0.0",
./src/Symfony/Bridge/Twig/composer.json:        "symfony/security-acl": "~2.6|~3.0.0",
./src/Symfony/Component/Security/composer.json:        "symfony/security-acl": "~2.7",
./composer.json:        "symfony/security-acl": "~2.7",
```
