### PR TITLE
[FrameworkBundle] Default to Apcu+Filesystem cache chain

### DIFF
--- a/UPGRADE-3.1.md
+++ b/UPGRADE-3.1.md
@@ -93,25 +93,8 @@ FrameworkBundle
    cache service. If you are using `serializer.mapping.cache.apc`, use
    `serializer.mapping.cache.doctrine.apc` instead.
 
- * The `framework.serializer.cache` option has been deprecated. Configure the
-   `cache.serializer` service under `framework.cache.pools` instead.
-
-   Before:
-
-   ```yaml
-   framework:
-       serializer:
-           cache: serializer.mapping.cache.apc
-   ```
-
-   After:
-
-   ```yaml
-   framework:
-       cache:
-           pools:
-               cache.serializer:
-                   adapter: cache.adapter.apcu
+ * The `framework.serializer.cache` option has been deprecated. APCu should now
+   be automatically used when available so you can remove this configuration key.
 
 HttpKernel
 ----------

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -80,26 +80,8 @@ FrameworkBundle
  * The service `serializer.mapping.cache.apc` has been removed; use
    `serializer.mapping.cache.doctrine.apc` instead.
 
- * The `framework.serializer.cache` option has been removed. Configure the
-   `cache.serializer` service under `framework.cache.pools` instead.
-
-   Before:
-
-   ```yaml
-   framework:
-       serializer:
-           cache: serializer.mapping.cache.apc
-   ```
-
-   After:
-
-   ```yaml
-   framework:
-       cache:
-           pools:
-               cache.serializer:
-                   adapter: cache.adapter.apcu
-   ```
+ * The `framework.serializer.cache` option has been removed. APCu should now
+   be automatically used when available so you can remove this configuration key.
 
 HttpKernel
 ----------

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -564,7 +564,7 @@ class Configuration implements ConfigurationInterface
                         ->end()
                         ->scalarNode('system')
                             ->info('System related cache pools configuration')
-                            ->defaultValue('cache.adapter.filesystem')
+                            ->defaultValue('cache.adapter.system')
                         ->end()
                         ->scalarNode('directory')->defaultValue('%kernel.cache_dir%/pools')->end()
                         ->scalarNode('default_doctrine_provider')->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1039,6 +1039,7 @@ class FrameworkExtension extends Extension
     {
         $nonce = substr(str_replace('/', '-', base64_encode(md5(uniqid(mt_rand(), true), true))), 0, -2);
         $container->getDefinition('cache.adapter.apcu')->replaceArgument(2, $nonce);
+        $container->getDefinition('cache.adapter.system')->replaceArgument(2, $nonce);
         $container->getDefinition('cache.adapter.filesystem')->replaceArgument(2, $config['directory']);
 
         foreach (array('doctrine', 'psr6', 'redis') as $name) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.xml
@@ -10,7 +10,7 @@
             <tag name="cache.pool" />
         </service>
 
-        <service id="cache.system" parent="cache.adapter.filesystem">
+        <service id="cache.system" parent="cache.adapter.system">
             <tag name="cache.pool" />
         </service>
 
@@ -20,6 +20,17 @@
 
         <service id="cache.serializer" parent="cache.system" public="false">
             <tag name="cache.pool" />
+        </service>
+
+        <service id="cache.adapter.system" class="Symfony\Component\Cache\Adapter\AdapterInterface" abstract="true">
+            <factory class="Symfony\Component\Cache\Adapter\AbstractAdapter" method="createSystemCache" />
+            <tag name="cache.pool" clearer="cache.default_clearer" />
+            <tag name="monolog.logger" channel="cache" />
+            <argument /> <!-- namespace -->
+            <argument /> <!-- default lifetime -->
+            <argument /> <!-- nonce -->
+            <argument>%kernel.cache_dir%/pools</argument>
+            <argument type="service" id="logger" on-invalid="ignore" />
         </service>
 
         <service id="cache.adapter.apcu" class="Symfony\Component\Cache\Adapter\ApcuAdapter" abstract="true">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -269,7 +269,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             'cache' => array(
                 'pools' => array(),
                 'app' => 'cache.adapter.filesystem',
-                'system' => 'cache.adapter.filesystem',
+                'system' => 'cache.adapter.system',
                 'directory' => '%kernel.cache_dir%/pools',
                 'default_redis_provider' => 'redis://localhost',
             ),

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension;
 use Symfony\Component\Cache\Adapter\ApcuAdapter;
+use Symfony\Component\Cache\Adapter\ChainAdapter;
 use Symfony\Component\Cache\Adapter\DoctrineAdapter;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\ProxyAdapter;
@@ -728,6 +729,9 @@ abstract class FrameworkExtensionTest extends TestCase
                 $this->assertSame(DoctrineAdapter::class, $parentDefinition->getClass());
                 break;
             case 'cache.app':
+                if (ChainAdapter::class === $parentDefinition->getClass()) {
+                    break;
+                }
             case 'cache.adapter.filesystem':
                 $this->assertSame(FilesystemAdapter::class, $parentDefinition->getClass());
                 break;

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -58,6 +58,7 @@
         "phpdocumentor/reflection-docblock": "<3.0"
     },
     "suggest": {
+        "ext-apcu": "For best performance of the system caches",
         "symfony/console": "For using the console commands",
         "symfony/form": "For using forms",
         "symfony/serializer": "For using the serializer service",

--- a/src/Symfony/Component/Cache/Adapter/ApcuAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ApcuAdapter.php
@@ -19,9 +19,14 @@ use Symfony\Component\Cache\Exception\CacheException;
  */
 class ApcuAdapter extends AbstractAdapter
 {
+    public static function isSupported()
+    {
+        return function_exists('apcu_fetch') && ini_get('apc.enabled') && !('cli' === PHP_SAPI && !ini_get('apc.enable_cli'));
+    }
+
     public function __construct($namespace = '', $defaultLifetime = 0, $nonce = null)
     {
-        if (!function_exists('apcu_fetch') || !ini_get('apc.enabled') || ('cli' === PHP_SAPI && !ini_get('apc.enable_cli'))) {
+        if (!static::isSupported()) {
             throw new CacheException('APCu is not enabled');
         }
         if ('cli' === PHP_SAPI) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | yes (perf) |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

In #16838, @dunglas benched that the filesystem cache is not the fastest one (not a surprise).
Yet, it is the default for now. I propose to replace this default by a dynamically created one that uses APCu when available (of course, we cannot do the check at container-build time), chained with the filesystem.

The benefit is double: APCu is automatically used when available without any configuration, and cache warming up is seeded by the filesystem cache so that the apcu cache can benefit from it.
