### PR TITLE
[Bridge/Doctrine] Use better exception in the register mapping pass

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterMappingsPass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterMappingsPass.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass;
 
-use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -175,8 +174,8 @@ abstract class RegisterMappingsPass implements CompilerPassInterface
      *
      * @return string The name of the chain driver service
      *
-     * @throws ParameterNotFoundException if non of the managerParameters has a
-     *                                    non-empty value.
+     * @throws InvalidArgumentException if non of the managerParameters has a
+     *                                  non-empty value.
      */
     protected function getChainDriverServiceName(ContainerBuilder $container)
     {
@@ -203,8 +202,8 @@ abstract class RegisterMappingsPass implements CompilerPassInterface
      *
      * @return string a service definition name
      *
-     * @throws ParameterNotFoundException if none of the managerParameters has a
-     *                                    non-empty value.
+     * @throws InvalidArgumentException if none of the managerParameters has a
+     *                                  non-empty value.
      */
     private function getConfigurationServiceName(ContainerBuilder $container)
     {
@@ -221,7 +220,7 @@ abstract class RegisterMappingsPass implements CompilerPassInterface
      *
      * @return string The name of the active manager.
      *
-     * @throws ParameterNotFoundException If none of the managerParameters is found in the container.
+     * @throws InvalidArgumentException If none of the managerParameters is found in the container.
      */
     private function getManagerName(ContainerBuilder $container)
     {
@@ -234,7 +233,10 @@ abstract class RegisterMappingsPass implements CompilerPassInterface
             }
         }
 
-        throw new ParameterNotFoundException('Could not determine the Doctrine manager. Either Doctrine is not configured or a bundle is misconfigured.');
+        throw new \InvalidArgumentException(sprintf(
+            'Could not find the manager name parameter in the container. Tried the following parameter names: "%s"',
+            implode('", "', $this->managerParameters)
+        ));
     }
 
     /**

--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterMappingsPassTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterMappingsPassTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Symfony\Bridge\Doctrine\Tests\DependencyInjection\CompilerPass;
+
+use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterMappingsPass;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class RegisterMappingsPassTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessageould Could not find the manager name parameter in the container. Tried the following parameter names: "manager.param.one", "manager.param.two"
+     */
+    public function testNoDriverParmeterException()
+    {
+        $container = $this->createBuilder([
+
+        ]);
+        $this->process($container, [
+            'manager.param.one',
+            'manager.param.two',
+        ]);
+    }
+
+    private function process(ContainerBuilder $container, array $managerParamNames)
+    {
+        $pass = new ConcreteMappingsPass(
+            new Definition('\stdClass'),
+            [],
+            $managerParamNames,
+            'some.%s.metadata_driver'
+        );
+
+        $pass->process($container);
+    }
+
+    private function createBuilder()
+    {
+        $container = new ContainerBuilder();
+
+        return $container;
+    }
+}
+
+class ConcreteMappingsPass extends RegisterMappingsPass
+{
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no/yes ? |
| Deprecations? | no |
| Tests pass? | ? |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Current when this mapping pass cannot find (any of) the configured managers the user receives the following exception:

```
[Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException]                                                                              
You have requested a non-existent parameter "Could not determine the Doctrine manager. Either Doctrine is not configured or a bundle is misconfigured.". 
```

Which is misleading and strange.

This PR changes the exception to an `InvalidArgumentException` and provides the following message:

```
[InvalidArgumentException]                                                                                                                     
Could not find the object manager name parameter. Tried: "cmf_routing.dynamic.persistence.orm.manager_name", "doctrine.default_entity_manager"  
```
