### PR TITLE
Optimized how we get the listener info in TraceableEventDispatcher

### DIFF
--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -315,9 +315,9 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
         $listenerHash = '';
 
         if (is_string($listener)) {
-            $listenerHash = md5($listener);
-            if (isset($this->listenerInfoCache[$listenerHash][$eventName])) {
-                return $this->listenerInfoCache[$listenerHash][$eventName];
+            $listenerHash = md5($listener.$eventName);
+            if (isset($this->listenerInfoCache[$listenerHash])) {
+                return $this->listenerInfoCache[$listenerHash];
             }
 
             try {
@@ -342,9 +342,9 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
             }
             $class = is_object($listener[0]) ? get_class($listener[0]) : $listener[0];
 
-            $listenerHash = md5($class);
-            if (isset($this->listenerInfoCache[$listenerHash][$eventName])) {
-                return $this->listenerInfoCache[$listenerHash][$eventName];
+            $listenerHash = md5($class.$listener[1].$eventName);
+            if (isset($this->listenerInfoCache[$listenerHash])) {
+                return $this->listenerInfoCache[$listenerHash];
             }
 
             try {

--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -366,7 +366,7 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
             );
         }
 
-        $this->listenerInfoCache[$listenerHash][$eventName] = $info;
+        $this->listenerInfoCache[$listenerHash] = $info;
 
         return $info;
     }

--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -315,7 +315,7 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
         $listenerHash = '';
 
         if (is_string($listener)) {
-            $listenerHash = md5($listenerHash);
+            $listenerHash = md5($listener);
             if (isset($this->listenerInfoCache[$listenerHash][$eventName])) {
                 return $this->listenerInfoCache[$listenerHash][$eventName];
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
### Context

I was reviewing a complex Symfony application with the Symfony Profiler:

![performance_metrics](https://cloud.githubusercontent.com/assets/73419/15430175/6f481aba-1ea4-11e6-8d96-08dc786d357f.png)

I wasn't happy with the performance, so I checked the timeline and I saw that the `ProfilerListener` almost takes 30% of the total time!!

![profiler_listener](https://cloud.githubusercontent.com/assets/73419/15430232/b42c1b54-1ea4-11e6-8ab2-441b67f22642.png)
### Problem

I profiled the app and then I saw that `getListenerInfo()`, a heavy method which uses PHP's Reflection, is called more than 1,000 times:

![get_listener_info](https://cloud.githubusercontent.com/assets/73419/15430271/ddeac6de-1ea4-11e6-9837-5241e246546a.png)
### Solution

I guess we could optimize `TraceableEventDispatcher` massively, but I thought about adding first a simple cache in the `getListenerInfo()` method. I profiled again and the comparison looks good:

![comparison_overall](https://cloud.githubusercontent.com/assets/73419/15430320/174f50ca-1ea5-11e6-9796-a931940e3957.png)

And some details:

![comparison_1](https://cloud.githubusercontent.com/assets/73419/15430323/1fa6cda2-1ea5-11e6-8c30-933377681ecc.png)

![comparison_2](https://cloud.githubusercontent.com/assets/73419/15430324/215c7494-1ea5-11e6-9887-0c76fa5a9608.png)

![comparison_3](https://cloud.githubusercontent.com/assets/73419/15430326/239759cc-1ea5-11e6-95db-38d2233a3e8e.png)

![comparison_4](https://cloud.githubusercontent.com/assets/73419/15430330/254f257e-1ea5-11e6-9f7f-c10d80ffcb53.png)
