### PR TITLE
Changed roundCurrency method to be public

### DIFF
--- a/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
+++ b/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
@@ -693,7 +693,7 @@ class NumberFormatter
      * @see http://en.wikipedia.org/wiki/Swedish_rounding
      * @see http://www.docjar.com/html/api/com/ibm/icu/util/Currency.java.html#1007
      */
-    private function roundCurrency($value, $currency)
+    public function roundCurrency($value, $currency)
     {
         $fractionDigits = Intl::getCurrencyBundle()->getFractionDigits($currency);
         $roundingIncrement = Intl::getCurrencyBundle()->getRoundingIncrement($currency);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This allows a developer to fetch the rounded amount of the currency without the symbol
