### PR TITLE
[2.3][Component/Security] Fixed phpdoc in AnonymousToken constructor for user param

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Token/AnonymousToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AnonymousToken.php
@@ -26,7 +26,7 @@ class AnonymousToken extends AbstractToken
      * Constructor.
      *
      * @param string          $key   The key shared with the authentication provider
-     * @param string          $user  The user
+     * @param string|object   $user  The user
      * @param RoleInterface[] $roles An array of roles
      */
     public function __construct($key, $user, array $roles = array())

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AnonymousToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AnonymousToken.php
@@ -26,7 +26,7 @@ class AnonymousToken extends AbstractToken
      * Constructor.
      *
      * @param string          $key   The key shared with the authentication provider
-     * @param string|object   $user  The user
+     * @param string|object   $user  The user can be a UserInterface instance, or an object implementing a __toString method or the username as a regular string.
      * @param RoleInterface[] $roles An array of roles
      */
     public function __construct($key, $user, array $roles = array())

--- a/src/Symfony/Component/Security/Core/Authentication/Token/PreAuthenticatedToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/PreAuthenticatedToken.php
@@ -26,7 +26,7 @@ class PreAuthenticatedToken extends AbstractToken
     /**
      * Constructor.
      *
-     * @param string|object            $user        The user
+     * @param string|object            $user        The user can be a UserInterface instance, or an object implementing a __toString method or the username as a regular string.
      * @param mixed                    $credentials The user credentials
      * @param string                   $providerKey The provider key
      * @param RoleInterface[]|string[] $roles       An array of roles


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.3 |
| Bug fix? | yes, phpdoc one |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Updated phpdoc of AnonymousToken $user param from string to string|object since an object is allowed to in the parent AbstractToken: https://github.com/symfony/symfony/blob/2.3/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php#L91
