### PR TITLE
[HttpKernel] Add an environment checking for an empty string

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -70,9 +70,15 @@ abstract class Kernel implements KernelInterface, TerminableInterface
      *
      * @param string $environment The environment
      * @param bool   $debug       Whether to enable debugging or not
+     *
+     * @throws \InvalidArgumentException if an environment is empty
      */
     public function __construct($environment, $debug)
     {
+        if (empty($environment)) {
+            throw new \InvalidArgumentException('An environment must not be empty.');
+        }
+
         $this->environment = $environment;
         $this->debug = (bool) $debug;
         $this->booted = false;

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -36,6 +36,15 @@ class KernelTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($kernel->getContainer());
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage An environment must not be empty.
+     */
+    public function testConstructorThrowsExceptionWhenEnvironmentIsEmptyString()
+    {
+        $kernel = new KernelForTest('', true);
+    }
+
     public function testClone()
     {
         $env = 'test_env';


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.3 |
| Bug fix? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

The Kernel accepts empty string as an environment value. It may cause some potential problems like this: https://github.com/symfony/symfony-standard/pull/977
