### PR TITLE
[2.8] [Form] Modified iterator_to_array's 2nd parameter to false in ViolationMapper

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapper.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapper.php
@@ -162,9 +162,7 @@ class ViolationMapper implements ViolationMapperInterface
             }
         }
 
-        $children = iterator_to_array(new \RecursiveIteratorIterator(
-            new InheritDataAwareIterator($form)
-        ));
+        $children = iterator_to_array(new \RecursiveIteratorIterator(new InheritDataAwareIterator($form)), false);
 
         while ($it->valid()) {
             if ($it->isIndex()) {
@@ -189,7 +187,7 @@ class ViolationMapper implements ViolationMapperInterface
             }
 
             /** @var FormInterface $child */
-            foreach ($children as $key => $child) {
+            foreach ($children as $i => $child) {
                 $childPath = (string) $child->getPropertyPath();
                 if ($childPath === $chunk) {
                     $target = $child;
@@ -198,7 +196,7 @@ class ViolationMapper implements ViolationMapperInterface
                     continue;
                 }
 
-                unset($children[$key]);
+                unset($children[$i]);
             }
 
             $it->next();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This bug was introduced in PR #17099. So does not represent in 2.8.2 or older.

If we have the following structure form:

``` php
$builder = $formFactory->createBuilder();

$form = $builder
    ->add(
        $builder->create('person1_name', FormType::class, ['inherit_data' => true])
            ->add('first', TextType::class, ['property_path' => '[person1_first_name]'])
            ->add('last', TextType::class, ['property_path' => '[person1_last_name]'])
    )
    ->add(
        $builder->create('person2_name', FormType::class, ['inherit_data' => true])
            ->add('first', TextType::class, ['property_path' => '[person2_first_name]'])
            ->add('last', TextType::class, ['property_path' => '[person2_last_name]'])
    )
    ->getForm()
;
```

The following mapping for this form doesn't work correctly:

``` php
$mapper = new ViolationMapper();
$mapper->mapViolation(new ConstraintViolation('', '', [], null, 'data[person1_first_name]', null), $form);

$form['person1_name']['first']->getErrors(); // empty
$form->getErrors(); // The violation is mapped to here instead.
```
## Cause

Because ViolationMapper uses `iterator_to_array` in [here](https://github.com/symfony/symfony/blob/f29d46f29b91ea5c30699cf6bdb8e65545d1dd26/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapper.php#L165) to collect the sub forms.

`person1_name` and `person2_name` enable `inherit_data` option. So ViolationMapper will attempt to collect the sub forms of root form like this:

``` php
[
    'first' => Form object, // root.person1_name.first
    'last'  => Form object, // root.person1_name.last
    'first' => Form object, // root.person2_name.first
    'last'  => Form object, // root.person2_name.last
]
```

As you can see, The name `first` and `last` are used in two places, thus we cannot get result like that.
(first/last of person1_name are overwritten by person2_name's)

So the violation will finally lost the form where it should map to. It should pass `false` to `iterator_to_array`'s 2nd parameter.
