### PR TITLE
[EventDispatcher] fix tests

### DIFF
--- a/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
@@ -73,16 +73,6 @@ class TraceableEventDispatcherTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(123, $tdispatcher->getListenerPriority('foo', $listeners[0]));
     }
 
-    public function testGetListenerPriorityReturnsZeroWhenWrappedMethodDoesNotExist()
-    {
-        $dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
-        $traceableEventDispatcher = new TraceableEventDispatcher($dispatcher, new Stopwatch());
-        $traceableEventDispatcher->addListener('foo', function () {}, 123);
-        $listeners = $traceableEventDispatcher->getListeners('foo');
-
-        $this->assertSame(0, $traceableEventDispatcher->getListenerPriority('foo', $listeners[0]));
-    }
-
     public function testAddRemoveSubscriber()
     {
         $dispatcher = new EventDispatcher();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.0 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The `getListenerPriority()` method was added to the event dispatcher
interface in Symfony 3.0. Thus, it no longer makes sense to have a test
that expects the method not to exist (the corresponding code in the
`TraceableEventDispatcher` was already removed in 576a55c.
