### PR TITLE
[WebProfilerBundle] Clickable url in result list

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/results.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/results.html.twig
@@ -48,7 +48,11 @@
                             {% endif %}
                         </td>
                         <td class="break-long-words">
-                            {{ result.url }}
+                            {% if result.method|upper in ['GET', 'HEAD'] %}
+                                <a href="{{ result.url }}">{{ result.url }}</a>
+                            {% else %}
+                                {{ result.url }}
+                            {% endif %}
                             {% if request.session is not null %}
                                 <a href="{{ path('_profiler_search_results', request.query.all|merge({'url': result.url, 'token': result.token})) }}" title="Search">
                                     <span title="Search" class="sf-icon sf-search">{{ include('@WebProfiler/Icon/search.svg') }}</span>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | – |
| License | MIT |
| Doc PR | – |

URLs in WebProfiler result list are clickable, if request method is `GET` or `HEAD` (like in summary part of header).
![webprofiler](https://cloud.githubusercontent.com/assets/1418898/15014101/3bb63c06-1204-11e6-9129-9c10a32fc45c.png)
