### PR TITLE
Release v2.7.14

### DIFF
--- a/CHANGELOG-2.7.md
+++ b/CHANGELOG-2.7.md
@@ -7,6 +7,32 @@ in 2.7 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.7.0...v2.7.1
 
+* 2.7.14 (2016-06-06)
+
+ * bug #18908 [DependencyInjection] force enabling the external XML entity loaders (xabbuh)
+ * bug #18893 [DependencyInjection] Skip deep reference check for 'service_container' (RobertMe)
+ * bug #18812 Catch \Throwable (fprochazka)
+ * bug #18821 [Form] Removed UTC specification with timestamp (francisbesset)
+ * bug #18861 Fix for #18843 (inso)
+ * bug #18907 [Routing] Fix the annotation loader taking a class constant as a beginning of a class name (jakzal, nicolas-grekas)
+ * bug #18879 [Console] SymfonyStyle: Align multi-line/very-long-line blocks (chalasr)
+ * bug #18864 [Console][DX] Fixed ambiguous error message when using a duplicate option shortcut (peterrehm)
+ * bug #18883 Fix js comment in profiler (linnaea)
+ * bug #18844 [Yaml] fix exception contexts (xabbuh)
+ * bug #18840 [Yaml] properly handle unindented collections (xabbuh)
+ * bug #18813 Catch \Throwable (fprochazka)
+ * bug #18839 People - person singularization (Keeo)
+ * bug #18828 [Yaml] chomp newlines only at the end of YAML documents (xabbuh)
+ * bug #18814 Fixed server status command when port has been omitted (peterrehm)
+ * bug #18799 Use levenshtein level for better Bundle matching (j0k3r)
+ * bug #18413 [WebProfilerBundle] Fix CORS ajax security issues (romainneutron)
+ * bug #18507 [BUG] Delete class 'control-group' in bootstrap 3 (Philippe Degeeter)
+ * bug #18747  [Form] Modified iterator_to_array's 2nd parameter to false in ViolationMapper (issei-m)
+ * bug #18635 [Console] Prevent fatal error when calling Command::getHelper without helperSet (chalasr)
+ * bug #18686 [console][table] adjust width of colspanned cell. (aitboudad)
+ * bug #18761  [Form] Modified iterator_to_array's 2nd parameter to false in ViolationMapper (issei-m)
+ * bug #18737 [Debug] Fix fatal error handlers on PHP 7 (nicolas-grekas)
+
 * 2.7.13 (2016-05-09)
 
  * security #18733 limited the maximum length of a submitted username (fabpot)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -39,8 +39,8 @@ Symfony is the result of the work of many people who made the code better
  - Maxime Steinhausser (ogizanagi)
  - Alexandre Salomé (alexandresalome)
  - William Durand (couac)
- - ornicar
  - Jules Pietri (heah)
+ - ornicar
  - stealth35 ‏ (stealth35)
  - Alexander Mols (asm89)
  - Francis Besset (francisbesset)
@@ -65,9 +65,9 @@ Symfony is the result of the work of many people who made the code better
  - Dariusz Górecki (canni)
  - Arnout Boks (aboks)
  - Iltar van der Berg (kjarli)
+ - Charles Sarrazin (csarrazi)
  - Ener-Getick (energetick)
  - Douglas Greenshields (shieldo)
- - Charles Sarrazin (csarrazi)
  - Lee McDermott
  - Brandon Turner
  - Luis Cordova (cordoval)
@@ -187,6 +187,7 @@ Symfony is the result of the work of many people who made the code better
  - Loïc Faugeron
  - Jannik Zschiesche (apfelbox)
  - Marco Pivetta (ocramius)
+ - Teoh Han Hui (teohhanhui)
  - julien pauli (jpauli)
  - Michael Lee (zerustech)
  - Lorenz Schori
@@ -213,6 +214,7 @@ Symfony is the result of the work of many people who made the code better
  - Pierre-Yves LEBECQ (pylebecq)
  - Daniel Espendiller
  - Jakub Kucharovic (jkucharovic)
+ - Robin Chalas (chalas_r)
  - Eugene Leonovich (rybakit)
  - Filippo Tessarotto
  - Joseph Rouff (rouffj)
@@ -275,7 +277,6 @@ Symfony is the result of the work of many people who made the code better
  - janschoenherr
  - Thomas Schulz (king2500)
  - Berny Cantos (xphere81)
- - Teoh Han Hui (teohhanhui)
  - Ricard Clau (ricardclau)
  - Mark Challoner (markchalloner)
  - Gregor Harlan (gharlan)
@@ -310,7 +311,6 @@ Symfony is the result of the work of many people who made the code better
  - Philipp Kräutli (pkraeutli)
  - Kirill chEbba Chebunin (chebba)
  - Greg Thornton (xdissent)
- - Robin Chalas (chalas_r)
  - Costin Bereveanu (schniper)
  - Loïc Chardonnet (gnusat)
  - Marek Kalnik (marekkalnik)
@@ -1414,6 +1414,7 @@ Symfony is the result of the work of many people who made the code better
  - Damon Jones (damon__jones)
  - David Badura (davidbadura)
  - Daniel Londero (dlondero)
+ - Sebastian Landwehr (dword123)
  - Adel ELHAIBA (eadel)
  - Damián Nohales (eagleoneraptor)
  - Elliot Anderson (elliot)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -58,12 +58,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '2.7.14-DEV';
+    const VERSION = '2.7.14';
     const VERSION_ID = 20714;
     const MAJOR_VERSION = 2;
     const MINOR_VERSION = 7;
     const RELEASE_VERSION = 14;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '05/2018';
     const END_OF_LIFE = '05/2019';


### PR DESCRIPTION
Changes since last release: https://github.com/symfony/symfony/compare/v2.7.13...c5a7f9f

**Changelog**
- bug #18893 [DependencyInjection] Skip deep reference check for 'service_container' (@RobertMe)
- bug #18812 Catch \Throwable (@fprochazka)
- bug #18821 [Form] Removed UTC specification with timestamp (@francisbesset)
- bug #18861 Fix for #18843 (@inso)
- bug #18907 [Routing] Fix the annotation loader taking a class constant as a beginning of a class name (@jakzal, @nicolas-grekas)
- bug #18879 [Console] SymfonyStyle: Align multi-line/very-long-line blocks (@chalasr)
- bug #18864 [Console][DX] Fixed ambiguous error message when using a duplicate option shortcut (@peterrehm)
- bug #18883 Fix js comment in profiler (@linnaea)
- bug #18844 [Yaml] fix exception contexts (@xabbuh)
- bug #18840 [Yaml] properly handle unindented collections (@xabbuh)
- bug #18813 Catch \Throwable (@fprochazka)
- bug #18839 People - person singularization (@Keeo)
- bug #18828 [Yaml] chomp newlines only at the end of YAML documents (@xabbuh)
- bug #18814 Fixed server status command when port has been omitted (@peterrehm)
- bug #18799 Use levenshtein level for better Bundle matching (@j0k3r)
- bug #18413 [WebProfilerBundle] Fix CORS ajax security issues (@romainneutron)
- bug #18507 [BUG] Delete class 'control-group' in bootstrap 3 (@Philippe Degeeter)
- bug #18747  [Form] Modified iterator_to_array's 2nd parameter to false in ViolationMapper (@issei-m)
- bug #18635 [Console] Prevent fatal error when calling Command::getHelper without helperSet (@chalasr)
- bug #18686 [console][table] adjust width of colspanned cell. (@aitboudad)
- bug #18761  [Form] Modified iterator_to_array's 2nd parameter to false in ViolationMapper (@issei-m)
- bug #18737 [Debug] Fix fatal error handlers on PHP 7 (@nicolas-grekas)
