### PR TITLE
[Console] Dispatcher available to extending classes

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -61,7 +61,7 @@ class Application
     private $autoExit;
     private $definition;
     private $helperSet;
-    private $dispatcher;
+    protected $dispatcher;
 
     /**
      * Constructor.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.3 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

Currently one can set a event dispatcher on console application but can not access it later.
This makes it impossible for extending classes and/or commands (which have a ref. to the application) to access the dispatcher to register as a listener or to dispatch (custom) events .
This results in applications having to keep a second ref. to the dispatcher, setup a whole new dispatcher or setup all listeners during construction.
