### PR TITLE
[FrameworkBundle][Serializer] Fix a deprecation triggered by the ClassMetadataFactory

### DIFF
--- a/UPGRADE-3.1.md
+++ b/UPGRADE-3.1.md
@@ -19,19 +19,19 @@ Form
  * Support for data objects that implements both `Traversable` and `ArrayAccess`
    in `ResizeFormListener::preSubmit` method has been deprecated and will be
    removed in Symfony 4.0.
- 
+
  * Using callable strings as choice options in ChoiceType has been deprecated
    in favor of `PropertyPath` in Symfony 4.0 use a "\Closure" instead.
-    
+
    Before:
-   
+
    ```php
    'choice_value' => new PropertyPath('range'),
    'choice_label' => 'strtoupper',
    ```
- 
+
    After:
-   
+
    ```php
    'choice_value' => 'range',
    'choice_label' => function ($choice) {
@@ -87,6 +87,27 @@ FrameworkBundle
    `serializer.mapping.cache.doctrine.apc` to be consistent with the validator
    cache service. If you are using `serializer.mapping.cache.apc`, use
    `serializer.mapping.cache.doctrine.apc` instead.
+
+ * The `framework.serializer.cache` option has been deprecated. Configure a cache pool
+   called `serializer` under `framework.cache.pools` instead.
+
+   Before:
+
+   ```yaml
+   framework:
+       serializer:
+           cache: serializer.mapping.cache.apc
+   ```
+
+   After:
+
+   ```yaml
+   framework:
+       serializer: ~
+           cache:
+               pools:
+                   serializer:
+                       adapter: cache.adapter.apcu
 
 HttpKernel
 ----------

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -16,26 +16,26 @@ Form
 
  * Support for data objects that implements both `Traversable` and
    `ArrayAccess` in `ResizeFormListener::preSubmit` method has been removed.
-   
- * Using callable strings as choice options in ChoiceType is not supported 
+
+ * Using callable strings as choice options in ChoiceType is not supported
    anymore in favor of passing PropertyPath instances.
-    
+
    Before:
-   
+
    ```php
    'choice_value' => new PropertyPath('range'),
    'choice_label' => 'strtoupper',
    ```
- 
+
    After:
-   
+
    ```php
    'choice_value' => 'range',
    'choice_label' => function ($choice) {
        return strtoupper($choice);
    },
    ```
-   
+
 
 FrameworkBundle
 ---------------
@@ -77,6 +77,28 @@ FrameworkBundle
 
  * The service `serializer.mapping.cache.apc` has been removed; use
    `serializer.mapping.cache.doctrine.apc` instead.
+
+ * The `framework.serializer.cache` option has been removed. Configure a cache pool
+   called `serializer` under `framework.cache.pools` instead.
+
+   Before:
+
+   ```yaml
+   framework:
+       serializer:
+           cache: serializer.mapping.cache.apc
+   ```
+
+   After:
+
+   ```yaml
+   framework:
+       serializer: ~
+           cache:
+               pools:
+                   serializer:
+                       adapter: cache.adapter.apcu
+   ```
 
 HttpKernel
 ----------

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -513,7 +513,7 @@ class Configuration implements ConfigurationInterface
                     ->canBeEnabled()
                     ->children()
                         ->booleanNode('enable_annotations')->defaultFalse()->end()
-                        ->scalarNode('cache')->defaultValue('serializer.mapping.cache.symfony')->end()
+                        ->scalarNode('cache')->end()
                         ->scalarNode('name_converter')->end()
                     ->end()
                 ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -982,7 +982,7 @@ class FrameworkExtension extends Extension
 
         $chainLoader->replaceArgument(0, $serializerLoaders);
 
-        if (!$container->getParameter('kernel.debug')) {
+        if (isset($config['cache']) && $config['cache']) {
             $container->setParameter(
                 'serializer.mapping.cache.prefix',
                 'serializer_'.$this->getKernelRootHash($container)

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache_pools.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache_pools.xml
@@ -25,6 +25,10 @@
             <tag name="cache.pool" clearer="cache.default_pools_clearer" />
         </service>
 
+        <service id="cache.pool.serializer" parent="cache.adapter.local" public="false">
+            <tag name="cache.pool" clearer="cache.default_pools_clearer" />
+        </service>
+
         <service id="cache.adapter.apcu" class="Symfony\Component\Cache\Adapter\ApcuAdapter" abstract="true">
             <argument /> <!-- namespace -->
             <argument /> <!-- default lifetime -->

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache_pools.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache_pools.xml
@@ -25,10 +25,6 @@
             <tag name="cache.pool" clearer="cache.default_pools_clearer" />
         </service>
 
-        <service id="cache.pool.serializer" parent="cache.adapter.local" public="false">
-            <tag name="cache.pool" clearer="cache.default_pools_clearer" />
-        </service>
-
         <service id="cache.adapter.apcu" class="Symfony\Component\Cache\Adapter\ApcuAdapter" abstract="true">
             <argument /> <!-- namespace -->
             <argument /> <!-- default lifetime -->

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
@@ -38,10 +38,6 @@
         </service>
 
         <!-- Cache -->
-        <service id="serializer.mapping.cache.symfony" class="Symfony\Component\Cache\DoctrineProvider" public="false">
-            <argument type="service" id="cache.pool.serializer" />
-        </service>
-
         <service id="serializer.mapping.cache.doctrine.apc" class="Doctrine\Common\Cache\ApcCache" public="false">
             <call method="setNamespace">
                 <argument>%serializer.mapping.cache.prefix%</argument>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -221,7 +221,6 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             'serializer' => array(
                 'enabled' => false,
                 'enable_annotations' => false,
-                'cache' => 'serializer.mapping.cache.symfony',
             ),
             'property_access' => array(
                 'magic_call' => false,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
@@ -66,7 +66,6 @@ $container->loadFromExtension('framework', array(
     'serializer' => array(
         'enabled' => true,
         'enable_annotations' => true,
-        'cache' => 'serializer.mapping.cache.doctrine.apc',
         'name_converter' => 'serializer.name_converter.camel_case_to_snake_case',
     ),
     'ide' => 'file%%link%%format',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/serializer_legacy_cache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/serializer_legacy_cache.php
@@ -1,0 +1,8 @@
+<?php
+
+$container->loadFromExtension('framework', array(
+    'serializer' => array(
+        'enabled' => true,
+        'cache' => 'foo',
+    ),
+));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
@@ -40,6 +40,6 @@
         </framework:translator>
         <framework:validation enabled="true" cache="validator.mapping.cache.doctrine.apc" />
         <framework:annotations cache="file" debug="true" file-cache-dir="%kernel.cache_dir%/annotations" />
-        <framework:serializer enabled="true" enable-annotations="true" cache="serializer.mapping.cache.doctrine.apc" name-converter="serializer.name_converter.camel_case_to_snake_case" />
+        <framework:serializer enabled="true" enable-annotations="true" name-converter="serializer.name_converter.camel_case_to_snake_case" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/serializer_legacy_cache.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/serializer_legacy_cache.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+        <framework:serializer enabled="true" cache="foo"/>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
@@ -52,7 +52,6 @@ framework:
     serializer:
          enabled:        true
          enable_annotations: true
-         cache:          serializer.mapping.cache.doctrine.apc
          name_converter: serializer.name_converter.camel_case_to_snake_case
     ide: file%%link%%format
     request:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/serializer_legacy_cache.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/serializer_legacy_cache.yml
@@ -1,0 +1,4 @@
+framework:
+    serializer:
+        enabled: true
+        cache: foo

--- a/src/Symfony/Component/Serializer/Mapping/Factory/ClassMetadataFactory.php
+++ b/src/Symfony/Component/Serializer/Mapping/Factory/ClassMetadataFactory.php
@@ -50,7 +50,7 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
         $this->cache = $cache;
 
         if (null !== $cache) {
-            @trigger_error(sprintf('Passing a Doctrine Cache instance as 2nd parameter of the "%s" constructor is deprecated. This parameter will be removed in Symfony 4.0. Use the "%s" class instead.', __CLASS__, CacheClassMetadataFactory::class), E_USER_DEPRECATED);
+            @trigger_error(sprintf('Passing a Doctrine Cache instance as 2nd parameter of the "%s" constructor is deprecated since version 3.1. This parameter will be removed in Symfony 4.0. Use the "%s" class instead.', __CLASS__, CacheClassMetadataFactory::class), E_USER_DEPRECATED);
         }
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |

Without apparent reasons, [FOSRestBundle's tests fail](https://travis-ci.org/FriendsOfSymfony/FOSRestBundle/jobs/124384888) since https://github.com/symfony/symfony/pull/18561.

```
Passing a Doctrine Cache instance as 2nd parameter of the "Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory" constructor is deprecated. This parameter will be removed in Symfony 4.0. Use the "Symfony\Component\Serializer\Mapping\Factory\CacheClassMetadataFactory" class instead: 6x
    1x in ErrorWithTemplatingFormatTest::testSerializeExceptionHtml from FOS\RestBundle\Tests\Functional
    1x in SerializerErrorTest::testSerializeExceptionJson from FOS\RestBundle\Tests\Functional
    1x in SerializerErrorTest::testSerializeExceptionJsonWithoutDebug from FOS\RestBundle\Tests\Functional
    1x in SerializerErrorTest::testSerializeExceptionXml from FOS\RestBundle\Tests\Functional
    1x in SerializerErrorTest::testSerializeInvalidFormJson from FOS\RestBundle\Tests\Functional
    1x in SerializerErrorTest::testSerializeInvalidFormXml from FOS\RestBundle\Tests\Functional
```

We don't use cache in our tests but some of them are not in `debug` mode (will change soon) so the cache is automatically used.

This PR fixes this deprecation by detecting if the cache used by the serializer is psr6 compliant or not (if it is, then it replaces the default metadata factory by an instance of the new class `CacheClassMetadataFactory`, otherwise the second parameter of the `ClassMetadataFactory` is used).
