### PR TITLE
[Form] CollectionType improve - added prototype_name to form view vars 

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -64,6 +64,7 @@ class CollectionType extends AbstractType
         if ($form->getConfig()->hasAttribute('prototype')) {
             $prototype = $form->getConfig()->getAttribute('prototype');
             $view->vars['prototype'] = $prototype->setParent($form)->createView($view);
+            $view->vars['prototype_name'] = $options['prototype_name'];
         }
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master", 2.3, 2.7, 2.8, 3.0, 3.1 |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? |  |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Added prototype_name to collectionType form view vars. It's required in template when prototype_name is not default value.
