### PR TITLE
[DependencyInjection] Skip deep reference check for 'service_container'

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1173,7 +1173,7 @@ EOF;
                     return true;
                 }
 
-                if ($deep && !isset($visited[(string) $argument])) {
+                if ($deep && !isset($visited[(string) $argument]) && 'service_container' !== (string) $argument) {
                     $visited[(string) $argument] = true;
 
                     $service = $this->container->getDefinition((string) $argument);

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -226,4 +226,15 @@ class PhpDumperTest extends \PHPUnit_Framework_TestCase
         $dumper = new PhpDumper($container);
         $dumper->dump();
     }
+
+    public function testInlinedDefinitionReferencingServiceContainer()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', 'stdClass')->addMethodCall('add', array(new Reference('service_container')))->setPublic(false);
+        $container->register('bar', 'stdClass')->addArgument(new Reference('foo'));
+        $container->compile();
+
+        $dumper = new PhpDumper($container);
+        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services13.php', $dumper->dump(), '->dump() dumps inline definitions which reference service_container');
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services13.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services13.php
@@ -1,0 +1,54 @@
+<?php
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\Exception\InactiveScopeException;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
+
+/**
+ * ProjectServiceContainer.
+ *
+ * This class has been auto-generated
+ * by the Symfony Dependency Injection Component.
+ */
+class ProjectServiceContainer extends Container
+{
+    private $parameters;
+    private $targetDirs = array();
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->services =
+        $this->scopedServices =
+        $this->scopeStacks = array();
+        $this->scopes = array();
+        $this->scopeChildren = array();
+        $this->methodMap = array(
+            'bar' => 'getBarService',
+        );
+
+        $this->aliases = array();
+    }
+
+    /**
+     * Gets the 'bar' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return \stdClass A stdClass instance.
+     */
+    protected function getBarService()
+    {
+        $a = new \stdClass();
+        $a->add($this);
+
+        return $this->services['bar'] = new \stdClass($a);
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.3 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The "hasReference" check when dumping the container fails in the case where a service has a method call which includes a reference to a private/inlined service when either that service, or a dependency of it, references the service_container. This because service_container isn't defined while it still tries to check the references of it. So the service_container must be skipped in this case, this shouldn't break anything as the service_container doesn't reference any services, and thus can't reference the service which it is checking for.
