### PR TITLE
[FrameworkBundle] Fix a typo and add a test to prevent new regressions

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -998,7 +998,7 @@ class FrameworkExtension extends Extension
             $cacheMetadataFactory = new Definition(
                 CacheClassMetadataFactory::class,
                 array(
-                    new Reference('serializer.mapping.class_metadata_factory.inner'),
+                    new Reference('serializer.mapping.cache_class_metadata_factory.inner'),
                     new Reference('cache.pool.serializer'),
                 )
             );

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDumpTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDumpTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+
+/**
+ * Checks that the container compiles correctly when all the bundle features are enabled.
+ */
+class ContainerDumpTest extends WebTestCase
+{
+    public function testContainerCompilationInDebug()
+    {
+        $client = $this->createClient(array('test_case' => 'ContainerDump', 'root_config' => 'config.yml'));
+
+        $this->assertTrue($client->getContainer()->has('serializer'));
+    }
+
+    public function testContainerCompilation()
+    {
+        $client = $this->createClient(array('test_case' => 'ContainerDump', 'root_config' => 'config.yml', 'debug' => false));
+
+        $this->assertTrue($client->getContainer()->has('serializer'));
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerDump/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerDump/bundles.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+
+return array(
+    new FrameworkBundle(),
+    new TestBundle(),
+);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerDump/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerDump/config.yml
@@ -1,0 +1,21 @@
+imports:
+    - { resource: ../config/default.yml }
+
+framework:
+    esi: true
+    ssi: true
+    fragments: true
+    profiler: true
+    router: true
+    session: true
+    request: true
+    templating:
+        enabled: true
+        engines: ['php']
+    assets: true
+    translator: true
+    validation: true
+    serializer: true
+    property_info: true
+    csrf_protection: true
+    form: true


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This fixes a typo introduced in #18630 and adds a new functional test to avoid most regressions in service definitions in the future when features are only available in non-debug mode.

cc @nicolas-grekas 
