### PR TITLE
[PropertyAccess][DX] Enhance exception that say that some methods are missing if they don't

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -722,7 +722,7 @@ class PropertyAccessor implements PropertyAccessorInterface
                         '"%s" given.',
                         $property,
                         $reflClass->name,
-                        implode(' and ', array_map(function($method){
+                        implode(' and ', array_map(function ($method) {
                             return '"'.$method.'()"';
                         }, $this->findAdderAndRemover($reflClass, $singulars))),
                         is_object($value) ? get_class($value) : gettype($value)

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -714,6 +714,19 @@ class PropertyAccessor implements PropertyAccessorInterface
                     // we call the getter and hope the __call do the job
                     $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_MAGIC;
                     $access[self::ACCESS_NAME] = $setter;
+                } elseif (null !== $this->findAdderAndRemover($reflClass, $singulars)) {
+                    $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_NOT_FOUND;
+                    $access[self::ACCESS_NAME] = sprintf(
+                        'The property "%s" in class "%s" can be defined with the methods %s but '.
+                        'the new value must be an array or an instance of \Traversable, '.
+                        '"%s" given.',
+                        $property,
+                        $reflClass->name,
+                        implode(' and ', array_map(function($method){
+                            return '"'.$method.'()"';
+                        }, $this->findAdderAndRemover($reflClass, $singulars))),
+                        is_object($value) ? get_class($value) : gettype($value)
+                    );
                 } else {
                     $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_NOT_FOUND;
                     $access[self::ACCESS_NAME] = sprintf(

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -714,17 +714,15 @@ class PropertyAccessor implements PropertyAccessorInterface
                     // we call the getter and hope the __call do the job
                     $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_MAGIC;
                     $access[self::ACCESS_NAME] = $setter;
-                } elseif (null !== $this->findAdderAndRemover($reflClass, $singulars)) {
+                } elseif (null !== $methods = $this->findAdderAndRemover($reflClass, $singulars)) {
                     $access[self::ACCESS_TYPE] = self::ACCESS_TYPE_NOT_FOUND;
                     $access[self::ACCESS_NAME] = sprintf(
-                        'The property "%s" in class "%s" can be defined with the methods %s but '.
+                        'The property "%s" in class "%s" can be defined with the methods "%s()" but '.
                         'the new value must be an array or an instance of \Traversable, '.
                         '"%s" given.',
                         $property,
                         $reflClass->name,
-                        implode(' and ', array_map(function ($method) {
-                            return '"'.$method.'()"';
-                        }, $this->findAdderAndRemover($reflClass, $singulars))),
+                        implode('()", "', $methods),
                         is_object($value) ? get_class($value) : gettype($value)
                     );
                 } else {

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTest.php
@@ -197,7 +197,7 @@ abstract class PropertyAccessorCollectionTest extends PropertyAccessorArrayAcces
 
     /**
      * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
-     * expectedExceptionMessageRegExp /The property "axes" in class "Mock_PropertyAccessorCollectionTest_Car[^"]*" can be defined with the methods "addAxis()" and "removeAxis()" but the new value must be an array or an instance of \Traversable, "string" given./
+     * expectedExceptionMessageRegExp /The property "axes" in class "Mock_PropertyAccessorCollectionTest_Car[^"]*" can be defined with the methods "addAxis()", "removeAxis()" but the new value must be an array or an instance of \Traversable, "string" given./
      */
     public function testSetValueFailsIfAdderAndRemoverExistButValueIsNotTraversable()
     {

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTest.php
@@ -194,7 +194,7 @@ abstract class PropertyAccessorCollectionTest extends PropertyAccessorArrayAcces
 
         $this->assertFalse($this->propertyAccessor->isWritable($car, 'axes', $axes));
     }
-    
+
     /**
      * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
      * expectedExceptionMessageRegExp /The property "axes" in class "Mock_PropertyAccessorCollectionTest_Car[^"]*" can be defined with the methods "addAxis()" and "removeAxis()" but the new value must be an array or an instance of \Traversable, "string" given./
@@ -202,7 +202,7 @@ abstract class PropertyAccessorCollectionTest extends PropertyAccessorArrayAcces
     public function testSetValueFailsIfAdderAndRemoverExistButValueIsNotTraversable()
     {
         $car = $this->getMock(__CLASS__.'_Car');
-        
+
         $this->propertyAccessor->setValue($car, 'axes', 'Not an array or Traversable');
     }
 }

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTest.php
@@ -194,4 +194,15 @@ abstract class PropertyAccessorCollectionTest extends PropertyAccessorArrayAcces
 
         $this->assertFalse($this->propertyAccessor->isWritable($car, 'axes', $axes));
     }
+    
+    /**
+     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
+     * expectedExceptionMessageRegExp /The property "axes" in class "Mock_PropertyAccessorCollectionTest_Car[^"]*" can be defined with the methods "addAxis()" and "removeAxis()" but the new value must be an array or an instance of \Traversable, "string" given./
+     */
+    public function testSetValueFailsIfAdderAndRemoverExistButValueIsNotTraversable()
+    {
+        $car = $this->getMock(__CLASS__.'_Car');
+        
+        $this->propertyAccessor->setValue($car, 'axes', 'Not an array or Traversable');
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18694 |
| License | MIT |
| Doc PR |  |

When you try do define a manyToMany association but you don't give an array or \Traversable, the raised exception say that some methods are missing while they don't. This PR check if the adder and setter methods exists and if so, give a exception that pointing on the real problem.
