### PR TITLE
[Console] SymfonyStyle: Fix alignment/prefixing of multi-line comments

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -339,7 +339,7 @@ class TextDescriptor extends Descriptor
      */
     protected function describeContainerAlias(Alias $alias, array $options = array())
     {
-        $options['output']->comment(sprintf("This service is an alias for the service <info>%s</info>\n", (string) $alias));
+        $options['output']->comment(sprintf('This service is an alias for the service <info>%s</info>', (string) $alias));
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_1.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_1.txt
@@ -1,1 +1,3 @@
-// This service is an alias for the service [32mservice_1[39m
+
+ // This service is an alias for the service [32mservice_1[39m                                                                  
+

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_2.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_2.txt
@@ -1,1 +1,3 @@
-// This service is an alias for the service [32mservice_2[39m
+
+ // This service is an alias for the service [32mservice_2[39m                                                                  
+

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -170,16 +170,18 @@ class SymfonyStyle extends OutputStyle
     }
 
     /**
-     * {@inheritdoc}
+     * Formats a command comment.
+     *
+     * @param string|array $message
      */
     public function comment($message)
     {
-        $this->autoPrependText();
-
         $messages = is_array($message) ? array_values($message) : array($message);
-        foreach ($messages as $message) {
-            $this->writeln(sprintf(' // %s', $message));
+        foreach ($messages as &$message) {
+            $message = $this->getFormatter()->format($message);
         }
+
+        $this->block($messages, null, null, ' // ');
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_11.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_11.php
@@ -1,0 +1,13 @@
+<?php
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tests\Style\SymfonyStyleWithForcedLineLength;
+
+//Ensure that all lines are aligned to the begin of the first one and start with '//' in a very long line comment
+return function (InputInterface $input, OutputInterface $output) {
+    $output = new SymfonyStyleWithForcedLineLength($input, $output);
+    $output->comment(
+        'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum'
+    );
+};

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_11.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_11.txt
@@ -1,0 +1,6 @@
+
+ // Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+ // aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. 
+ // Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur    
+ // sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum                 
+

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_5.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_5.txt
@@ -11,5 +11,8 @@ Lorem ipsum dolor sit amet
  consectetur adipiscing elit
 
 Lorem ipsum dolor sit amet
- // Lorem ipsum dolor sit amet
- // consectetur adipiscing elit
+
+ // Lorem ipsum dolor sit amet                                                                                          
+ //                                                                                                                     
+ // consectetur adipiscing elit                                                                                         
+


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Pointed in https://github.com/symfony/symfony/issues/18564#issuecomment-210861051.

Very-long-line comment:

``` php
SymfonyStyle::comment('Lorem ipsum ...');
```

Before:
![](http://image.prntscr.com/image/9190081d7fd740a89d17a7247dbbb244.png)

After:
![](http://image.prntscr.com/image/109c8c19c1574172bc22199ac90b6dd6.png)

Multi-line comment:

``` php
SymfonyStyle::comment(['Lorem ipsum...', 'Lorem ipsum...']);
```

Before:
![](http://image.prntscr.com/image/24228f7e89e647b3a5d66fd83c7216cd.png)

After:
![](http://image.prntscr.com/image/fe9320369fad45acab92564f0e5de344.png)
