### PR TITLE
[Console] Prevent fatal error when calling Command::getHelper without helperSet

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -601,10 +601,15 @@ class Command
      *
      * @return mixed The helper value
      *
-     * @throws InvalidArgumentException if the helper is not defined
+     * @throws LogicException           If no HelperSet is defined
+     * @throws InvalidArgumentException If the helper is not defined
      */
     public function getHelper($name)
     {
+        if (null === $this->helperSet) {
+            throw new LogicException(sprintf('Cannot retrieve helper "%s" because there is no HelperSet defined. Did you forget to add your command to the application or to set the application on the command using the setApplication() method? You can also set the HelperSet directly using the setHelperSet() method.', $name));
+        }
+
         return $this->helperSet->get($name);
     }
 

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -173,6 +173,16 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($formatterHelper->getName(), $command->getHelper('formatter')->getName(), '->getHelper() returns the correct helper');
     }
 
+    /**
+     * @expectedException        \LogicException
+     * @expectedExceptionMessage Cannot retrieve helper "formatter" because there is no HelperSet defined.
+     */
+    public function testGetHelperWithoutHelperSet()
+    {
+        $command = new \TestCommand();
+        $command->getHelper('formatter');
+    }
+
     public function testMergeApplicationDefinition()
     {
         $application1 = new Application();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18619 |
| License | MIT |
| Doc PR | n/a |

Patch attached to #18619
