### PR TITLE
[OptionsResolver] Fixed readme

### DIFF
--- a/src/Symfony/Component/OptionsResolver/README.md
+++ b/src/Symfony/Component/OptionsResolver/README.md
@@ -1,7 +1,7 @@
 OptionsResolver Component
 =========================
 
-The OptionsResolver component is `array_replace on steroids. It allows you to
+The OptionsResolver component is `array_replace` on steroids. It allows you to
 create an options system with required options, defaults, validation (type,
 value), normalization and more.
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.3 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This PR fix bad markdown syntax in readme file of OptionsResolver component.
