### PR TITLE
[WebProfilerBundle] Fixed forwarded request data in templates

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -13,7 +13,7 @@
         {% endset %}
     {% endif %}
 
-    {% if collector.forward %}
+    {% if collector.forward|default(false) %}
         {% set forward_handler %}
             {% import _self as helper %}
             {{ helper.set_handler(collector.forward.controller) }}
@@ -26,7 +26,7 @@
         <span class="sf-toolbar-status sf-toolbar-status-{{ request_status_code_color }}">{{ collector.statuscode }}</span>
         {% if collector.route %}
             {% if collector.redirect %}{{ include('@WebProfiler/Icon/redirect.svg') }}{% endif %}
-            {% if collector.forward %}{{ include('@WebProfiler/Icon/forward.svg') }}{% endif %}
+            {% if collector.forward|default(false) %}{{ include('@WebProfiler/Icon/forward.svg') }}{% endif %}
             <span class="sf-toolbar-label">{{ 'GET' != collector.method ? collector.method }} @</span>
             <span class="sf-toolbar-value sf-toolbar-info-piece-additional">{{ collector.route }}</span>
         {% endif %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
@@ -44,7 +44,7 @@
                             </dl>
                         {%- endif %}
 
-                        {% if request_collector and request_collector.forward and request_collector.forward.controller.class is defined -%}
+                        {% if request_collector and request_collector.forward|default(false) and request_collector.forward.controller.class is defined -%}
                             {%- set forward = request_collector.forward -%}
                             {%- set controller = forward.controller -%}
                             <dl class="metadata">


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/silexphp/Silex-WebProfiler/issues/92 |
| License | MIT |
| Doc PR | ~ |

Fixes a bug occurring  when the `FrameworkBundle` is not part of the dependencies (i.e using Silex).
