### PR TITLE
[Asset] set version automatically from git commit hash

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -574,10 +574,16 @@ class FrameworkExtension extends Extension
     {
         $loader->load('assets.xml');
 
+        $removeGitStrategy = true;
+
         $defaultVersion = null;
 
         if ($config['version_strategy']) {
             $defaultVersion = new Reference($config['version_strategy']);
+
+            if ($config['version_strategy'] == 'assets.git_version_strategy') {
+                $removeGitStrategy = false;
+            }
         } else {
             $defaultVersion = $this->createVersion($container, $config['version'], $config['version_format'], '_default');
         }
@@ -589,6 +595,10 @@ class FrameworkExtension extends Extension
         foreach ($config['packages'] as $name => $package) {
             if (null !== $package['version_strategy']) {
                 $version = new Reference($package['version_strategy']);
+
+                if ($package['version_strategy'] == "assets.git_version_strategy") {
+                    $removeGitStrategy = false;
+                }
             } elseif (!array_key_exists('version', $package)) {
                 $version = $defaultVersion;
             } else {
@@ -604,6 +614,10 @@ class FrameworkExtension extends Extension
             ->replaceArgument(0, new Reference('assets._default_package'))
             ->replaceArgument(1, $namedPackages)
         ;
+
+        if ($removeGitStrategy) {
+            $container->removeDefinition('assets.git_version_strategy');
+        }
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -596,7 +596,7 @@ class FrameworkExtension extends Extension
             if (null !== $package['version_strategy']) {
                 $version = new Reference($package['version_strategy']);
 
-                if ($package['version_strategy'] == "assets.git_version_strategy") {
+                if ($package['version_strategy'] == 'assets.git_version_strategy') {
                     $removeGitStrategy = false;
                 }
             } elseif (!array_key_exists('version', $package)) {

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -34,6 +34,7 @@ use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\SerializerPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\UnusedTagsPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ConfigCachePass;
 use Symfony\Component\Debug\ErrorHandler;
+use Symfony\Component\DependencyInjection\Compiler\GitCommitHashPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
@@ -91,6 +92,7 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new PropertyInfoPass());
         $container->addCompilerPass(new ControllerArgumentValueResolverPass());
         $container->addCompilerPass(new CachePoolPass());
+        $container->addCompilerPass(new GitCommitHashPass());
 
         if ($container->getParameter('kernel.debug')) {
             $container->addCompilerPass(new UnusedTagsPass(), PassConfig::TYPE_AFTER_REMOVING);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/assets.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/assets.xml
@@ -38,5 +38,10 @@
 
         <service id="assets.empty_version_strategy" class="Symfony\Component\Asset\VersionStrategy\EmptyVersionStrategy" public="false" />
 
+        <service id="assets.git_version_strategy" class="Symfony\Component\Asset\VersionStrategy\GitVersionStrategy" public="false">
+            <argument /> <!-- version -->
+            <argument /> <!-- format -->
+        </service>
+
     </services>
 </container>

--- a/src/Symfony/Component/Asset/CompilerPass/GitCommitHashCompilerPass.php
+++ b/src/Symfony/Component/Asset/CompilerPass/GitCommitHashCompilerPass.php
@@ -16,12 +16,16 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Process\Process;
 
 /**
- * Disable version for all assets.
+ * Save git commit hash to parameter and then use it as assets version.
  *
  * @author Evgenii Sokolov <ewgraf@gmail.com>
  */
 class GitCommitHashCompilerPass implements CompilerPassInterface
 {
+    /**
+     * @param ContainerBuilder $container
+     * @throws \Exception
+     */
     public function process(ContainerBuilder $container)
     {
         $process = new Process('git log -1');

--- a/src/Symfony/Component/Asset/CompilerPass/GitCommitHashCompilerPass.php
+++ b/src/Symfony/Component/Asset/CompilerPass/GitCommitHashCompilerPass.php
@@ -31,7 +31,7 @@ class GitCommitHashCompilerPass implements CompilerPassInterface
         $process = new Process('git log -1');
 
         if (0 !== $process->run()) {
-            throw new \Exception("Git command return wrong exit code");
+            throw new \Exception('Git command return wrong exit code');
         }
 
         $container->setParameter('git_commit_hash_version_strategy', sha1($process->getOutput()));

--- a/src/Symfony/Component/Asset/CompilerPass/GitCommitHashCompilerPass.php
+++ b/src/Symfony/Component/Asset/CompilerPass/GitCommitHashCompilerPass.php
@@ -24,6 +24,7 @@ class GitCommitHashCompilerPass implements CompilerPassInterface
 {
     /**
      * @param ContainerBuilder $container
+     *
      * @throws \Exception
      */
     public function process(ContainerBuilder $container)

--- a/src/Symfony/Component/Asset/CompilerPass/GitCommitHashCompilerPass.php
+++ b/src/Symfony/Component/Asset/CompilerPass/GitCommitHashCompilerPass.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Asset\CompilerPass;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Process\Process;
+
+/**
+ * Disable version for all assets.
+ *
+ * @author Evgenii Sokolov <ewgraf@gmail.com>
+ */
+class GitCommitHashCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $process = new Process('git log -1');
+
+        if (0 !== $process->run()) {
+            throw new \Exception("Git command return wrong exit code");
+        }
+
+        $container->setParameter('git_commit_hash_version_strategy', sha1($process->getOutput()));
+    }
+}

--- a/src/Symfony/Component/Asset/VersionStrategy/GitVersionStrategy.php
+++ b/src/Symfony/Component/Asset/VersionStrategy/GitVersionStrategy.php
@@ -16,19 +16,20 @@ use Symfony\Component\Asset\Exception\InvalidArgumentException;
 /**
  * Returns the version as git hash from latest commit.
  *
- * @author Evgeniy Sokolov <ewgraf@gmail.com>
+ * @author Evgenii Sokolov <ewgraf@gmail.com>
  */
 class GitVersionStrategy extends StaticVersionStrategy
 {
     /**
      * @param string $version Version number
      * @param string $format  Url format
+     *
      * @throws InvalidArgumentException
      */
     public function __construct($version, $format = null)
     {
         if (!$version) {
-            throw new InvalidArgumentException("Version must be git a hash.");
+            throw new InvalidArgumentException('Version must be git a hash.');
         }
 
         parent::__construct($version, $format);

--- a/src/Symfony/Component/Asset/VersionStrategy/GitVersionStrategy.php
+++ b/src/Symfony/Component/Asset/VersionStrategy/GitVersionStrategy.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Asset\VersionStrategy;
+
+use Symfony\Component\Asset\Exception\InvalidArgumentException;
+
+/**
+ * Returns the version as git hash from latest commit.
+ *
+ * @author Evgeniy Sokolov <ewgraf@gmail.com>
+ */
+class GitVersionStrategy extends StaticVersionStrategy
+{
+    /**
+     * @param string $version Version number
+     * @param string $format  Url format
+     * @throws InvalidArgumentException
+     */
+    public function __construct($version, $format = null)
+    {
+        if (!$version) {
+            throw new InvalidArgumentException("Version must be git a hash.");
+        }
+
+        parent::__construct($version, $format);
+    }
+
+}

--- a/src/Symfony/Component/DependencyInjection/Compiler/GitCommitHashPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/GitCommitHashPass.php
@@ -23,8 +23,6 @@ class GitCommitHashPass implements CompilerPassInterface
 {
     /**
      * @param ContainerBuilder $container
-     *
-     * @throws \Exception
      */
     public function process(ContainerBuilder $container)
     {

--- a/src/Symfony/Component/DependencyInjection/Compiler/GitCommitHashPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/GitCommitHashPass.php
@@ -26,8 +26,12 @@ class GitCommitHashPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
+        if (!$container->hasDefinition('assets.git_version_strategy')) {
+            return;
+        }
+
         $process = new Process('git rev-parse HEAD', $container->getParameter('kernel.root_dir'));
         $process->mustRun();
-        $container->setParameter('git_commit_hash', trim($process->getOutput()));
+        $container->getDefinition('assets.git_version_strategy')->replaceArgument(0, trim($process->getOutput()));
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Compiler/GitCommitHashPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/GitCommitHashPass.php
@@ -26,8 +26,8 @@ class GitCommitHashPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $process = new Process('git log -1', $container->getParameter('kernel.root_dir'));
+        $process = new Process('git rev-parse HEAD', $container->getParameter('kernel.root_dir'));
         $process->mustRun();
-        $container->setParameter('git_commit_hash', sha1($process->getOutput()));
+        $container->setParameter('git_commit_hash', trim($process->getOutput()));
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Compiler/GitCommitHashPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/GitCommitHashPass.php
@@ -9,9 +9,8 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Asset\CompilerPass;
+namespace Symfony\Component\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Process\Process;
 
@@ -20,7 +19,7 @@ use Symfony\Component\Process\Process;
  *
  * @author Evgenii Sokolov <ewgraf@gmail.com>
  */
-class GitCommitHashCompilerPass implements CompilerPassInterface
+class GitCommitHashPass implements CompilerPassInterface
 {
     /**
      * @param ContainerBuilder $container
@@ -29,12 +28,8 @@ class GitCommitHashCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $process = new Process('git log -1');
-
-        if (0 !== $process->run()) {
-            throw new \Exception('Git command return wrong exit code');
-        }
-
-        $container->setParameter('git_commit_hash_version_strategy', sha1($process->getOutput()));
+        $process = new Process('git log -1', $container->getParameter('kernel.root_dir'));
+        $process->mustRun();
+        $container->setParameter('git_commit_hash', sha1($process->getOutput()));
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

There is old idea to implement auto versions for assets without external tools like "sed" and so on on build stage. This PR is a _concept_ for get version from latest git commit hash.

I think this strategy will cover most of Symfony deployment cycles. Also there is can be another strategies, like get directory timestamp, tag name and so on.

Usage is simple:

1) Register compiler pass: 

``` php
class AppBundle extends Bundle
{
    public function build(ContainerBuilder $container)
    {
        parent::build($container);
        $container->addCompilerPass(new GitCommitHashCompilerPass());
    }
}
```

2) Create version strategy: 

``` yaml
    assets.version.strategy.gitcommithash:
        class: Symfony\Component\Asset\VersionStrategy\StaticVersionStrategy
        arguments: ["%git_commit_hash_version_strategy%"]
```

3) Set strategy:

``` yaml
    assets:
        version_strategy: assets.version.strategy.gitcommithash
```

If idea will be accepted in general, I will add tests and try to make it more general to reduce number of steps that needed to enable it.
