### PR TITLE
[2.3] [CS] [minor] Use `sprintf()` within `trigger_error()` messages

### DIFF
--- a/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
+++ b/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
@@ -358,7 +358,7 @@ class NumberFormatter
     {
         // The original NumberFormatter does not support this format type
         if ($type == self::TYPE_CURRENCY) {
-            trigger_error(__METHOD__.'(): Unsupported format type '.$type, \E_USER_WARNING);
+            trigger_error(sprintf('%s(): Unsupported format type %s', __METHOD__, $type), \E_USER_WARNING);
 
             return false;
         }
@@ -515,7 +515,7 @@ class NumberFormatter
     public function parse($value, $type = self::TYPE_DOUBLE, &$position = 0)
     {
         if ($type == self::TYPE_DEFAULT || $type == self::TYPE_CURRENCY) {
-            trigger_error(__METHOD__.'(): Unsupported format type '.$type, \E_USER_WARNING);
+            trigger_error(sprintf('%s(): Unsupported format type %s', __METHOD__, $type), \E_USER_WARNING);
 
             return false;
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | 2.3 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Exception and error message strings should be concatenated using `sprintf()`.
