### PR TITLE
Release v3.1.0

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -7,6 +7,12 @@ in 3.1 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v3.1.0...v3.1.1
 
+* 3.1.0 (2016-05-30)
+
+ * bug #18889 [Console] SymfonyStyle: Fix alignment/prefixing of multi-line comments (chalasr)
+ * bug #18907 [Routing] Fix the annotation loader taking a class constant as a beginning of a class name (jakzal, nicolas-grekas)
+ * bug #18899 [Yaml] search for colons in strings only (xabbuh)
+
 * 3.1.0-RC1 (2016-05-26)
 
  * bug #18879 [Console] SymfonyStyle: Align multi-line/very-long-line blocks (chalasr)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -59,12 +59,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '3.1.0-DEV';
+    const VERSION = '3.1.0';
     const VERSION_ID = 30100;
     const MAJOR_VERSION = 3;
     const MINOR_VERSION = 1;
     const RELEASE_VERSION = 0;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '01/2017';
     const END_OF_LIFE = '07/2017';


### PR DESCRIPTION
Changes since last release: https://github.com/symfony/symfony/compare/v3.1.0-RC1...e62f832

**Changelog**
- bug #18889 [Console] SymfonyStyle: Fix alignment/prefixing of multi-line comments (@chalasr)
- bug #18907 [Routing] Fix the annotation loader taking a class constant as a beginning of a class name (@jakzal, @nicolas-grekas)
- bug #18899 [Yaml] search for colons in strings only (@xabbuh)
