### PR TITLE
Update UPGRADE FROM 2.x to 3.0

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -233,7 +233,8 @@ UPGRADE FROM 2.x to 3.0
 
 ### Form
 
- * The `max_length` option was removed. Use the `attr` option instead by setting it to an `array` with a `maxlength` key.
+ * The `max_length` option was removed. Use the `attr` option instead by setting it to
+   an `array` with a `maxlength` key.
 
  * The `getBlockPrefix()` method was added to the `FormTypeInterface` in replacement of
    the `getName()` method which has been removed.

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -233,7 +233,7 @@ UPGRADE FROM 2.x to 3.0
 
 ### Form
 
- * The max_length option was removed. Use the attr option instead by setting it to an array with a maxlength key.
+ * The `max_length` option was removed. Use the `attr` option instead by setting it to an `array` with a `maxlength` key.
 
  * The `getBlockPrefix()` method was added to the `FormTypeInterface` in replacement of
    the `getName()` method which has been removed.

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -233,6 +233,8 @@ UPGRADE FROM 2.x to 3.0
 
 ### Form
 
+ * The max_length option was removed. Use the attr option instead by setting it to an array with a maxlength key.
+
  * The `getBlockPrefix()` method was added to the `FormTypeInterface` in replacement of
    the `getName()` method which has been removed.
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | deprecated in 2.7 removed in 3.0 |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | http://symfony.com/doc/2.8/reference/forms/types/text.html for starters |

You missed the Form max_length option deprecation in several field types (Text, Password, Email, etc...).
