### PR TITLE
[DependencyInjection] Improved the validation of the service names for XML files

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -101,7 +101,7 @@
       <xsd:element name="property" type="property" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="autowiring-type" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
     </xsd:choice>
-    <xsd:attribute name="id" type="xsd:string" />
+    <xsd:attribute name="id" type="service_id" />
     <xsd:attribute name="class" type="xsd:string" />
     <xsd:attribute name="shared" type="boolean" />
     <xsd:attribute name="scope" type="xsd:string" />
@@ -207,6 +207,12 @@
   <xsd:simpleType name="boolean">
     <xsd:restriction base="xsd:string">
       <xsd:pattern value="(%.+%|true|false)" />
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="service_id">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="([^._-][a-z0-9._-]+[^._-])" />
     </xsd:restriction>
   </xsd:simpleType>
 </xsd:schema>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services25.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services25.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="._-foo-_." class="Foo">
+    </service>
+  </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -550,4 +550,15 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($container->getDefinition('bar')->isAutowired());
     }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
+     * @expectedExceptionMessageRegExp /Unable to parse file ".+.xml"/
+     */
+    public function testParsingServiceWithNonValidIdThrowsException()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader->load('services25.xml');
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

Added a regex constraint for the service id in the xsd
