### PR TITLE
Release v2.8.6

### DIFF
--- a/CHANGELOG-2.8.md
+++ b/CHANGELOG-2.8.md
@@ -7,6 +7,18 @@ in 2.8 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.8.0...v2.8.1
 
+* 2.8.6 (2016-05-09)
+
+ * security #18736 Fixed issue with blank password with Ldap (csarrazi)
+ * security #18733 limited the maximum length of a submitted username (fabpot)
+ * bug #18730 [FrameworkBundle] prevent calling get() for service_container service (xabbuh)
+ * bug #18705 added a conflict between Monolog bridge 2.8 and HTTP Kernel 3.0+ (fabpot)
+ * bug #18709 [DependencyInjection] top-level anonymous services must be public (xabbuh)
+ * bug #18388 [EventDispatcher] check for method to exist (xabbuh)
+ * bug #18699 [DependencyInjection] Use the priority of service decoration on service with parent (hason)
+ * bug #18692 add @Event annotation for KernelEvents (Haehnchen)
+ * bug #18246 [DependencyInjection] fix ambiguous services schema (backbone87)
+
 * 2.8.5 (2016-04-29)
 
  * bug #18180 [Form] fixed BC break with pre selection of choices with `ChoiceType` and its children (HeahDude)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -59,12 +59,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '2.8.6-DEV';
+    const VERSION = '2.8.6';
     const VERSION_ID = 20806;
     const MAJOR_VERSION = 2;
     const MINOR_VERSION = 8;
     const RELEASE_VERSION = 6;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '11/2018';
     const END_OF_LIFE = '11/2019';


### PR DESCRIPTION
Changes since last release: https://github.com/symfony/symfony/compare/v2.8.5...6d3b1e2

**Changelog**
- security #18736 Fixed issue with blank password with Ldap (@csarrazi)
- security #18733 limited the maximum length of a submitted username (@fabpot)
- bug #18730 [FrameworkBundle] prevent calling get() for service_container service (@xabbuh)
- bug #18705 added a conflict between Monolog bridge 2.8 and HTTP Kernel 3.0+ (@fabpot)
- bug #18709 [DependencyInjection] top-level anonymous services must be public (@xabbuh)
- bug #18388 [EventDispatcher] check for method to exist (@xabbuh)
- bug #18699 [DependencyInjection] Use the priority of service decoration on service with parent (@hason)
- bug #18692 add @Event annotation for KernelEvents (@Haehnchen)
- bug #18246 [DependencyInjection] fix ambiguous services schema (@backbone87)
