### PR TITLE
Catch \Throwable

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -44,8 +44,8 @@ class AutowirePass implements CompilerPassInterface
                     $this->completeDefinition($id, $definition);
                 }
             }
-        } catch (\Error $e) {
         } catch (\Exception $e) {
+        } catch (\Throwable $e) {
         }
 
         spl_autoload_unregister($throwingAutoloader);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8, 3.0 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | Mostly! |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

The first commit is based on symfony/symfony#15949 
Depends on symfony/symfony#18813, symfony/symfony#18812

---

I'm new to symfony, so I'm not sure where are all the places where it makes sense to actually catch the throwable and where not. I added most places that seemed logical and when I wasn't sure, I added it anyway. I'm hoping you guys (and girls?) can point out the places where the catch should not be added, I'll fix it and then I can create several PR's for the older branches. A lot of this IMHO should go also to 3.0.
