### PR TITLE
[2.3][Form] Removed UTC specification with timestamp

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
@@ -126,7 +126,7 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
 
         try {
             // read timestamp into DateTime object - the formatter delivers in UTC
-            $dateTime = new \DateTime(sprintf('@%s UTC', $timestamp));
+            $dateTime = new \DateTime(sprintf('@%s', $timestamp));
         } catch (\Exception $e) {
             throw new TransformationFailedException($e->getMessage(), $e->getCode(), $e);
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.3 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

The function `date_parse()` indicates a warning if a timezone is used with the timestamp: `Double timezone specification`. I removed the UTC specification and this time it's more faster! 
