### PR TITLE
[HttpKernel] Fix context dependent test

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerResolverTest.php
@@ -150,7 +150,7 @@ class ControllerResolverTest extends BaseControllerResolverTest
     {
         return array(
             array('foo', '\LogicException', 'Unable to parse the controller name "foo".'),
-            array('foo::bar', '\InvalidArgumentException', 'Class "foo" does not exist.'),
+            array('oof::bar', '\InvalidArgumentException', 'Class "oof" does not exist.'),
             array('stdClass', '\LogicException', 'Unable to parse the controller name "stdClass".'),
             array(
                 'Symfony\Component\HttpKernel\Tests\Controller\ControllerResolverTest::bar',

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
@@ -127,7 +127,7 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array('foo'),
-            array('foo::bar'),
+            array('oof::bar'),
             array('stdClass'),
             array('Symfony\Component\HttpKernel\Tests\Controller\ControllerResolverTest::bar'),
         );


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Class `Foo` exists when the ClassLoader component is tested alongside with HttpKernel
