### PR TITLE
[PhpUnitBridge] Make ClockMock match namespaces that begin with Tests\\

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/ClockMock.php
+++ b/src/Symfony/Bridge/PhpUnit/ClockMock.php
@@ -74,9 +74,11 @@ class ClockMock
         $self = get_called_class();
 
         $mockedNs = array(substr($class, 0, strrpos($class, '\\')));
-        if (strpos($class, '\\Tests\\')) {
+        if (false !== strpos($class, '\\Tests\\')) {
             $ns = str_replace('\\Tests\\', '\\', $class);
             $mockedNs[] = substr($ns, 0, strrpos($ns, '\\'));
+        } elseif (0 === strpos($class, 'Tests\\')) {
+            $mockedNs[] = substr($class, 6, strrpos($class, '\\') - 6);
         }
         foreach ($mockedNs as $ns) {
             if (function_exists($ns.'\time')) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | yes? |
| New feature? | no |
| BC breaks? | no? |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | symfony/symfony-docs#6546 |

See symfony/symfony-standard#969
