### PR TITLE
[FrameworkBundle] prevent calling get() for service_container service

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -274,6 +274,10 @@ abstract class Descriptor implements DescriptorInterface
             return $builder->getAlias($serviceId);
         }
 
+        if ('service_container' === $serviceId) {
+            return $builder;
+        }
+
         // the service has been injected in some special way, just return the service
         return $builder->get($serviceId);
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This change will simply fix the tests once #18728 gets merged. An alternative approach would be to compile the container so that the code would still work even for services that have been set directly using `set()`. However, compiling the container in a descriptor imo is an unexpected side effect which I tried to avoid here.
