### PR TITLE
[Validator] Support for DateTimeImmutable

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
@@ -30,7 +30,7 @@ class DateTimeValidator extends DateValidator
             throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\DateTime');
         }
 
-        if (null === $value || '' === $value || $value instanceof \DateTime) {
+        if (null === $value || '' === $value || $value instanceof \DateTimeInterface) {
             return;
         }
 

--- a/src/Symfony/Component/Validator/Constraints/DateValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateValidator.php
@@ -47,7 +47,7 @@ class DateValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Date');
         }
 
-        if (null === $value || '' === $value || $value instanceof \DateTime) {
+        if (null === $value || '' === $value || $value instanceof \DateTimeInterface) {
             return;
         }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
@@ -43,6 +43,16 @@ class DateTimeValidatorTest extends AbstractConstraintValidatorTest
     }
 
     /**
+     * @requires PHP 5.5.0
+     */
+    public function testDateTimeImmutableClassIsValid()
+    {
+        $this->validator->validate(new \DateTimeImmutable(), new DateTime());
+
+        $this->assertNoViolation();
+    }
+
+    /**
      * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
      */
     public function testExpectsStringCompatibleType()

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
@@ -41,10 +41,7 @@ class DateTimeValidatorTest extends AbstractConstraintValidatorTest
 
         $this->assertNoViolation();
     }
-
-    /**
-     * @requires PHP 5.5.0
-     */
+    
     public function testDateTimeImmutableClassIsValid()
     {
         $this->validator->validate(new \DateTimeImmutable(), new DateTime());

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
@@ -41,7 +41,7 @@ class DateTimeValidatorTest extends AbstractConstraintValidatorTest
 
         $this->assertNoViolation();
     }
-    
+
     public function testDateTimeImmutableClassIsValid()
     {
         $this->validator->validate(new \DateTimeImmutable(), new DateTime());

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
@@ -41,10 +41,7 @@ class DateValidatorTest extends AbstractConstraintValidatorTest
 
         $this->assertNoViolation();
     }
-
-    /**
-     * @requires PHP 5.5.0
-     */
+    
     public function testDateTimeImmutableClassIsValid()
     {
         $this->validator->validate(new \DateTimeImmutable(), new Date());

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
@@ -41,7 +41,7 @@ class DateValidatorTest extends AbstractConstraintValidatorTest
 
         $this->assertNoViolation();
     }
-    
+
     public function testDateTimeImmutableClassIsValid()
     {
         $this->validator->validate(new \DateTimeImmutable(), new Date());

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
@@ -43,6 +43,16 @@ class DateValidatorTest extends AbstractConstraintValidatorTest
     }
 
     /**
+     * @requires PHP 5.5.0
+     */
+    public function testDateTimeImmutableClassIsValid()
+    {
+        $this->validator->validate(new \DateTimeImmutable(), new Date());
+
+        $this->assertNoViolation();
+    }
+
+    /**
      * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
      */
     public function testExpectsStringCompatibleType()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.0 |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18752 |
| License | MIT |
| Doc PR |  |

When validating with DateTime constraint UnexpectedTypeException is thrown for DateTimeImmutable instances.

Why PR?
- DateTimeImmutable behaves like a DateTime. Both implements the same interface DateTimeInterface.
- DateTimeInterface cannot be implemented by the client.
