### PR TITLE
[Form] fixed EntityType test with query_builder option as null

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -222,8 +222,13 @@ class EntityTypeTest extends TypeTestCase
         $field->submit('2');
     }
 
-    public function testConfigureQueryBuilderWithClosureReturningNull()
+    public function testConfigureQueryBuilderWithClosureReturningNullUseDefault()
     {
+        $entity1 = new SingleIntIdEntity(1, 'Foo');
+        $entity2 = new SingleIntIdEntity(2, 'Bar');
+
+        $this->persist(array($entity1, $entity2));
+
         $field = $this->factory->createNamed('name', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', null, array(
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
@@ -232,7 +237,7 @@ class EntityTypeTest extends TypeTestCase
             },
         ));
 
-        $this->assertEquals(array(), $field->createView()->vars['choices']);
+        $this->assertEquals(array(1 => new ChoiceView($entity1, '1', 'Foo'), 2 => new ChoiceView($entity2, '2', 'Bar')), $field->createView()->vars['choices']);
     }
 
     public function testSetDataSingleNull()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8+ |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | symfony/symfony-docs#6599 |

ref https://github.com/symfony/symfony/pull/13990#issuecomment-220788142.
