### PR TITLE
Make failed autowiring error messages more explicit

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -155,7 +155,7 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage Unable to autowire argument of type "Symfony\Component\DependencyInjection\Tests\Compiler\CollisionInterface" for the service "a". No services were found matching this interface.
+     * @expectedExceptionMessage Unable to autowire argument of type "Symfony\Component\DependencyInjection\Tests\Compiler\CollisionInterface" for the service "a". No services were found matching this interface and it cannot be auto-registered.
      */
     public function testTypeNotGuessableNoServicesFound()
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no (better DX integration) |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18658 |
| License | MIT |
| Doc PR | N/A |

@nicolas-grekas This is a port from #18691 (which was for **2.8**).
It looks like the original PR has been already mostly implemented in **master** by @weaverryan (in #17877).

IMO, this PR is still improving two use cases:
- In case a class cannot be autowired because no service can be found AND a service cannot be registered automatically, the error message now mentions both conditions (instead of simply saying no service has been found)
- In case a class with no service attached to it can be automatically instantiated but cannot be autowired because of further problems, an exception mentioning this is now thrown instead of the lower level exception, making the situation easier to debug. (The lower level exception is still available through `getPrevious()`)

Hence, I still think this PR provides useful additional DX features and is worth to be merged.
