### PR TITLE
[Routing] Added trim flag to Route::setPath

### DIFF
--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -148,14 +148,15 @@ class Route implements \Serializable
      * This method implements a fluent interface.
      *
      * @param string $pattern The path pattern
+     * @param bool   $trim    whether or not to trim and format the $pattern.
      *
      * @return Route The current Route instance
      */
-    public function setPath($pattern)
+    public function setPath($pattern, $trim = true)
     {
         // A pattern must start with a slash and must not have multiple slashes at the beginning because the
         // generated path for this route would be confused with a network path, e.g. '//domain.com/path'.
-        $this->path = '/'.ltrim(trim($pattern), '/');
+        $this->path = $trim ? '/'.ltrim(trim($pattern), '/') : $pattern;
         $this->compiled = null;
 
         return $this;

--- a/src/Symfony/Component/Routing/Tests/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteTest.php
@@ -236,4 +236,17 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($route, $unserialized);
         $this->assertNotSame($route, $unserialized);
     }
+
+    /**
+     * Tests that the setPath trim flag can be changed to allow non-trimming
+     * of routes.
+     */
+    public function testSetPathTrimFlag()
+    {
+        $route = new Route('/');
+        $path = ' path ';
+        $route->setPath($path, false);
+
+        $this->assertEquals($path, $route->getPath());
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | N/A |

silexphp/silex#149

Added a trim flag to the Route setPath. This replaces #18701 

Signed-off-by: RJ Garcia rj@bighead.net
