### PR TITLE
[RFC] [Form] [DX] Add a FormTypes class with core types FQCN as constants

### DIFF
--- a/src/Symfony/Component/Form/FormTypes.php
+++ b/src/Symfony/Component/Form/FormTypes.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form;
+
+/**
+ * To learn more about how form types work check the documentation
+ * entry at {@link http://symfony.com/doc/2.8/reference/forms/types.html}.
+ *
+ * @author Jules Pietri <jules@heahprod.com>
+ */
+final class FormTypes
+{
+    const BIRTHDAY = 'Symfony\Component\Form\Extension\Core\Type\BirthdayType';
+
+    const BUTTON = 'Symfony\Component\Form\Extension\Core\Type\ButtonType';
+
+    const CHECKBOX = 'Symfony\Component\Form\Extension\Core\Type\CheckboxType';
+
+    const CHOICE = 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
+
+    const COLLECTION = 'Symfony\Component\Form\Extension\Core\Type\CollectionType';
+
+    const COUNTRY = 'Symfony\Component\Form\Extension\Core\Type\CountryType';
+
+    const CURRENCY = 'Symfony\Component\Form\Extension\Core\Type\CurrencyType';
+
+    const DATETIME = 'Symfony\Component\Form\Extension\Core\Type\DateTimeType';
+
+    const DATE = 'Symfony\Component\Form\Extension\Core\Type\DateType';
+
+    const EMAIL = 'Symfony\Component\Form\Extension\Core\Type\EmailType';
+
+    const FILE = 'Symfony\Component\Form\Extension\Core\Type\FileType';
+
+    const FORM = 'Symfony\Component\Form\Extension\Core\Type\FormType';
+
+    const HIDDEN = 'Symfony\Component\Form\Extension\Core\Type\HiddenType';
+
+    const INTEGER = 'Symfony\Component\Form\Extension\Core\Type\IntegerType';
+
+    const LANGUAGE = 'Symfony\Component\Form\Extension\Core\Type\LanguageType';
+
+    const LOCALE = 'Symfony\Component\Form\Extension\Core\Type\LocaleType';
+
+    const MONEY = 'Symfony\Component\Form\Extension\Core\Type\MoneyType';
+
+    const NUMBER = 'Symfony\Component\Form\Extension\Core\Type\NumberType';
+
+    const PASSWORD = 'Symfony\Component\Form\Extension\Core\Type\PasswordType';
+
+    const PERCENT = 'Symfony\Component\Form\Extension\Core\Type\PercentType';
+
+    const RADIO = 'Symfony\Component\Form\Extension\Core\Type\RadioType';
+
+    const RANGE = 'Symfony\Component\Form\Extension\Core\Type\RangeType';
+
+    const REPEAT = 'Symfony\Component\Form\Extension\Core\Type\RepeatType';
+
+    const RESET = 'Symfony\Component\Form\Extension\Core\Type\ResetType';
+
+    const SEARCH = 'Symfony\Component\Form\Extension\Core\Type\SearchType';
+
+    const SUBMIT = 'Symfony\Component\Form\Extension\Core\Type\SubmitType';
+
+    const TEXTAREA = 'Symfony\Component\Form\Extension\Core\Type\TextareaType';
+
+    const TEXT = 'Symfony\Component\Form\Extension\Core\Type\TextType';
+
+    const TIME = 'Symfony\Component\Form\Extension\Core\Type\TimeType';
+
+    const TIMEZONE = 'Symfony\Component\Form\Extension\Core\Type\TimezoneType';
+
+    const URL = 'Symfony\Component\Form\Extension\Core\Type\UrlType';
+
+    private function __construct()
+    {
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | TODO |

---

**Note**

This PR is about adding a file which doesn't do any logic. Its concern is only about DX.

**Considering**

2.3 is EOL at the end of the month and 2.8 is the longest LTS version until November 2019 (3 and a half years), supporting both BC breaks and PHP 5.3.9.

**Problem**

Although the docs and upgrade files suggest using the short `class` keyword style (i.e `LocaleType::class`), it may not be possible in some legacy projects needing soon to upgrade to 2.7 or 2.8 and having to use `Symfony\Component\Form\Extension\Core\Type\LocaleType`.

**Solution**

It's common in Symfony to use a class to define a group of event names (e.g `KernelEvents`, `FormEvents`). Why not do the same with `FormTypes::TEXT` or `FormTypes::LOCALE`.

**Drawback**

Please comment, I don't see any.

**Advantages**
- eases auto-completion in IDE while working with PHP 5.3 (with only one use statement)
- only one use statement!
- this practice might help when dealing with many custom types, and we could encourage something like:
  
  ``` php
  use Acme\AcmeSomeBundle\Form\AcmeSomeTypes;
  use Symfony\Component\Form\FormTypes;
  ```
- consistent with `*Events` classes

**Questions**
- Should the name of the constants be like  `TEXT_TYPE` instead of `TEXT`? It may be a problem with `INTEGER`.
- What about `EntityType`?
- What do you think?

Thanks!
