### PR TITLE
Release v3.0.7

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -7,6 +7,37 @@ in 3.0 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v3.0.0...v3.0.1
 
+* 3.0.7 (2016-06-06)
+
+ * bug #18908 [DependencyInjection] force enabling the external XML entity loaders (xabbuh)
+ * bug #18893 [DependencyInjection] Skip deep reference check for 'service_container' (RobertMe)
+ * bug #18812 Catch \Throwable (fprochazka)
+ * bug #18821 [Form] Removed UTC specification with timestamp (francisbesset)
+ * bug #18861 Fix for #18843 (inso)
+ * bug #18889 [Console] SymfonyStyle: Fix alignment/prefixing of multi-line comments (chalasr)
+ * bug #18907 [Routing] Fix the annotation loader taking a class constant as a beginning of a class name (jakzal, nicolas-grekas)
+ * bug #18879 [Console] SymfonyStyle: Align multi-line/very-long-line blocks (chalasr)
+ * bug #18864 [Console][DX] Fixed ambiguous error message when using a duplicate option shortcut (peterrehm)
+ * bug #18883 Fix js comment in profiler (linnaea)
+ * bug #18844 [Yaml] fix exception contexts (xabbuh)
+ * bug #18840 [Yaml] properly handle unindented collections (xabbuh)
+ * bug #18765 Catch \Throwable (fprochazka)
+ * bug #18813 Catch \Throwable (fprochazka)
+ * bug #18839 People - person singularization (Keeo)
+ * bug #18828 [Yaml] chomp newlines only at the end of YAML documents (xabbuh)
+ * bug #18814 Fixed server status command when port has been omitted (peterrehm)
+ * bug #18759 [Validator] Support for DateTimeImmutable (krzysiekpiasecki)
+ * bug #18799 Use levenshtein level for better Bundle matching (j0k3r)
+ * bug #18413 [WebProfilerBundle] Fix CORS ajax security issues (romainneutron)
+ * bug #18774 [console][table] adjust width of colspanned cell. (aitboudad)
+ * bug #18507 [BUG] Delete class 'control-group' in bootstrap 3 (Philippe Degeeter)
+ * bug #18747  [Form] Modified iterator_to_array's 2nd parameter to false in ViolationMapper (issei-m)
+ * bug #18635 [Console] Prevent fatal error when calling Command::getHelper without helperSet (chalasr)
+ * bug #18686 [console][table] adjust width of colspanned cell. (aitboudad)
+ * bug #18761  [Form] Modified iterator_to_array's 2nd parameter to false in ViolationMapper (issei-m)
+ * bug #18745 [MonologBridge] Uninstallable together with symfony/http-kernel in 3.0.6 (ymc-dabe)
+ * bug #18737 [Debug] Fix fatal error handlers on PHP 7 (nicolas-grekas)
+
 * 3.0.6 (2016-05-10)
 
  * security #18736 Fixed issue with blank password with Ldap (csarrazi)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -59,12 +59,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '3.0.7-DEV';
+    const VERSION = '3.0.7';
     const VERSION_ID = 30007;
     const MAJOR_VERSION = 3;
     const MINOR_VERSION = 0;
     const RELEASE_VERSION = 7;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '07/2016';
     const END_OF_LIFE = '01/2017';


### PR DESCRIPTION
Changes since last release: https://github.com/symfony/symfony/compare/v3.0.6...fa7e940

**Changelog**
- bug #18893 [DependencyInjection] Skip deep reference check for 'service_container' (@RobertMe)
- bug #18812 Catch \Throwable (@fprochazka)
- bug #18821 [Form] Removed UTC specification with timestamp (@francisbesset)
- bug #18861 Fix for #18843 (@inso)
- bug #18889 [Console] SymfonyStyle: Fix alignment/prefixing of multi-line comments (@chalasr)
- bug #18907 [Routing] Fix the annotation loader taking a class constant as a beginning of a class name (@jakzal, @nicolas-grekas)
- bug #18879 [Console] SymfonyStyle: Align multi-line/very-long-line blocks (@chalasr)
- bug #18864 [Console][DX] Fixed ambiguous error message when using a duplicate option shortcut (@peterrehm)
- bug #18883 Fix js comment in profiler (@linnaea)
- bug #18844 [Yaml] fix exception contexts (@xabbuh)
- bug #18840 [Yaml] properly handle unindented collections (@xabbuh)
- bug #18765 Catch \Throwable (@fprochazka)
- bug #18813 Catch \Throwable (@fprochazka)
- bug #18839 People - person singularization (@Keeo)
- bug #18828 [Yaml] chomp newlines only at the end of YAML documents (@xabbuh)
- bug #18814 Fixed server status command when port has been omitted (@peterrehm)
- bug #18759 [Validator] Support for DateTimeImmutable (@krzysiekpiasecki)
- bug #18799 Use levenshtein level for better Bundle matching (@j0k3r)
- bug #18413 [WebProfilerBundle] Fix CORS ajax security issues (@romainneutron)
- bug #18774 [console][table] adjust width of colspanned cell. (@aitboudad)
- bug #18507 [BUG] Delete class 'control-group' in bootstrap 3 (@Philippe Degeeter)
- bug #18747  [Form] Modified iterator_to_array's 2nd parameter to false in ViolationMapper (@issei-m)
- bug #18635 [Console] Prevent fatal error when calling Command::getHelper without helperSet (@chalasr)
- bug #18686 [console][table] adjust width of colspanned cell. (@aitboudad)
- bug #18761  [Form] Modified iterator_to_array's 2nd parameter to false in ViolationMapper (@issei-m)
- bug #18745 [MonologBridge] Uninstallable together with symfony/http-kernel in 3.0.6 (@ymc-dabe)
- bug #18737 [Debug] Fix fatal error handlers on PHP 7 (@nicolas-grekas)
