### PR TITLE
[HttpKernel] tweaked redirection profiling in RequestDataCollector

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Added `Controller::json` to simplify creating JSON responses when using the Serializer component
  * Deprecated absolute template paths support in the template name parser
  * Deprecated using core form types without dependencies as services
+ * Added `Symfony\Component\HttpHernel\DataCollector\RequestDataCollector::onKernelResponse()`
  * Added `Symfony\Bundle\FrameworkBundle\DataCollector\RequestDataCollector`
  * Deprecated service `serializer.mapping.cache.apc` (use `serializer.mapping.cache.doctrine.apc` instead)
 

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -143,18 +143,6 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
                 'status_text' => Response::$statusTexts[(int) $statusCode],
             ));
         }
-
-        if ($parentRequestAttributes = $request->attributes->get('_forwarded')) {
-            if ($parentRequestAttributes instanceof ParameterBag) {
-                $parentRequestAttributes->set('_forward_token', $response->headers->get('x-debug-token'));
-            }
-        }
-        if ($request->attributes->has('_forward_controller')) {
-            $this->data['forward'] = array(
-                'token' => $request->attributes->get('_forward_token'),
-                'controller' => $this->parseController($request->attributes->get('_forward_controller')),
-            );
-        }
     }
 
     public function getMethod()

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -130,10 +130,8 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
         }
 
         if (isset($session)) {
-            if ($session->has('sf_redirected')) {
-                $this->data['redirect'] = $session->get('sf_redirect');
-                $session->remove('sf_redirect');
-                $session->remove('sf_redirected');
+            if ($request->attributes->has('_redirected')) {
+                $this->data['redirect'] = $session->remove('sf_redirect');
             }
 
             if ($response->isRedirect()) {
@@ -297,7 +295,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
         }
 
         if ($event->getRequest()->getSession()->has('sf_redirect')) {
-            $event->getRequest()->getSession()->set('sf_redirected', true);
+            $event->getRequest()->attributes->set('_redirected', true);
         }
     }
 

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\HeaderBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -128,20 +129,23 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
             unset($this->controllers[$request]);
         }
 
-        if ($request->hasSession() && $request->getSession()->has('sf_redirect')) {
-            $this->data['redirect'] = $request->getSession()->get('sf_redirect');
-            $request->getSession()->remove('sf_redirect');
-        }
+        if (isset($session)) {
+            if ($session->has('sf_redirected')) {
+                $this->data['redirect'] = $session->get('sf_redirect');
+                $session->remove('sf_redirect');
+                $session->remove('sf_redirected');
+            }
 
-        if ($request->hasSession() && $response->isRedirect()) {
-            $request->getSession()->set('sf_redirect', array(
-                'token' => $response->headers->get('x-debug-token'),
-                'route' => $request->attributes->get('_route', 'n/a'),
-                'method' => $request->getMethod(),
-                'controller' => $this->parseController($request->attributes->get('_controller')),
-                'status_code' => $statusCode,
-                'status_text' => Response::$statusTexts[(int) $statusCode],
-            ));
+            if ($response->isRedirect()) {
+                $session->set('sf_redirect', array(
+                    'token' => $response->headers->get('x-debug-token'),
+                    'route' => $request->attributes->get('_route', 'n/a'),
+                    'method' => $request->getMethod(),
+                    'controller' => $this->parseController($request->attributes->get('_controller')),
+                    'status_code' => $statusCode,
+                    'status_text' => Response::$statusTexts[(int) $statusCode],
+                ));
+            }
         }
     }
 
@@ -286,9 +290,23 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
         $this->controllers[$event->getRequest()] = $event->getController();
     }
 
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+        if (!$event->isMasterRequest() || !$event->getRequest()->hasSession()) {
+            return;
+        }
+
+        if ($event->getRequest()->getSession()->has('sf_redirect')) {
+            $event->getRequest()->getSession()->set('sf_redirected', true);
+        }
+    }
+
     public static function getSubscribedEvents()
     {
-        return array(KernelEvents::CONTROLLER => 'onKernelController');
+        return array(
+            KernelEvents::CONTROLLER => 'onKernelController',
+            KernelEvents::RESPONSE => 'onKernelResponse',
+        );
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |
- c8ba3b2 removes duplicated code forgotten in #17589
- a47d2e8 fixes the collecting of redirect data in first sub request instead of redirected master request.
