### PR TITLE
[EventDispatcher] Add listener caller extension point

### DIFF
--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -29,6 +29,7 @@ class EventDispatcher implements EventDispatcherInterface
 {
     private $listeners = array();
     private $sorted = array();
+    private $listenerCaller;
 
     /**
      * {@inheritdoc}
@@ -155,6 +156,11 @@ class EventDispatcher implements EventDispatcherInterface
         }
     }
 
+    public function setListenerCaller(EventListenerCallerInterface $listenerCaller)
+    {
+        $this->listenerCaller = $listenerCaller;
+    }
+
     /**
      * Triggers the listeners of an event.
      *
@@ -167,12 +173,27 @@ class EventDispatcher implements EventDispatcherInterface
      */
     protected function doDispatch($listeners, $eventName, Event $event)
     {
+        $listenerCaller = $this->getListenerCaller();
+
         foreach ($listeners as $listener) {
             if ($event->isPropagationStopped()) {
                 break;
             }
-            call_user_func($listener, $event, $eventName, $this);
+
+            $listenerCaller->call($listener, $event, $eventName, $this);
         }
+    }
+
+    /**
+     * @return EventListenerCallerInterface
+     */
+    private function getListenerCaller()
+    {
+        if (null === $this->listenerCaller) {
+            $this->listenerCaller = new StandardEventListenerCaller();
+        }
+
+        return $this->listenerCaller;
     }
 
     /**

--- a/src/Symfony/Component/EventDispatcher/EventListenerCallerInterface.php
+++ b/src/Symfony/Component/EventDispatcher/EventListenerCallerInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher;
+
+/**
+ *
+ */
+interface EventListenerCallerInterface
+{
+    /**
+     * @param callable                 $listener
+     * @param Event                    $event
+     * @param string                   $eventName
+     * @param EventDispatcherInterface $eventDispatcher
+     */
+    public function call(callable $listener, Event $event, $eventName, EventDispatcherInterface $eventDispatcher);
+}

--- a/src/Symfony/Component/EventDispatcher/StandardEventListenerCaller.php
+++ b/src/Symfony/Component/EventDispatcher/StandardEventListenerCaller.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher;
+
+/**
+ *
+ */
+final class StandardEventListenerCaller implements EventListenerCallerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function call(callable $listener, Event $event, $eventName, EventDispatcherInterface $eventDispatcher)
+    {
+        call_user_func($listener, $event, $eventName, $eventDispatcher);
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | sort of |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | let's see |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

In our project we reuse infrastructure of the EventDispatcher for dispatching domain events. In the past we had 2 issues:
- inheriting the `Event` class (because it makes our domain coupled on the framework and it also contains undesirable `propagation` logic);
- having `eventName`, i.e. our "event name" is simple `get_class($event)`.

We introduced `DomainEventEnvelope extends \Symfony\Component\EventDispatcher\Event` and the following dispatcher:

``` php
final class DomainEventAwareEventDispatcher extends ContainerAwareEventDispatcher
{
    /**
     * {@inheritdoc}
     */
    protected function doDispatch($listeners, $eventName, Event $event) {
        if ($event instanceof DomainEventEnvelope) {
            foreach ($listeners as $listener) {
                $listener($event->getDomainEvent(), $event->getMetadata());
            }
        } else {
            parent::doDispatch($listeners, $eventName, $event);
        }
    }
}
```

It works, but this solution is rather bad. This PR adds new extension point in the `EventDispatcher` which allows to solve issue above with composition:

``` php
final class DomainEventListenerCaller implements EventListenerCallerInterface
{
    private $fallbackListenerCaller;

    public function __construct(EventListenerCallerInterface $fallbackListenerCaller)
    {
        $this->fallbackListenerCaller = $fallbackListenerCaller;
    }

    public function call(callable $listener, Event $event, $eventName, EventDispatcherInterface $eventDispatcher)
    {
        if ($event instanceof DomainEventEnvelope) {
            $listener($event->getDomainEvent(), $event->getMetadata());
            return;
        }

        $this->fallbackListenerCaller->call($listener, $event, $eventName, $eventDispatcher);
    }
}
```
