### PR TITLE
[Filesystem] Added Filesystem::getContents method

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -78,6 +78,22 @@ class Filesystem
     }
 
     /**
+     * Return the contents of the file at the given path.
+     *
+     * @param string $path
+     *
+     * @return string
+     */
+    public function getContents($path)
+    {
+        if (false === $this->isReadable($path)) {
+            throw new IOException(sprintf('Unable to read file "%s". Either it does not exist or it is not readable.', 0, null, $path));
+        }
+
+        return file_get_contents($path);
+    }
+
+    /**
      * Creates a directory recursively.
      *
      * @param string|array|\Traversable $dirs The directory path

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1163,4 +1163,23 @@ class FilesystemTest extends FilesystemTestCase
 
         $this->assertFilePermissions(767, $targetFilePath);
     }
+
+    public function testGetContents()
+    {
+        $path = $this->workspace.DIRECTORY_SEPARATOR.'contents';
+        $contents = 'Foobar';
+        file_put_contents($path, $contents);
+
+        $this->assertEquals($contents, $this->filesystem->getContents($path));
+    }
+
+    /**
+     * @expectedException Symfony\Component\Filesystem\Exception\IOException
+     * @expectedExceptionMessage Unable to read file
+     */
+    public function testGetContentsThrowExceptionNotExist()
+    {
+        $path = $this->workspace.DIRECTORY_SEPARATOR.'contents';
+        $this->filesystem->getContents($path);
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

This PR adds a `getContents` method to the Filesystem component.
### Why?

Frequently when using the Filesystem component in a class it is necessary to
write files: `file_put_contents` is used.

This means that actual filesystem writes are made when _testing_ the class, whereas if
the filesystem is mocked and features this method, those writes can be avoided.
