### PR TITLE
Updating the error message of an AuthenticationEntryPointInterface

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -203,7 +203,15 @@ class ExceptionListener
             }
         }
 
-        return $this->authenticationEntryPoint->start($request, $authException);
+        $response = $this->authenticationEntryPoint->start($request, $authException);
+
+        if (!$response instanceof Response) {
+            $given = is_object($response) ? get_class($response) : gettype($response);
+
+            throw new \LogicException(sprintf('The %s::start() method must return a Response object (%s returned)', get_class($this->authenticationEntryPoint), $given));
+        }
+
+        return $response;
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ExceptionListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ExceptionListenerTest.php
@@ -65,6 +65,20 @@ class ExceptionListenerTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testExceptionWhenEntryPointReturnsBadValue()
+    {
+        $event = $this->createEvent(new AuthenticationException());
+
+        $entryPoint = $this->getMock('Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface');
+        $entryPoint->expects($this->once())->method('start')->will($this->returnValue('NOT A RESPONSE'));
+
+        $listener = $this->createExceptionListener(null, null, null, $entryPoint);
+        $listener->onKernelException($event);
+        // the exception has been replaced by our LogicException
+        $this->assertInstanceOf('LogicException', $event->getException());
+        $this->assertStringEndsWith('start() method must return a Response object (string returned)', $event->getException()->getMessage());
+    }
+
     /**
      * @dataProvider getAccessDeniedExceptionProvider
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | not necessary |

During a training, we forgot to fill in the `start()` method for an entry point and got a _horrible_ error message. Now, if you mess up `start()`, you get:

![screen shot 2016-04-27 at 12 49 50 pm](https://cloud.githubusercontent.com/assets/121003/14860378/92578e68-0c76-11e6-9fe5-45141fe2ce43.png)

Thanks!
