### PR TITLE
[Console] [SymfonyStyle] Replace long word wrapping test to directly test output

### DIFF
--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_11.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_11.php
@@ -1,0 +1,12 @@
+<?php
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tests\Style\SymfonyStyleWithForcedLineLength;
+
+//Ensure long words are properly wrapped in blocks
+return function (InputInterface $input, OutputInterface $output) {
+    $word = 'Lopadotemachoselachogaleokranioleipsanodrimhypotrimmatosilphioparaomelitokatakechymenokichlepikossyphophattoperisteralektryonoptekephalliokigklopeleiolagoiosiraiobaphetraganopterygon';
+    $sfStyle = new SymfonyStyleWithForcedLineLength($input, $output);
+    $sfStyle->block($word, 'CUSTOM', 'fg=white;bg=blue', ' § ', false);
+};

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_11.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_11.txt
@@ -1,0 +1,4 @@
+
+ § [CUSTOM] Lopadotemachoselachogaleokranioleipsanodrimhypotrimmatosilphioparaomelitokatakechymenokichlepikossyphophatto
+ §          peristeralektryonoptekephalliokigklopeleiolagoiosiraiobaphetraganopterygon                                  
+

--- a/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
@@ -54,22 +54,6 @@ class SymfonyStyleTest extends PHPUnit_Framework_TestCase
 
         return array_map(null, glob($baseDir.'/command/command_*.php'), glob($baseDir.'/output/output_*.txt'));
     }
-
-    public function testLongWordsBlockWrapping()
-    {
-        $word = 'Lopadotemachoselachogaleokranioleipsanodrimhypotrimmatosilphioparaomelitokatakechymenokichlepikossyphophattoperisteralektryonoptekephalliokigklopeleiolagoiosiraiobaphetraganopterygovgollhjvhvljfezefeqifzeiqgiqzhrsdgihqzridghqridghqirshdghdghieridgheirhsdgehrsdvhqrsidhqshdgihrsidvqhneriqsdvjzergetsrfhgrstsfhsetsfhesrhdgtesfhbzrtfbrztvetbsdfbrsdfbrn';
-        $wordLength = strlen($word);
-        $maxLineLength = SymfonyStyle::MAX_LINE_LENGTH - 3;
-
-        $this->command->setCode(function (InputInterface $input, OutputInterface $output) use ($word) {
-            $sfStyle = new SymfonyStyleWithForcedLineLength($input, $output);
-            $sfStyle->block($word, 'CUSTOM', 'fg=white;bg=blue', ' § ', false);
-        });
-
-        $this->tester->execute(array(), array('interactive' => false, 'decorated' => false));
-        $expectedCount = (int) ceil($wordLength / ($maxLineLength)) + (int) ($wordLength > $maxLineLength - 5);
-        $this->assertSame($expectedCount, substr_count($this->tester->getDisplay(true), ' § '));
-    }
 }
 
 /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/pull/18879#discussion_r64783524 |
| License | MIT |
| Doc PR | - |

This [line](https://github.com/symfony/symfony/pull/18879/files#diff-d3625f2548a3b329058ca5a0f5aa57feR60) should not have been changed in order to the test to pass. I assume the test was flawed at first, so I suggest to simply test the output as we did for other ones.

Ping @chalasr 
