### PR TITLE
[MonologBridge] Uninstallable together with symfony/http-kernel in 3.0.6

### DIFF
--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -24,9 +24,6 @@
         "symfony/console": "~2.8|~3.0",
         "symfony/event-dispatcher": "~2.8|~3.0"
     },
-    "conflict": {
-        "symfony/http-kernel": ">=3.0"
-    },
     "suggest": {
         "symfony/http-kernel": "For using the debugging handlers together with the response life cycle of the HTTP kernel.",
         "symfony/console": "For the possibility to show log messages in console commands depending on verbosity settings. You need version ~2.3 of the console for it.",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.0 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Caused by #18705, it is impossible to install v3.0.6 of symfony/monolog-bridge
together with v3.0.6 of symfony/http-kernel.

The intention of #18705 "added a conflict between Monolog bridge 2.8 and
HTTP Kernel 3.0+" was to prevent installing symfony/monolog-bridge from the
3.0 series with http-kernel from the 2.8 series of symfony. While this now
works correctly in v2.8.6, it breaks installing symfony/monolog-bridge v3.0.6
with symfony/http-kernel v3.0.6.

This PR resolves this issue.
# How to reproduce
- Create a test directory and change into it - e.g. with `mkdir /tmp/reproduce-symfony-18745 && cd /tmp/reproduce-symfony-18745`
- Add the following composer.json to this test directory

```
{
   "require": {
     "symfony/monolog-bridge": "3.0.6",
     "symfony/http-kernel": "3.0.6"
  }
}
```
- Run `composer install` from the test directory
## Expected behavior

Composer installs symfony/monolog-bridge and symfony/http-kernel (together with their dependencies).
## Actual behavior

Composer fails with the following error messages:

```
#:/tmp/reproduce-symfony-18745$ composer install
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for symfony/monolog-bridge 3.0.6 -> satisfiable by symfony/monolog-bridge[v3.0.6].
    - symfony/http-kernel v3.0.6 conflicts with symfony/monolog-bridge[v3.0.6].
    - Installation request for symfony/http-kernel 3.0.6 -> satisfiable by symfony/http-kernel[v3.0.6].
```
