### PR TITLE
[Security] comparePasswords failes when passing null

### DIFF
--- a/src/Symfony/Component/Security/Core/Encoder/BasePasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/BasePasswordEncoder.php
@@ -81,6 +81,13 @@ abstract class BasePasswordEncoder implements PasswordEncoderInterface
      */
     protected function comparePasswords($password1, $password2)
     {
+        if (
+            ($password1 === null || $password2 === null) &&
+            !($password1 === null && $password2 === null)
+        ) {
+            return false;
+        }
+
         return hash_equals($password1, $password2);
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

comparePasswords should be able to handle null values. If one password is null, but not both are null, then they are not the same value.
