### PR TITLE
added a conflict between Monolog bridge 2.8 and HTTP Kernel 3.0+

### DIFF
--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -24,6 +24,9 @@
         "symfony/console": "~2.4|~3.0.0",
         "symfony/event-dispatcher": "~2.2|~3.0.0"
     },
+    "conflict": {
+        "symfony/http-kernel": ">=3.0"
+    },
     "suggest": {
         "symfony/http-kernel": "For using the debugging handlers together with the response life cycle of the HTTP kernel.",
         "symfony/console": "For the possibility to show log messages in console commands depending on verbosity settings. You need version ~2.3 of the console for it.",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Monolog Bridge 2.8 cannot be used with HTTP Kernel 3.0 as the LoggerInterface is not defined anymore. That's a problem for the Silex Skeleton for instance.
