### PR TITLE
Update phpdocumentor/reflection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,10 +86,10 @@
         "monolog/monolog": "~1.11",
         "ocramius/proxy-manager": "~0.4|~1.0|~2.0",
         "egulias/email-validator": "~1.2",
-        "phpdocumentor/reflection": "^1.0.7"
+        "phpdocumentor/reflection": "^3.0.1"
     },
     "conflict": {
-        "phpdocumentor/reflection": "<1.0.7"
+        "phpdocumentor/reflection": "<3.0.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -49,7 +49,7 @@
         "symfony/validator": "~2.5|~3.0.0",
         "symfony/yaml": "~2.0,>=2.0.5|~3.0.0",
         "symfony/property-info": "~2.8|~3.0.0",
-        "phpdocumentor/reflection": "^1.0.7",
+        "phpdocumentor/reflection": "^3.0.1",
         "twig/twig": "~1.23|~2.0"
     },
     "suggest": {

--- a/src/Symfony/Component/PropertyInfo/composer.json
+++ b/src/Symfony/Component/PropertyInfo/composer.json
@@ -27,11 +27,11 @@
     },
     "require-dev": {
         "symfony/serializer": "~2.7|~3.0.0",
-        "phpdocumentor/reflection": "^1.0.7",
+        "phpdocumentor/reflection": "^3.0.1",
         "doctrine/annotations": "~1.0"
     },
     "conflict": {
-        "phpdocumentor/reflection": "<1.0.7"
+        "phpdocumentor/reflection": "<3.0.1"
     },
     "suggest": {
         "symfony/doctrine-bridge": "To use Doctrine metadata",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8, 3.0 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Version 3 “was created to support php-7 syntax […] No new functionality
was added.” [0]

```
0: https://github.com/phpDocumentor/Reflection/releases
```
