### PR TITLE
[Cache] Create NullAdapter to disable cache if needed

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/NullAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/NullAdapter.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Adapter;
+
+use Psr\Cache\CacheItemInterface;
+use Symfony\Component\Cache\CacheItem;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+class NullAdapter implements AdapterInterface
+{
+    private $createCacheItem;
+
+    public function __construct()
+    {
+        $this->createCacheItem = \Closure::bind(
+            function ($key) {
+                $item = new CacheItem();
+                $item->key = $key;
+                $item->isHit = false;
+
+                return $item;
+            },
+            $this,
+            CacheItem::class
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItem($key)
+    {
+        $f = $this->createCacheItem;
+
+        return $f($key);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItems(array $keys = array())
+    {
+        return $this->generateItems($keys);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasItem($key)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clear()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteItem($key)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteItems(array $keys)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function save(CacheItemInterface $item)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function saveDeferred(CacheItemInterface $item)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function commit()
+    {
+        return false;
+    }
+
+    private function generateItems(array $keys)
+    {
+        $f = $this->createCacheItem;
+
+        foreach ($keys as $key) {
+            yield $key => $f($key);
+        }
+    }
+}

--- a/src/Symfony/Component/Cache/Tests/Adapter/NullAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/NullAdapterTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Adapter;
+
+use Psr\Cache\CacheItemInterface;
+use Symfony\Component\Cache\Adapter\NullAdapter;
+
+class NullAdapterTest extends \PHPUnit_Framework_TestCase
+{
+    public function createCachePool()
+    {
+        return new NullAdapter();
+    }
+
+    public function testGetItem()
+    {
+        $adapter = $this->createCachePool();
+
+        $item = $adapter->getItem('key');
+        $this->assertFalse($item->isHit());
+        $this->assertNull($item->get(), "Item's value must be null when isHit is false.");
+    }
+
+    public function testHasItem()
+    {
+        $this->assertFalse($this->createCachePool()->hasItem('key'));
+    }
+
+    public function testGetItems()
+    {
+        $adapter = $this->createCachePool();
+
+        $keys = array('foo', 'bar', 'baz', 'biz');
+
+        /** @var CacheItemInterface[] $items */
+        $items = $adapter->getItems($keys);
+        $count = 0;
+
+        foreach ($items as $key => $item) {
+            $itemKey = $item->getKey();
+
+            $this->assertEquals($itemKey, $key, 'Keys must be preserved when fetching multiple items');
+            $this->assertTrue(in_array($key, $keys), 'Cache key can not change.');
+            $this->assertFalse($item->isHit());
+
+            // Remove $key for $keys
+            foreach ($keys as $k => $v) {
+                if ($v === $key) {
+                    unset($keys[$k]);
+                }
+            }
+
+            ++$count;
+        }
+
+        $this->assertSame(4, $count);
+    }
+
+    public function testIsHit()
+    {
+        $adapter = $this->createCachePool();
+
+        $item = $adapter->getItem('key');
+        $this->assertFalse($item->isHit());
+    }
+
+    public function testClear()
+    {
+        $this->assertTrue($this->createCachePool()->clear());
+    }
+
+    public function testDeleteItem()
+    {
+        $this->assertTrue($this->createCachePool()->deleteItem('key'));
+    }
+
+    public function testDeleteItems()
+    {
+        $this->assertTrue($this->createCachePool()->deleteItems(array('key', 'foo', 'bar')));
+    }
+
+    public function testSave()
+    {
+        $adapter = $this->createCachePool();
+
+        $item = $adapter->getItem('key');
+        $this->assertFalse($item->isHit());
+        $this->assertNull($item->get(), "Item's value must be null when isHit is false.");
+
+        $this->assertFalse($adapter->save($item));
+    }
+
+    public function testDeferredSave()
+    {
+        $adapter = $this->createCachePool();
+
+        $item = $adapter->getItem('key');
+        $this->assertFalse($item->isHit());
+        $this->assertNull($item->get(), "Item's value must be null when isHit is false.");
+
+        $this->assertFalse($adapter->saveDeferred($item));
+    }
+
+    public function testCommit()
+    {
+        $adapter = $this->createCachePool();
+
+        $item = $adapter->getItem('key');
+        $this->assertFalse($item->isHit());
+        $this->assertNull($item->get(), "Item's value must be null when isHit is false.");
+
+        $this->assertFalse($adapter->saveDeferred($item));
+        $this->assertFalse($this->createCachePool()->commit());
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | WIP |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Tthis PR aims to implement a Symfony Cache Null adapter able to disable cache if needed (very useful in tests or in the case of the fallback of the OpCacheAdapter for instance).

This PR is required by https://github.com/symfony/symfony/pull/18823 and https://github.com/symfony/symfony/pull/18533
