### PR TITLE
[Security] Add a JSON authentication listener

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/JsonLoginFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/JsonLoginFactory.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\DefinitionDecorator;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * JsonLoginFactory creates services for JSON login authentication.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class JsonLoginFactory extends AbstractFactory
+{
+    public function __construct()
+    {
+        $this->addOption('username_path', 'username');
+        $this->addOption('password_path', 'password');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPosition()
+    {
+        return 'form';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getKey()
+    {
+        return 'json-login';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createAuthProvider(ContainerBuilder $container, $id, $config, $userProviderId)
+    {
+        $provider = 'security.authentication.provider.dao.'.$id;
+        $container
+            ->setDefinition($provider, new DefinitionDecorator('security.authentication.provider.dao'))
+            ->replaceArgument(0, new Reference($userProviderId))
+            ->replaceArgument(1, new Reference('security.user_checker.'.$id))
+            ->replaceArgument(2, $id)
+        ;
+
+        return $provider;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getListenerId()
+    {
+        return 'security.authentication.listener.json';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function isRememberMeAware($config)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createListener($container, $id, $config, $userProvider)
+    {
+        $listenerId = $this->getListenerId();
+        $listener = new DefinitionDecorator($listenerId);
+        $listener->replaceArgument(2, $id);
+        $listener->replaceArgument(3, new Reference($this->createAuthenticationSuccessHandler($container, $id, $config)));
+        $listener->replaceArgument(4, new Reference($this->createAuthenticationFailureHandler($container, $id, $config)));
+        $listener->replaceArgument(5, array_intersect_key($config, $this->options));
+
+        $listenerId .= '.'.$id;
+        $container->setDefinition($listenerId, $listener);
+
+        return $listenerId;
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
@@ -140,7 +140,20 @@
             <argument /> <!-- x509 user -->
             <argument /> <!-- x509 credentials -->
             <argument type="service" id="logger" on-invalid="null" />
-            <argument type="service" id="event_dispatcher" on-invalid="null"/>
+            <argument type="service" id="event_dispatcher" on-invalid="null" />
+        </service>
+
+        <service id="security.authentication.listener.json" class="Symfony\Component\Security\Http\Firewall\UsernamePasswordJsonAuthenticationListener" public="false" abstract="true">
+            <tag name="monolog.logger" channel="security" />
+            <argument type="service" id="security.token_storage" />
+            <argument type="service" id="security.authentication.manager" />
+            <argument /> <!-- Provider-shared Key -->
+            <argument type="service" id="security.authentication.success_handler" />
+            <argument type="service" id="security.authentication.failure_handler" />
+            <argument type="collection" /> <!-- Options -->
+            <argument type="service" id="logger" on-invalid="null" />
+            <argument type="service" id="event_dispatcher" on-invalid="null" />
+            <argument type="service" id="property_accessor" on-invalid="null" />
         </service>
 
         <service id="security.authentication.listener.remote_user" class="Symfony\Component\Security\Http\Firewall\RemoteUserAuthenticationListener" public="false" abstract="true">

--- a/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
+++ b/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\SecurityBundle;
 
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\JsonLoginFactory;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\AddSecurityVotersPass;
@@ -42,6 +43,7 @@ class SecurityBundle extends Bundle
         $extension = $container->getExtension('security');
         $extension->addSecurityListenerFactory(new FormLoginFactory());
         $extension->addSecurityListenerFactory(new FormLoginLdapFactory());
+        $extension->addSecurityListenerFactory(new JsonLoginFactory());
         $extension->addSecurityListenerFactory(new HttpBasicFactory());
         $extension->addSecurityListenerFactory(new HttpBasicLdapFactory());
         $extension->addSecurityListenerFactory(new HttpDigestFactory());

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/JsonLoginBundle/Controller/TestController.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/JsonLoginBundle/Controller/TestController.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\JsonLoginBundle\Controller;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class TestController
+{
+    public function loginCheckAction()
+    {
+        throw new \RuntimeException(sprintf('%s should never be called.', __FUNCTION__));
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/JsonLoginBundle/JsonLoginBundle.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/JsonLoginBundle/JsonLoginBundle.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\JsonLoginBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class JsonLoginBundle extends Bundle
+{
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/JsonLoginTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/JsonLoginTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class JsonLoginTest extends WebTestCase
+{
+    public function testJsonLoginSuccess()
+    {
+        $client = $this->createClient(array('test_case' => 'JsonLogin', 'root_config' => 'config.yml'));
+        $client->request('POST', '/chk', array(), array(), array(), '{"user": {"login": "dunglas", "password": "foo"}}');
+        $this->assertEquals('http://localhost/', $client->getResponse()->headers->get('location'));
+    }
+
+    public function testJsonLoginFailure()
+    {
+        $client = $this->createClient(array('test_case' => 'JsonLogin', 'root_config' => 'config.yml'));
+        $client->request('POST', '/chk', array(), array(), array(), '{"user": {"login": "dunglas", "password": "bad"}}');
+        $this->assertEquals('http://localhost/login', $client->getResponse()->headers->get('location'));
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/bundles.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/bundles.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return array(
+    new Symfony\Bundle\SecurityBundle\SecurityBundle(),
+    new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+    new Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\JsonLoginBundle\JsonLoginBundle(),
+);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/config.yml
@@ -1,0 +1,24 @@
+imports:
+    - { resource: ./../config/framework.yml }
+
+security:
+    encoders:
+        Symfony\Component\Security\Core\User\User: plaintext
+
+    providers:
+        in_memory:
+            memory:
+                users:
+                    dunglas: { password: foo, roles: [ROLE_USER] }
+
+    firewalls:
+        main:
+            pattern: ^/
+            anonymous: true
+            json_login:
+               check_path:    /mychk
+               username_path: user.login
+               password_path: user.password
+
+    access_control:
+        - { path: ^/foo, roles: ROLE_USER }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/routing.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/routing.yml
@@ -1,0 +1,3 @@
+login_check:
+    path: /chk
+    defaults: { _controller: JsonLoginBundle:Test:loginCheck }

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "symfony/security": "~3.2",
+        "symfony/security": "~3.3",
         "symfony/http-kernel": "~3.2",
         "symfony/polyfill-php70": "~1.0"
     },

--- a/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordJsonAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordJsonAuthenticationListener.php
@@ -77,17 +77,17 @@ class UsernamePasswordJsonAuthenticationListener implements ListenerInterface
         try {
             $username = $this->propertyAccessor->getValue($data, $this->options['username_path']);
         } catch (AccessException $e) {
-            throw new BadCredentialsException(sprintf('Missing key "%s".', $this->options['username_path']));
+            throw new BadCredentialsException(sprintf('The key "%s" must be provided.', $this->options['username_path']));
         }
 
         try {
             $password = $this->propertyAccessor->getValue($data, $this->options['password_path']);
         } catch (AccessException $e) {
-            throw new BadCredentialsException(sprintf('Missing key "%s".', $this->options['password_path']));
+            throw new BadCredentialsException(sprintf('The key "%s" must be provided.', $this->options['password_path']));
         }
 
         if (!is_string($username)) {
-            throw new BadCredentialsException(sprintf('The key "%s" must contain a string.', $this->options['username_path']));
+            throw new BadCredentialsException(sprintf('The key "%s" must be a string.', $this->options['username_path']));
         }
 
         if (strlen($username) > Security::MAX_USERNAME_LENGTH) {
@@ -95,7 +95,7 @@ class UsernamePasswordJsonAuthenticationListener implements ListenerInterface
         }
 
         if (!is_string($password)) {
-            throw new BadCredentialsException(sprintf('The key "%s" must contain a string.', $this->options['password_path']));
+            throw new BadCredentialsException(sprintf('The key "%s" must be a string.', $this->options['password_path']));
         }
 
         try {

--- a/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordJsonAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordJsonAuthenticationListener.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Firewall;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+use Symfony\Component\Security\Http\HttpUtils;
+use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface;
+
+/**
+ * UsernamePasswordJsonAuthenticationListener is an implementation of
+ * an authentication via a JSON document composed of a username and a password.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class UsernamePasswordJsonAuthenticationListener extends AbstractAuthenticationListener
+{
+    public function __construct(TokenStorageInterface $tokenStorage, AuthenticationManagerInterface $authenticationManager, SessionAuthenticationStrategyInterface $sessionStrategy, HttpUtils $httpUtils, $providerKey, AuthenticationSuccessHandlerInterface $successHandler, AuthenticationFailureHandlerInterface $failureHandler, array $options = array(), LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null)
+    {
+        parent::__construct($tokenStorage, $authenticationManager, $sessionStrategy, $httpUtils, $providerKey, $successHandler, $failureHandler, array_merge(array(
+            'username_parameter' => '_username',
+            'password_parameter' => '_password',
+        ), $options), $logger, $dispatcher);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function attemptAuthentication(Request $request)
+    {
+        $data = json_decode($request->getContent(), true);
+
+        if (!isset($data[$this->options['username_parameter']])) {
+            throw new BadCredentialsException(sprintf('Missing key "%s".', $this->options['username_parameter']));
+        }
+
+        if (!isset($data[$this->options['password_parameter']])) {
+            throw new BadCredentialsException(sprintf('Missing key "%s".', $this->options['password_parameter']));
+        }
+
+        $username = $data[$this->options['username_parameter']];
+        if (!is_string($username)) {
+            throw new BadCredentialsException(sprintf('The key "%s" must contain a string.', $this->options['username_parameter']));
+        }
+
+        if (strlen($username) > Security::MAX_USERNAME_LENGTH) {
+            throw new BadCredentialsException('Invalid username.');
+        }
+
+        $password = $data[$this->options['password_parameter']];
+        if (!is_string($password)) {
+            throw new BadCredentialsException(sprintf('The key "%s" must contain a string.', $this->options['password_parameter']));
+        }
+
+        return $this->authenticationManager->authenticate(new UsernamePasswordToken($username, $password, $this->providerKey));
+    }
+}

--- a/src/Symfony/Component/Security/Tests/Http/Firewall/UsernamePasswordJsonAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Firewall/UsernamePasswordJsonAuthenticationListenerTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Tests\Http\Firewall;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+use Symfony\Component\Security\Http\Firewall\UsernamePasswordJsonAuthenticationListener;
+use Symfony\Component\Security\Http\HttpUtils;
+use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class UsernamePasswordJsonAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var UsernamePasswordJsonAuthenticationListener
+     */
+    private $listener;
+
+    /**
+     * @var \ReflectionMethod
+     */
+    private $attemptAuthenticationMethod;
+
+    protected function setUp() {
+        $tokenStorage = $this->getMock(TokenStorageInterface::class);
+        $authenticationManager = $this->getMock(AuthenticationManagerInterface::class);
+        $authenticationManager->method('authenticate')->willReturn(true);
+        $sessionAuthenticationStrategyInterface = $this->getMock(SessionAuthenticationStrategyInterface::class);
+        $httpUtils = $this->getMock(HttpUtils::class);
+        $authenticationSuccessHandler = $this->getMock(AuthenticationSuccessHandlerInterface::class);
+        $authenticationFailureHandler = $this->getMock(AuthenticationFailureHandlerInterface::class);
+
+        $this->listener = new UsernamePasswordJsonAuthenticationListener($tokenStorage, $authenticationManager, $sessionAuthenticationStrategyInterface, $httpUtils, 'providerKey',  $authenticationSuccessHandler, $authenticationFailureHandler);
+        $this->attemptAuthenticationMethod = new \ReflectionMethod($this->listener, 'attemptAuthentication');
+        $this->attemptAuthenticationMethod->setAccessible(true);
+    }
+
+    public function testAttemptAuthentication()
+    {
+        $request = new Request(array(), array(), array(), array(), array(), array(), '{"_username": "dunglas", "_password": "foo"}');
+
+        $result = $this->attemptAuthenticationMethod->invokeArgs($this->listener, array($request));
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
+     */
+    public function testAttemptAuthenticationNoUsername()
+    {
+        $request = new Request(array(), array(), array(), array(), array(), array(), '{"usr": "dunglas", "_password": "foo"}');
+        $this->attemptAuthenticationMethod->invokeArgs($this->listener, array($request));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
+     */
+    public function testAttemptAuthenticationNoPassword()
+    {
+        $request = new Request(array(), array(), array(), array(), array(), array(), '{"_username": "dunglas", "pass": "foo"}');
+        $this->attemptAuthenticationMethod->invokeArgs($this->listener, array($request));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
+     */
+    public function testAttemptAuthenticationUsernameNotAString()
+    {
+        $request = new Request(array(), array(), array(), array(), array(), array(), '{"_username": 1, "_password": "foo"}');
+        $this->attemptAuthenticationMethod->invokeArgs($this->listener, array($request));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
+     */
+    public function testAttemptAuthenticationPasswordNotAString()
+    {
+        $request = new Request(array(), array(), array(), array(), array(), array(), '{"_username": "dunglas", "_password": 1}');
+        $this->attemptAuthenticationMethod->invokeArgs($this->listener, array($request));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
+     */
+    public function testAttemptAuthenticationUsernameTooLong()
+    {
+        $username = str_repeat('x', Security::MAX_USERNAME_LENGTH + 1);
+        $request = new Request(array(), array(), array(), array(), array(), array(), sprintf('{"_username": "%s", "_password": 1}', $username));
+
+        $this->attemptAuthenticationMethod->invokeArgs($this->listener, array($request));
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | symfony/symfony-docs#7081 |

Add a new authentication listener allowing to login by sending a JSON document like:

 `{"_username": "dunglas", "_password": "foo"}`.

It is similar to the traditional form login (but take a JSON document as entry) and is convenient for APIs, especially used in combination with JWT.

See https://github.com/api-platform/core/issues/563 and https://github.com/lexik/LexikJWTAuthenticationBundle/issues/123#issuecomment-173860682 for previous discussions.
- [x] Add functional tests in security bundle
