### PR TITLE
[Serializer] Add the possibility to filter attributes

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -95,7 +95,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 throw new LogicException(sprintf('Cannot normalize attribute "%s" because the injected serializer is not a normalizer', $attribute));
             }
 
-            $data = $this->updateData($data, $attribute, $this->serializer->normalize($attributeValue, $format, $context));
+            $data = $this->updateData($data, $attribute, $this->serializer->normalize($attributeValue, $format, $this->createChildContext($context, $attribute)));
         }
 
         return $data;
@@ -268,7 +268,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 }
 
                 if ($this->serializer->supportsDenormalization($data, $class, $format)) {
-                    return $this->serializer->denormalize($data, $class, $format, $context);
+                    return $this->serializer->denormalize($data, $class, $format, $this->createChildContext($context, $attribute));
                 }
             }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | todo |

This new features give the possibility to the end user to select select fields to normalize.

Exemple:

``` php
class Foo
{
    public $a = '1';
    public $b = '2';
    public $c = '3';
}

$normalizer = new \Symfony\Component\Serializer\Normalizer\ObjectNormalizer();
$normalizer->normalize(new Foo(), null, ['attributes' => ['a', 'c']]);
// ['a' => '1', 'c' => '3']
```

Denormalization is also supported. This feature works for any normalizer using the `Symfony\Component\Serializer\Normalizer\AbstractNormalizer` class.

The main use case is to permit to API clients to optimize responses length by dropping unnecessary information like in the following example:

```
http://exemple.com/cars?fields=a,c

{'a' => 1, 'c' => 2}
```

Nested parameters are also supported:

```php
class Foo
{
    public $a = '1';
    public $b = '2';
    public $c = '3';
    public $bar = new Bar();
}

class Bar
{
    public $x = 'x';
    public $y = 'y';
    public $z = 'z';
}

$serializer = new \Symfony\Component\Serializer(
    [new \Symfony\Component\Serializer\Normalizer\ObjectNormalizer()]
);
$serializer->normalize(new Foo(), null, ['attributes' => ['a', 'c', 'bar' => ['y']]]);
// ['a' => '1', 'c' => '3', 'bar' => ['y' => 'y']
```

Thanks to this PR, support for this feature will be available out of the box in [API Platform](https://api-platform.com).
