### PR TITLE
[HttpKernel] Move duplicated logic from Esi/Ssi to an AbstractSurrogate

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/AbstractSurrogate.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/AbstractSurrogate.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\HttpCache;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * Abstract class implementing Surrogate capabilities to Request and Response instances.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+abstract class AbstractSurrogate implements SurrogateInterface
+{
+    protected $contentTypes;
+    protected $phpEscapeMap = array(
+        array('<?', '<%', '<s', '<S'),
+        array('<?php echo "<?"; ?>', '<?php echo "<%"; ?>', '<?php echo "<s"; ?>', '<?php echo "<S"; ?>'),
+    );
+
+    /**
+     * Constructor.
+     *
+     * @param array $contentTypes An array of content-type that should be parsed for Surrogate information.
+     *                            (default: text/html, text/xml, application/xhtml+xml, and application/xml)
+     */
+    public function __construct(array $contentTypes = array('text/html', 'text/xml', 'application/xhtml+xml', 'application/xml'))
+    {
+        $this->contentTypes = $contentTypes;
+    }
+
+    /**
+     * Returns a new cache strategy instance.
+     *
+     * @return ResponseCacheStrategyInterface A ResponseCacheStrategyInterface instance
+     */
+    public function createCacheStrategy()
+    {
+        return new ResponseCacheStrategy();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasSurrogateCapability(Request $request)
+    {
+        if (null === $value = $request->headers->get('Surrogate-Capability')) {
+            return false;
+        }
+
+        return false !== strpos($value, sprintf('%s/1.0', strtoupper($this->getName())));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addSurrogateCapability(Request $request)
+    {
+        $current = $request->headers->get('Surrogate-Capability');
+        $new = sprintf('symfony2="%s/1.0"', strtoupper($this->getName()));
+
+        $request->headers->set('Surrogate-Capability', $current ? $current.', '.$new : $new);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function needsParsing(Response $response)
+    {
+        if (!$control = $response->headers->get('Surrogate-Control')) {
+            return false;
+        }
+
+        $pattern = sprintf('#content="[^"]*%s/1.0[^"]*"#', strtoupper($this->getName()));
+
+        return (bool) preg_match($pattern, $control);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(HttpCache $cache, $uri, $alt, $ignoreErrors)
+    {
+        $subRequest = Request::create($uri, Request::METHOD_GET, array(), $cache->getRequest()->cookies->all(), array(), $cache->getRequest()->server->all());
+
+        try {
+            $response = $cache->handle($subRequest, HttpKernelInterface::SUB_REQUEST, true);
+
+            if (!$response->isSuccessful()) {
+                throw new \RuntimeException(sprintf('Error when rendering "%s" (Status code is %s).', $subRequest->getUri(), $response->getStatusCode()));
+            }
+
+            return $response->getContent();
+        } catch (\Exception $e) {
+            if ($alt) {
+                return $this->handle($cache, $alt, '', $ignoreErrors);
+            }
+
+            if (!$ignoreErrors) {
+                throw $e;
+            }
+        }
+    }
+
+    /**
+     * Remove the Surrogate from the Surrogate-Control header.
+     *
+     * @param Response $response
+     */
+    protected function removeFromControl(Response $response)
+    {
+        if (!$response->headers->has('Surrogate-Control')) {
+            return;
+        }
+
+        $value = $response->headers->get('Surrogate-Control');
+        $upperName = strtoupper($this->getName());
+
+        if (sprintf('content="%s/1.0"', $upperName) == $value) {
+            $response->headers->remove('Surrogate-Control');
+        } elseif (preg_match(sprintf('#,\s*content="%s/1.0"#', $upperName), $value)) {
+            $response->headers->set('Surrogate-Control', preg_replace(sprintf('#,\s*content="%s/1.0"#', $upperName), '', $value));
+        } elseif (preg_match(sprintf('#content="%s/1.0",\s*#', $upperName), $value)) {
+            $response->headers->set('Surrogate-Control', preg_replace(sprintf('#content="%s/1.0",\s*#', $upperName), '', $value));
+        }
+    }
+}

--- a/src/Symfony/Component/HttpKernel/HttpCache/Ssi.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Ssi.php
@@ -13,32 +13,14 @@ namespace Symfony\Component\HttpKernel\HttpCache;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 /**
  * Ssi implements the SSI capabilities to Request and Response instances.
  *
  * @author Sebastian Krebs <krebs.seb@gmail.com>
  */
-class Ssi implements SurrogateInterface
+class Ssi extends AbstractSurrogate
 {
-    private $contentTypes;
-    private $phpEscapeMap = array(
-        array('<?', '<%', '<s', '<S'),
-        array('<?php echo "<?"; ?>', '<?php echo "<%"; ?>', '<?php echo "<s"; ?>', '<?php echo "<S"; ?>'),
-    );
-
-    /**
-     * Constructor.
-     *
-     * @param array $contentTypes An array of content-type that should be parsed for SSI information.
-     *                            (default: text/html, text/xml, application/xhtml+xml, and application/xml)
-     */
-    public function __construct(array $contentTypes = array('text/html', 'text/xml', 'application/xhtml+xml', 'application/xml'))
-    {
-        $this->contentTypes = $contentTypes;
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -50,54 +32,11 @@ class Ssi implements SurrogateInterface
     /**
      * {@inheritdoc}
      */
-    public function createCacheStrategy()
-    {
-        return new ResponseCacheStrategy();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function hasSurrogateCapability(Request $request)
-    {
-        if (null === $value = $request->headers->get('Surrogate-Capability')) {
-            return false;
-        }
-
-        return false !== strpos($value, 'SSI/1.0');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function addSurrogateCapability(Request $request)
-    {
-        $current = $request->headers->get('Surrogate-Capability');
-        $new = 'symfony2="SSI/1.0"';
-
-        $request->headers->set('Surrogate-Capability', $current ? $current.', '.$new : $new);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function addSurrogateControl(Response $response)
     {
         if (false !== strpos($response->getContent(), '<!--#include')) {
             $response->headers->set('Surrogate-Control', 'content="SSI/1.0"');
         }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function needsParsing(Response $response)
-    {
-        if (!$control = $response->headers->get('Surrogate-Control')) {
-            return false;
-        }
-
-        return (bool) preg_match('#content="[^"]*SSI/1.0[^"]*"#', $control);
     }
 
     /**
@@ -154,41 +93,6 @@ class Ssi implements SurrogateInterface
         $response->headers->set('X-Body-Eval', 'SSI');
 
         // remove SSI/1.0 from the Surrogate-Control header
-        if ($response->headers->has('Surrogate-Control')) {
-            $value = $response->headers->get('Surrogate-Control');
-            if ('content="SSI/1.0"' == $value) {
-                $response->headers->remove('Surrogate-Control');
-            } elseif (preg_match('#,\s*content="SSI/1.0"#', $value)) {
-                $response->headers->set('Surrogate-Control', preg_replace('#,\s*content="SSI/1.0"#', '', $value));
-            } elseif (preg_match('#content="SSI/1.0",\s*#', $value)) {
-                $response->headers->set('Surrogate-Control', preg_replace('#content="SSI/1.0",\s*#', '', $value));
-            }
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function handle(HttpCache $cache, $uri, $alt, $ignoreErrors)
-    {
-        $subRequest = Request::create($uri, 'get', array(), $cache->getRequest()->cookies->all(), array(), $cache->getRequest()->server->all());
-
-        try {
-            $response = $cache->handle($subRequest, HttpKernelInterface::SUB_REQUEST, true);
-
-            if (!$response->isSuccessful()) {
-                throw new \RuntimeException(sprintf('Error when rendering "%s" (Status code is %s).', $subRequest->getUri(), $response->getStatusCode()));
-            }
-
-            return $response->getContent();
-        } catch (\Exception $e) {
-            if ($alt) {
-                return $this->handle($cache, $alt, '', $ignoreErrors);
-            }
-
-            if (!$ignoreErrors) {
-                throw $e;
-            }
-        }
+        $this->removeFromControl($response);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This moves the not-specific logic from the Esi/Ssi classes into an abstract class that they extend.
This class (`AbstractSurrogate`) can be extended by any class implementing a Surrogate-Capability to the Request+Response instances, as Esi/Ssi do for ESI/SSI capabilities.
