### PR TITLE
[Console][DX] Fixed ambiguous error message when using a duplicate option shortcut

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -307,13 +307,13 @@ class Command
             return;
         }
 
+        $this->definition->addOptions($this->application->getDefinition()->getOptions());
+
         if ($mergeArgs) {
             $currentArguments = $this->definition->getArguments();
             $this->definition->setArguments($this->application->getDefinition()->getArguments());
             $this->definition->addArguments($currentArguments);
         }
-
-        $this->definition->addOptions($this->application->getDefinition()->getOptions());
 
         $this->applicationDefinitionMerged = true;
         if ($mergeArgs) {

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -736,6 +736,33 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \LogicException
+     * @expectedExceptionMessage An option with shortcut "e" already exists.
+     */
+    public function testAddingOptionWithDuplicateShortcut()
+    {
+        $dispatcher = new EventDispatcher();
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+        $application->setDispatcher($dispatcher);
+
+        $application->getDefinition()->addOption(new InputOption('--env', '-e', InputOption::VALUE_REQUIRED, 'Environment'));
+
+        $application
+            ->register('foo')
+            ->setAliases(['f'])
+            ->setDefinition(array(new InputOption('survey', 'e', InputOption::VALUE_REQUIRED, 'My option with a shortcut.')))
+            ->setCode(function (InputInterface $input, OutputInterface $output) {})
+        ;
+
+        $input = new ArrayInput(array('command' => 'foo'));
+        $output = new NullOutput();
+
+        $application->run($input, $output);
+    }
+
+    /**
+     * @expectedException \LogicException
      * @dataProvider getAddingAlreadySetDefinitionElementData
      */
     public function testAddingAlreadySetDefinitionElementData($def)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.3 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18856 |
| License | MIT |
| Doc PR | - |

I assume this should be merged into 2.3 as per @stof's comment.

There is a race condition when you run a command which has a duplicate option shortcut. Simply changing the order so that Options are merged before the Arguments solves that race condition.

``` php
$this->setName('my:super:command')
->setAliases(['my:super:commandalias'])
->setDescription('Performs some irrelevant work.')
->addOption('survey', 'e', InputOption::VALUE_REQUIRED, 'My option with a shortcut.')
```

Gives the error message:

```
  [Symfony\Component\Console\Exception\LogicException]
  An argument with name "command" already exists.
```

This happens as the first time the definition is merged happens here:

https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Console/Application.php#L820

As this throws an error here:

https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Console/Command/Command.php#L309

The commans are merged but not the options. 

Merging it then again when the command is run

https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Console/Command/Command.php#L217

throws an error due to the duplicate argument as the arguments already have been merged. This time the error message is not surpressed and will confuse the user.

Changing the order should fix the issue for duplicate arguments as well as for duplicate options.
