### PR TITLE
[3.1][Security] Fix DebugAccessDecisionManager when object is not a scalar

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/DebugAccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/DebugAccessDecisionManager.php
@@ -103,7 +103,14 @@ class DebugAccessDecisionManager implements AccessDecisionManagerInterface
         }
 
         if (!is_object($object)) {
-            return sprintf('%s (%s)', gettype($object), $object);
+            if (is_bool($object)) {
+                return sprintf('%s (%s)', gettype($object), $object ? 'true' : 'false');
+            }
+            if (is_scalar($object)) {
+                return sprintf('%s (%s)', gettype($object), $object);
+            }
+
+            return gettype($object);
         }
 
         $objectClass = class_exists('Doctrine\Common\Util\ClassUtils') ? ClassUtils::getClass($object) : get_class($object);

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/DebugAccessDecisionManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/DebugAccessDecisionManagerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Tests\Authorization;
+
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
+use Symfony\Component\Security\Core\Authorization\DebugAccessDecisionManager;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+class DebugAccessDecisionManagerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider provideObjectsAndLogs
+     */
+    public function testDecideLog($expectedLog, $object)
+    {
+        $adm = new DebugAccessDecisionManager(new AccessDecisionManager());
+        $adm->decide($this->getMock(TokenInterface::class), array('ATTRIBUTE_1'), $object);
+
+        $this->assertSame($expectedLog, $adm->getDecisionLog());
+    }
+
+    public function provideObjectsAndLogs()
+    {
+        $object = new \stdClass();
+
+        yield array(array(array('attributes' => array('ATTRIBUTE_1'), 'object' => 'NULL', 'result' => false)), null);
+        yield array(array(array('attributes' => array('ATTRIBUTE_1'), 'object' => 'boolean (true)', 'result' => false)), true);
+        yield array(array(array('attributes' => array('ATTRIBUTE_1'), 'object' => 'string (jolie string)', 'result' => false)), 'jolie string');
+        yield array(array(array('attributes' => array('ATTRIBUTE_1'), 'object' => 'integer (12345)', 'result' => false)), 12345);
+        yield array(array(array('attributes' => array('ATTRIBUTE_1'), 'object' => 'resource', 'result' => false)), fopen(__FILE__, 'r'));
+        yield array(array(array('attributes' => array('ATTRIBUTE_1'), 'object' => 'array', 'result' => false)), array());
+        yield array(array(array('attributes' => array('ATTRIBUTE_1'), 'object' => sprintf('stdClass (object hash: %s)', spl_object_hash($object)), 'result' => false)), $object);
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
