### PR TITLE
Allow a shortcut for UUID when defining requirements

### DIFF
--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -470,6 +470,7 @@ class Route implements \Serializable
     public function addRequirements(array $requirements)
     {
         foreach ($requirements as $key => $regex) {
+            $regex = $this->convertUuidRegex($regex);
             $this->requirements[$key] = $this->sanitizeRequirement($key, $regex);
         }
         $this->compiled = null;
@@ -511,6 +512,7 @@ class Route implements \Serializable
      */
     public function setRequirement($key, $regex)
     {
+        $regex = $this->convertUuidRegex($regex);
         $this->requirements[$key] = $this->sanitizeRequirement($key, $regex);
         $this->compiled = null;
 
@@ -581,6 +583,22 @@ class Route implements \Serializable
 
         if ('' === $regex) {
             throw new \InvalidArgumentException(sprintf('Routing requirement for "%s" cannot be empty.', $key));
+        }
+
+        return $regex;
+    }
+
+    /**
+     * Convert uuid placeholders to regular expressions.
+     *
+     * @param string $regex
+     *
+     * @return string
+     */
+    private function convertUuidRegex($regex)
+    {
+        if ($regex === '\uuid') {
+            $regex = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
         }
 
         return $regex;

--- a/src/Symfony/Component/Routing/Tests/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteTest.php
@@ -110,6 +110,9 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $route->addRequirements(array('bar' => '\d+'));
         $this->assertEquals($route, $route->addRequirements(array()), '->addRequirements() implements a fluent interface');
         $this->assertEquals(array('foo' => '\d+', 'bar' => '\d+'), $route->getRequirements(), '->addRequirement() keep previous requirements');
+
+        $route->setRequirements(array('foo' => '\uuid'));
+        $this->assertEquals(array('foo' => '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'), $route->getRequirements(), '->addRequirements() converts \uuid4');
     }
 
     public function testRequirement()
@@ -119,6 +122,9 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $route->setRequirement('foo', '^\d+$');
         $this->assertEquals('\d+', $route->getRequirement('foo'), '->setRequirement() removes ^ and $ from the path');
         $this->assertTrue($route->hasRequirement('foo'), '->hasRequirement() return true if requirement is set');
+
+        $route->setRequirement('foo', '\uuid');
+        $this->assertEquals(array('foo' => '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'), $route->getRequirements(), '->addRequirement() converts \uuid4');
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | TODO |

Related to https://github.com/sensiolabs/SensioFrameworkExtraBundle/pull/412

---

I use an uuid (v4) in my URL to identify an entity (like you always should). This is a recommended security measure if you compare with just using an auto incremental numeric id (which is standard for a Doctrine/Mysql setup). I want of course make sure that my routes are properly defined and that I have a `requirement` on all my variables. So I write something like this:

``` php
/**
* @Route("/show/{uuid}", name="show_user", requirements={"uuid" = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"})
*/
public function showAction(User $user)
```

The regex for the uuid is quite long and horrible to write/remember. This PR allows you to write a shortcut for that ugly regex. So instead you would write: 

``` php
/**
 * @Route("/show/{uuid}", name="show_user", requirements={"uuid" = "\uuid"})
 */
public function showAction(User $user)
```

This will also work in Yaml, XML and PHP. 
### BC break?

This is not a BC break because nobody will have the string `\uuid` as an requirement. If you would write `\uuid` or `\uxxx` in the requirements you would get an error like: 

```
Warning: preg_match(): Compilation failed: PCRE does not support \L, \l, \N{name}, \U, or \u at offset 17
```
