### PR TITLE
[2.7] [CS] [minor] [WIP] Use `sprintf()` within `trigger_error()` messages

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bridge\Doctrine\Form\ChoiceList;
 
-@trigger_error('The '.__NAMESPACE__.'\EntityChoiceList class is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Bridge\Doctrine\Form\ChoiceList\DoctrineChoiceLoader instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\EntityChoiceList class is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Bridge\Doctrine\Form\ChoiceList\DoctrineChoiceLoader instead.', __NAMESPACE__), E_USER_DEPRECATED);
 
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Persistence\ObjectManager;
@@ -316,7 +316,7 @@ class EntityChoiceList extends ObjectChoiceList
      */
     public function getIndicesForChoices(array $entities)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.4 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.4 and will be removed in 3.0.', __METHOD__), E_USER_DEPRECATED);
 
         // Performance optimization
         if (empty($entities)) {
@@ -359,7 +359,7 @@ class EntityChoiceList extends ObjectChoiceList
      */
     public function getIndicesForValues(array $values)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.4 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.4 and will be removed in 3.0.', __METHOD__), E_USER_DEPRECATED);
 
         // Performance optimization
         if (empty($values)) {

--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
@@ -57,14 +57,14 @@ class ORMQueryBuilderLoader implements EntityLoaderInterface
         }
 
         if ($queryBuilder instanceof \Closure) {
-            @trigger_error('Passing a QueryBuilder closure to '.__CLASS__.'::__construct() is deprecated since version 2.7 and will be removed in 3.0.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('Passing a QueryBuilder closure to %s::__construct() is deprecated since version 2.7 and will be removed in 3.0.', __CLASS__), E_USER_DEPRECATED);
 
             if (!$manager instanceof ObjectManager) {
                 throw new UnexpectedTypeException($manager, 'Doctrine\Common\Persistence\ObjectManager');
             }
 
-            @trigger_error('Passing an EntityManager to '.__CLASS__.'::__construct() is deprecated since version 2.7 and will be removed in 3.0.', E_USER_DEPRECATED);
-            @trigger_error('Passing a class to '.__CLASS__.'::__construct() is deprecated since version 2.7 and will be removed in 3.0.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('Passing an EntityManager to %s::__construct() is deprecated since version 2.7 and will be removed in 3.0.', __CLASS__), E_USER_DEPRECATED);
+            @trigger_error(sprintf('Passing a class to %s::__construct() is deprecated since version 2.7 and will be removed in 3.0.', __CLASS__), E_USER_DEPRECATED);
 
             $queryBuilder = $queryBuilder($manager->getRepository($class));
 

--- a/src/Symfony/Bridge/Doctrine/Tests/DoctrineOrmTestCase.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DoctrineOrmTestCase.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bridge\Doctrine\Tests;
 
-@trigger_error('The '.__NAMESPACE__.'\DoctrineOrmTestCase class is deprecated since version 2.4 and will be removed in 3.0. Use Symfony\Bridge\Doctrine\Test\DoctrineTestHelper class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\DoctrineOrmTestCase class is deprecated since version 2.4 and will be removed in 3.0. Use Symfony\Bridge\Doctrine\Test\DoctrineTestHelper class instead.', __NAMESPACE__), E_USER_DEPRECATED);
 
 use Doctrine\ORM\EntityManager;
 use Symfony\Bridge\Doctrine\Test\DoctrineTestHelper;

--- a/src/Symfony/Bridge/Monolog/Logger.php
+++ b/src/Symfony/Bridge/Monolog/Logger.php
@@ -27,7 +27,7 @@ class Logger extends BaseLogger implements LoggerInterface, DebugLoggerInterface
      */
     public function emerg($message, array $context = array())
     {
-        @trigger_error('The '.__METHOD__.' method inherited from the Symfony\Component\HttpKernel\Log\LoggerInterface interface is deprecated since version 2.2 and will be removed in 3.0. Use the emergency() method instead, which is PSR-3 compatible.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method inherited from the Symfony\Component\HttpKernel\Log\LoggerInterface interface is deprecated since version 2.2 and will be removed in 3.0. Use the emergency() method instead, which is PSR-3 compatible.', __METHOD__), E_USER_DEPRECATED);
 
         return parent::addRecord(BaseLogger::EMERGENCY, $message, $context);
     }
@@ -37,7 +37,7 @@ class Logger extends BaseLogger implements LoggerInterface, DebugLoggerInterface
      */
     public function crit($message, array $context = array())
     {
-        @trigger_error('The '.__METHOD__.' method inherited from the Symfony\Component\HttpKernel\Log\LoggerInterface interface is deprecated since version 2.2 and will be removed in 3.0. Use the method critical() method instead, which is PSR-3 compatible.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method inherited from the Symfony\Component\HttpKernel\Log\LoggerInterface interface is deprecated since version 2.2 and will be removed in 3.0. Use the method critical() method instead, which is PSR-3 compatible.', __METHOD__), E_USER_DEPRECATED);
 
         return parent::addRecord(BaseLogger::CRITICAL, $message, $context);
     }
@@ -47,7 +47,7 @@ class Logger extends BaseLogger implements LoggerInterface, DebugLoggerInterface
      */
     public function err($message, array $context = array())
     {
-        @trigger_error('The '.__METHOD__.' method inherited from the Symfony\Component\HttpKernel\Log\LoggerInterface interface is deprecated since version 2.2 and will be removed in 3.0. Use the error() method instead, which is PSR-3 compatible.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method inherited from the Symfony\Component\HttpKernel\Log\LoggerInterface interface is deprecated since version 2.2 and will be removed in 3.0. Use the error() method instead, which is PSR-3 compatible.', __METHOD__), E_USER_DEPRECATED);
 
         return parent::addRecord(BaseLogger::ERROR, $message, $context);
     }
@@ -57,7 +57,7 @@ class Logger extends BaseLogger implements LoggerInterface, DebugLoggerInterface
      */
     public function warn($message, array $context = array())
     {
-        @trigger_error('The '.__METHOD__.' method inherited from the Symfony\Component\HttpKernel\Log\LoggerInterface interface is deprecated since version 2.2 and will be removed in 3.0. Use the warning() method instead, which is PSR-3 compatible.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method inherited from the Symfony\Component\HttpKernel\Log\LoggerInterface interface is deprecated since version 2.2 and will be removed in 3.0. Use the warning() method instead, which is PSR-3 compatible.', __METHOD__), E_USER_DEPRECATED);
 
         return parent::addRecord(BaseLogger::WARNING, $message, $context);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -274,7 +274,7 @@ class Controller extends ContainerAware
      */
     public function getRequest()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.4 and will be removed in 3.0. The only reliable way to get the "Request" object is to inject it in the action method.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.4 and will be removed in 3.0. The only reliable way to get the "Request" object is to inject it in the action method.', __METHOD__), E_USER_DEPRECATED);
 
         return $this->container->get('request_stack')->getCurrentRequest();
     }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FragmentRendererPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FragmentRendererPass.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 
-@trigger_error('The '.__NAMESPACE__.'\FragmentRendererPass class is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\HttpKernel\DependencyInjection\FragmentRendererPass instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\FragmentRendererPass class is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\HttpKernel\DependencyInjection\FragmentRendererPass instead.', __NAMESPACE__), E_USER_DEPRECATED);
 
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TemplatingAssetHelperPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TemplatingAssetHelperPass.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
-@trigger_error('The '.__NAMESPACE__.'\TemplatingAssetHelperPass class is deprecated since version 2.7 and will be removed in 3.0.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\TemplatingAssetHelperPass class is deprecated since version 2.7 and will be removed in 3.0.', __NAMESPACE__), E_USER_DEPRECATED);
 
 /**
  * @deprecated since 2.7, will be removed in 3.0

--- a/src/Symfony/Bundle/FrameworkBundle/Fragment/ContainerAwareHIncludeFragmentRenderer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Fragment/ContainerAwareHIncludeFragmentRenderer.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Fragment;
 
-@trigger_error('The '.__NAMESPACE__.'\ContainerAwareHIncludeFragmentRenderer class is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Bundle\FrameworkBundle\Fragment\HIncludeFragmentRenderer instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\ContainerAwareHIncludeFragmentRenderer class is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Bundle\FrameworkBundle\Fragment\HIncludeFragmentRenderer instead.', __NAMESPACE__), E_USER_DEPRECATED);
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;

--- a/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
@@ -84,7 +84,7 @@ abstract class HttpCache extends BaseHttpCache
      */
     protected function createEsi()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use createSurrogate() instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.6 and will be removed in 3.0. Use createSurrogate() instead.', __METHOD__), E_USER_DEPRECATED);
 
         return $this->createSurrogate();
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Debugger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Debugger.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Templating;
 
-@trigger_error('The '.__NAMESPACE__.'\Debugger class is deprecated since version 2.4 and will be removed in 3.0. Use the Psr\Log\LoggerInterface interface instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\Debugger class is deprecated since version 2.4 and will be removed in 3.0. Use the Psr\Log\LoggerInterface interface instead.', __NAMESPACE__), E_USER_DEPRECATED);
 
 use Symfony\Component\Templating\DebuggerInterface;
 use Psr\Log\LoggerInterface;

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
@@ -42,7 +42,7 @@ class GlobalVariables
      */
     public function getSecurity()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.6 and will be removed in 3.0.', __METHOD__), E_USER_DEPRECATED);
 
         if ($this->container->has('security.context')) {
             return $this->container->get('security.context');

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/RequestHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/RequestHelper.php
@@ -35,7 +35,7 @@ class RequestHelper extends Helper
     public function __construct($requestStack)
     {
         if ($requestStack instanceof Request) {
-            @trigger_error('Since version 2.5, passing a Request instance into the '.__METHOD__.' is deprecated and support for it will be removed in 3.0. Inject a Symfony\Component\HttpFoundation\RequestStack instance instead.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('Since version 2.5, passing a Request instance into the %s is deprecated and support for it will be removed in 3.0. Inject a Symfony\Component\HttpFoundation\RequestStack instance instead.', __METHOD__), E_USER_DEPRECATED);
             $this->request = $requestStack;
         } elseif ($requestStack instanceof RequestStack) {
             $this->requestStack = $requestStack;

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/SessionHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/SessionHelper.php
@@ -35,7 +35,7 @@ class SessionHelper extends Helper
     public function __construct($requestStack)
     {
         if ($requestStack instanceof Request) {
-            @trigger_error('Since version 2.5, passing a Request instance into the '.__METHOD__.' is deprecated and support for it will be removed in 3.0. Inject a Symfony\Component\HttpFoundation\RequestStack instance instead.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('Since version 2.5, passing a Request instance into the %s is deprecated and support for it will be removed in 3.0. Inject a Symfony\Component\HttpFoundation\RequestStack instance instead.', __METHOD__), E_USER_DEPRECATED);
             $this->session = $requestStack->getSession();
         } elseif ($requestStack instanceof RequestStack) {
             $this->requestStack = $requestStack;

--- a/src/Symfony/Bundle/SecurityBundle/Templating/Helper/LogoutUrlHelper.php
+++ b/src/Symfony/Bundle/SecurityBundle/Templating/Helper/LogoutUrlHelper.php
@@ -39,7 +39,7 @@ class LogoutUrlHelper extends Helper
     public function __construct($generator, UrlGeneratorInterface $router = null, TokenStorageInterface $tokenStorage = null)
     {
         if ($generator instanceof ContainerInterface) {
-            @trigger_error('The '.__CLASS__.' constructor will require a LogoutUrlGenerator instead of a ContainerInterface instance in 3.0.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('The %s constructor will require a LogoutUrlGenerator instead of a ContainerInterface instance in 3.0.', __CLASS__), E_USER_DEPRECATED);
 
             if ($generator->has('security.logout_url_generator')) {
                 $this->generator = $generator->get('security.logout_url_generator');

--- a/src/Symfony/Bundle/SecurityBundle/Twig/Extension/LogoutUrlExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/Twig/Extension/LogoutUrlExtension.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\SecurityBundle\Twig\Extension;
 
-@trigger_error('The '.__NAMESPACE__.'\LogoutUrlExtension class is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Bridge\Twig\Extension\LogoutUrlExtension instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\LogoutUrlExtension class is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Bridge\Twig\Extension\LogoutUrlExtension instead.', __NAMESPACE__), E_USER_DEPRECATED);
 
 use Symfony\Bundle\SecurityBundle\Templating\Helper\LogoutUrlHelper;
 

--- a/src/Symfony/Bundle/TwigBundle/Debug/TimedTwigEngine.php
+++ b/src/Symfony/Bundle/TwigBundle/Debug/TimedTwigEngine.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\TwigBundle\Debug;
 
-@trigger_error('The '.__NAMESPACE__.'\TimedTwigEngine class is deprecated since version 2.7 and will be removed in 3.0. Use the Twig native profiler instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\TimedTwigEngine class is deprecated since version 2.7 and will be removed in 3.0. Use the Twig native profiler instead.', __NAMESPACE__), E_USER_DEPRECATED);
 
 use Symfony\Bundle\TwigBundle\TwigEngine;
 use Symfony\Component\Templating\TemplateNameParserInterface;

--- a/src/Symfony/Bundle/TwigBundle/Extension/ActionsExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/Extension/ActionsExtension.php
@@ -36,7 +36,7 @@ class ActionsExtension extends \Twig_Extension
         if ($handler instanceof FragmentHandler) {
             $this->handler = $handler;
         } elseif ($handler instanceof ContainerInterface) {
-            @trigger_error('The ability to pass a ContainerInterface instance as a first argument to '.__METHOD__.' method is deprecated since version 2.7 and will be removed in 3.0. Pass a FragmentHandler instance instead.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('The ability to pass a ContainerInterface instance as a first argument to %s method is deprecated since version 2.7 and will be removed in 3.0. Pass a FragmentHandler instance instead.', __METHOD__), E_USER_DEPRECATED);
 
             $this->handler = $handler->get('fragment.handler');
         } else {

--- a/src/Symfony/Bundle/TwigBundle/Extension/AssetsExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/Extension/AssetsExtension.php
@@ -14,7 +14,7 @@ namespace Symfony\Bundle\TwigBundle\Extension;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Routing\RequestContext;
 
-@trigger_error('The '.__NAMESPACE__.'\AssetsExtension class is deprecated since version 2.7 and will be removed in 3.0. Use the Symfony\Bridge\Twig\Extension\AssetExtension class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\AssetsExtension class is deprecated since version 2.7 and will be removed in 3.0. Use the Symfony\Bridge\Twig\Extension\AssetExtension class instead.', __NAMESPACE__), E_USER_DEPRECATED);
 
 /**
  * Twig extension for Symfony assets helper.

--- a/src/Symfony/Bundle/TwigBundle/TwigDefaultEscapingStrategy.php
+++ b/src/Symfony/Bundle/TwigBundle/TwigDefaultEscapingStrategy.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\TwigBundle;
 
-@trigger_error('The '.__NAMESPACE__.'\TwigDefaultEscapingStrategy class is deprecated in version 2.7 and will be removed in version 3.0. Use the "filename" auto-escaping strategy instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\TwigDefaultEscapingStrategy class is deprecated in version 2.7 and will be removed in version 3.0. Use the "filename" auto-escaping strategy instead.', __NAMESPACE__), E_USER_DEPRECATED);
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>

--- a/src/Symfony/Bundle/TwigBundle/TwigEngine.php
+++ b/src/Symfony/Bundle/TwigBundle/TwigEngine.php
@@ -47,7 +47,7 @@ class TwigEngine extends BaseEngine implements EngineInterface
      */
     public function setDefaultEscapingStrategy($strategy)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.7 and will be removed in 3.0. Inject the escaping strategy in the Twig_Environment object instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.7 and will be removed in 3.0. Inject the escaping strategy in the Twig_Environment object instead.', __METHOD__), E_USER_DEPRECATED);
 
         $this->environment->getExtension('escaper')->setDefaultStrategy($strategy);
     }
@@ -58,7 +58,7 @@ class TwigEngine extends BaseEngine implements EngineInterface
      */
     public function guessDefaultEscapingStrategy($filename)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.7 and will be removed in 3.0. Use the Twig_FileExtensionEscapingStrategy::guess method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.7 and will be removed in 3.0. Use the Twig_FileExtensionEscapingStrategy::guess method instead.', __METHOD__), E_USER_DEPRECATED);
 
         return \Twig_FileExtensionEscapingStrategy::guess($filename);
     }

--- a/src/Symfony/Component/ClassLoader/ApcUniversalClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/ApcUniversalClassLoader.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\ClassLoader;
 
-@trigger_error('The '.__NAMESPACE__.'\ApcUniversalClassLoader class is deprecated since version 2.7 and will be removed in 3.0. Use the Symfony\Component\ClassLoader\ApcClassLoader class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\ApcUniversalClassLoader class is deprecated since version 2.7 and will be removed in 3.0. Use the Symfony\Component\ClassLoader\ApcClassLoader class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 /**
  * ApcUniversalClassLoader implements a "universal" autoloader cached in APC for PHP 5.3.

--- a/src/Symfony/Component/ClassLoader/DebugClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/DebugClassLoader.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\ClassLoader;
 
-@trigger_error('The '.__NAMESPACE__.'\DebugClassLoader class is deprecated since version 2.4 and will be removed in 3.0. Use the Symfony\Component\Debug\DebugClassLoader class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\DebugClassLoader class is deprecated since version 2.4 and will be removed in 3.0. Use the Symfony\Component\Debug\DebugClassLoader class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 /**
  * Autoloader checking if the class is really defined in the file found.

--- a/src/Symfony/Component/ClassLoader/DebugUniversalClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/DebugUniversalClassLoader.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\ClassLoader;
 
-@trigger_error('The '.__NAMESPACE__.'\DebugUniversalClassLoader class is deprecated since version 2.4 and will be removed in 3.0. Use the Symfony\Component\Debug\DebugClassLoader class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\DebugUniversalClassLoader class is deprecated since version 2.4 and will be removed in 3.0. Use the Symfony\Component\Debug\DebugClassLoader class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 /**
  * Checks that the class is actually declared in the included file.

--- a/src/Symfony/Component/ClassLoader/UniversalClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/UniversalClassLoader.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\ClassLoader;
 
-@trigger_error('The '.__NAMESPACE__.'\UniversalClassLoader class is deprecated since version 2.7 and will be removed in 3.0. Use the Symfony\Component\ClassLoader\ClassLoader class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\UniversalClassLoader class is deprecated since version 2.7 and will be removed in 3.0. Use the Symfony\Component\ClassLoader\ClassLoader class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 /**
  * UniversalClassLoader implements a "universal" autoloader for PHP 5.3.

--- a/src/Symfony/Component/Config/Definition/ReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/ReferenceDumper.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Config\Definition;
 
-@trigger_error('The '.__NAMESPACE__.'\ReferenceDumper class is deprecated since version 2.4 and will be removed in 3.0. Use the Symfony\Component\Config\Definition\Dumper\YamlReferenceDumper class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\ReferenceDumper class is deprecated since version 2.4 and will be removed in 3.0. Use the Symfony\Component\Config\Definition\Dumper\YamlReferenceDumper class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Config\Definition\Dumper\YamlReferenceDumper;
 

--- a/src/Symfony/Component/Config/Loader/FileLoader.php
+++ b/src/Symfony/Component/Config/Loader/FileLoader.php
@@ -88,7 +88,7 @@ abstract class FileLoader extends Loader
                 // @deprecated should be removed in 3.0
                 $locator = $loader->getLocator();
                 if (null === $locator) {
-                    @trigger_error('Not calling the parent constructor in '.get_class($loader).' which extends '.__CLASS__.' is deprecated since version 2.7 and will not be supported anymore in 3.0.', E_USER_DEPRECATED);
+                    @trigger_error(sprintf('Not calling the parent constructor in %s which extends %s is deprecated since version 2.7 and will not be supported anymore in 3.0.', get_class($loader), __CLASS__), E_USER_DEPRECATED);
                     $locator = $this->locator;
                 }
 

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -592,7 +592,7 @@ class Application
      */
     public function asText($namespace = null, $raw = false)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.3 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.3 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
 
         $descriptor = new TextDescriptor();
         $output = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, !$raw);
@@ -613,7 +613,7 @@ class Application
      */
     public function asXml($namespace = null, $asDom = false)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.3 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.3 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
 
         $descriptor = new XmlDescriptor();
 

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -614,7 +614,7 @@ class Command
      */
     public function asText()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.3 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.3 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
 
         $descriptor = new TextDescriptor();
         $output = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, true);
@@ -634,7 +634,7 @@ class Command
      */
     public function asXml($asDom = false)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.3 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.3 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
 
         $descriptor = new XmlDescriptor();
 

--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -178,7 +178,7 @@ class ProgressBar
      */
     public function getStep()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use the getProgress() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.6 and will be removed in 3.0. Use the getProgress() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         return $this->getProgress();
     }
@@ -361,7 +361,7 @@ class ProgressBar
      */
     public function setCurrent($step)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use the setProgress() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.6 and will be removed in 3.0. Use the setProgress() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         $this->setProgress($step);
     }

--- a/src/Symfony/Component/Console/Helper/ProgressHelper.php
+++ b/src/Symfony/Component/Console/Helper/ProgressHelper.php
@@ -122,7 +122,7 @@ class ProgressHelper extends Helper
     public function __construct($triggerDeprecationError = true)
     {
         if ($triggerDeprecationError) {
-            @trigger_error('The '.__CLASS__.' class is deprecated since version 2.5 and will be removed in 3.0. Use the Symfony\Component\Console\Helper\ProgressBar class instead.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('The %s class is deprecated since version 2.5 and will be removed in 3.0. Use the Symfony\Component\Console\Helper\ProgressBar class instead.', __CLASS__),  E_USER_DEPRECATED);
         }
     }
 

--- a/src/Symfony/Component/Console/Helper/TableHelper.php
+++ b/src/Symfony/Component/Console/Helper/TableHelper.php
@@ -37,7 +37,7 @@ class TableHelper extends Helper
     public function __construct($triggerDeprecationError = true)
     {
         if ($triggerDeprecationError) {
-            @trigger_error('The '.__CLASS__.' class is deprecated since version 2.5 and will be removed in 3.0. Use the Symfony\Component\Console\Helper\Table class instead.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('The %s class is deprecated since version 2.5 and will be removed in 3.0. Use the Symfony\Component\Console\Helper\Table class instead.', __CLASS__),  E_USER_DEPRECATED);
         }
 
         $this->table = new Table(new NullOutput());

--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -419,7 +419,7 @@ class InputDefinition
      */
     public function asText()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.3 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.3 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
 
         $descriptor = new TextDescriptor();
         $output = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, true);
@@ -439,7 +439,7 @@ class InputDefinition
      */
     public function asXml($asDom = false)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.3 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.3 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
 
         $descriptor = new XmlDescriptor();
 

--- a/src/Symfony/Component/Console/Input/StringInput.php
+++ b/src/Symfony/Component/Console/Input/StringInput.php
@@ -36,7 +36,7 @@ class StringInput extends ArgvInput
     public function __construct($input, InputDefinition $definition = null)
     {
         if ($definition) {
-            @trigger_error('The $definition argument of the '.__METHOD__.' method is deprecated and will be removed in 3.0. Set this parameter with the bind() method instead.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('The $definition argument of the %s method is deprecated and will be removed in 3.0. Set this parameter with the bind() method instead.', __METHOD__),  E_USER_DEPRECATED);
         }
 
         parent::__construct(array(), null);

--- a/src/Symfony/Component/Debug/DebugClassLoader.php
+++ b/src/Symfony/Component/Debug/DebugClassLoader.php
@@ -42,7 +42,7 @@ class DebugClassLoader
         $this->wasFinder = is_object($classLoader) && method_exists($classLoader, 'findFile');
 
         if ($this->wasFinder) {
-            @trigger_error('The '.__METHOD__.' method will no longer support receiving an object into its $classLoader argument in 3.0.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('The %s method will no longer support receiving an object into its $classLoader argument in 3.0.', __METHOD__),  E_USER_DEPRECATED);
             $this->classLoader = array($classLoader, 'loadClass');
             $this->isFinder = true;
         } else {
@@ -143,7 +143,7 @@ class DebugClassLoader
      */
     public function findFile($class)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.5 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
 
         if ($this->wasFinder) {
             return $this->classLoader[0]->findFile($class);

--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -644,7 +644,7 @@ class ErrorHandler
      */
     public function setLevel($level)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use the throwAt() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.6 and will be removed in 3.0. Use the throwAt() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         $level = null === $level ? error_reporting() : $level;
         $this->throwAt($level, true);
@@ -659,7 +659,7 @@ class ErrorHandler
      */
     public function setDisplayErrors($displayErrors)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use the throwAt() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.6 and will be removed in 3.0. Use the throwAt() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         if ($displayErrors) {
             $this->throwAt($this->displayErrors, true);
@@ -680,7 +680,7 @@ class ErrorHandler
      */
     public static function setLogger(LoggerInterface $logger, $channel = 'deprecation')
     {
-        @trigger_error('The '.__METHOD__.' static method is deprecated since version 2.6 and will be removed in 3.0. Use the setLoggers() or setDefaultLogger() methods instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s static method is deprecated since version 2.6 and will be removed in 3.0. Use the setLoggers() or setDefaultLogger() methods instead.', __METHOD__),  E_USER_DEPRECATED);
 
         $handler = set_error_handler('var_dump');
         $handler = is_array($handler) ? $handler[0] : null;
@@ -717,7 +717,7 @@ class ErrorHandler
      */
     public function handleFatal()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use the handleFatalError() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.6 and will be removed in 3.0. Use the handleFatalError() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         static::handleFatalError();
     }

--- a/src/Symfony/Component/Debug/Exception/DummyException.php
+++ b/src/Symfony/Component/Debug/Exception/DummyException.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Debug\Exception;
 
-@trigger_error('The '.__NAMESPACE__.'\DummyException class is deprecated since version 2.5 and will be removed in 3.0.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\DummyException class is deprecated since version 2.5 and will be removed in 3.0.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>

--- a/src/Symfony/Component/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/Debug/ExceptionHandler.php
@@ -431,7 +431,7 @@ EOF;
      */
     protected static function utf8Htmlize($str)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.7 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.7 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
 
         return htmlspecialchars($str, ENT_QUOTES | (PHP_VERSION_ID >= 50400 ? ENT_SUBSTITUTE : 0), 'UTF-8');
     }

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1063,7 +1063,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     private function synchronize($id)
     {
         if ('request' !== $id) {
-            @trigger_error('The '.__METHOD__.' method is deprecated in version 2.7 and will be removed in version 3.0.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('The %s method is deprecated in version 2.7 and will be removed in version 3.0.', __METHOD__),  E_USER_DEPRECATED);
         }
 
         foreach ($this->definitions as $definitionId => $definition) {

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -108,7 +108,7 @@ class Definition
     public function getFactoryClass($triggerDeprecationError = true)
     {
         if ($triggerDeprecationError) {
-            @trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('The %s method is deprecated since version 2.6 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
         }
 
         return $this->factoryClass;
@@ -177,7 +177,7 @@ class Definition
     public function getFactoryMethod($triggerDeprecationError = true)
     {
         if ($triggerDeprecationError) {
-            @trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('The %s method is deprecated since version 2.6 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
         }
 
         return $this->factoryMethod;
@@ -213,7 +213,7 @@ class Definition
     public function getFactoryService($triggerDeprecationError = true)
     {
         if ($triggerDeprecationError) {
-            @trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('The %s method is deprecated since version 2.6 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
         }
 
         return $this->factoryService;
@@ -596,7 +596,7 @@ class Definition
     public function setSynchronized($boolean, $triggerDeprecationError = true)
     {
         if ($triggerDeprecationError) {
-            @trigger_error('The '.__METHOD__.' method is deprecated since version 2.7 and will be removed in 3.0.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('The %s method is deprecated since version 2.7 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
         }
 
         $this->synchronized = (bool) $boolean;
@@ -614,7 +614,7 @@ class Definition
     public function isSynchronized($triggerDeprecationError = true)
     {
         if ($triggerDeprecationError) {
-            @trigger_error('The '.__METHOD__.' method is deprecated since version 2.7 and will be removed in 3.0.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('The %s method is deprecated since version 2.7 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
         }
 
         return $this->synchronized;

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1444,7 +1444,7 @@ EOF;
      */
     public function addExpressionLanguageProvider(ExpressionFunctionProviderInterface $provider)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.6.2 and will be removed in 3.0. Use the Symfony\Component\DependencyInjection\ContainerBuilder::addExpressionLanguageProvider method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.6.2 and will be removed in 3.0. Use the Symfony\Component\DependencyInjection\ContainerBuilder::addExpressionLanguageProvider method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         $this->expressionLanguageProviders[] = $provider;
     }

--- a/src/Symfony/Component/DependencyInjection/SimpleXMLElement.php
+++ b/src/Symfony/Component/DependencyInjection/SimpleXMLElement.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection;
 
-@trigger_error('The '.__NAMESPACE__.'\SimpleXMLElement class is deprecated since version 2.5 and will be removed in 3.0.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\SimpleXMLElement class is deprecated since version 2.5 and will be removed in 3.0.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Config\Util\XmlUtils;
 use Symfony\Component\ExpressionLanguage\Expression;

--- a/src/Symfony/Component/EventDispatcher/Event.php
+++ b/src/Symfony/Component/EventDispatcher/Event.php
@@ -87,7 +87,7 @@ class Event
      */
     public function getDispatcher()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.4 and will be removed in 3.0. The event dispatcher instance can be received in the listener call instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.4 and will be removed in 3.0. The event dispatcher instance can be received in the listener call instead.', __METHOD__),  E_USER_DEPRECATED);
 
         return $this->dispatcher;
     }
@@ -101,7 +101,7 @@ class Event
      */
     public function getName()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.4 and will be removed in 3.0. The event name can be received in the listener call instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.4 and will be removed in 3.0. The event name can be received in the listener call instead.', __METHOD__),  E_USER_DEPRECATED);
 
         return $this->name;
     }

--- a/src/Symfony/Component/Form/ButtonBuilder.php
+++ b/src/Symfony/Component/Form/ButtonBuilder.php
@@ -597,7 +597,7 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      */
     public function getVirtual()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Form\FormConfigBuilder::getInheritData method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Form\FormConfigBuilder::getInheritData method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         return false;
     }

--- a/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
@@ -46,7 +46,7 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
     public function createListFromFlippedChoices($choices, $value = null, $triggerDeprecationNotice = true)
     {
         if ($triggerDeprecationNotice) {
-            @trigger_error('The '.__METHOD__.' is deprecated since version 2.7 and will be removed in 3.0.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('The %s is deprecated since version 2.7 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
         }
 
         return new ArrayKeyChoiceList($choices, $value);

--- a/src/Symfony/Component/Form/Exception/AlreadyBoundException.php
+++ b/src/Symfony/Component/Form/Exception/AlreadyBoundException.php
@@ -22,7 +22,7 @@ class AlreadyBoundException extends LogicException
     public function __construct($message = '', $code = 0, \Exception $previous = null)
     {
         if (__CLASS__ === get_class($this)) {
-            @trigger_error('The '.__CLASS__.' class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Form\Exception\AlreadySubmittedException class instead.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('The %s class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Form\Exception\AlreadySubmittedException class instead.', __CLASS__),  E_USER_DEPRECATED);
         }
 
         parent::__construct($message, $code, $previous);

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/ChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/ChoiceList.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Form\Extension\Core\ChoiceList;
 
-@trigger_error('The '.__NAMESPACE__.'\ChoiceList class is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\ChoiceList\ArrayChoiceList instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\ChoiceList class is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\ChoiceList\ArrayChoiceList instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Form\FormConfigBuilder;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
@@ -208,7 +208,7 @@ class ChoiceList implements ChoiceListInterface
      */
     public function getIndicesForChoices(array $choices)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.4 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.4 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
 
         $choices = $this->fixChoices($choices);
         $indices = array();
@@ -236,7 +236,7 @@ class ChoiceList implements ChoiceListInterface
      */
     public function getIndicesForValues(array $values)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.4 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.4 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
 
         $values = $this->fixValues($values);
         $indices = array();

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/LazyChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/LazyChoiceList.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Form\Extension\Core\ChoiceList;
 
-@trigger_error('The '.__NAMESPACE__.'\LazyChoiceList class is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\ChoiceList\ArrayChoiceList instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\LazyChoiceList class is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\ChoiceList\ArrayChoiceList instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Form\Exception\InvalidArgumentException;
 
@@ -115,7 +115,7 @@ abstract class LazyChoiceList implements ChoiceListInterface
      */
     public function getIndicesForChoices(array $choices)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.4 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.4 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
 
         if (!$this->choiceList) {
             $this->load();
@@ -131,7 +131,7 @@ abstract class LazyChoiceList implements ChoiceListInterface
      */
     public function getIndicesForValues(array $values)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.4 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.4 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
 
         if (!$this->choiceList) {
             $this->load();

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/ObjectChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/ObjectChoiceList.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Form\Extension\Core\ChoiceList;
 
-@trigger_error('The '.__NAMESPACE__.'\ObjectChoiceList class is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\ChoiceList\ArrayChoiceList instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\ObjectChoiceList class is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\ChoiceList\ArrayChoiceList instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Form\Exception\StringCastException;
 use Symfony\Component\Form\Exception\InvalidArgumentException;
@@ -196,7 +196,7 @@ class ObjectChoiceList extends ChoiceList
      */
     public function getIndicesForChoices(array $choices)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.4 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.4 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
 
         if (!$this->valuePath) {
             return parent::getIndicesForChoices($choices);

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/SimpleChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/SimpleChoiceList.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Form\Extension\Core\ChoiceList;
 
-@trigger_error('The '.__NAMESPACE__.'\SimpleChoiceList class is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\ChoiceList\ArrayChoiceList instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\SimpleChoiceList class is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\ChoiceList\ArrayChoiceList instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 /**
  * A choice list for choices of type string or integer.

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToBooleanArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToBooleanArrayTransformer.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Form\Extension\Core\DataTransformer;
 
-@trigger_error('The class '.__NAMESPACE__.'\ChoiceToBooleanArrayTransformer is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\Extension\Core\DataMapper\RadioListMapper instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The class %s\ChoiceToBooleanArrayTransformer is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\Extension\Core\DataMapper\RadioListMapper instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
 use Symfony\Component\Form\DataTransformerInterface;

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToBooleanArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToBooleanArrayTransformer.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Form\Extension\Core\DataTransformer;
 
-@trigger_error('The class '.__NAMESPACE__.'\ChoicesToBooleanArrayTransformer is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\Extension\Core\DataMapper\CheckboxListMapper instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The class %s\ChoicesToBooleanArrayTransformer is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\Extension\Core\DataMapper\CheckboxListMapper instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
 use Symfony\Component\Form\DataTransformerInterface;

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/FixCheckboxInputListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/FixCheckboxInputListener.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Form\Extension\Core\EventListener;
 
-@trigger_error('The class '.__NAMESPACE__.'\FixCheckboxInputListener is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\Extension\Core\DataMapper\CheckboxListMapper instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The class %s\FixCheckboxInputListener is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\Extension\Core\DataMapper\CheckboxListMapper instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
@@ -91,7 +91,7 @@ class FixCheckboxInputListener implements EventSubscriberInterface
      */
     public function preBind(FormEvent $event)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.3 and will be removed in 3.0. Use the preSubmit() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.3 and will be removed in 3.0. Use the preSubmit() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         $this->preSubmit($event);
     }

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/FixRadioInputListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/FixRadioInputListener.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Form\Extension\Core\EventListener;
 
-@trigger_error('The class '.__NAMESPACE__.'\FixRadioInputListener is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\Extension\Core\DataMapper\RadioListMapper instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The class %s\FixRadioInputListener is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\Extension\Core\DataMapper\RadioListMapper instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
@@ -73,7 +73,7 @@ class FixRadioInputListener implements EventSubscriberInterface
      */
     public function preBind(FormEvent $event)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.3 and will be removed in 3.0. Use the preSubmit() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.3 and will be removed in 3.0. Use the preSubmit() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         $this->preSubmit($event);
     }

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/FixUrlProtocolListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/FixUrlProtocolListener.php
@@ -51,7 +51,7 @@ class FixUrlProtocolListener implements EventSubscriberInterface
      */
     public function onBind(FormEvent $event)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.3 and will be removed in 3.0. Use the onSubmit() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.3 and will be removed in 3.0. Use the onSubmit() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         $this->onSubmit($event);
     }

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/MergeCollectionListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/MergeCollectionListener.php
@@ -134,7 +134,7 @@ class MergeCollectionListener implements EventSubscriberInterface
      */
     public function onBind(FormEvent $event)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.3 and will be removed in 3.0. Use the onSubmit() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.3 and will be removed in 3.0. Use the onSubmit() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         $this->onSubmit($event);
     }

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
@@ -185,7 +185,7 @@ class ResizeFormListener implements EventSubscriberInterface
      */
     public function preBind(FormEvent $event)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.3 and will be removed in 3.0. Use the preSubmit() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.3 and will be removed in 3.0. Use the preSubmit() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         $this->preSubmit($event);
     }
@@ -198,7 +198,7 @@ class ResizeFormListener implements EventSubscriberInterface
      */
     public function onBind(FormEvent $event)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.3 and will be removed in 3.0. Use the onSubmit() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.3 and will be removed in 3.0. Use the onSubmit() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         $this->onSubmit($event);
     }

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/TrimListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/TrimListener.php
@@ -45,7 +45,7 @@ class TrimListener implements EventSubscriberInterface
      */
     public function preBind(FormEvent $event)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.3 and will be removed in 3.0. Use the preSubmit() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.3 and will be removed in 3.0. Use the preSubmit() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         $this->preSubmit($event);
     }

--- a/src/Symfony/Component/Form/Extension/Core/View/ChoiceView.php
+++ b/src/Symfony/Component/Form/Extension/Core/View/ChoiceView.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Form\Extension\Core\View;
 
-@trigger_error('The '.__NAMESPACE__.'\ChoiceView class is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\ChoiceList\View\ChoiceView instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\ChoiceView class is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Form\ChoiceList\View\ChoiceView instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 /*
  * Represents a choice in templates.

--- a/src/Symfony/Component/Form/Extension/Csrf/CsrfProvider/CsrfProviderAdapter.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/CsrfProvider/CsrfProviderAdapter.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Form\Extension\Csrf\CsrfProvider;
 
-@trigger_error('The '.__NAMESPACE__.'\CsrfProviderAdapter class is deprecated since version 2.4 and will be removed in version 3.0. Use the Symfony\Component\Security\Csrf\CsrfTokenManager class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\CsrfProviderAdapter class is deprecated since version 2.4 and will be removed in version 3.0. Use the Symfony\Component\Security\Csrf\CsrfTokenManager class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Form\Exception\BadMethodCallException;
 use Symfony\Component\Security\Csrf\CsrfToken;

--- a/src/Symfony/Component/Form/Extension/Csrf/CsrfProvider/CsrfTokenManagerAdapter.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/CsrfProvider/CsrfTokenManagerAdapter.php
@@ -38,7 +38,7 @@ class CsrfTokenManagerAdapter implements CsrfProviderInterface
     public function getTokenManager($triggerDeprecationError = true)
     {
         if ($triggerDeprecationError) {
-            @trigger_error('The '.__METHOD__.' method is deprecated since version 2.4 and will be removed in version 3.0. Use the Symfony\Component\Security\Csrf\CsrfTokenManager class instead.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('The %s method is deprecated since version 2.4 and will be removed in version 3.0. Use the Symfony\Component\Security\Csrf\CsrfTokenManager class instead.', __METHOD__),  E_USER_DEPRECATED);
         }
 
         return $this->tokenManager;
@@ -49,7 +49,7 @@ class CsrfTokenManagerAdapter implements CsrfProviderInterface
      */
     public function generateCsrfToken($intention)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.4 and will be removed in version 3.0. Use the Symfony\Component\Security\Csrf\CsrfTokenManager class instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.4 and will be removed in version 3.0. Use the Symfony\Component\Security\Csrf\CsrfTokenManager class instead.', __METHOD__),  E_USER_DEPRECATED);
 
         return $this->tokenManager->getToken($intention)->getValue();
     }
@@ -59,7 +59,7 @@ class CsrfTokenManagerAdapter implements CsrfProviderInterface
      */
     public function isCsrfTokenValid($intention, $token)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.4 and will be removed in version 3.0. Use the Symfony\Component\Security\Csrf\CsrfTokenManager class instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.4 and will be removed in version 3.0. Use the Symfony\Component\Security\Csrf\CsrfTokenManager class instead.', __METHOD__),  E_USER_DEPRECATED);
 
         return $this->tokenManager->isTokenValid(new CsrfToken($intention, $token));
     }

--- a/src/Symfony/Component/Form/Extension/Csrf/CsrfProvider/DefaultCsrfProvider.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/CsrfProvider/DefaultCsrfProvider.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Form\Extension\Csrf\CsrfProvider;
 
 use Symfony\Component\Security\Core\Util\StringUtils;
 
-@trigger_error('The '.__NAMESPACE__.'\DefaultCsrfProvider is deprecated since version 2.4 and will be removed in version 3.0. Use the \Symfony\Component\Security\Csrf\TokenStorage\NativeSessionTokenStorage class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\DefaultCsrfProvider is deprecated since version 2.4 and will be removed in version 3.0. Use the \Symfony\Component\Security\Csrf\TokenStorage\NativeSessionTokenStorage class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 /**
  * Default implementation of CsrfProviderInterface.

--- a/src/Symfony/Component/Form/Extension/Csrf/CsrfProvider/SessionCsrfProvider.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/CsrfProvider/SessionCsrfProvider.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Form\Extension\Csrf\CsrfProvider;
 
-@trigger_error('The '.__NAMESPACE__.'\SessionCsrfProvider is deprecated since version 2.4 and will be removed in version 3.0. Use the Symfony\Component\Security\Csrf\TokenStorage\SessionTokenStorage class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\SessionCsrfProvider is deprecated since version 2.4 and will be removed in version 3.0. Use the Symfony\Component\Security\Csrf\TokenStorage\SessionTokenStorage class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\HttpFoundation\Session\Session;
 

--- a/src/Symfony/Component/Form/Extension/Csrf/EventListener/CsrfValidationListener.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/EventListener/CsrfValidationListener.php
@@ -123,7 +123,7 @@ class CsrfValidationListener implements EventSubscriberInterface
      */
     public function preBind(FormEvent $event)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.3 and will be removed in 3.0. Use the preSubmit() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.3 and will be removed in 3.0. Use the preSubmit() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         $this->preSubmit($event);
     }

--- a/src/Symfony/Component/Form/Extension/HttpFoundation/EventListener/BindRequestListener.php
+++ b/src/Symfony/Component/Form/Extension/HttpFoundation/EventListener/BindRequestListener.php
@@ -42,7 +42,7 @@ class BindRequestListener implements EventSubscriberInterface
             return;
         }
 
-        @trigger_error('The '.__CLASS__.' class is deprecated since version 2.3 and will be removed in 3.0. Pass the Request instance to the \Symfony\Component\Form\Form::handleRequest() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s class is deprecated since version 2.3 and will be removed in 3.0. Pass the Request instance to the \Symfony\Component\Form\Form::handleRequest() method instead.', __CLASS__),  E_USER_DEPRECATED);
 
         $name = $form->getConfig()->getName();
         $default = $form->getConfig()->getCompound() ? array() : null;

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -834,7 +834,7 @@ class Form implements \IteratorAggregate, FormInterface
      */
     public function getErrorsAsString($level = 0)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0. Use (string) Form::getErrors(true, false) instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.5 and will be removed in 3.0. Use (string) Form::getErrors(true, false) instead.', __METHOD__),  E_USER_DEPRECATED);
 
         return self::indent((string) $this->getErrors(true, false), $level);
     }

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -497,7 +497,7 @@ class Form implements \IteratorAggregate, FormInterface
     public function submit($submittedData, $clearMissing = true)
     {
         if ($submittedData instanceof Request) {
-            @trigger_error('Passing a Symfony\Component\HttpFoundation\Request object to the '.__CLASS__.'::bind and '.__METHOD__.' methods is deprecated since 2.3 and will be removed in 3.0. Use the '.__CLASS__.'::handleRequest method instead. If you want to test whether the form was submitted separately, you can use the '.__CLASS__.'::isSubmitted method.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('Passing a Symfony\Component\HttpFoundation\Request object to the %1$s::bind and %2$s methods is deprecated since 2.3 and will be removed in 3.0. Use the %1$s::handleRequest method instead. If you want to test whether the form was submitted separately, you can use the %1$s::isSubmitted method.', __CLASS__, __METHOD__), E_USER_DEPRECATED);
         }
 
         if ($this->submitted) {
@@ -674,7 +674,7 @@ class Form implements \IteratorAggregate, FormInterface
         // This method is deprecated for Request too, but the error is
         // triggered in Form::submit() method.
         if (!$submittedData instanceof Request) {
-            @trigger_error('The '.__METHOD__.' method is deprecated since version 2.3 and will be removed in 3.0. Use the '.__CLASS__.'::submit method instead.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('The %s method is deprecated since version 2.3 and will be removed in 3.0. Use the %s::submit method instead.', __METHOD__, __CLASS__), E_USER_DEPRECATED);
         }
 
         return $this->submit($submittedData);
@@ -714,7 +714,7 @@ class Form implements \IteratorAggregate, FormInterface
      */
     public function isBound()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.3 and will be removed in 3.0. Use the '.__CLASS__.'::isSubmitted method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.3 and will be removed in 3.0. Use the %s::isSubmitted method instead.', __METHOD__, __CLASS__), E_USER_DEPRECATED);
 
         return $this->submitted;
     }

--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -356,7 +356,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      */
     public function getVirtual()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.3 and will be removed in 3.0. Use the FormConfigBuilder::getInheritData() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.3 and will be removed in 3.0. Use the FormConfigBuilder::getInheritData() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         return $this->getInheritData();
     }
@@ -722,7 +722,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      */
     public function setVirtual($inheritData)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.3 and will be removed in 3.0. Use the FormConfigBuilder::setInheritData() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.3 and will be removed in 3.0. Use the FormConfigBuilder::setInheritData() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         $this->setInheritData($inheritData);
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TypeTestCase.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TypeTestCase.php
@@ -21,7 +21,7 @@ abstract class TypeTestCase extends BaseTypeTestCase
 {
     protected function setUp()
     {
-        @trigger_error('Abstract class '.__CLASS__.' is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Form\Test\TypeTestCase class instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('Abstract class %s is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Form\Test\TypeTestCase class instead.', __CLASS__),  E_USER_DEPRECATED);
         parent::setUp();
     }
 }

--- a/src/Symfony/Component/Form/Tests/FormIntegrationTestCase.php
+++ b/src/Symfony/Component/Form/Tests/FormIntegrationTestCase.php
@@ -24,7 +24,7 @@ abstract class FormIntegrationTestCase extends BaseFormIntegrationTestCase
      */
     protected function setUp()
     {
-        @trigger_error('The '.__CLASS__.' class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Form\Test\FormIntegrationTestCase class instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Form\Test\FormIntegrationTestCase class instead.', __CLASS__),  E_USER_DEPRECATED);
         parent::setUp();
     }
 }

--- a/src/Symfony/Component/Form/Tests/FormPerformanceTestCase.php
+++ b/src/Symfony/Component/Form/Tests/FormPerformanceTestCase.php
@@ -24,7 +24,7 @@ abstract class FormPerformanceTestCase extends BaseFormPerformanceTestCase
      */
     protected function setUp()
     {
-        @trigger_error('The '.__CLASS__.' class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Form\Test\FormPerformanceTestCase class instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Form\Test\FormPerformanceTestCase class instead.', __CLASS__),  E_USER_DEPRECATED);
         parent::setUp();
     }
 }

--- a/src/Symfony/Component/Form/Util/VirtualFormAwareIterator.php
+++ b/src/Symfony/Component/Form/Util/VirtualFormAwareIterator.php
@@ -34,7 +34,7 @@ class VirtualFormAwareIterator extends \IteratorIterator implements \RecursiveIt
          * forces this argument to false.
          */
         if (__CLASS__ === get_class($this)) {
-            @trigger_error('The '.__CLASS__.' class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Form\Util\InheritDataAwareIterator class instead.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('The %s class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Form\Util\InheritDataAwareIterator class instead.', __CLASS__),  E_USER_DEPRECATED);
         }
 
         parent::__construct($iterator);

--- a/src/Symfony/Component/HttpFoundation/Session/Flash/FlashBag.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Flash/FlashBag.php
@@ -175,7 +175,7 @@ class FlashBag implements FlashBagInterface, \IteratorAggregate
      */
     public function getIterator()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.4 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.4 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
 
         return new \ArrayIterator($this->all());
     }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/LegacyPdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/LegacyPdoSessionHandler.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
 
-@trigger_error('The '.__NAMESPACE__.'\LegacyPdoSessionHandler class is deprecated since version 2.6 and will be removed in 3.0. Use the Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\LegacyPdoSessionHandler class is deprecated since version 2.6 and will be removed in 3.0. Use the Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 /**
  * Session handler using a PDO connection to read and write data.

--- a/src/Symfony/Component/HttpKernel/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/HttpKernel/Debug/ErrorHandler.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\Debug;
 
-@trigger_error('The '.__NAMESPACE__.'\ErrorHandler class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Debug\ErrorHandler class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\ErrorHandler class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Debug\ErrorHandler class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Debug\ErrorHandler as DebugErrorHandler;
 

--- a/src/Symfony/Component/HttpKernel/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/HttpKernel/Debug/ExceptionHandler.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\Debug;
 
-@trigger_error('The '.__NAMESPACE__.'\ExceptionHandler class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Debug\ExceptionHandler class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\ExceptionHandler class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Debug\ExceptionHandler class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Debug\ExceptionHandler as DebugExceptionHandler;
 

--- a/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
@@ -38,7 +38,7 @@ class TraceableEventDispatcher extends BaseTraceableEventDispatcher
      */
     public function setProfiler(Profiler $profiler = null)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.4 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.4 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/ContainerAwareHttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/ContainerAwareHttpKernel.php
@@ -46,7 +46,7 @@ class ContainerAwareHttpKernel extends HttpKernel
         parent::__construct($dispatcher, $controllerResolver, $requestStack);
 
         if ($triggerDeprecation) {
-            @trigger_error('The '.__CLASS__.' class is deprecated since version 2.7 and will be removed in 3.0. Use the Symfony\Component\HttpKernel\HttpKernel class instead.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('The %s class is deprecated since version 2.7 and will be removed in 3.0. Use the Symfony\Component\HttpKernel\HttpKernel class instead.', __CLASS__),  E_USER_DEPRECATED);
         }
 
         $this->container = $container;

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterListenersPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterListenersPass.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\DependencyInjection;
 
-@trigger_error('The '.__NAMESPACE__.'\RegisterListenersPass is deprecated since version 2.5 and will be removed in 3.0. Use the Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\RegisterListenersPass is deprecated since version 2.5 and will be removed in 3.0. Use the Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass as BaseRegisterListenersPass;
 

--- a/src/Symfony/Component/HttpKernel/EventListener/ErrorsLoggerListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ErrorsLoggerListener.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\EventListener;
 
-@trigger_error('The '.__NAMESPACE__.'\ErrorsLoggerListener class is deprecated since version 2.6 and will be removed in 3.0. Use the Symfony\Component\HttpKernel\EventListener\DebugHandlersListener class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\ErrorsLoggerListener class is deprecated since version 2.6 and will be removed in 3.0. Use the Symfony\Component\HttpKernel\EventListener\DebugHandlersListener class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Debug\ErrorHandler;

--- a/src/Symfony/Component/HttpKernel/EventListener/EsiListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/EsiListener.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\EventListener;
 
-@trigger_error('The '.__NAMESPACE__.'\EsiListener class is deprecated since version 2.6 and will be removed in 3.0. Use the Symfony\Component\HttpKernel\EventListener\SurrogateListener class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\EsiListener class is deprecated since version 2.6 and will be removed in 3.0. Use the Symfony\Component\HttpKernel\EventListener\SurrogateListener class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 /**
  * EsiListener adds a Surrogate-Control HTTP header when the Response needs to be parsed for ESI.

--- a/src/Symfony/Component/HttpKernel/EventListener/FragmentListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/FragmentListener.php
@@ -101,7 +101,7 @@ class FragmentListener implements EventSubscriberInterface
      */
     protected function getLocalIpAddresses()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.3.19 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.3.19 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
 
         return array('127.0.0.1', 'fe80::1', '::1');
     }

--- a/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
@@ -58,7 +58,7 @@ class LocaleListener implements EventSubscriberInterface
      */
     public function setRequest(Request $request = null)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.4 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.4 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
 
         if (null === $request) {
             return;

--- a/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
@@ -53,7 +53,7 @@ class ProfilerListener implements EventSubscriberInterface
             // Prevent the deprecation notice to be triggered all the time.
             // The onKernelRequest() method fires some logic only when the
             // RequestStack instance is not provided as a dependency.
-            @trigger_error('Since version 2.4, the '.__METHOD__.' method must accept a RequestStack instance to get the request instead of using the '.__CLASS__.'::onKernelRequest method that will be removed in 3.0.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('Since version 2.4, the %s method must accept a RequestStack instance to get the request instead of using the %s::onKernelRequest method that will be removed in 3.0.', __METHOD__, __CLASS__), E_USER_DEPRECATED);
         }
 
         $this->profiler = $profiler;

--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -90,7 +90,7 @@ class RouterListener implements EventSubscriberInterface
      */
     public function setRequest(Request $request = null)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.4 and will be made private in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.4 and will be made private in 3.0.', __METHOD__),  E_USER_DEPRECATED);
 
         $this->setCurrentRequest($request);
     }

--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -68,7 +68,7 @@ class RouterListener implements EventSubscriberInterface
         }
 
         if (!$requestStack instanceof RequestStack) {
-            @trigger_error('The '.__METHOD__.' method now requires a RequestStack instance as '.__CLASS__.'::setRequest method will not be supported anymore in 3.0.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('The %s method now requires a RequestStack instance as %s::setRequest method will not be supported anymore in 3.0.', __METHOD__, __CLASS__), E_USER_DEPRECATED);
         }
 
         $this->matcher = $matcher;

--- a/src/Symfony/Component/HttpKernel/Exception/FatalErrorException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/FatalErrorException.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\Exception;
 
-@trigger_error('The '.__NAMESPACE__.'\FatalErrorException class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Debug\Exception\FatalErrorException class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\FatalErrorException class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Debug\Exception\FatalErrorException class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 /*
  * Fatal Error Exception.

--- a/src/Symfony/Component/HttpKernel/Exception/FlattenException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/FlattenException.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\Exception;
 
-@trigger_error('The '.__NAMESPACE__.'\FlattenException class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Debug\Exception\FlattenException class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\FlattenException class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Debug\Exception\FlattenException class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 /*
  * FlattenException wraps a PHP Exception to be able to serialize it.

--- a/src/Symfony/Component/HttpKernel/Fragment/FragmentHandler.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/FragmentHandler.php
@@ -80,7 +80,7 @@ class FragmentHandler
      */
     public function setRequest(Request $request = null)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.4 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.4 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
 
         $this->request = $request;
     }

--- a/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
@@ -87,7 +87,7 @@ class Esi implements SurrogateInterface
      */
     public function hasSurrogateEsiCapability(Request $request)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use the hasSurrogateCapability() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.6 and will be removed in 3.0. Use the hasSurrogateCapability() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         return $this->hasSurrogateCapability($request);
     }
@@ -114,7 +114,7 @@ class Esi implements SurrogateInterface
      */
     public function addSurrogateEsiCapability(Request $request)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use the addSurrogateCapability() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.6 and will be removed in 3.0. Use the addSurrogateCapability() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         $this->addSurrogateCapability($request);
     }
@@ -160,7 +160,7 @@ class Esi implements SurrogateInterface
      */
     public function needsEsiParsing(Response $response)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use the needsParsing() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.6 and will be removed in 3.0. Use the needsParsing() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         return $this->needsParsing($response);
     }

--- a/src/Symfony/Component/HttpKernel/HttpCache/EsiResponseCacheStrategy.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/EsiResponseCacheStrategy.php
@@ -15,7 +15,7 @@
 
 namespace Symfony\Component\HttpKernel\HttpCache;
 
-@trigger_error('The '.__NAMESPACE__.'\EsiResponseCacheStrategy class is deprecated since version 2.6 and will be removed in 3.0. Use the Symfony\Component\HttpKernel\HttpCache\ResponseCacheStrategy class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\EsiResponseCacheStrategy class is deprecated since version 2.6 and will be removed in 3.0. Use the Symfony\Component\HttpKernel\HttpCache\ResponseCacheStrategy class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 /**
  * EsiResponseCacheStrategy knows how to compute the Response cache HTTP header

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -177,7 +177,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      */
     public function getEsi()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use the getSurrogate() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.6 and will be removed in 3.0. Use the getSurrogate() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         return $this->getSurrogate();
     }

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -99,7 +99,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
      */
     public function init()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.3 and will be removed in 3.0. Move your logic to the constructor method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.3 and will be removed in 3.0. Move your logic to the constructor method instead.', __METHOD__),  E_USER_DEPRECATED);
     }
 
     public function __clone()
@@ -209,7 +209,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
      */
     public function isClassInActiveBundle($class)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in version 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.6 and will be removed in version 3.0.', __METHOD__),  E_USER_DEPRECATED);
 
         foreach ($this->getBundles() as $bundle) {
             if (0 === strpos($class, $bundle->getNamespace())) {

--- a/src/Symfony/Component/HttpKernel/Log/NullLogger.php
+++ b/src/Symfony/Component/HttpKernel/Log/NullLogger.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\Log;
 
-@trigger_error('The '.__NAMESPACE__.'\NullLogger class is deprecated since version 2.2 and will be removed in 3.0. Use the Psr\Log\NullLogger class instead from the psr/log Composer package.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\NullLogger class is deprecated since version 2.2 and will be removed in 3.0. Use the Psr\Log\NullLogger class instead from the psr/log Composer package.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Psr\Log\NullLogger as PsrNullLogger;
 
@@ -24,21 +24,21 @@ class NullLogger extends PsrNullLogger implements LoggerInterface
 {
     public function emerg($message, array $context = array())
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.2 and will be removed in 3.0. You should use the new emergency() method instead, which is PSR-3 compatible.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.2 and will be removed in 3.0. You should use the new emergency() method instead, which is PSR-3 compatible.', __METHOD__),  E_USER_DEPRECATED);
     }
 
     public function crit($message, array $context = array())
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.2 and will be removed in 3.0. You should use the new critical() method instead, which is PSR-3 compatible.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.2 and will be removed in 3.0. You should use the new critical() method instead, which is PSR-3 compatible.', __METHOD__),  E_USER_DEPRECATED);
     }
 
     public function err($message, array $context = array())
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.2 and will be removed in 3.0. You should use the new error() method instead, which is PSR-3 compatible.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.2 and will be removed in 3.0. You should use the new error() method instead, which is PSR-3 compatible.', __METHOD__),  E_USER_DEPRECATED);
     }
 
     public function warn($message, array $context = array())
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.2 and will be removed in 3.0. You should use the new warning() method instead, which is PSR-3 compatible.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.2 and will be removed in 3.0. You should use the new warning() method instead, which is PSR-3 compatible.', __METHOD__),  E_USER_DEPRECATED);
     }
 }

--- a/src/Symfony/Component/Locale/Exception/MethodArgumentNotImplementedException.php
+++ b/src/Symfony/Component/Locale/Exception/MethodArgumentNotImplementedException.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Locale\Exception;
 
-@trigger_error('The '.__NAMESPACE__.'\MethodArgumentNotImplementedException class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\Exception\MethodArgumentNotImplementedException class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\MethodArgumentNotImplementedException class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\Exception\MethodArgumentNotImplementedException class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Intl\Exception\MethodArgumentNotImplementedException as BaseMethodArgumentNotImplementedException;
 

--- a/src/Symfony/Component/Locale/Exception/MethodArgumentValueNotImplementedException.php
+++ b/src/Symfony/Component/Locale/Exception/MethodArgumentValueNotImplementedException.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Locale\Exception;
 
-@trigger_error('The '.__NAMESPACE__.'\MethodArgumentValueNotImplementedException class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\MethodArgumentValueNotImplementedException class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException as BaseMethodArgumentValueNotImplementedException;
 

--- a/src/Symfony/Component/Locale/Exception/MethodNotImplementedException.php
+++ b/src/Symfony/Component/Locale/Exception/MethodNotImplementedException.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Locale\Exception;
 
-@trigger_error('The '.__NAMESPACE__.'\MethodNotImplementedException class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\Exception\MethodNotImplementedException class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\MethodNotImplementedException class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\Exception\MethodNotImplementedException class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Intl\Exception\MethodNotImplementedException as BaseMethodNotImplementedException;
 

--- a/src/Symfony/Component/Locale/Exception/NotImplementedException.php
+++ b/src/Symfony/Component/Locale/Exception/NotImplementedException.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Locale\Exception;
 
-@trigger_error('The '.__NAMESPACE__.'\NotImplementedException class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\Exception\NotImplementedException class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\NotImplementedException class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\Exception\NotImplementedException class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Intl\Exception\NotImplementedException as BaseNotImplementedException;
 

--- a/src/Symfony/Component/Locale/Locale.php
+++ b/src/Symfony/Component/Locale/Locale.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Locale;
 
-@trigger_error('The '.__NAMESPACE__.'\Locale class is deprecated since version 2.7, to be removed in Symfony 3.0. Use the methods provided by the \Symfony\Component\Intl\Intl class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\Locale class is deprecated since version 2.7, to be removed in Symfony 3.0. Use the methods provided by the \Symfony\Component\Intl\Intl class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Intl\Intl;
 

--- a/src/Symfony/Component/Locale/Stub/DateFormat/AmPmTransformer.php
+++ b/src/Symfony/Component/Locale/Stub/DateFormat/AmPmTransformer.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Locale\Stub\DateFormat;
 
-@trigger_error('The '.__NAMESPACE__.'\AmPmTransformer class is deprecated since version 2.3 and will be removed in Symfony 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\AmPmTransformer class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\AmPmTransformer class is deprecated since version 2.3 and will be removed in Symfony 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\AmPmTransformer class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Intl\DateFormatter\DateFormat\AmPmTransformer as BaseAmPmTransformer;
 

--- a/src/Symfony/Component/Locale/Stub/DateFormat/DayOfWeekTransformer.php
+++ b/src/Symfony/Component/Locale/Stub/DateFormat/DayOfWeekTransformer.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Locale\Stub\DateFormat;
 
-@trigger_error('The '.__NAMESPACE__.'\DayOfWeekTransformer class is deprecated since version 2.3 and will be removed in Symfony 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\DayOfWeekTransformer class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\DayOfWeekTransformer class is deprecated since version 2.3 and will be removed in Symfony 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\DayOfWeekTransformer class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Intl\DateFormatter\DateFormat\DayOfWeekTransformer as BaseDayOfWeekTransformer;
 

--- a/src/Symfony/Component/Locale/Stub/DateFormat/DayOfYearTransformer.php
+++ b/src/Symfony/Component/Locale/Stub/DateFormat/DayOfYearTransformer.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Locale\Stub\DateFormat;
 
-@trigger_error('The '.__NAMESPACE__.'\DayOfYearTransformer class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\DayOfYearTransformer class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\DayOfYearTransformer class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\DayOfYearTransformer class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Intl\DateFormatter\DateFormat\DayOfYearTransformer as BaseDayOfYearTransformer;
 

--- a/src/Symfony/Component/Locale/Stub/DateFormat/DayTransformer.php
+++ b/src/Symfony/Component/Locale/Stub/DateFormat/DayTransformer.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Locale\Stub\DateFormat;
 
-@trigger_error('The '.__NAMESPACE__.'\DayTransformer class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\DayTransformer class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\DayTransformer class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\DayTransformer class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Intl\DateFormatter\DateFormat\DayTransformer as BaseDayTransformer;
 

--- a/src/Symfony/Component/Locale/Stub/DateFormat/FullTransformer.php
+++ b/src/Symfony/Component/Locale/Stub/DateFormat/FullTransformer.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Locale\Stub\DateFormat;
 
-@trigger_error('The '.__NAMESPACE__.'\FullTransformer class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\FullTransformer class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\FullTransformer class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\FullTransformer class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Intl\DateFormatter\DateFormat\FullTransformer as BaseFullTransformer;
 

--- a/src/Symfony/Component/Locale/Stub/DateFormat/Hour1200Transformer.php
+++ b/src/Symfony/Component/Locale/Stub/DateFormat/Hour1200Transformer.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Locale\Stub\DateFormat;
 
-@trigger_error('The '.__NAMESPACE__.'\Hour1200Transformer class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\Hour1200Transformer class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\Hour1200Transformer class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\Hour1200Transformer class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Intl\DateFormatter\DateFormat\Hour1200Transformer as BaseHour1200Transformer;
 

--- a/src/Symfony/Component/Locale/Stub/DateFormat/Hour1201Transformer.php
+++ b/src/Symfony/Component/Locale/Stub/DateFormat/Hour1201Transformer.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Locale\Stub\DateFormat;
 
-@trigger_error('The '.__NAMESPACE__.'\Hour1201Transformer class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\Hour1201Transformer class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\Hour1201Transformer class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\Hour1201Transformer class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Intl\DateFormatter\DateFormat\Hour1201Transformer as BaseHour1201Transformer;
 

--- a/src/Symfony/Component/Locale/Stub/DateFormat/Hour2400Transformer.php
+++ b/src/Symfony/Component/Locale/Stub/DateFormat/Hour2400Transformer.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Locale\Stub\DateFormat;
 
-@trigger_error('The '.__NAMESPACE__.'\Hour2400Transformer class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\Hour2400Transformer class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\Hour2400Transformer class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\Hour2400Transformer class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Intl\DateFormatter\DateFormat\Hour2400Transformer as BaseHour2400Transformer;
 

--- a/src/Symfony/Component/Locale/Stub/DateFormat/Hour2401Transformer.php
+++ b/src/Symfony/Component/Locale/Stub/DateFormat/Hour2401Transformer.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Locale\Stub\DateFormat;
 
-@trigger_error('The '.__NAMESPACE__.'\Hour2401Transformer class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\Hour2401Transformer class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\Hour2401Transformer class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\Hour2401Transformer class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Intl\DateFormatter\DateFormat\Hour2401Transformer as BaseHour2401Transformer;
 

--- a/src/Symfony/Component/Locale/Stub/DateFormat/HourTransformer.php
+++ b/src/Symfony/Component/Locale/Stub/DateFormat/HourTransformer.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Locale\Stub\DateFormat;
 
-@trigger_error('The '.__NAMESPACE__.'\HourTransformer class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\HourTransformer class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\HourTransformer class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\HourTransformer class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Intl\DateFormatter\DateFormat\HourTransformer as BaseHourTransformer;
 

--- a/src/Symfony/Component/Locale/Stub/DateFormat/MinuteTransformer.php
+++ b/src/Symfony/Component/Locale/Stub/DateFormat/MinuteTransformer.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Locale\Stub\DateFormat;
 
-@trigger_error('The '.__NAMESPACE__.'\MinuteTransformer class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\MinuteTransformer class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\MinuteTransformer class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\MinuteTransformer class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Intl\DateFormatter\DateFormat\MinuteTransformer as BaseMinuteTransformer;
 

--- a/src/Symfony/Component/Locale/Stub/DateFormat/MonthTransformer.php
+++ b/src/Symfony/Component/Locale/Stub/DateFormat/MonthTransformer.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Locale\Stub\DateFormat;
 
-@trigger_error('The '.__NAMESPACE__.'\MonthTransformer class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\MonthTransformer class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\MonthTransformer class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\MonthTransformer class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Intl\DateFormatter\DateFormat\MonthTransformer as BaseMonthTransformer;
 

--- a/src/Symfony/Component/Locale/Stub/DateFormat/QuarterTransformer.php
+++ b/src/Symfony/Component/Locale/Stub/DateFormat/QuarterTransformer.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Locale\Stub\DateFormat;
 
-@trigger_error('The '.__NAMESPACE__.'\QuarterTransformer class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\QuarterTransformer class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\QuarterTransformer class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\QuarterTransformer class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Intl\DateFormatter\DateFormat\QuarterTransformer as BaseQuarterTransformer;
 

--- a/src/Symfony/Component/Locale/Stub/DateFormat/SecondTransformer.php
+++ b/src/Symfony/Component/Locale/Stub/DateFormat/SecondTransformer.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Locale\Stub\DateFormat;
 
-@trigger_error('The '.__NAMESPACE__.'\SecondTransformer class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\SecondTransformer class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\SecondTransformer class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\SecondTransformer class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Intl\DateFormatter\DateFormat\SecondTransformer as BaseSecondTransformer;
 

--- a/src/Symfony/Component/Locale/Stub/DateFormat/TimeZoneTransformer.php
+++ b/src/Symfony/Component/Locale/Stub/DateFormat/TimeZoneTransformer.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Locale\Stub\DateFormat;
 
-@trigger_error('The '.__NAMESPACE__.'\TimeZoneTransformer class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\TimeZoneTransformer class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\TimeZoneTransformer class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\TimeZoneTransformer class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Intl\DateFormatter\DateFormat\TimeZoneTransformer as BaseTimeZoneTransformer;
 

--- a/src/Symfony/Component/Locale/Stub/DateFormat/Transformer.php
+++ b/src/Symfony/Component/Locale/Stub/DateFormat/Transformer.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Locale\Stub\DateFormat;
 
-@trigger_error('The '.__NAMESPACE__.'\Transformer class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\Transformer class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\Transformer class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\Transformer class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Intl\DateFormatter\DateFormat\Transformer as BaseTransformer;
 

--- a/src/Symfony/Component/Locale/Stub/DateFormat/YearTransformer.php
+++ b/src/Symfony/Component/Locale/Stub/DateFormat/YearTransformer.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Locale\Stub\DateFormat;
 
-@trigger_error('The '.__NAMESPACE__.'\YearTransformer class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\YearTransformer class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\YearTransformer class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\DateFormat\YearTransformer class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Intl\DateFormatter\DateFormat\YearTransformer as BaseYearTransformer;
 

--- a/src/Symfony/Component/Locale/Stub/StubCollator.php
+++ b/src/Symfony/Component/Locale/Stub/StubCollator.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Locale\Stub;
 
-@trigger_error('The '.__NAMESPACE__.'\StubCollator class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\Collator\Collator class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\StubCollator class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\Collator\Collator class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Intl\Collator\Collator;
 

--- a/src/Symfony/Component/Locale/Stub/StubIntl.php
+++ b/src/Symfony/Component/Locale/Stub/StubIntl.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Locale\Stub;
 
-@trigger_error('The '.__NAMESPACE__.'\StubIntl class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\Globals\IntlGlobals class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\StubIntl class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\Globals\IntlGlobals class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Intl\Globals\IntlGlobals;
 

--- a/src/Symfony/Component/Locale/Stub/StubIntlDateFormatter.php
+++ b/src/Symfony/Component/Locale/Stub/StubIntlDateFormatter.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Locale\Stub;
 
-@trigger_error('The '.__NAMESPACE__.'\StubIntlDateFormatter class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\IntlDateFormatter class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\StubIntlDateFormatter class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\DateFormatter\IntlDateFormatter class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Intl\DateFormatter\IntlDateFormatter;
 

--- a/src/Symfony/Component/Locale/Stub/StubLocale.php
+++ b/src/Symfony/Component/Locale/Stub/StubLocale.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Locale\Stub;
 
-@trigger_error('The '.__NAMESPACE__.'\StubLocale class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\Locale\Locale and Symfony\Component\Intl\Intl classes instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\StubLocale class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\Locale\Locale and Symfony\Component\Intl\Intl classes instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Intl\Intl;
 use Symfony\Component\Intl\Locale\Locale;

--- a/src/Symfony/Component/Locale/Stub/StubNumberFormatter.php
+++ b/src/Symfony/Component/Locale/Stub/StubNumberFormatter.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Locale\Stub;
 
-@trigger_error('The '.__NAMESPACE__.'\StubNumberFormatter class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\NumberFormatter\NumberFormatter class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\StubNumberFormatter class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Intl\NumberFormatter\NumberFormatter class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Intl\NumberFormatter\NumberFormatter;
 

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -438,7 +438,7 @@ class OptionsResolver implements Options, OptionsResolverInterface
      */
     public function setNormalizers(array $normalizers)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use setNormalizer() instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.6 and will be removed in 3.0. Use setNormalizer() instead.', __METHOD__),  E_USER_DEPRECATED);
 
         foreach ($normalizers as $option => $normalizer) {
             $this->setNormalizer($option, $normalizer);
@@ -476,7 +476,7 @@ class OptionsResolver implements Options, OptionsResolverInterface
 
         // BC
         if (is_array($option) && null === $allowedValues) {
-            @trigger_error('Calling the '.__METHOD__.' method with an array of options is deprecated since version 2.6 and will be removed in 3.0. Use the new signature with a single option instead.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('Calling the %s method with an array of options is deprecated since version 2.6 and will be removed in 3.0. Use the new signature with a single option instead.', __METHOD__),  E_USER_DEPRECATED);
 
             foreach ($option as $optionName => $optionValues) {
                 $this->setAllowedValues($optionName, $optionValues);
@@ -532,7 +532,7 @@ class OptionsResolver implements Options, OptionsResolverInterface
 
         // BC
         if (is_array($option) && null === $allowedValues) {
-            @trigger_error('Calling the '.__METHOD__.' method with an array of options is deprecated since version 2.6 and will be removed in 3.0. Use the new signature with a single option instead.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('Calling the %s method with an array of options is deprecated since version 2.6 and will be removed in 3.0. Use the new signature with a single option instead.', __METHOD__),  E_USER_DEPRECATED);
 
             foreach ($option as $optionName => $optionValues) {
                 $this->addAllowedValues($optionName, $optionValues);
@@ -588,7 +588,7 @@ class OptionsResolver implements Options, OptionsResolverInterface
 
         // BC
         if (is_array($option) && null === $allowedTypes) {
-            @trigger_error('Calling the '.__METHOD__.' method with an array of options is deprecated since version 2.6 and will be removed in 3.0. Use the new signature with a single option instead.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('Calling the %s method with an array of options is deprecated since version 2.6 and will be removed in 3.0. Use the new signature with a single option instead.', __METHOD__),  E_USER_DEPRECATED);
 
             foreach ($option as $optionName => $optionTypes) {
                 $this->setAllowedTypes($optionName, $optionTypes);
@@ -638,7 +638,7 @@ class OptionsResolver implements Options, OptionsResolverInterface
 
         // BC
         if (is_array($option) && null === $allowedTypes) {
-            @trigger_error('Calling the '.__METHOD__.' method with an array of options is deprecated since version 2.6 and will be removed in 3.0. Use the new signature with a single option instead.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('Calling the %s method with an array of options is deprecated since version 2.6 and will be removed in 3.0. Use the new signature with a single option instead.', __METHOD__),  E_USER_DEPRECATED);
 
             foreach ($option as $optionName => $optionTypes) {
                 $this->addAllowedTypes($optionName, $optionTypes);
@@ -1041,7 +1041,7 @@ class OptionsResolver implements Options, OptionsResolverInterface
      */
     public function set($option, $value)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use the setDefaults() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.6 and will be removed in 3.0. Use the setDefaults() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         return $this->setDefault($option, $value);
     }
@@ -1053,7 +1053,7 @@ class OptionsResolver implements Options, OptionsResolverInterface
      */
     public function replace(array $defaults)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use the clear() and setDefaults() methods instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.6 and will be removed in 3.0. Use the clear() and setDefaults() methods instead.', __METHOD__),  E_USER_DEPRECATED);
 
         $this->clear();
 
@@ -1067,7 +1067,7 @@ class OptionsResolver implements Options, OptionsResolverInterface
      */
     public function overload($option, $value)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use the setDefault() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.6 and will be removed in 3.0. Use the setDefault() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         return $this->setDefault($option, $value);
     }
@@ -1079,7 +1079,7 @@ class OptionsResolver implements Options, OptionsResolverInterface
      */
     public function get($option)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use the ArrayAccess syntax instead to get an option value.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.6 and will be removed in 3.0. Use the ArrayAccess syntax instead to get an option value.', __METHOD__),  E_USER_DEPRECATED);
 
         return $this->offsetGet($option);
     }
@@ -1091,7 +1091,7 @@ class OptionsResolver implements Options, OptionsResolverInterface
      */
     public function has($option)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use the ArrayAccess syntax instead to get an option value.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.6 and will be removed in 3.0. Use the ArrayAccess syntax instead to get an option value.', __METHOD__),  E_USER_DEPRECATED);
 
         return $this->offsetExists($option);
     }
@@ -1103,7 +1103,7 @@ class OptionsResolver implements Options, OptionsResolverInterface
      */
     public function replaceDefaults(array $defaultValues)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use the clear() and setDefaults() methods instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.6 and will be removed in 3.0. Use the clear() and setDefaults() methods instead.', __METHOD__),  E_USER_DEPRECATED);
 
         $this->clear();
 
@@ -1117,7 +1117,7 @@ class OptionsResolver implements Options, OptionsResolverInterface
      */
     public function setOptional(array $optionNames)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use the setDefined() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.6 and will be removed in 3.0. Use the setDefined() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         return $this->setDefined($optionNames);
     }
@@ -1129,7 +1129,7 @@ class OptionsResolver implements Options, OptionsResolverInterface
      */
     public function isKnown($option)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use the isDefined() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.6 and will be removed in 3.0. Use the isDefined() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         return $this->isDefined($option);
     }

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1033,7 +1033,7 @@ class Process
      */
     public function getStdin()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0. Use the getInput() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.5 and will be removed in 3.0. Use the getInput() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         return $this->getInput();
     }
@@ -1063,7 +1063,7 @@ class Process
      */
     public function setStdin($stdin)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0. Use the setInput() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.5 and will be removed in 3.0. Use the setInput() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         return $this->setInput($stdin);
     }

--- a/src/Symfony/Component/PropertyAccess/Exception/UnexpectedTypeException.php
+++ b/src/Symfony/Component/PropertyAccess/Exception/UnexpectedTypeException.php
@@ -36,7 +36,7 @@ class UnexpectedTypeException extends RuntimeException
                 $path->getElement($pathIndex)
             );
         } else {
-            @trigger_error('The '.__CLASS__.' constructor now expects 3 arguments: the invalid property value, the '.__NAMESPACE__.'\PropertyPathInterface object and the current index of the property path.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('The %s constructor now expects 3 arguments: the invalid property value, the %s\PropertyPathInterface object and the current index of the property path.', __CLASS__, __NAMESPACE__), E_USER_DEPRECATED);
 
             $message = sprintf(
                 'Expected argument of type "%s", "%s" given',

--- a/src/Symfony/Component/PropertyAccess/PropertyAccess.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccess.php
@@ -48,7 +48,7 @@ final class PropertyAccess
      */
     public static function getPropertyAccessor()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.3 and will be removed in 3.0. Use the createPropertyAccessor() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.3 and will be removed in 3.0. Use the createPropertyAccessor() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         return self::createPropertyAccessor();
     }

--- a/src/Symfony/Component/Routing/Annotation/Route.php
+++ b/src/Symfony/Component/Routing/Annotation/Route.php
@@ -59,7 +59,7 @@ class Route
      */
     public function setPattern($pattern)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.2 and will be removed in 3.0. Use the setPath() method instead and use the "path" option instead of the "pattern" option in the route definition.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.2 and will be removed in 3.0. Use the setPath() method instead and use the "path" option instead of the "pattern" option in the route definition.', __METHOD__),  E_USER_DEPRECATED);
 
         $this->path = $pattern;
     }
@@ -69,7 +69,7 @@ class Route
      */
     public function getPattern()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.2 and will be removed in 3.0. Use the getPath() method instead and use the "path" option instead of the "pattern" option in the route definition.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.2 and will be removed in 3.0. Use the getPath() method instead and use the "path" option instead of the "pattern" option in the route definition.', __METHOD__),  E_USER_DEPRECATED);
 
         return $this->path;
     }

--- a/src/Symfony/Component/Routing/Matcher/ApacheUrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/ApacheUrlMatcher.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Routing\Matcher;
 
-@trigger_error('The '.__NAMESPACE__.'\ApacheUrlMatcher class is deprecated since version 2.5 and will be removed in 3.0. It\'s hard to replicate the behaviour of the PHP implementation and the performance gains are minimal.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\ApacheUrlMatcher class is deprecated since version 2.5 and will be removed in 3.0. It\'s hard to replicate the behaviour of the PHP implementation and the performance gains are minimal.', __NAMESPACE__), E_USER_DEPRECATED);
 
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 

--- a/src/Symfony/Component/Routing/Matcher/Dumper/ApacheMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/ApacheMatcherDumper.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Routing\Matcher\Dumper;
 
-@trigger_error('The '.__NAMESPACE__.'\ApacheMatcherDumper class is deprecated since version 2.5 and will be removed in 3.0. It\'s hard to replicate the behaviour of the PHP implementation and the performance gains are minimal.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\ApacheMatcherDumper class is deprecated since version 2.5 and will be removed in 3.0. It\'s hard to replicate the behaviour of the PHP implementation and the performance gains are minimal.', __NAMESPACE__), E_USER_DEPRECATED);
 
 use Symfony\Component\Routing\Route;
 

--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -147,7 +147,7 @@ class Route implements \Serializable
      */
     public function getPattern()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.2 and will be removed in 3.0. Use the getPath() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.2 and will be removed in 3.0. Use the getPath() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         return $this->path;
     }
@@ -165,7 +165,7 @@ class Route implements \Serializable
      */
     public function setPattern($pattern)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.2 and will be removed in 3.0. Use the setPath() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.2 and will be removed in 3.0. Use the setPath() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         return $this->setPath($pattern);
     }

--- a/src/Symfony/Component/Security/Core/SecurityContext.php
+++ b/src/Symfony/Component/Security/Core/SecurityContext.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Security\Core;
 
-@trigger_error('The '.__NAMESPACE__.'\SecurityContext class is deprecated since version 2.6 and will be removed in 3.0. Use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage or Symfony\Component\Security\Core\Authorization\AuthorizationChecker instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\SecurityContext class is deprecated since version 2.6 and will be removed in 3.0. Use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage or Symfony\Component\Security\Core\Authorization\AuthorizationChecker instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;

--- a/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
@@ -61,7 +61,7 @@ class JsonDecode implements DecoderInterface
      */
     public function getLastError()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0. Catch the exception raised by the decode() method instead to get the last JSON decoding error.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.5 and will be removed in 3.0. Catch the exception raised by the decode() method instead to get the last JSON decoding error.', __METHOD__),  E_USER_DEPRECATED);
 
         return $this->lastError;
     }

--- a/src/Symfony/Component/Serializer/Encoder/JsonEncode.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonEncode.php
@@ -39,7 +39,7 @@ class JsonEncode implements EncoderInterface
      */
     public function getLastError()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0. Catch the exception raised by the encode() method instead to get the last JSON encoding error.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.5 and will be removed in 3.0. Catch the exception raised by the encode() method instead to get the last JSON encoding error.', __METHOD__),  E_USER_DEPRECATED);
 
         return $this->lastError;
     }

--- a/src/Symfony/Component/Serializer/Encoder/JsonEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonEncoder.php
@@ -45,7 +45,7 @@ class JsonEncoder implements EncoderInterface, DecoderInterface
      */
     public function getLastEncodingError()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0. Catch the exception raised by the Symfony\Component\Serializer\Encoder\JsonEncode::encode() method instead to get the last JSON encoding error.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.5 and will be removed in 3.0. Catch the exception raised by the Symfony\Component\Serializer\Encoder\JsonEncode::encode() method instead to get the last JSON encoding error.', __METHOD__),  E_USER_DEPRECATED);
 
         return $this->encodingImpl->getLastError();
     }
@@ -59,7 +59,7 @@ class JsonEncoder implements EncoderInterface, DecoderInterface
      */
     public function getLastDecodingError()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0. Catch the exception raised by the Symfony\Component\Serializer\Encoder\JsonDecode::decode() method instead to get the last JSON decoding error.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.5 and will be removed in 3.0. Catch the exception raised by the Symfony\Component\Serializer\Encoder\JsonDecode::decode() method instead to get the last JSON decoding error.', __METHOD__),  E_USER_DEPRECATED);
 
         return $this->decodingImpl->getLastError();
     }

--- a/src/Symfony/Component/Templating/Loader/Loader.php
+++ b/src/Symfony/Component/Templating/Loader/Loader.php
@@ -50,7 +50,7 @@ abstract class Loader implements LoaderInterface
      */
     public function setDebugger(DebuggerInterface $debugger)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.4 and will be removed in 3.0. Use the setLogger() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.4 and will be removed in 3.0. Use the setLogger() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         $this->debugger = $debugger;
     }

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -163,7 +163,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
      */
     public function setFallbackLocale($locales)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.3 and will be removed in 3.0. Use the setFallbackLocales() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.3 and will be removed in 3.0. Use the setFallbackLocales() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         $this->setFallbackLocales(is_array($locales) ? $locales : array($locales));
     }

--- a/src/Symfony/Component/Validator/ConstraintValidator.php
+++ b/src/Symfony/Component/Validator/ConstraintValidator.php
@@ -63,7 +63,7 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
      */
     protected function buildViolation($message, array $parameters = array())
     {
-        @trigger_error('The '.__METHOD__.' is deprecated since version 2.5 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s is deprecated since version 2.5 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
 
         if ($this->context instanceof ExecutionContextInterface2Dot5) {
             return $this->context->buildViolation($message, $parameters);
@@ -86,7 +86,7 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
      */
     protected function buildViolationInContext(ExecutionContextInterface $context, $message, array $parameters = array())
     {
-        @trigger_error('The '.__METHOD__.' is deprecated since version 2.5 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s is deprecated since version 2.5 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
 
         if ($context instanceof ExecutionContextInterface2Dot5) {
             return $context->buildViolation($message, $parameters);

--- a/src/Symfony/Component/Validator/ConstraintViolation.php
+++ b/src/Symfony/Component/Validator/ConstraintViolation.php
@@ -147,7 +147,7 @@ class ConstraintViolation implements ConstraintViolationInterface
      */
     public function getMessageParameters()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.7, to be removed in 3.0. Use the ConstraintViolation::getParameters() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.7, to be removed in 3.0. Use the ConstraintViolation::getParameters() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         return $this->parameters;
     }
@@ -168,7 +168,7 @@ class ConstraintViolation implements ConstraintViolationInterface
      */
     public function getMessagePluralization()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.7, to be removed in 3.0. Use the ConstraintViolation::getPlural() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.7, to be removed in 3.0. Use the ConstraintViolation::getPlural() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         return $this->plural;
     }

--- a/src/Symfony/Component/Validator/Constraints/Callback.php
+++ b/src/Symfony/Component/Validator/Constraints/Callback.php
@@ -46,7 +46,7 @@ class Callback extends Constraint
         }
 
         if (is_array($options) && isset($options['methods'])) {
-            @trigger_error('The "methods" option of the '.__CLASS__.' class is deprecated since version 2.4 and will be removed in 3.0. Use the "callback" option instead.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('The "methods" option of the %s class is deprecated since version 2.4 and will be removed in 3.0. Use the "callback" option instead.', __CLASS__),  E_USER_DEPRECATED);
         }
 
         if (is_array($options) && !isset($options['callback']) && !isset($options['methods']) && !isset($options['groups']) && !isset($options['payload'])) {

--- a/src/Symfony/Component/Validator/Constraints/Collection/Optional.php
+++ b/src/Symfony/Component/Validator/Constraints/Collection/Optional.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints\Collection;
 
-@trigger_error('The '.__NAMESPACE__.'\Optional class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Validator\Constraints\Optional class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\Optional class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Validator\Constraints\Optional class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Validator\Constraints\Optional as BaseOptional;
 

--- a/src/Symfony/Component/Validator/Constraints/Collection/Required.php
+++ b/src/Symfony/Component/Validator/Constraints/Collection/Required.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints\Collection;
 
-@trigger_error('The '.__NAMESPACE__.'\Required class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Validator\Constraints\Required class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\Required class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Validator\Constraints\Required class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Validator\Constraints\Required as BaseRequired;
 

--- a/src/Symfony/Component/Validator/Constraints/False.php
+++ b/src/Symfony/Component/Validator/Constraints/False.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-@trigger_error('The '.__NAMESPACE__.'\False class is deprecated since version 2.7 and will be removed in 3.0. Use the IsFalse class in the same namespace instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\False class is deprecated since version 2.7 and will be removed in 3.0. Use the IsFalse class in the same namespace instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 /**
  * @Annotation

--- a/src/Symfony/Component/Validator/Constraints/FalseValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FalseValidator.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-@trigger_error('The '.__NAMESPACE__.'\FalseValidator class is deprecated since version 2.7 and will be removed in 3.0. Use the IsFalseValidator class in the same namespace instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\FalseValidator class is deprecated since version 2.7 and will be removed in 3.0. Use the IsFalseValidator class in the same namespace instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>

--- a/src/Symfony/Component/Validator/Constraints/GroupSequence.php
+++ b/src/Symfony/Component/Validator/Constraints/GroupSequence.php
@@ -104,7 +104,7 @@ class GroupSequence implements \ArrayAccess, \IteratorAggregate, \Countable
      */
     public function getIterator()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.5 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
 
         return new \ArrayIterator($this->groups);
     }
@@ -122,7 +122,7 @@ class GroupSequence implements \ArrayAccess, \IteratorAggregate, \Countable
      */
     public function offsetExists($offset)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.5 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
 
         return isset($this->groups[$offset]);
     }
@@ -142,7 +142,7 @@ class GroupSequence implements \ArrayAccess, \IteratorAggregate, \Countable
      */
     public function offsetGet($offset)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.5 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
 
         if (!isset($this->groups[$offset])) {
             throw new OutOfBoundsException(sprintf(
@@ -166,7 +166,7 @@ class GroupSequence implements \ArrayAccess, \IteratorAggregate, \Countable
      */
     public function offsetSet($offset, $value)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.5 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
 
         if (null !== $offset) {
             $this->groups[$offset] = $value;
@@ -188,7 +188,7 @@ class GroupSequence implements \ArrayAccess, \IteratorAggregate, \Countable
      */
     public function offsetUnset($offset)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.5 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
 
         unset($this->groups[$offset]);
     }
@@ -204,7 +204,7 @@ class GroupSequence implements \ArrayAccess, \IteratorAggregate, \Countable
      */
     public function count()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.5 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
 
         return count($this->groups);
     }

--- a/src/Symfony/Component/Validator/Constraints/Null.php
+++ b/src/Symfony/Component/Validator/Constraints/Null.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-@trigger_error('The '.__NAMESPACE__.'\Null class is deprecated since version 2.7 and will be removed in 3.0. Use the IsNull class in the same namespace instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\Null class is deprecated since version 2.7 and will be removed in 3.0. Use the IsNull class in the same namespace instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 /**
  * @Annotation

--- a/src/Symfony/Component/Validator/Constraints/NullValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NullValidator.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-@trigger_error('The '.__NAMESPACE__.'\NullValidator class is deprecated since version 2.7 and will be removed in 3.0. Use the IsNullValidator class in the same namespace instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\NullValidator class is deprecated since version 2.7 and will be removed in 3.0. Use the IsNullValidator class in the same namespace instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>

--- a/src/Symfony/Component/Validator/Constraints/True.php
+++ b/src/Symfony/Component/Validator/Constraints/True.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-@trigger_error('The '.__NAMESPACE__.'\True class is deprecated since version 2.7 and will be removed in 3.0. Use the IsTrue class in the same namespace instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\True class is deprecated since version 2.7 and will be removed in 3.0. Use the IsTrue class in the same namespace instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 /**
  * @Annotation

--- a/src/Symfony/Component/Validator/Constraints/TrueValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TrueValidator.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-@trigger_error('The '.__NAMESPACE__.'\TrueValidator class is deprecated since version 2.7 and will be removed in 3.0. Use the IsTrueValidator class in the same namespace instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\TrueValidator class is deprecated since version 2.7 and will be removed in 3.0. Use the IsTrueValidator class in the same namespace instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>

--- a/src/Symfony/Component/Validator/Context/ExecutionContext.php
+++ b/src/Symfony/Component/Validator/Context/ExecutionContext.php
@@ -189,7 +189,7 @@ class ExecutionContext implements ExecutionContextInterface
         // API, as they are not present in the new interface anymore.
         // You should use buildViolation() instead.
         if (func_num_args() > 2) {
-            @trigger_error('The parameters $invalidValue, $plural and $code in method '.__METHOD__.' are deprecated since version 2.5 and will be removed in 3.0. Use the '.__CLASS__.'::buildViolation method instead.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('The parameters $invalidValue, $plural and $code in method %s are deprecated since version 2.5 and will be removed in 3.0. Use the %s::buildViolation method instead.', __METHOD__, __CLASS__), E_USER_DEPRECATED);
 
             $this
                 ->buildViolation($message, $parameters)
@@ -318,7 +318,7 @@ class ExecutionContext implements ExecutionContextInterface
      */
     public function addViolationAt($subPath, $message, array $parameters = array(), $invalidValue = null, $plural = null, $code = null)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0. Use the '.__CLASS__.'::buildViolation method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.5 and will be removed in 3.0. Use the %s::buildViolation method instead.', __METHOD__, __CLASS__), E_USER_DEPRECATED);
 
         if (func_num_args() > 2) {
             $this
@@ -345,7 +345,7 @@ class ExecutionContext implements ExecutionContextInterface
      */
     public function validate($value, $subPath = '', $groups = null, $traverse = false, $deep = false)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0. Use the '.__CLASS__.'::getValidator() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.5 and will be removed in 3.0. Use the %s::getValidator() method instead.', __METHOD__, __CLASS__), E_USER_DEPRECATED);
 
         if (is_array($value)) {
             // The $traverse flag is ignored for arrays
@@ -383,7 +383,7 @@ class ExecutionContext implements ExecutionContextInterface
      */
     public function validateValue($value, $constraints, $subPath = '', $groups = null)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0. Use the '.__CLASS__.'::getValidator() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.5 and will be removed in 3.0. Use the %s::getValidator() method instead.', __METHOD__, __CLASS__), E_USER_DEPRECATED);
 
         return $this
             ->getValidator()

--- a/src/Symfony/Component/Validator/Context/ExecutionContext.php
+++ b/src/Symfony/Component/Validator/Context/ExecutionContext.php
@@ -398,7 +398,7 @@ class ExecutionContext implements ExecutionContextInterface
      */
     public function getMetadataFactory()
     {
-        @trigger_error('The '.__METHOD__.' is deprecated since version 2.5 and will be removed in 3.0. Use the new Symfony\Component\Validator\Context\ExecutionContext::getValidator method in combination with Symfony\Component\Validator\Validator\ValidatorInterface::getMetadataFor or Symfony\Component\Validator\Validator\ValidatorInterface::hasMetadataFor method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s is deprecated since version 2.5 and will be removed in 3.0. Use the new Symfony\Component\Validator\Context\ExecutionContext::getValidator method in combination with Symfony\Component\Validator\Validator\ValidatorInterface::getMetadataFor or Symfony\Component\Validator\Validator\ValidatorInterface::hasMetadataFor method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         $validator = $this->getValidator();
 

--- a/src/Symfony/Component/Validator/Context/LegacyExecutionContext.php
+++ b/src/Symfony/Component/Validator/Context/LegacyExecutionContext.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Validator\Context;
 
-@trigger_error('The '.__NAMESPACE__.'\LegacyExecutionContext class is deprecated since version 2.5 and will be removed in 3.0.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\LegacyExecutionContext class is deprecated since version 2.5 and will be removed in 3.0.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\MetadataFactoryInterface;

--- a/src/Symfony/Component/Validator/Context/LegacyExecutionContextFactory.php
+++ b/src/Symfony/Component/Validator/Context/LegacyExecutionContextFactory.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Validator\Context;
 
-@trigger_error('The '.__NAMESPACE__.'\LegacyExecutionContextFactory class is deprecated since version 2.5 and will be removed in 3.0.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\LegacyExecutionContextFactory class is deprecated since version 2.5 and will be removed in 3.0.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\MetadataFactoryInterface;

--- a/src/Symfony/Component/Validator/DefaultTranslator.php
+++ b/src/Symfony/Component/Validator/DefaultTranslator.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Validator;
 
-@trigger_error('The class '.__NAMESPACE__.'\DefaultTranslator is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Translation\IdentityTranslator instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The class %s\DefaultTranslator is deprecated since version 2.7 and will be removed in 3.0. Use Symfony\Component\Translation\IdentityTranslator instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Exception\BadMethodCallException;

--- a/src/Symfony/Component/Validator/ExecutionContext.php
+++ b/src/Symfony/Component/Validator/ExecutionContext.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Validator;
 
-@trigger_error('The '.__NAMESPACE__.'\ExecutionContext class is deprecated since version 2.5 and will be removed in 3.0. Use the Symfony\Component\Validator\Context\ExecutionContext class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\ExecutionContext class is deprecated since version 2.5 and will be removed in 3.0. Use the Symfony\Component\Validator\Context\ExecutionContext class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Translation\TranslatorInterface;
 

--- a/src/Symfony/Component/Validator/Mapping/BlackholeMetadataFactory.php
+++ b/src/Symfony/Component/Validator/Mapping/BlackholeMetadataFactory.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Validator\Mapping;
 
-@trigger_error('The '.__NAMESPACE__.'\BlackholeMetadataFactory class is deprecated since version 2.5 and will be removed in 3.0. Use the Symfony\Component\Validator\Mapping\Factory\BlackHoleMetadataFactory class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\BlackholeMetadataFactory class is deprecated since version 2.5 and will be removed in 3.0. Use the Symfony\Component\Validator\Mapping\Factory\BlackHoleMetadataFactory class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Validator\Mapping\Factory\BlackHoleMetadataFactory as MappingBlackHoleMetadataFactory;
 

--- a/src/Symfony/Component/Validator/Mapping/Cache/ApcCache.php
+++ b/src/Symfony/Component/Validator/Mapping/Cache/ApcCache.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Validator\Mapping\Cache;
 
-@trigger_error('The '.__NAMESPACE__.'\ApcCache class is deprecated since version 2.5 and will be removed in 3.0. Use DoctrineCache with the Doctrine\Common\Cache\ApcCache class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\ApcCache class is deprecated since version 2.5 and will be removed in 3.0. Use DoctrineCache with the Doctrine\Common\Cache\ApcCache class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -133,7 +133,7 @@ class ClassMetadata extends ElementMetadata implements ClassMetadataInterface
      */
     public function accept(ValidationVisitorInterface $visitor, $value, $group, $propertyPath, $propagatedGroup = null)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.5 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
 
         if (null === $propagatedGroup && Constraint::DEFAULT_GROUP === $group
                 && ($this->hasGroupSequence() || $this->isGroupSequenceProvider())) {
@@ -377,7 +377,7 @@ class ClassMetadata extends ElementMetadata implements ClassMetadataInterface
      */
     protected function addMemberMetadata(MemberMetadata $metadata)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use the addPropertyMetadata() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.6 and will be removed in 3.0. Use the addPropertyMetadata() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         $this->addPropertyMetadata($metadata);
     }
@@ -393,7 +393,7 @@ class ClassMetadata extends ElementMetadata implements ClassMetadataInterface
      */
     public function hasMemberMetadatas($property)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use the hasPropertyMetadata() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.6 and will be removed in 3.0. Use the hasPropertyMetadata() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         return $this->hasPropertyMetadata($property);
     }
@@ -409,7 +409,7 @@ class ClassMetadata extends ElementMetadata implements ClassMetadataInterface
      */
     public function getMemberMetadatas($property)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.6 and will be removed in 3.0. Use the getPropertyMetadata() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.6 and will be removed in 3.0. Use the getPropertyMetadata() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         return $this->getPropertyMetadata($property);
     }

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadataFactory.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadataFactory.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Validator\Mapping;
 
-@trigger_error('The '.__NAMESPACE__.'\ClassMetadataFactory class is deprecated since version 2.5 and will be removed in 3.0. Use the Symfony\Component\Validator\Mapping\Factory\LazyLoadingMetadataFactory class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\ClassMetadataFactory class is deprecated since version 2.5 and will be removed in 3.0. Use the Symfony\Component\Validator\Mapping\Factory\LazyLoadingMetadataFactory class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Validator\Mapping\Factory\LazyLoadingMetadataFactory;
 

--- a/src/Symfony/Component/Validator/Mapping/ElementMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ElementMetadata.php
@@ -24,7 +24,7 @@ abstract class ElementMetadata extends GenericMetadata
     public function __construct()
     {
         if (!$this instanceof MemberMetadata && !$this instanceof ClassMetadata) {
-            @trigger_error('The '.__CLASS__.' class is deprecated since version 2.5 and will be removed in 3.0. Use the Symfony\Component\Validator\Mapping\GenericMetadata class instead.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('The %s class is deprecated since version 2.5 and will be removed in 3.0. Use the Symfony\Component\Validator\Mapping\GenericMetadata class instead.', __CLASS__),  E_USER_DEPRECATED);
         }
     }
 }

--- a/src/Symfony/Component/Validator/Mapping/MemberMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/MemberMetadata.php
@@ -82,7 +82,7 @@ abstract class MemberMetadata extends ElementMetadata implements PropertyMetadat
      */
     public function accept(ValidationVisitorInterface $visitor, $value, $group, $propertyPath, $propagatedGroup = null)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.5 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
 
         $visitor->visit($this, $value, $group, $propertyPath);
 
@@ -192,7 +192,7 @@ abstract class MemberMetadata extends ElementMetadata implements PropertyMetadat
      */
     public function isCascaded()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0. Use the getCascadingStrategy() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.5 and will be removed in 3.0. Use the getCascadingStrategy() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         return (bool) ($this->cascadingStrategy & CascadingStrategy::CASCADE);
     }
@@ -208,7 +208,7 @@ abstract class MemberMetadata extends ElementMetadata implements PropertyMetadat
      */
     public function isCollectionCascaded()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0. Use the getTraversalStrategy() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.5 and will be removed in 3.0. Use the getTraversalStrategy() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         return (bool) ($this->traversalStrategy & (TraversalStrategy::IMPLICIT | TraversalStrategy::TRAVERSE));
     }
@@ -224,7 +224,7 @@ abstract class MemberMetadata extends ElementMetadata implements PropertyMetadat
      */
     public function isCollectionCascadedDeeply()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0. Use the getTraversalStrategy() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.5 and will be removed in 3.0. Use the getTraversalStrategy() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         return !($this->traversalStrategy & TraversalStrategy::STOP_RECURSION);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractConstraintValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractConstraintValidatorTest.php
@@ -256,7 +256,7 @@ abstract class AbstractConstraintValidatorTest extends \PHPUnit_Framework_TestCa
      */
     protected function assertViolation($message, array $parameters = array(), $propertyPath = 'property.path', $invalidValue = 'InvalidValue', $plural = null, $code = null)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.3 and will be removed in 3.0. Use the buildViolation() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.3 and will be removed in 3.0. Use the buildViolation() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         $this->buildViolation($message)
             ->setParameters($parameters)
@@ -275,7 +275,7 @@ abstract class AbstractConstraintValidatorTest extends \PHPUnit_Framework_TestCa
      */
     protected function assertViolations(array $expected)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.3 and will be removed in 3.0. Use the buildViolation() method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.3 and will be removed in 3.0. Use the buildViolation() method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         $violations = $this->context->getViolations();
 

--- a/src/Symfony/Component/Validator/ValidationVisitor.php
+++ b/src/Symfony/Component/Validator/ValidationVisitor.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Validator;
 
-@trigger_error('The '.__NAMESPACE__.'\ValidationVisitor class is deprecated since version 2.5 and will be removed in 3.0.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\ValidationVisitor class is deprecated since version 2.5 and will be removed in 3.0.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Exception\NoSuchMetadataException;

--- a/src/Symfony/Component/Validator/Validator.php
+++ b/src/Symfony/Component/Validator/Validator.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Validator;
 
-@trigger_error('The '.__NAMESPACE__.'\Validator class is deprecated since version 2.5 and will be removed in 3.0. Use the Symfony\Component\Validator\Validator\RecursiveValidator class instead.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\Validator class is deprecated since version 2.5 and will be removed in 3.0. Use the Symfony\Component\Validator\Validator\RecursiveValidator class instead.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraints\Valid;

--- a/src/Symfony/Component/Validator/Validator/LegacyValidator.php
+++ b/src/Symfony/Component/Validator/Validator/LegacyValidator.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Validator\Validator;
 
-@trigger_error('The '.__NAMESPACE__.'\LegacyValidator class is deprecated since version 2.5 and will be removed in 3.0.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\LegacyValidator class is deprecated since version 2.5 and will be removed in 3.0.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 /**
  * A validator that supports both the API of Symfony < 2.5 and Symfony 2.5+.

--- a/src/Symfony/Component/Validator/Validator/RecursiveValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveValidator.php
@@ -161,7 +161,7 @@ class RecursiveValidator implements ValidatorInterface, LegacyValidatorInterface
      */
     public function validateValue($value, $constraints, $groups = null)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated in version 2.5 and will be removed in version 3.0. Use the Symfony\Component\Validator\Validator\ValidatorInterface::validate method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated in version 2.5 and will be removed in version 3.0. Use the Symfony\Component\Validator\Validator\ValidatorInterface::validate method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         return $this->validate($value, $constraints, $groups);
     }
@@ -171,7 +171,7 @@ class RecursiveValidator implements ValidatorInterface, LegacyValidatorInterface
      */
     public function getMetadataFactory()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated in version 2.5 and will be removed in version 3.0. Use the Symfony\Component\Validator\Validator\ValidatorInterface::getMetadataFor or Symfony\Component\Validator\Validator\ValidatorInterface::hasMetadataFor method instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated in version 2.5 and will be removed in version 3.0. Use the Symfony\Component\Validator\Validator\ValidatorInterface::getMetadataFor or Symfony\Component\Validator\Validator\ValidatorInterface::hasMetadataFor method instead.', __METHOD__),  E_USER_DEPRECATED);
 
         return $this->metadataFactory;
     }

--- a/src/Symfony/Component/Validator/ValidatorBuilder.php
+++ b/src/Symfony/Component/Validator/ValidatorBuilder.php
@@ -300,7 +300,7 @@ class ValidatorBuilder implements ValidatorBuilderInterface
      */
     public function setPropertyAccessor(PropertyAccessorInterface $propertyAccessor)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 2.5 and will be removed in 3.0. The validator will function without a property accessor.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since version 2.5 and will be removed in 3.0. The validator will function without a property accessor.', __METHOD__),  E_USER_DEPRECATED);
 
         if (null !== $this->validatorFactory) {
             throw new ValidatorException('You cannot set a property accessor after setting a custom validator factory. Configure your validator factory instead.');
@@ -318,7 +318,7 @@ class ValidatorBuilder implements ValidatorBuilderInterface
      */
     public function setApiVersion($apiVersion)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated in version 2.7 and will be removed in version 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated in version 2.7 and will be removed in version 3.0.', __METHOD__),  E_USER_DEPRECATED);
 
         if (!in_array($apiVersion, array(Validation::API_VERSION_2_4, Validation::API_VERSION_2_5, Validation::API_VERSION_2_5_BC))) {
             throw new InvalidArgumentException(sprintf('The requested API version is invalid: "%s"', $apiVersion));

--- a/src/Symfony/Component/Validator/Violation/LegacyConstraintViolationBuilder.php
+++ b/src/Symfony/Component/Validator/Violation/LegacyConstraintViolationBuilder.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Validator\Violation;
 
-@trigger_error('The '.__NAMESPACE__.'\LegacyConstraintViolationBuilder class is deprecated since version 2.5 and will be removed in 3.0.', E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s\LegacyConstraintViolationBuilder class is deprecated since version 2.5 and will be removed in 3.0.', __NAMESPACE__),  E_USER_DEPRECATED);
 
 use Symfony\Component\Validator\ExecutionContextInterface;
 

--- a/src/Symfony/Component/VarDumper/Caster/ReflectionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ReflectionCaster.php
@@ -36,7 +36,7 @@ class ReflectionCaster
      */
     public static function castReflector(\Reflector $c, array $a, Stub $stub, $isNested)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since Symfony 2.7 and will be removed in 3.0.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since Symfony 2.7 and will be removed in 3.0.', __METHOD__),  E_USER_DEPRECATED);
         $a[Caster::PREFIX_VIRTUAL.'reflection'] = $c->__toString();
 
         return $a;

--- a/src/Symfony/Component/VarDumper/Cloner/Data.php
+++ b/src/Symfony/Component/VarDumper/Cloner/Data.php
@@ -95,7 +95,7 @@ class Data
      */
     public function getLimitedClone($maxDepth, $maxItemsPerDepth, $useRefHandles = true)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since Symfony 2.7 and will be removed in 3.0. Use withMaxDepth, withMaxItemsPerDepth or withRefHandles methods instead.', E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated since Symfony 2.7 and will be removed in 3.0. Use withMaxDepth, withMaxItemsPerDepth or withRefHandles methods instead.', __METHOD__),  E_USER_DEPRECATED);
 
         $data = clone $this;
         $data->maxDepth = (int) $maxDepth;

--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -49,7 +49,7 @@ class Yaml
         // if input is a file, process it
         $file = '';
         if (strpos($input, "\n") === false && is_file($input)) {
-            @trigger_error('The ability to pass file names to the '.__METHOD__.' method is deprecated since version 2.2 and will be removed in 3.0. Pass the YAML contents of the file instead.', E_USER_DEPRECATED);
+            @trigger_error(sprintf('The ability to pass file names to the %s method is deprecated since version 2.2 and will be removed in 3.0. Pass the YAML contents of the file instead.', __METHOD__),  E_USER_DEPRECATED);
 
             if (false === is_readable($input)) {
                 throw new ParseException(sprintf('Unable to parse "%s" as the file is not readable.', $input));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Exception and error message strings should be concatenated using `sprintf()`.
