### PR TITLE
[FrameworkBundle] Skip redis cache pools test on failed connection

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
@@ -54,11 +54,6 @@ class CachePoolsTest extends WebTestCase
                 throw $e;
             }
             $this->markTestSkipped($e->getMessage());
-        } catch (InvalidArgumentException $e) {
-            if (0 !== strpos($e->getMessage(), 'Redis connection failed')) {
-                throw $e;
-            }
-            $this->markTestSkipped($e->getMessage());
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
+use Symfony\Component\Cache\Exception\InvalidArgumentException;
 
 class CachePoolsTest extends WebTestCase
 {
@@ -33,6 +34,11 @@ class CachePoolsTest extends WebTestCase
                 throw $e;
             }
             $this->markTestSkipped($e->getMessage());
+        } catch (InvalidArgumentException $e) {
+            if (0 !== strpos($e->getMessage(), 'Redis connection failed')) {
+                throw $e;
+            }
+            $this->markTestSkipped($e->getMessage());
         }
     }
 
@@ -45,6 +51,11 @@ class CachePoolsTest extends WebTestCase
             $this->doTestCachePools(array('root_config' => 'redis_custom_config.yml', 'environment' => 'custom_redis_cache'), RedisAdapter::class);
         } catch (\PHPUnit_Framework_Error_Warning $e) {
             if (0 !== strpos($e->getMessage(), 'unable to connect to 127.0.0.1')) {
+                throw $e;
+            }
+            $this->markTestSkipped($e->getMessage());
+        } catch (InvalidArgumentException $e) {
+            if (0 !== strpos($e->getMessage(), 'Redis connection failed')) {
                 throw $e;
             }
             $this->markTestSkipped($e->getMessage());


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Actually, running the FrameworkBundle tests suit leads to a failure that says:

> 1) Symfony\Bundle\FrameworkBundle\Tests\Functional\CachePoolsTest::testRedisCachePools
> Symfony\Component\Cache\Exception\InvalidArgumentException: Redis connection failed: redis://localhost
> [...]
> [...]/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php:59
> [...]/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php:30

So I propose to catch this specific exception in case of redis is not (locally) supported, in order to be sure that tests stay green.
