### PR TITLE
Fixed server status command when port has been omitted

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerStatusCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerStatusCommand.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Command;
 
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -32,6 +33,7 @@ class ServerStatusCommand extends ServerCommand
         $this
             ->setDefinition(array(
                 new InputArgument('address', InputArgument::OPTIONAL, 'Address:port', '127.0.0.1:8000'),
+                new InputOption('port', 'p', InputOption::VALUE_REQUIRED, 'Address port number', '8000'),
             ))
             ->setName('server:status')
             ->setDescription('Outputs the status of the built-in web server for the given address')
@@ -45,6 +47,10 @@ class ServerStatusCommand extends ServerCommand
     {
         $io = new SymfonyStyle($input, $output);
         $address = $input->getArgument('address');
+
+        if (false === strpos($address, ':')) {
+            $address = $address.':'.$input->getOption('port');
+        }
 
         // remove an orphaned lock file
         if (file_exists($this->getLockFile($address)) && !$this->isServerRunning($address)) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18810 |
| License | MIT |
| Doc PR | - |

Modified the status command to behave exactly as the server:start command. When the port is omitted in the address argument the default port is added from the port option.
