### PR TITLE
Release v2.3.42

### DIFF
--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -7,6 +7,22 @@ in 2.3 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.3.0...v2.3.1
 
+* 2.3.42 (2016-05-30)
+
+ * bug #18908 [DependencyInjection] force enabling the external XML entity loaders (xabbuh)
+ * bug #18893 [DependencyInjection] Skip deep reference check for 'service_container' (RobertMe)
+ * bug #18812 Catch \Throwable (fprochazka)
+ * bug #18821 [Form] Removed UTC specification with timestamp (francisbesset)
+ * bug #18861 Fix for #18843 (inso)
+ * bug #18907 [Routing] Fix the annotation loader taking a class constant as a beginning of a class name (jakzal, nicolas-grekas)
+ * bug #18864 [Console][DX] Fixed ambiguous error message when using a duplicate option shortcut (peterrehm)
+ * bug #18844 [Yaml] fix exception contexts (xabbuh)
+ * bug #18840 [Yaml] properly handle unindented collections (xabbuh)
+ * bug #18839 People - person singularization (Keeo)
+ * bug #18828 [Yaml] chomp newlines only at the end of YAML documents (xabbuh)
+ * bug #18635 [Console] Prevent fatal error when calling Command::getHelper without helperSet (chalasr)
+ * bug #18761  [Form] Modified iterator_to_array's 2nd parameter to false in ViolationMapper (issei-m)
+
 * 2.3.41 (2016-05-09)
 
  * security #18733 limited the maximum length of a submitted username (fabpot)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -23,8 +23,8 @@ Symfony is the result of the work of many people who made the code better
  - Pascal Borreli (pborreli)
  - Joseph Bielawski (stloyd)
  - Wouter De Jong (wouterj)
- - Karma Dordrak (drak)
  - Romain Neutron (romain)
+ - Karma Dordrak (drak)
  - Lukas Kahwe Smith (lsmith)
  - Martin Hasoň (hason)
  - Jeremy Mikola (jmikola)
@@ -53,11 +53,11 @@ Symfony is the result of the work of many people who made the code better
  - Bilal Amarni (bamarni)
  - Florin Patan (florinpatan)
  - Kevin Bond (kbond)
+ - Peter Rehm (rpet)
  - Gábor Egyed (1ed)
  - Michel Weimerskirch (mweimerskirch)
  - Eric Clemmons (ericclemmons)
  - Andrej Hudec (pulzarraider)
- - Peter Rehm (rpet)
  - Christian Raue
  - Matthias Pigulla (mpdude)
  - Deni
@@ -67,6 +67,7 @@ Symfony is the result of the work of many people who made the code better
  - Iltar van der Berg (kjarli)
  - Ener-Getick (energetick)
  - Douglas Greenshields (shieldo)
+ - Charles Sarrazin (csarrazi)
  - Lee McDermott
  - Brandon Turner
  - Luis Cordova (cordoval)
@@ -74,7 +75,6 @@ Symfony is the result of the work of many people who made the code better
  - Pierre du Plessis (pierredup)
  - Bart van den Burg (burgov)
  - Jordan Alliot (jalliot)
- - Charles Sarrazin (csarrazi)
  - John Wards (johnwards)
  - Toni Uebernickel (havvg)
  - Fran Moreno (franmomu)
@@ -89,6 +89,7 @@ Symfony is the result of the work of many people who made the code better
  - Alexander M. Turek (derrabus)
  - Dariusz Ruminski
  - marc.weistroff
+ - Issei Murasawa (issei_m)
  - lenar
  - Włodzimierz Gajda (gajdaw)
  - Alexander Schwenn (xelaris)
@@ -97,13 +98,12 @@ Symfony is the result of the work of many people who made the code better
  - Colin Frei
  - Adrien Brault (adrienbrault)
  - Joshua Thijssen
- - Issei Murasawa (issei_m)
+ - Baptiste Clavié (talus)
  - Peter Kokot (maastermedia)
  - excelwebzone
  - Jacob Dreesen (jdreesen)
  - Jérémy DERUSSÉ (jderusse)
  - Vladimir Reznichenko (kalessil)
- - Baptiste Clavié (talus)
  - Fabien Pennequin (fabienpennequin)
  - Gordon Franke (gimler)
  - David Buchmann (dbu)
@@ -121,6 +121,7 @@ Symfony is the result of the work of many people who made the code better
  - Evgeniy (ewgraf)
  - Guilherme Blanco (guilhermeblanco)
  - Pablo Godel (pgodel)
+ - Titouan Galopin (tgalopin)
  - Jérémie Augustin (jaugustin)
  - Sebastiaan Stok (sstok)
  - Tugdual Saunier (tucksaun)
@@ -129,10 +130,10 @@ Symfony is the result of the work of many people who made the code better
  - Arnaud Kleinpeter (nanocom)
  - Joel Wurtz (brouznouf)
  - Philipp Wahala (hifi)
- - Titouan Galopin (tgalopin)
  - Richard Shank (iampersistent)
  - Thomas Rabaix (rande)
  - Vincent AUBERT (vincent)
+ - Rouven Weßling (realityking)
  - Mikael Pajunen
  - Clemens Tolboom
  - Helmer Aaviksoo
@@ -143,7 +144,6 @@ Symfony is the result of the work of many people who made the code better
  - Amal Raghav (kertz)
  - Jonathan Ingram (jonathaningram)
  - Artur Kotyrba
- - Rouven Weßling (realityking)
  - Warnar Boekkooi (boekkooi)
  - Dmitrii Chekaliuk (lazyhammer)
  - Clément JOBEILI (dator)
@@ -211,6 +211,7 @@ Symfony is the result of the work of many people who made the code better
  - Kristen Gilden (kgilden)
  - Dawid Nowak
  - Pierre-Yves LEBECQ (pylebecq)
+ - Daniel Espendiller
  - Jakub Kucharovic (jkucharovic)
  - Eugene Leonovich (rybakit)
  - Filippo Tessarotto
@@ -240,7 +241,6 @@ Symfony is the result of the work of many people who made the code better
  - Michael Holm (hollo)
  - Marc Weistroff (futurecat)
  - Hidde Wieringa (hiddewie)
- - Daniel Espendiller
  - Chris Smith (cs278)
  - Florian Klein (docteurklein)
  - Manuel Kiessling (manuelkiessling)
@@ -293,6 +293,7 @@ Symfony is the result of the work of many people who made the code better
  - Inal DJAFAR (inalgnu)
  - Christian Gärtner (dagardner)
  - Tomasz Kowalczyk (thunderer)
+ - Christian Schmidt
  - François-Xavier de Guillebon (de-gui_f)
  - Damien Alexandre (damienalexandre)
  - Felix Labrecque
@@ -309,6 +310,7 @@ Symfony is the result of the work of many people who made the code better
  - Philipp Kräutli (pkraeutli)
  - Kirill chEbba Chebunin (chebba)
  - Greg Thornton (xdissent)
+ - Robin Chalas (chalas_r)
  - Costin Bereveanu (schniper)
  - Loïc Chardonnet (gnusat)
  - Marek Kalnik (marekkalnik)
@@ -319,12 +321,14 @@ Symfony is the result of the work of many people who made the code better
  - Pavel Volokitin (pvolok)
  - Endre Fejes
  - Tobias Naumann (tna)
+ - Daniel Beyer
  - Shein Alexey
  - Baptiste Lafontaine
  - Joe Lencioni
  - Daniel Tschinder
  - Kai
  - Lee Rowlands
+ - Krzysztof Piasecki (krzysztek)
  - Maximilian Reichel (phramz)
  - Loick Piera (pyrech)
  - Karoly Negyesi (chx)
@@ -364,7 +368,6 @@ Symfony is the result of the work of many people who made the code better
  - EdgarPE
  - Florian Pfitzer (marmelatze)
  - Asier Illarramendi (doup)
- - Christian Schmidt
  - Chris Sedlmayr (catchamonkey)
  - Seb Koelen
  - Christoph Mewes (xrstf)
@@ -382,6 +385,7 @@ Symfony is the result of the work of many people who made the code better
  - Mathieu Lemoine
  - franek (franek)
  - Christian Wahler
+ - Mathieu Lemoine
  - Gintautas Miselis
  - Zander Baldwin
  - Adam Harvey
@@ -419,7 +423,6 @@ Symfony is the result of the work of many people who made the code better
  - Anthony Ferrara
  - Ioan Negulescu
  - Jakub Škvára (jskvara)
- - Daniel Beyer
  - Andrew Udvare (audvare)
  - alexpods
  - Tristan Darricau (nicofuma)
@@ -448,6 +451,7 @@ Symfony is the result of the work of many people who made the code better
  - Denis Gorbachev (starfall)
  - Peter van Dommelen
  - Tim van Densen
+ - Martin Morávek (keeo)
  - Steven Surowiec
  - Kevin Saliou (kbsali)
  - NothingWeAre
@@ -462,7 +466,6 @@ Symfony is the result of the work of many people who made the code better
  - Ziumin
  - Jeremy Benoist
  - Lenar Lõhmus
- - Krzysztof Piasecki (krzysztek)
  - Benjamin Laugueux (yzalis)
  - Zach Badgett (zachbadgett)
  - Aurélien Fredouelle
@@ -501,6 +504,7 @@ Symfony is the result of the work of many people who made the code better
  - Javier López (loalf)
  - Reinier Kip
  - Dustin Dobervich (dustin10)
+ - dantleech
  - Anne-Sophie Bachelard (annesophie)
  - Sebastian Marek (proofek)
  - Erkhembayar Gantulga (erheme318)
@@ -563,6 +567,7 @@ Symfony is the result of the work of many people who made the code better
  - Peter Ward
  - Dominik Ritter (dritter)
  - Sebastian Grodzicki (sgrodzicki)
+ - SpacePossum
  - Martin Hujer (martinhujer)
  - Pascal Helfenstein
  - Baldur Rensch (brensch)
@@ -613,6 +618,7 @@ Symfony is the result of the work of many people who made the code better
  - Adrien Lucas (adrienlucas)
  - James Michael DuPont
  - Tom Klingenberg
+ - Filip Procházka (fprochazka)
  - Christopher Hall (mythmakr)
  - Paul Kamer (pkamer)
  - Rafał Wrzeszcz (rafalwrzeszcz)
@@ -629,6 +635,7 @@ Symfony is the result of the work of many people who made the code better
  - Alaattin Kahramanlar (alaattin)
  - Maksim Kotlyar (makasim)
  - Neil Ferreira
+ - Nathanael Noblet (gnat)
  - Dmitry Parnas (parnas)
  - Théo FIDRY (theofidry)
  - Paul LE CORRE
@@ -745,7 +752,6 @@ Symfony is the result of the work of many people who made the code better
  - Guillaume Royer
  - Artem (digi)
  - boite
- - dantleech
  - Vadim Tyukov (vatson)
  - Sortex
  - chispita
@@ -851,6 +857,7 @@ Symfony is the result of the work of many people who made the code better
  - Christian Sciberras
  - Anton Bakai
  - Clement Herreman (clemherreman)
+ - Dan Ionut Dumitriu (danionut90)
  - Nyro (nyro)
  - Marco
  - Marc Torres
@@ -870,7 +877,6 @@ Symfony is the result of the work of many people who made the code better
  - ConneXNL
  - Aharon Perkel
  - Abdul.Mohsen B. A. A
- - SpacePossum
  - BenoÃ®t Burnichon
  - Remi Collet
  - pthompson
@@ -1059,6 +1065,7 @@ Symfony is the result of the work of many people who made the code better
  - stloyd
  - Chris Tickner
  - Andrew Coulton
+ - Jeremy Benoist
  - Michal Gebauer
  - Gleb Sidora
  - David Stone
@@ -1108,7 +1115,6 @@ Symfony is the result of the work of many people who made the code better
  - Simon Sargeant
  - efeen
  - Michał Dąbrowski (defrag)
- - Nathanael Noblet (gnat)
  - Simone Fumagalli (hpatoio)
  - Brian Graham (incognito)
  - Kevin Vergauwen (innocenzo)
@@ -1214,8 +1220,10 @@ Symfony is the result of the work of many people who made the code better
  - Alan Chen
  - Maerlyn
  - Even André Fiskvik
+ - Erik van Wingerden
  - Dane Powell
  - Gerrit Drost
+ - Linnaea Von Lavia
  - Lenar Lõhmus
  - Cristian Gonzalez
  - AlberT
@@ -1271,6 +1279,7 @@ Symfony is the result of the work of many people who made the code better
  - Joseph Deray
  - Damian Sromek
  - Ben
+ - dasmfm
  - Arnaud Buathier (arnapou)
  - chesteroni (chesteroni)
  - Mauricio Lopez (diaspar)
@@ -1358,7 +1367,6 @@ Symfony is the result of the work of many people who made the code better
  - Norman Soetbeer
  - zorn
  - Benjamin Long
- - Robin Chalas
  - Matt Janssen
  - Peter Gribanov
  - kwiateusz
@@ -1443,6 +1451,7 @@ Symfony is the result of the work of many people who made the code better
  - ollie harridge (ollietb)
  - Paul Andrieux (paulandrieux)
  - Paweł Szczepanek (pauluz)
+ - Philippe Degeeter (pdegeeter)
  - Christian López Espínola (penyaskito)
  - Petr Jaroš (petajaros)
  - Philipp Hoffmann (philipphoffmann)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -58,12 +58,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '2.3.42-DEV';
+    const VERSION = '2.3.42';
     const VERSION_ID = 20342;
     const MAJOR_VERSION = 2;
     const MINOR_VERSION = 3;
     const RELEASE_VERSION = 42;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     /**
      * Constructor.


### PR DESCRIPTION
Changes since last release: https://github.com/symfony/symfony/compare/v2.3.41...7143b29

**Changelog**
- bug #18893 [DependencyInjection] Skip deep reference check for 'service_container' (@RobertMe)
- bug #18812 Catch \Throwable (@fprochazka)
- bug #18821 [Form] Removed UTC specification with timestamp (@francisbesset)
- bug #18861 Fix for #18843 (@inso)
- bug #18907 [Routing] Fix the annotation loader taking a class constant as a beginning of a class name (@jakzal, @nicolas-grekas)
- bug #18864 [Console][DX] Fixed ambiguous error message when using a duplicate option shortcut (@peterrehm)
- bug #18844 [Yaml] fix exception contexts (@xabbuh)
- bug #18840 [Yaml] properly handle unindented collections (@xabbuh)
- bug #18839 People - person singularization (@Keeo)
- bug #18828 [Yaml] chomp newlines only at the end of YAML documents (@xabbuh)
- bug #18635 [Console] Prevent fatal error when calling Command::getHelper without helperSet (@chalasr)
- bug #18761  [Form] Modified iterator_to_array's 2nd parameter to false in ViolationMapper (@issei-m)
