### PR TITLE
[HttpFoundation] Added a unique request ID

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -275,6 +275,12 @@ class Request
         $this->basePath = null;
         $this->method = null;
         $this->format = null;
+
+        // if the request doesn't contain a unique ID, generate a random one
+        if (!$this->headers->has('X_REQUEST_ID')) {
+            $uuid = sprintf('%04x%04x-%04x-%04x-%04x-%04x%04x%04x', mt_rand(0, 0xffff), mt_rand(0, 0xffff), mt_rand(0, 0xffff), mt_rand(0, 0x0fff) | 0x4000,  mt_rand(0, 0x3fff) | 0x8000, mt_rand(0, 0xffff), mt_rand(0, 0xffff), mt_rand(0, 0xffff));
+            $this->headers->set('X_REQUEST_ID', $uuid);
+        }
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1824,6 +1824,20 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             array(str_repeat(':', 101)),
         );
     }
+
+    public function testExistingRequestId()
+    {
+        $request = Request::create('/', 'GET', array(), array(), array(), array('HTTP_X_REQUEST_ID' => 'custom-request-id-value'));
+
+        $this->assertEquals('custom-request-id-value', $request->headers->get('X-Request-Id'));
+    }
+
+    public function testGeneratedRequestId()
+    {
+        $request = Request::create('/');
+
+        $this->assertRegexp('/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/', $request->headers->get('X-Request-Id'));
+    }
 }
 
 class RequestContentProxy extends Request


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11573 |
| License | MIT |
| Doc PR | - |

Comments:
- Why is this useful? _"The unique request id can be used to trace a request end-to-end and would typically end up being part of log files from multiple pieces of the stack."_
- In the original issue people were discussing about listeners and integrating external libraries. I propose a much simpler solution (it's so simple that it may be wrong or incomplete)
- RubyOnRails sanitizes any existing request ID ([see code](https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/middleware/request_id.rb)) Should we do the same?
