### PR TITLE
[Cache] Drop counting hit/miss in ProxyAdapter

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/ProxyAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ProxyAdapter.php
@@ -24,8 +24,6 @@ class ProxyAdapter implements AdapterInterface
     private $namespace;
     private $namespaceLen;
     private $createCacheItem;
-    private $hits = 0;
-    private $misses = 0;
 
     public function __construct(CacheItemPoolInterface $pool, $namespace = '', $defaultLifetime = 0)
     {
@@ -54,13 +52,8 @@ class ProxyAdapter implements AdapterInterface
     {
         $f = $this->createCacheItem;
         $item = $this->pool->getItem($this->getId($key));
-        if ($isHit = $item->isHit()) {
-            ++$this->hits;
-        } else {
-            ++$this->misses;
-        }
 
-        return $f($key, $item->get(), $isHit);
+        return $f($key, $item->get(), $item->isHit());
     }
 
     /**
@@ -158,37 +151,12 @@ class ProxyAdapter implements AdapterInterface
         $f = $this->createCacheItem;
 
         foreach ($items as $key => $item) {
-            if ($isHit = $item->isHit()) {
-                ++$this->hits;
-            } else {
-                ++$this->misses;
-            }
             if ($this->namespaceLen) {
                 $key = substr($key, $this->namespaceLen);
             }
 
-            yield $key => $f($key, $item->get(), $isHit);
+            yield $key => $f($key, $item->get(), $item->isHit());
         }
-    }
-
-    /**
-     * Returns the number of cache read hits.
-     *
-     * @return int
-     */
-    public function getHits()
-    {
-        return $this->hits;
-    }
-
-    /**
-     * Returns the number of cache read misses.
-     *
-     * @return int
-     */
-    public function getMisses()
-    {
-        return $this->misses;
     }
 
     private function getId($key)

--- a/src/Symfony/Component/Cache/Tests/Adapter/ProxyAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ProxyAdapterTest.php
@@ -29,21 +29,4 @@ class ProxyAdapterTest extends CachePoolTest
     {
         return new ProxyAdapter(new ArrayAdapter());
     }
-
-    public function testGetHitsMisses()
-    {
-        $pool = $this->createCachePool();
-
-        $this->assertSame(0, $pool->getHits());
-        $this->assertSame(0, $pool->getMisses());
-
-        $bar = $pool->getItem('bar');
-        $this->assertSame(0, $pool->getHits());
-        $this->assertSame(1, $pool->getMisses());
-
-        $pool->save($bar->set('baz'));
-        $bar = $pool->getItem('bar');
-        $this->assertSame(1, $pool->getHits());
-        $this->assertSame(1, $pool->getMisses());
-    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

We have no use case for these methods yet. Let's drop them and save some BC constraints.
