### PR TITLE
[PropertyAccess] ->getValue() should be read-only

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -275,10 +275,11 @@ class PropertyAccessor implements PropertyAccessorInterface
                     (is_array($zval[self::VALUE]) && !isset($zval[self::VALUE][$property]) && !array_key_exists($property, $zval[self::VALUE]))
                 ) {
                     if ($i + 1 < $propertyPath->getLength()) {
-                        $zval[self::VALUE][$property] = array();
-
                         if (isset($zval[self::REF])) {
+                            $zval[self::VALUE][$property] = array();
                             $zval[self::REF] = $zval[self::VALUE];
+                        } else {
+                            $zval[self::VALUE] = array($property => array());
                         }
                     }
                 }

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -92,9 +92,11 @@ class PropertyAccessorTest extends \PHPUnit_Framework_TestCase
 
     public function testGetValueReadsArrayWithMissingIndexForCustomPropertyPath()
     {
-        $array = array('child' => array('index' => array()));
+        $object = new \ArrayObject();
+        $array = array('child' => array('index' => $object));
 
-        $this->assertNull($this->propertyAccessor->getValue($array, '[child][index][firstName]'));
+        $this->assertNull($this->propertyAccessor->getValue($array, '[child][index][foo][bar]'));
+        $this->assertSame(array(), $object->getArrayCopy());
     }
 
     public function testGetValueReadsProperty()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.3 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18601 |
| License | MIT |
| Doc PR | - |
