### PR TITLE
[PhpUnitBridge] Make DnsMock match namespaces that begin with Tests\\

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DnsMock.php
+++ b/src/Symfony/Bridge/PhpUnit/DnsMock.php
@@ -169,6 +169,8 @@ class DnsMock
         if (0 < strpos($class, '\\Tests\\')) {
             $ns = str_replace('\\Tests\\', '\\', $class);
             $mockedNs[] = substr($ns, 0, strrpos($ns, '\\'));
+        } elseif (0 === strpos($class, 'Tests\\')) {
+            $mockedNs[] = substr($class, 6, strrpos($class, '\\') - 6);
         }
         foreach ($mockedNs as $ns) {
             if (function_exists($ns.'\checkdnsrr')) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | yes? |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | symfony/symfony-docs#6546 |

Related to symfony/symfony-standard#969
