### PR TITLE
use stable 1.0.x Composer versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ before_install:
     - if [[ ! $skip && $PHP = 5.* ]]; then pecl install -f memcached-2.1.0; fi
     - if [[ ! $skip && $PHP != hhvm ]]; then echo extension = ldap.so >> $INI_FILE; fi
     - if [[ ! $skip && $PHP != hhvm ]]; then phpenv config-rm xdebug.ini; fi
-    - if [[ ! $skip ]]; then composer self-update; fi
+    - if [[ ! $skip ]]; then composer self-update --stable; fi
     - if [[ ! $skip ]]; then cp .composer/* ~/.composer/; composer global install; fi
     - if [[ ! $skip ]]; then ./phpunit install; fi
     - if [[ ! $skip && $deps ]]; then composer global remove hirak/prestissimo; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,7 +49,7 @@ install:
     - IF %PHP%==1 echo extension=php_pdo_sqlite.dll >> php.ini-max
     - IF %PHP%==1 echo extension=php_curl.dll >> php.ini-max
     - IF %PHP%==1 echo curl.cainfo=c:\php\cacert.pem >> php.ini-max
-    - appveyor DownloadFile https://getcomposer.org/composer.phar
+    - IF %PHP%==1 appveyor DownloadFile https://getcomposer.org/download/1.0.2/composer.phar
     - copy /Y php.ini-max php.ini
     - cd c:\projects\symfony
     - mkdir %APPDATA%\Composer


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.3 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This will make our tests pass on AppVeyor again where we always used the latest Composer snapshot (this is 1.1.x-dev now which the `hirak/prestissimo` plugin is not compatible yet, but I opened hirak/prestissimo#79 to make that happen).
