### PR TITLE
[PropertyAccess] Add missing arguments to PropertyAccess::createPropertyAccessor()

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccess.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccess.php
@@ -25,9 +25,9 @@ final class PropertyAccess
      *
      * @return PropertyAccessor The new property accessor
      */
-    public static function createPropertyAccessor($throwExceptionOnInvalidIndex = false)
+    public static function createPropertyAccessor($throwExceptionOnInvalidIndex = false, $magicCall = false)
     {
-        return self::createPropertyAccessorBuilder($throwExceptionOnInvalidIndex)->getPropertyAccessor();
+        return self::createPropertyAccessorBuilder($throwExceptionOnInvalidIndex, $magicCall)->getPropertyAccessor();
     }
 
     /**
@@ -37,12 +37,16 @@ final class PropertyAccess
      *
      * @return PropertyAccessorBuilder The new property accessor builder
      */
-    public static function createPropertyAccessorBuilder($enableExceptionOnInvalidIndex = false)
+    public static function createPropertyAccessorBuilder($enableExceptionOnInvalidIndex = false, $enableMagicCall = false)
     {
         $propertyAccessorBuilder = new PropertyAccessorBuilder();
 
         if ($enableExceptionOnInvalidIndex) {
             $propertyAccessorBuilder->enableExceptionOnInvalidIndex();
+        }
+
+        if ($enableMagicCall) {
+            $propertyAccessorBuilder->enableMagicCall();
         }
 
         return $propertyAccessorBuilder;

--- a/src/Symfony/Component/PropertyAccess/PropertyAccess.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccess.php
@@ -21,36 +21,25 @@ final class PropertyAccess
     /**
      * Creates a property accessor with the default configuration.
      *
-     * @param bool $throwExceptionOnInvalidIndex Will be added to the signature in 4.0
+     * @param bool $throwExceptionOnInvalidIndex
      *
      * @return PropertyAccessor The new property accessor
      */
-    public static function createPropertyAccessor(/* $throwExceptionOnInvalidIndex = false */)
+    public static function createPropertyAccessor($throwExceptionOnInvalidIndex = false)
     {
-        $throwExceptionOnInvalidIndex = false;
-
-        if (func_num_args()) {
-            $throwExceptionOnInvalidIndex = func_get_arg(0);
-        }
-
         return self::createPropertyAccessorBuilder($throwExceptionOnInvalidIndex)->getPropertyAccessor();
     }
 
     /**
      * Creates a property accessor builder.
      *
-     * @param bool $enableExceptionOnInvalidIndex Will be added to the signature in 4.0.
+     * @param bool $enableExceptionOnInvalidIndex
      *
      * @return PropertyAccessorBuilder The new property accessor builder
      */
-    public static function createPropertyAccessorBuilder(/* $enableExceptionOnInvalidIndex = false */)
+    public static function createPropertyAccessorBuilder($enableExceptionOnInvalidIndex = false)
     {
         $propertyAccessorBuilder = new PropertyAccessorBuilder();
-        $enableExceptionOnInvalidIndex = false;
-
-        if (func_num_args()) {
-            $enableExceptionOnInvalidIndex = func_get_arg(0);
-        }
 
         if ($enableExceptionOnInvalidIndex) {
             $propertyAccessorBuilder->enableExceptionOnInvalidIndex();

--- a/src/Symfony/Component/PropertyAccess/PropertyAccess.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccess.php
@@ -21,21 +21,31 @@ final class PropertyAccess
     /**
      * Creates a property accessor with the default configuration.
      *
+     * @param bool $throwExceptionOnInvalidIndex
+     *
      * @return PropertyAccessor The new property accessor
      */
-    public static function createPropertyAccessor()
+    public static function createPropertyAccessor($throwExceptionOnInvalidIndex = false)
     {
-        return self::createPropertyAccessorBuilder()->getPropertyAccessor();
+        return self::createPropertyAccessorBuilder($throwExceptionOnInvalidIndex)->getPropertyAccessor();
     }
 
     /**
      * Creates a property accessor builder.
      *
+     * @param bool $enableExceptionOnInvalidIndex
+     *
      * @return PropertyAccessorBuilder The new property accessor builder
      */
-    public static function createPropertyAccessorBuilder()
+    public static function createPropertyAccessorBuilder($enableExceptionOnInvalidIndex = false)
     {
-        return new PropertyAccessorBuilder();
+        $propertyAccessorBuilder = new PropertyAccessorBuilder();
+
+        if ($enableExceptionOnInvalidIndex) {
+            $propertyAccessorBuilder->enableExceptionOnInvalidIndex();
+        }
+
+        return $propertyAccessorBuilder;
     }
 
     /**

--- a/src/Symfony/Component/PropertyAccess/PropertyAccess.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccess.php
@@ -21,25 +21,36 @@ final class PropertyAccess
     /**
      * Creates a property accessor with the default configuration.
      *
-     * @param bool $throwExceptionOnInvalidIndex
+     * @param bool $throwExceptionOnInvalidIndex Will be added to the signature in 4.0
      *
      * @return PropertyAccessor The new property accessor
      */
-    public static function createPropertyAccessor($throwExceptionOnInvalidIndex = false)
+    public static function createPropertyAccessor(/* $throwExceptionOnInvalidIndex = false */)
     {
+        $throwExceptionOnInvalidIndex = false;
+
+        if (func_num_args()) {
+            $throwExceptionOnInvalidIndex = func_get_arg(0);
+        }
+
         return self::createPropertyAccessorBuilder($throwExceptionOnInvalidIndex)->getPropertyAccessor();
     }
 
     /**
      * Creates a property accessor builder.
      *
-     * @param bool $enableExceptionOnInvalidIndex
+     * @param bool $enableExceptionOnInvalidIndex Will be added to the signature in 4.0.
      *
      * @return PropertyAccessorBuilder The new property accessor builder
      */
-    public static function createPropertyAccessorBuilder($enableExceptionOnInvalidIndex = false)
+    public static function createPropertyAccessorBuilder(/* $enableExceptionOnInvalidIndex = false */)
     {
         $propertyAccessorBuilder = new PropertyAccessorBuilder();
+        $enableExceptionOnInvalidIndex = false;
+
+        if (func_num_args()) {
+            $enableExceptionOnInvalidIndex = func_get_arg(0);
+        }
 
         if ($enableExceptionOnInvalidIndex) {
             $propertyAccessorBuilder->enableExceptionOnInvalidIndex();

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyAccess\Tests;
+
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
+
+/**
+ * @author Robin Chalas <robin.chalas@gmail.com
+ */
+class PropertyAccessTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCreatePropertyAccessor()
+    {
+        $this->assertInstanceOf(PropertyAccessor::class, PropertyAccess::createPropertyAccessor());
+    }
+
+    public function testCreatePropertyAccessorWithExceptionOnInvalidIndex()
+    {
+        $this->assertInstanceOf(PropertyAccessor::class, PropertyAccess::createPropertyAccessor(true));
+    }
+}

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\PropertyAccess\PropertyAccessor;
 /**
  * @author Robin Chalas <robin.chalas@gmail.com
  */
-class PropertyAccessTest extends \PHPUnit_Framework_TestCase
+final class PropertyAccessTest extends \PHPUnit_Framework_TestCase
 {
     public function testCreatePropertyAccessor()
     {

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessTest.php
@@ -28,4 +28,9 @@ final class PropertyAccessTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertInstanceOf(PropertyAccessor::class, PropertyAccess::createPropertyAccessor(true));
     }
+
+    public function testCreatePropertyAccessorWithMagicCallEnabled()
+    {
+        $this->assertInstanceOf(PropertyAccessor::class, PropertyAccess::createPropertyAccessor(false, true));
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/6640 |

Actually, the recommended way to use the PropertyAccessor is to use `PropertyAccess::createPropertyAccessor`. 

The problem is that using this way, we can't specify that invalid indexes should throw an exception, and so when calling `PropertyAccessor::isReadable([], '[foo]')` it returns always true. 

It should be possible to make the exception thrown, plus the `PropertyAccessor::$throwExceptionOnInvalidIndex` already exists but is not used in `PropertyAccess::createPropertyAccessor`.
