### PR TITLE
[Config] Allow schemed paths in FileResource

### DIFF
--- a/src/Symfony/Component/Config/Resource/FileResource.php
+++ b/src/Symfony/Component/Config/Resource/FileResource.php
@@ -36,6 +36,10 @@ class FileResource implements SelfCheckingResourceInterface, \Serializable
     {
         $this->resource = realpath($resource);
 
+        if (false === $this->resource && file_exists($resource)) {
+            $this->resource = $resource;
+        }
+
         if (false === $this->resource) {
             throw new \InvalidArgumentException(sprintf('The file "%s" does not exist.', $resource));
         }

--- a/src/Symfony/Component/Config/Tests/Resource/FileResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/FileResourceTest.php
@@ -21,7 +21,7 @@ class FileResourceTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->file = realpath(sys_get_temp_dir()).'/tmp.xml';
+        $this->file = sys_get_temp_dir().'/tmp.xml';
         $this->time = time();
         touch($this->file, $this->time);
         $this->resource = new FileResource($this->file);
@@ -39,6 +39,12 @@ class FileResourceTest extends \PHPUnit_Framework_TestCase
     public function testGetResource()
     {
         $this->assertSame(realpath($this->file), $this->resource->getResource(), '->getResource() returns the path to the resource');
+    }
+
+    public function testGetResourceWithScheme()
+    {
+        $resource = new FileResource('file://'.$this->file);
+        $this->assertSame('file://'.$this->file, $resource->getResource(), '->getResource() returns the path to the schemed resource');
     }
 
     public function testToString()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17598 |
| License | MIT |
| Doc PR | - |

This is a small new feature fixing a BC break that has been introduced in #17598 on 3.1.
It happens that 3.1 is breaking a `phar` app on our side where we end up doing something like `new FileResource('phar://...')`.

Ping @xabbuh and @javiereguiluz esp.
