### PR TITLE
[Component] [Validator] Support for DateTimeImmutable

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
@@ -31,7 +31,7 @@ class DateTimeValidator extends DateValidator
             throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\DateTime');
         }
 
-        if (null === $value || '' === $value || $value instanceof \DateTime) {
+        if (null === $value || '' === $value || $value instanceof \DateTimeInterface) {
             return;
         }
 

--- a/src/Symfony/Component/Validator/Constraints/DateValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateValidator.php
@@ -48,7 +48,7 @@ class DateValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Date');
         }
 
-        if (null === $value || '' === $value || $value instanceof \DateTime) {
+        if (null === $value || '' === $value || $value instanceof \DateTimeInterface) {
             return;
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | no |
| New feature? | yes/no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

When validating with DateTime constraint UnexpectedTypeException is thrown for DateTimeImmutable instances.
- DateTimeImmutable behaves like a DateTime. Both implements the same interface DateTimeInterface.
- DateTimeInterface cannot be implemented by the client.
