### PR TITLE
[WIP][Routing] Fix the annotation loader taking a class constant as a beginning of a class name

### DIFF
--- a/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
@@ -96,6 +96,8 @@ class AnnotationFileLoader extends FileLoader
             $token = $tokens[$i];
 
             if (!isset($token[1])) {
+                $class = false;
+
                 continue;
             }
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotatedClasses/FooTrait.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotatedClasses/FooTrait.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses;
+
+trait FooTrait
+{
+    public function doBar()
+    {
+        $baz = self::class;
+        if (true) {
+        }
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationFileLoaderTest.php
@@ -36,6 +36,16 @@ class AnnotationFileLoaderTest extends AbstractAnnotationLoaderTest
     }
 
     /**
+     * @requires PHP 5.4
+     */
+    public function testLoadTraitWithClassConstant()
+    {
+        $this->reader->expects($this->never())->method('getClassAnnotation');
+
+        $this->loader->load(__DIR__.'/../Fixtures/AnnotatedClasses/FooTrait.php');
+    }
+
+    /**
      * @requires PHP 5.6
      */
     public function testLoadVariadic()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.3 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18633 |
| License | MIT |
| Doc PR | - |

Hold on with the merge. I'd like to see if there should be more test cases added first.
