### PR TITLE
add @Event annotation and description for KernelEvents::FINISH_REQUES…

### DIFF
--- a/src/Symfony/Component/HttpKernel/KernelEvents.php
+++ b/src/Symfony/Component/HttpKernel/KernelEvents.php
@@ -108,6 +108,10 @@ final class KernelEvents
      *
      * This event allows you to reset the global and environmental state of
      * the application, when it was changed during the request.
+     * The event listener method receives a
+     * Symfony\Component\HttpKernel\Event\FinishRequestEvent instance.
+     *
+     * @Event
      *
      * @var string
      */

--- a/src/Symfony/Component/Security/Core/AuthenticationEvents.php
+++ b/src/Symfony/Component/Security/Core/AuthenticationEvents.php
@@ -20,6 +20,8 @@ final class AuthenticationEvents
      * The event listener method receives a
      * Symfony\Component\Security\Core\Event\AuthenticationEvent instance.
      *
+     * @Event
+     * 
      * @var string
      */
     const AUTHENTICATION_SUCCESS = 'security.authentication.success';
@@ -31,6 +33,8 @@ final class AuthenticationEvents
      * The event listener method receives a
      * Symfony\Component\Security\Core\Event\AuthenticationFailureEvent
      * instance.
+     *
+     * @Event
      *
      * @var string
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | 3.0 |
| Bug fix | no |
| New feature | no |
| BC breaks | no |
| Deprecations | no |
| Tests pass | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
#12299 added "@Event" annotations for events. They are now used by PhpStorm Plugin. This adds some missing docs

External issue:
https://github.com/Haehnchen/idea-php-symfony2-plugin/issues/493
