### PR TITLE
[PropertyAccess] Bug: Throw exception on no such index

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -435,6 +435,14 @@ class PropertyAccessor implements PropertyAccessorInterface
             } elseif (is_object($result[self::VALUE])) {
                 $result[self::REF] = $result[self::VALUE];
             }
+        } else {
+            $message = sprintf('Undefined index %s.', $index);
+
+            if ($keys = array_keys($zval[self::VALUE])) {
+                $message .= sprintf('Available indexes are "%s".', print_r($keys, true));
+            }
+
+            throw new NoSuchIndexException($message);
         }
 
         return $result;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | not yet |
| Fixed tickets | #18969 |
| License | MIT |
| Doc PR | n/a |

Patch for #18969, if it is confirmed, I'll adapt the tests. 
It seems that tests expect this behavior but I find that really strange.
