### PR TITLE
[Validator] Replaced usage of `new \DateTime()` by `date_create()`

### DIFF
--- a/src/Symfony/Component/Validator/ConstraintValidator.php
+++ b/src/Symfony/Component/Validator/ConstraintValidator.php
@@ -119,7 +119,7 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
      * (i.e. "false" for false, "1" for 1 etc.). Strings are always wrapped
      * in double quotes ("). Objects, arrays and resources are formatted as
      * "object", "array" and "resource". If the $format bitmask contains
-     * the PRETTY_DATE bit, then {@link \DateTime} objects will be formatted 
+     * the PRETTY_DATE bit, then {@link \DateTime} objects will be formatted
      * as RFC-3339 dates ("Y-m-d H:i:s").
      *
      * Be careful when passing message parameters to a constraint violation
@@ -146,7 +146,7 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
                 // neither the native nor the stub IntlDateFormatter support
                 // DateTimeImmutable as of yet
                 if (!$value instanceof \DateTime) {
-                    $value = new \DateTime(
+                    $value = date_create(
                         $value->format('Y-m-d H:i:s.u e'),
                         $value->getTimezone()
                     );

--- a/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
@@ -44,13 +44,13 @@ abstract class AbstractComparisonValidator extends ConstraintValidator
         // the DateTime constructor:
         // http://php.net/manual/en/datetime.formats.php
         if (is_string($comparedValue)) {
-            if ($value instanceof \DatetimeImmutable) {
+            if ($value instanceof \DateTimeImmutable) {
                 // If $value is immutable, convert the compared value to a
                 // DateTimeImmutable too
-                $comparedValue = new \DatetimeImmutable($comparedValue);
+                $comparedValue = new \DateTimeImmutable($comparedValue);
             } elseif ($value instanceof \DateTime || $value instanceof \DateTimeInterface) {
                 // Otherwise use DateTime
-                $comparedValue = new \DateTime($comparedValue);
+                $comparedValue = date_create($comparedValue);
             }
         }
 

--- a/src/Symfony/Component/Validator/Constraints/RangeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/RangeValidator.php
@@ -59,11 +59,11 @@ class RangeValidator extends ConstraintValidator
         // http://php.net/manual/en/datetime.formats.php
         if ($value instanceof \DateTime || $value instanceof \DateTimeInterface) {
             if (is_string($min)) {
-                $min = new \DateTime($min);
+                $min = date_create($min);
             }
 
             if (is_string($max)) {
-                $max = new \DateTime($max);
+                $max = date_create($max);
             }
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

It is impossible to override `new \DateTime()` in functional tests. And it is sometimes necessary with planning projects.
I purpose to use `date_create()` function to add the possibility to mock like that (inspired of ClockMock):

``` php
<?php

namespace AppBundle\PhpUnit;

class DateMock
{
    private static $now;

    public static function withDateMock($date = false)
    {
        self::$now = $date ? new \DateTime($date) : false;
    }

    public static function dateCreate($time, \DateTimeZone $timezone = null)
    {
        if (!self::$now) {
            return \date_create($time, $timezone);
        }

        $date = clone self::$now;
        if ($timezone) {
            $date->setTimeZone($timezone);
        }

        return $date->modify($time);
    }

    public static function register($ns)
    {
        if (function_exists($ns.'\date_create')) {
            return;
        }

        eval(<<<EOPHP
namespace $ns;
function date_create(\$time, \DateTimeZone \$timezone = null)
{
    return \\$self::dateCreate(\$time, \$timezone);
}
EOPHP
            );
    }
}
```

Followed by this usage:

``` php
<?php
DateMock::regiter('Symfony\Component\Validator\Constraints');
DateMock::withDateMock('2012-03-01 03:23:29');
```
