### PR TITLE
[Routing] Throw exception when PHP start tag is missing

### DIFF
--- a/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
@@ -92,6 +92,11 @@ class AnnotationFileLoader extends FileLoader
         $class = false;
         $namespace = false;
         $tokens = token_get_all(file_get_contents($file));
+
+        if (1 === count($tokens) && T_INLINE_HTML === $tokens[0][0]) {
+            throw new \InvalidArgumentException(sprintf('The file "%s" does not contain PHP code. Did you forgot to add the "<?php" start tag at the beginning of the file?', $file));
+        }
+
         for ($i = 0; isset($tokens[$i]); ++$i) {
             $token = $tokens[$i];
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/OtherAnnotatedClasses/NoStartTagClass.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/OtherAnnotatedClasses/NoStartTagClass.php
@@ -1,0 +1,3 @@
+class NoStartTagClass
+{
+}

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationFileLoaderTest.php
@@ -46,6 +46,15 @@ class AnnotationFileLoaderTest extends AbstractAnnotationLoaderTest
     }
 
     /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Did you forgot to add the "<?php" start tag at the beginning of the file?
+     */
+    public function testLoadFileWithoutStartTag()
+    {
+        $this->loader->load(__DIR__.'/../Fixtures/OtherAnnotatedClasses/NoStartTagClass.php');
+    }
+
+    /**
      * @requires PHP 5.6
      */
     public function testLoadVariadic()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master (?) |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony-docs/issues/6116 (and many more) |
| License | MIT |
| Doc PR | - |
## The Problem

In the documentation, we never use the PHP start tag. However, in the first tutorials, people simply copy/past the code examples, save the file and expect things to work. They seem to often forget to add the PHP start tag.

Without start tag, the annotation file loader simply skips the file without providing any reason why. As a big framework is quite overwhelming, simple things like this are completely forgotten.
## The Fix

If a `*.php` file only consists of `T_INLINE_HTML`, it means there is no `<?php` start tag. In this case, instead of skipping the file, an exception is throwed with a possible fix.
## BC Break?

As the file loader is only executed for `*.php` files, I think the BC break is minimal, but it is possible that people have applications with `*.php` files _without_ a start tag. If this file lives in a routing loaded directory (e.g. when doing `@AppBundle/Controller`), it would now result in an exception.

I think this BC break is minimal and can be ignored. If you don't agree, we can add a little str match to check if `class ... {` exists. If that's the case, I think it's safe to say that it was meant to be a PHP file.
## Bug or Feature?

I don't know if this is considered a bug or a feature, so I submitted it as a feature.
