### PR TITLE
Use levenshtein level for better Bundle matching

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerNameParser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerNameParser.php
@@ -142,6 +142,7 @@ class ControllerNameParser
             $lev = levenshtein($nonExistentBundleName, $bundleName);
             if ($lev <= strlen($nonExistentBundleName) / 3 && ($alternative === null || $lev < $shortest)) {
                 $alternative = $bundleName;
+                $shortest = $lev;
             }
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerNameParserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerNameParserTest.php
@@ -59,8 +59,8 @@ class ControllerNameParserTest extends TestCase
     {
         $parser = $this->createParser();
 
-        $this->assertEquals('FooBundle:Default:index', $parser->build('TestBundle\FooBundle\Controller\DefaultController::indexAction'), '->parse() converts a class::method string to a short a:b:c notation string');
-        $this->assertEquals('FooBundle:Sub\Default:index', $parser->build('TestBundle\FooBundle\Controller\Sub\DefaultController::indexAction'), '->parse() converts a class::method string to a short a:b:c notation string');
+        $this->assertEquals('FoooooBundle:Default:index', $parser->build('TestBundle\FooBundle\Controller\DefaultController::indexAction'), '->parse() converts a class::method string to a short a:b:c notation string');
+        $this->assertEquals('FoooooBundle:Sub\Default:index', $parser->build('TestBundle\FooBundle\Controller\Sub\DefaultController::indexAction'), '->parse() converts a class::method string to a short a:b:c notation string');
 
         try {
             $parser->build('TestBundle\FooBundle\Controller\DefaultController::index');
@@ -132,8 +132,9 @@ class ControllerNameParserTest extends TestCase
     public function getInvalidBundleNameTests()
     {
         return array(
-            array('FoodBundle:Default:index', 'FooBundle:Default:index'),
-            array('CrazyBundle:Default:index', false),
+            'Alternative will be found using levenshtein' => array('FoodBundle:Default:index', 'FooBundle:Default:index'),
+            'Alternative will be found using partial match' => array('FabpotFooBund:Default:index', 'FabpotFooBundle:Default:index'),
+            'Bundle does not exist at all' => array('CrazyBundle:Default:index', false),
         );
     }
 
@@ -162,6 +163,7 @@ class ControllerNameParserTest extends TestCase
         $bundles = array(
             'SensioFooBundle' => $this->getBundle('TestBundle\Fabpot\FooBundle', 'FabpotFooBundle'),
             'SensioCmsFooBundle' => $this->getBundle('TestBundle\Sensio\Cms\FooBundle', 'SensioCmsFooBundle'),
+            'FoooooBundle' => $this->getBundle('TestBundle\FooBundle', 'FoooooBundle'),
             'FooBundle' => $this->getBundle('TestBundle\FooBundle', 'FooBundle'),
             'FabpotFooBundle' => $this->getBundle('TestBundle\Fabpot\FooBundle', 'FabpotFooBundle'),
         );


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

_I've targetted 2.7 branch since this was introduced in the 2.6 version but the 2.6 isn't maintain anymore._

**TL;DR:** I found unused code in bad bundle exception when Symfony try to find the best bundle to fix the typo. Should we remove that code (and got a potential lower matching bundle name) or keep it and make it work?

---

I've noticed that a part of the code wasn't used when determining which bundle typo was written on _bad bundle exception_, from https://github.com/symfony/symfony/pull/11210.

``` php
$alternative = null;
$shortest = null;
foreach ($bundleNames as $bundleName) {
    // if there's a partial match, return it immediately
    if (false !== strpos($bundleName, $nonExistentBundleName)) {
        return $bundleName;
    }

    $lev = levenshtein($nonExistentBundleName, $bundleName);
    if ($lev <= strlen($nonExistentBundleName) / 3 && ($alternative === null || $lev < $shortest)) {
        $alternative = $bundleName;
    }
}
```

In this snippet, the `$shortest` wasn't update in the `foreach`. Reading the code, I guess it was supposed to add an even better accuracy when multiple bundle matche the typo'd bundle name.

Which mean when an alternative is found, we have to assign the level `$lev` from that match to `$shortest`.

``` php
if ($lev <= strlen($nonExistentBundleName) / 3 && ($alternative === null || $lev < $shortest)) {
    $alternative = $bundleName;
    $shortest = $lev;
}
```

Let say you have these bundles: `FoooooBundle` and `FooBundle` and you request the bundle `FoodBundle`.
- Without `$shortest` updated, you'll got a suggestion with `FoooooBundle` (first matching bundle found)
- With `$shortest` upadted, you'll got a suggestion with `FooBundle` (because it has a better level than `FoooooBundle`)

This isn't a _bug fix_ since this is only supposed to help developper but not the final user.

**Question is**: should we keep that level comparison or just remove it?
