### PR TITLE
[DependencyInjection] Suggest ExpressionLanguage in composer.json

### DIFF
--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -29,6 +29,7 @@
     "suggest": {
         "symfony/yaml": "",
         "symfony/config": "",
+        "symfony/expression-language": "For using expressions in service container configuration",
         "symfony/proxy-manager-bridge": "Generate service proxies to lazy load them"
     },
     "autoload": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

As the DependencyInjection component has lots of classes containing uses of the ExpressionLanguage component, I propose to add it to the composer.json suggests. 
