### PR TITLE
[Console] SymfonyStyle: Align multi-line/very-long-line blocks

### DIFF
--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -68,21 +68,34 @@ class SymfonyStyle extends OutputStyle
     {
         $this->autoPrependBlock();
         $messages = is_array($messages) ? array_values($messages) : array($messages);
+        $indentLength = 0;
         $lines = array();
 
-        // add type
         if (null !== $type) {
-            $messages[0] = sprintf('[%s] %s', $type, $messages[0]);
+            $typePrefix = sprintf('[%s] ', $type);
+            $indentLength = strlen($typePrefix);
+            $lineIndentation = str_repeat(' ', $indentLength);
         }
 
         // wrap and add newlines for each element
         foreach ($messages as $key => $message) {
             $message = OutputFormatter::escape($message);
-            $lines = array_merge($lines, explode(PHP_EOL, wordwrap($message, $this->lineLength - Helper::strlen($prefix), PHP_EOL, true)));
+            $lines = array_merge($lines, explode(PHP_EOL, wordwrap($message, $this->lineLength - Helper::strlen($prefix) - $indentLength, PHP_EOL, true)));
+
+            // prefix each line with a number of spaces equivalent to the type length
+            if (null !== $type) {
+                foreach ($lines as &$line) {
+                    $line = $lineIndentation === substr($line, 0, $indentLength) ? $line : $lineIndentation.$line;
+                }
+            }
 
             if (count($messages) > 1 && $key < count($messages) - 1) {
                 $lines[] = '';
             }
+        }
+
+        if (null !== $type) {
+            $lines[0] = substr_replace($lines[0], $typePrefix, 0, $indentLength);
         }
 
         if ($padding && $this->isDecorated()) {

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_10.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_10.php
@@ -1,0 +1,17 @@
+<?php
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tests\Style\SymfonyStyleWithForcedLineLength;
+
+//Ensure that all lines are aligned to the begin of the first line in a very long line block
+return function (InputInterface $input, OutputInterface $output) {
+    $output = new SymfonyStyleWithForcedLineLength($input, $output);
+    $output->block(
+        'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum',
+        'CUSTOM',
+        'fg=white;bg=green',
+        'X ',
+        true
+    );
+};

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_9.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_9.php
@@ -1,0 +1,11 @@
+<?php
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tests\Style\SymfonyStyleWithForcedLineLength;
+
+//Ensure that all lines are aligned to the begin of the first line in a multi-line block
+return function (InputInterface $input, OutputInterface $output) {
+    $output = new SymfonyStyleWithForcedLineLength($input, $output);
+    $output->block(['Custom block', 'Second custom block line'], 'CUSTOM', 'fg=white;bg=green', 'X ', true);
+};

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_10.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_10.txt
@@ -1,0 +1,7 @@
+
+X [CUSTOM] Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et      
+X          dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+X          commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat    
+X          nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit    
+X          anim id est laborum                                                                                          
+

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_9.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_9.txt
@@ -1,0 +1,5 @@
+
+X [CUSTOM] Custom block                                                                                                 
+X                                                                                                                       
+X          Second custom block line                                                                                     
+

--- a/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
@@ -57,7 +57,7 @@ class SymfonyStyleTest extends PHPUnit_Framework_TestCase
 
     public function testLongWordsBlockWrapping()
     {
-        $word = 'Lopadotemachoselachogaleokranioleipsanodrimhypotrimmatosilphioparaomelitokatakechymenokichlepikossyphophattoperisteralektryonoptekephalliokigklopeleiolagoiosiraiobaphetraganopterygon';
+        $word = 'Lopadotemachoselachogaleokranioleipsanodrimhypotrimmatosilphioparaomelitokatakechymenokichlepikossyphophattoperisteralektryonoptekephalliokigklopeleiolagoiosiraiobaphetraganopterygovgollhjvhvljfezefeqifzeiqgiqzhrsdgihqzridghqridghqirshdghdghieridgheirhsdgehrsdvhqrsidhqshdgihrsidvqhneriqsdvjzergetsrfhgrstsfhsetsfhesrhdgtesfhbzrtfbrztvetbsdfbrsdfbrn';
         $wordLength = strlen($word);
         $maxLineLength = SymfonyStyle::MAX_LINE_LENGTH - 3;
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18564 |
| License | MIT |
| Doc PR | n/a |

This PR makes all lines aligned in multi-line blocks.

Very-long-line block:

``` php
SymfonyStyle::warning('Lorem ipsum...');
```

Before:
![before-1](http://image.prntscr.com/image/d8443d3a85924a0182a62bd6d3dc1086.png)
After:
![after-1](http://image.prntscr.com/image/dbbdd275bff140bdad06de336f032ec1.png)

Multi-line block:

``` php
SymfonyStyle::success(['Lorem ipsum...', 'Lorem ipsum...', 'Lorem ipsum...']);
```

Before:
![before-2](http://image.prntscr.com/image/6d7c05b4ab3a42f0b0be652527aed7c8.png)
After:
![after-2](http://image.prntscr.com/image/bba017309f4a4dd09e0147d5917cb0ae.png)

Also @javiereguiluz pointed the case of `SymfonyStyle::comment()` in #18564, I needed to make it calling `SymfonyStyle::block()` with `//` as prefix to fit the first intention of this one.
So if this one is merged I'll propose the changes for comments in a second PR (out of this scope).
