### PR TITLE
[PhpUnitBridge] make PHPUnit environment variables configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ composer.phar
 package.tar
 /packages.json
 /.phpunit
+/.phpunit.php

--- a/phpunit
+++ b/phpunit
@@ -183,7 +183,13 @@ if (isset($argv[1]) && 'symfony' === $argv[1]) {
     // Run regular phpunit in a subprocess
 
     $errFile = tempnam(sys_get_temp_dir(), 'phpunit.stderr.');
-    if ($proc = proc_open(sprintf($cmd, '', ' 2> '.ProcessUtils::escapeArgument($errFile)), array(1 => array('pipe', 'w')), $pipes)) {
+    $env = null;
+
+    if (is_file(__DIR__.'/.phpunit.php')) {
+        $env = require __DIR__.'/.phpunit.php';
+    }
+
+    if ($proc = proc_open(sprintf($cmd, '', ' 2> '.ProcessUtils::escapeArgument($errFile)), array(1 => array('pipe', 'w')), $pipes, null, $env)) {
         stream_copy_to_stream($pipes[1], STDOUT);
         fclose($pipes[1]);
         $exit = proc_close($proc);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.3 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Whenever I try to use Xdebug locally while executing the Symfony test suite, I have to modify the `phpunit` wrapper script to pass the `XDEBUG_CONFIG` variable to PHPUnit. With this change, one can create `.phpunit.php` files locally containing something like this instead:

``` php
<?php
return array(
    'XDEBUG_CONFIG' => 'remote_enable=1 remote_mode=req remote_port=9000 remote_host=127.0.0.1 remote_connect_back=0',
);
```
