### PR TITLE
[Console] Add SymfonyStyle::setInputStream() to ease command testing

### DIFF
--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -40,6 +40,7 @@ class SymfonyStyle extends OutputStyle
     private $progressBar;
     private $lineLength;
     private $bufferedOutput;
+    private $inputStream;
 
     /**
      * @param InputInterface  $input
@@ -350,6 +351,10 @@ class SymfonyStyle extends OutputStyle
 
         if (!$this->questionHelper) {
             $this->questionHelper = new SymfonyQuestionHelper();
+
+            if ($this->inputStream) {
+                $this->questionHelper->setInputStream($this->inputStream);
+            }
         }
 
         $answer = $this->questionHelper->ask($this->input, $this, $question);
@@ -387,6 +392,22 @@ class SymfonyStyle extends OutputStyle
     {
         parent::newLine($count);
         $this->bufferedOutput->write(str_repeat("\n", $count));
+    }
+
+    /**
+     * Sets the input stream to read from when interacting with the user.
+     *
+     * This is mainly useful for testing purpose.
+     *
+     * @param resource $stream The input stream
+     */
+    public function setInputStream($stream)
+    {
+        $this->inputStream = $stream;
+
+        if ($this->questionHelper) {
+            $this->questionHelper->setInputStream($stream);
+        }
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/interactive_command_1.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/interactive_command_1.php
@@ -1,0 +1,25 @@
+<?php
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tests\Style\SymfonyStyleWithForcedLineLength;
+
+//Ensure that questions have the expected outputs
+return function (InputInterface $input, OutputInterface $output) {
+    $output = new SymfonyStyleWithForcedLineLength($input, $output);
+    $questions = array(
+        'What\'s your name?',
+        'How are you?',
+        'Where do you come from?',
+    );
+    $inputs = array('Foo', 'Bar', 'Baz');
+    $stream = fopen('php://memory', 'r+', false);
+
+    fputs($stream, implode(PHP_EOL, $inputs));
+    rewind($stream);
+
+    $output->setInputStream($stream);
+    $output->ask($questions[0]);
+    $output->ask($questions[1]);
+    $output->ask($questions[2]);
+};

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/interactive_output_1.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/interactive_output_1.txt
@@ -1,0 +1,7 @@
+
+ What's your name?:
+ > 
+ How are you?:
+ > 
+ Where do you come from?:
+ > 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | not yet |

To make a command that uses `SymfonyStyle::ask()` able to be tested, I propose to add a `SymfonyStyle::setInputStream()`. I added a test that shows how to use it and depending on maintainer reactions, I'll quickly submit a doc PR.

Adding a setQuestionHelper as in #17136  doesn't make sense to me because if I have to test a command with the normal QuestionHelper, I would simply use `MyCommand::getHelper('question')->ask()` out of the SymfonyStyle IO.

This PR would makes #18710 even better (working for SymfonyStyle by simply doing `SymfonyStyle::setInputStream($this->getHelper('question')->getInputStream())` from inside a command).
