### PR TITLE
deprecate get() for uncompiled container builders

### DIFF
--- a/UPGRADE-3.2.md
+++ b/UPGRADE-3.2.md
@@ -1,0 +1,8 @@
+UPGRADE FROM 3.1 to 3.2
+=======================
+
+DependencyInjection
+-------------------
+
+ * Calling `get()` on a `ContainerBuilder` instance before compiling the
+   container is deprecated and will throw an exception in Symfony 4.0.

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -4,6 +4,9 @@ UPGRADE FROM 3.x to 4.0
 DependencyInjection
 -------------------
 
+ * Calling `get()` on a `ContainerBuilder` instance before compiling the
+   container is not supported anymore and will throw an exception.
+
  * Using unsupported configuration keys in YAML configuration files raises an
    exception.
 

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/ContainerBuilderTest.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/ContainerBuilderTest.php
@@ -33,6 +33,8 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $builder->register('foo1', 'ProxyManagerBridgeFooClass')->setFile(__DIR__.'/Fixtures/includes/foo.php');
         $builder->getDefinition('foo1')->setLazy(true);
 
+        $builder->compile();
+
         /* @var $foo1 \ProxyManager\Proxy\LazyLoadingInterface|\ProxyManager\Proxy\ValueHolderInterface */
         $foo1 = $builder->get('foo1');
 

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -256,6 +256,10 @@ abstract class Descriptor implements DescriptorInterface
             return $builder->getAlias($serviceId);
         }
 
+        if ('service_container' === $serviceId) {
+            return $builder;
+        }
+
         // the service has been injected in some special way, just return the service
         return $builder->get($serviceId);
     }

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
@@ -96,11 +96,11 @@ class WebProfilerExtensionTest extends TestCase
 
         $this->assertSame($listenerInjected, $this->container->has('web_profiler.debug_toolbar'));
 
+        $this->assertSaneContainer($this->getDumpedContainer());
+
         if ($listenerInjected) {
             $this->assertSame($listenerEnabled, $this->container->get('web_profiler.debug_toolbar')->isEnabled());
         }
-
-        $this->assertSaneContainer($this->getDumpedContainer());
     }
 
     public function getDebugModes()

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -412,7 +412,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     public function get($id, $invalidBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE)
     {
         if (!$this->compiled) {
-            @trigger_error(sprintf('Calling %s before compiling the container is deprecated since version 3.2 and will throw an exception in 4.0.', __METHOD__), E_USER_DEPRECATED);
+            @trigger_error(sprintf('Calling %s() before compiling the container is deprecated since version 3.2 and will throw an exception in 4.0.', __METHOD__), E_USER_DEPRECATED);
         }
 
         $id = strtolower($id);

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -94,6 +94,8 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      */
     private $usedTags = array();
 
+    private $compiled = false;
+
     /**
      * Sets the track resources flag.
      *
@@ -409,6 +411,10 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      */
     public function get($id, $invalidBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE)
     {
+        if (!$this->compiled) {
+            @trigger_error(sprintf('Calling %s before compiling the container is deprecated since version 3.2 and will throw an exception in 4.0.', __METHOD__), E_USER_DEPRECATED);
+        }
+
         $id = strtolower($id);
 
         if ($service = parent::get($id, ContainerInterface::NULL_ON_INVALID_REFERENCE)) {
@@ -543,6 +549,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         }
 
         $compiler->compile($this);
+        $this->compiled = true;
 
         if ($this->trackResources) {
             foreach ($this->definitions as $definition) {

--- a/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
@@ -180,14 +180,17 @@ class GraphvizDumper extends Dumper
         }
 
         foreach ($container->getServiceIds() as $id) {
-            $service = $container->get($id);
-
             if (array_key_exists($id, $container->getAliases())) {
                 continue;
             }
 
             if (!$container->hasDefinition($id)) {
-                $class = ('service_container' === $id) ? get_class($this->container) : get_class($service);
+                if ('service_container' === $id) {
+                    $class = get_class($this->container);
+                } else {
+                    $class = get_class($container->get($id));
+                }
+
                 $nodes[$id] = array('class' => str_replace('\\', '\\\\', $class), 'attributes' => $this->options['node.instance']);
             }
         }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutoAliasServicePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutoAliasServicePassTest.php
@@ -57,7 +57,6 @@ class AutoAliasServicePassTest extends \PHPUnit_Framework_TestCase
         $pass->process($container);
 
         $this->assertEquals('Symfony\Component\DependencyInjection\Tests\Compiler\ServiceClassDefault', $container->getDefinition('example')->getClass());
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Tests\Compiler\ServiceClassDefault', $container->get('example'));
     }
 
     public function testProcessWithExistingAlias()
@@ -75,7 +74,7 @@ class AutoAliasServicePassTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($container->hasAlias('example'));
         $this->assertEquals('mysql.example', $container->getAlias('example'));
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Tests\Compiler\ServiceClassMysql', $container->get('example'));
+        $this->assertSame('Symfony\Component\DependencyInjection\Tests\Compiler\ServiceClassMysql', $container->getDefinition('mysql.example')->getClass());
     }
 
     public function testProcessWithManualAlias()
@@ -86,7 +85,7 @@ class AutoAliasServicePassTest extends \PHPUnit_Framework_TestCase
           ->addTag('auto_alias', array('format' => '%existing%.example'));
 
         $container->register('mysql.example', 'Symfony\Component\DependencyInjection\Tests\Compiler\ServiceClassMysql');
-        $container->register('mariadb.example', 'Symfony\Component\DependencyInjection\Tests\Compiler\ServiceClassMariadb');
+        $container->register('mariadb.example', 'Symfony\Component\DependencyInjection\Tests\Compiler\ServiceClassMariaDb');
         $container->setAlias('example', 'mariadb.example');
         $container->setParameter('existing', 'mysql');
 
@@ -95,7 +94,7 @@ class AutoAliasServicePassTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($container->hasAlias('example'));
         $this->assertEquals('mariadb.example', $container->getAlias('example'));
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Tests\Compiler\ServiceClassMariaDb', $container->get('example'));
+        $this->assertSame('Symfony\Component\DependencyInjection\Tests\Compiler\ServiceClassMariaDb', $container->getDefinition('mariadb.example')->getClass());
     }
 }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.2 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/issues/18673#issuecomment-216183042 |
| License | MIT |
| Doc PR |  |
