### PR TITLE
[BrowserKit] Bump the dom-crawler minimum version requirement

### DIFF
--- a/src/Symfony/Component/BrowserKit/composer.json
+++ b/src/Symfony/Component/BrowserKit/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/dom-crawler": "~2.0,>=2.0.5"
+        "symfony/dom-crawler": "~2.1"
     },
     "require-dev": {
         "symfony/process": "~2.3.34|~2.7,>=2.7.6",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.3 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18826 |
| License | MIT |
| Doc PR | - |

The BrowserKit Client will not work with DomCrawler 2.0 if the CssSelector component is not installed.

This will require an amendment when merging into the 2.8 branch. It currently uses `~2.0,>=2.0.5|~3.0.0`, while it should be `~2.1|~3.0.0`.
