### PR TITLE
[FrameworkBundle] Add path argument to dump a specific option in debug:config

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
@@ -39,6 +39,23 @@ class ConfigDebugCommandTest extends WebTestCase
         $this->assertContains('custom: foo', $tester->getDisplay());
     }
 
+    public function testDumpBundleOption()
+    {
+        $tester = $this->createCommandTester();
+        $ret = $tester->execute(array('name' => 'TestBundle', 'path' => 'custom'));
+
+        $this->assertSame(0, $ret, 'Returns 0 in case of success');
+        $this->assertContains('foo', $tester->getDisplay());
+    }
+
+    public function testDumpUndefinedBundleOption()
+    {
+        $tester = $this->createCommandTester();
+        $ret = $tester->execute(array('name' => 'TestBundle', 'path' => 'foo'));
+
+        $this->assertContains('Unable to find configuration for "test.foo"', $tester->getDisplay());
+    }
+
     /**
      * @return CommandTester
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This adds the ability to dump a specific bundle config option from the `debug:config` command.

For instance `debug:config StofDoctrineExtensionsBundle uploadable` gives:

![](http://image.prntscr.com/image/b78953dbe34c4efd817bb6f831ddd0ba.png)

I hesitated to just look for a `.` in the `name` argument rather than adding a `path` argument that doesn't include the bundle alias (that is took from the first argument of the command), let me know what you think about that.
