### PR TITLE
[Console] Show aliases in command description instead of in different lines in application description

### DIFF
--- a/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
@@ -198,6 +198,11 @@ class TextDescriptor extends Descriptor
             }
 
             // add commands by namespace
+            $commandNames = [];
+            foreach($description->getCommands() as $name => $command) {
+                $commandNames[] = $name;
+            }
+
             foreach ($description->getNamespaces() as $namespace) {
                 if (!$describedNamespace && ApplicationDescription::GLOBAL_NAMESPACE !== $namespace['id']) {
                     $this->writeText("\n");
@@ -205,9 +210,13 @@ class TextDescriptor extends Descriptor
                 }
 
                 foreach ($namespace['commands'] as $name) {
-                    $this->writeText("\n");
-                    $spacingWidth = $width - strlen($name);
-                    $this->writeText(sprintf('  <info>%s</info>%s%s', $name, str_repeat(' ', $spacingWidth), $description->getCommand($name)->getDescription()), $options);
+                    if(in_array($name, $commandNames)) {
+                        $this->writeText("\n");
+                        $spacingWidth = $width - strlen($name);
+                        $command = $description->getCommand($name);
+                        $commandAliases = $this->getCommandAliasesText($command);
+                        $this->writeText(sprintf('  <info>%s</info>%s%s', $name, str_repeat(' ', $spacingWidth), $commandAliases.$command->getDescription()), $options);
+                    }
                 }
             }
 
@@ -225,6 +234,26 @@ class TextDescriptor extends Descriptor
             isset($options['raw_output']) ? !$options['raw_output'] : true
         );
     }
+
+    /**
+     * Formats command aliases to show them in the command description.
+     * 
+     * @param Command $command
+     * 
+     * @return string
+     */
+    private function getCommandAliasesText($command)
+    {
+        $text = '';
+        $aliases = $command->getAliases();
+
+        if(count($aliases) > 0) {
+            $text = '['.implode('|',$aliases).'] ';
+        }
+
+        return $text;
+    }
+
 
     /**
      * Formats input option/argument default value.

--- a/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
@@ -198,10 +198,7 @@ class TextDescriptor extends Descriptor
             }
 
             // add commands by namespace
-            $commandNames = [];
-            foreach($description->getCommands() as $name => $command) {
-                $commandNames[] = $name;
-            }
+            $commands = $description->getCommands();
 
             foreach ($description->getNamespaces() as $namespace) {
                 if (!$describedNamespace && ApplicationDescription::GLOBAL_NAMESPACE !== $namespace['id']) {
@@ -210,10 +207,10 @@ class TextDescriptor extends Descriptor
                 }
 
                 foreach ($namespace['commands'] as $name) {
-                    if(in_array($name, $commandNames)) {
+                    if (isset($commands[$name])) {
                         $this->writeText("\n");
                         $spacingWidth = $width - strlen($name);
-                        $command = $description->getCommand($name);
+                        $command = $commands[$name];
                         $commandAliases = $this->getCommandAliasesText($command);
                         $this->writeText(sprintf('  <info>%s</info>%s%s', $name, str_repeat(' ', $spacingWidth), $commandAliases.$command->getDescription()), $options);
                     }
@@ -247,8 +244,8 @@ class TextDescriptor extends Descriptor
         $text = '';
         $aliases = $command->getAliases();
 
-        if(count($aliases) > 0) {
-            $text = '['.implode('|',$aliases).'] ';
+        if ($aliases) {
+            $text = '['.implode('|', $aliases).'] ';
         }
 
         return $text;

--- a/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
@@ -254,7 +254,6 @@ class TextDescriptor extends Descriptor
         return $text;
     }
 
-
     /**
      * Formats input option/argument default value.
      *

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.txt
@@ -13,10 +13,8 @@
   <info>-v|vv|vvv, --verbose</info>  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 
 <comment>Available commands:</comment>
-  <info>alias1</info>               command 1 description
-  <info>alias2</info>               command 1 description
   <info>help</info>                 Displays help for a command
   <info>list</info>                 Lists commands
  <comment>descriptor</comment>
-  <info>descriptor:command1</info>  command 1 description
+  <info>descriptor:command1</info>  [alias1|alias2] command 1 description
   <info>descriptor:command2</info>  command 2 description


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18351 |
| License | MIT |
| Doc PR |  |

This PR is a suggestion about the bug referenced in ticket 18351. The problem is that aliases create new lines with identical descriptions in the application description, it is suggested to show the aliases in the command description.

I had to modify one application fixture to meet this new behaviour and make the tests pass, but I don't think that a new application fixture is needed to test this having the application fixture 2. 

Comments are welcome, this is my first PR in Symfony so if I need to meet any more requirements to make it correct to merge just tell me please.
