### PR TITLE
[Dumper] Add support for XmlReader objets

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/XmlReaderCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/XmlReaderCaster.php
@@ -71,6 +71,13 @@ class XmlReaderCaster
             'isDefault' => $reader->isDefault,
             'isEmptyElement' => $reader->isEmptyElement,
             'nodeType' => $nodeType,
+
+            Caster::PREFIX_VIRTUAL.'parserProperties' => array(
+                'LOADDTD' => $reader->getParserProperty(\XmlReader::LOADDTD),
+                'DEFAULTATTRS' => $reader->getParserProperty(\XmlReader::DEFAULTATTRS),
+                'VALIDATE' => $reader->getParserProperty(\XmlReader::VALIDATE),
+                'SUBST_ENTITIES' => $reader->getParserProperty(\XmlReader::SUBST_ENTITIES),
+            ),
         );
 
         if ($reader->hasValue && (\XmlReader::TEXT === $reader->nodeType || \XmlReader::ATTRIBUTE === $reader->nodeType)) {
@@ -92,6 +99,8 @@ class XmlReaderCaster
             $cut = array(
                 'nodeType' => $nodeType,
                 'depth' => $reader->depth,
+
+                Caster::PREFIX_VIRTUAL.'parserProperties' => $infos[Caster::PREFIX_VIRTUAL.'parserProperties'],
             );
 
             if ('#text' !== $reader->localName) {

--- a/src/Symfony/Component/VarDumper/Caster/XmlReaderCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/XmlReaderCaster.php
@@ -65,17 +65,16 @@ class XmlReaderCaster
             'SUBST_ENTITIES' => $reader->getParserProperty(\XmlReader::SUBST_ENTITIES),
         ));
 
-        $infos = array(
-            'nodeType' => $nodeType,
-            Caster::PREFIX_VIRTUAL.'parserProperties' => $parserProperties,
-        );
-
         if (\XmlReader::NONE === $reader->nodeType) {
-            return $infos;
+            return array(
+                'nodeType' => $nodeType,
+                Caster::PREFIX_VIRTUAL.'parserProperties' => $parserProperties,
+            );
         }
 
-        $infos = $infos + array(
+        $infos = array(
             'localName' => $reader->localName,
+            'nodeType' => $nodeType,
 
             'depth' => $reader->depth,
 
@@ -107,12 +106,12 @@ class XmlReaderCaster
             }
         }
 
+        $infos[Caster::PREFIX_VIRTUAL.'parserProperties'] = $parserProperties;
+
         if (isset(static::$filteredTypes[$reader->nodeType])) {
             $cut = array(
                 'nodeType' => $nodeType,
                 'depth' => $reader->depth,
-
-                Caster::PREFIX_VIRTUAL.'parserProperties' => $parserProperties,
             );
 
             if ('#text' !== $reader->localName) {
@@ -131,6 +130,8 @@ class XmlReaderCaster
                 $cut['prefix'] = $reader->prefix;
                 $cut['namespaceURI'] = $reader->namespaceURI;
             }
+
+            $cut[Caster::PREFIX_VIRTUAL.'parserProperties'] = $parserProperties;
 
             $stub->cut += count($infos) - count($cut);
 

--- a/src/Symfony/Component/VarDumper/Caster/XmlReaderCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/XmlReaderCaster.php
@@ -60,6 +60,20 @@ class XmlReaderCaster
         $nodeType = new ConstStub(self::$nodeTypes[$reader->nodeType], $reader->nodeType);
 
         $infos = array(
+            'nodeType' => $nodeType,
+            Caster::PREFIX_VIRTUAL.'parserProperties' => array(
+                'LOADDTD' => $reader->getParserProperty(\XmlReader::LOADDTD),
+                'DEFAULTATTRS' => $reader->getParserProperty(\XmlReader::DEFAULTATTRS),
+                'VALIDATE' => $reader->getParserProperty(\XmlReader::VALIDATE),
+                'SUBST_ENTITIES' => $reader->getParserProperty(\XmlReader::SUBST_ENTITIES),
+            ),
+        );
+
+        if (\XmlReader::NONE === $reader->nodeType) {
+            return $infos;
+        }
+
+        $infos = $infos + array(
             'localName' => $reader->localName,
 
             'depth' => $reader->depth,
@@ -70,14 +84,6 @@ class XmlReaderCaster
             'hasValue' => $reader->hasValue,
             'isDefault' => $reader->isDefault,
             'isEmptyElement' => $reader->isEmptyElement,
-            'nodeType' => $nodeType,
-
-            Caster::PREFIX_VIRTUAL.'parserProperties' => array(
-                'LOADDTD' => $reader->getParserProperty(\XmlReader::LOADDTD),
-                'DEFAULTATTRS' => $reader->getParserProperty(\XmlReader::DEFAULTATTRS),
-                'VALIDATE' => $reader->getParserProperty(\XmlReader::VALIDATE),
-                'SUBST_ENTITIES' => $reader->getParserProperty(\XmlReader::SUBST_ENTITIES),
-            ),
         );
 
         if ('' !== $reader->prefix) {

--- a/src/Symfony/Component/VarDumper/Caster/XmlReaderCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/XmlReaderCaster.php
@@ -80,6 +80,11 @@ class XmlReaderCaster
             ),
         );
 
+        if ('' !== $reader->prefix) {
+            $infos['prefix'] = $reader->prefix;
+            $infos['namespaceURI'] = $reader->namespaceURI;
+        }
+
         if ($reader->hasValue && (\XmlReader::TEXT === $reader->nodeType || \XmlReader::ATTRIBUTE === $reader->nodeType)) {
             $infos['value'] = $reader->value;
 
@@ -113,6 +118,11 @@ class XmlReaderCaster
                 if ($reader->hasValue) {
                     $cut['value'] = $reader->value;
                 }
+            }
+
+            if ('' !== $reader->prefix) {
+                $cut['prefix'] = $reader->prefix;
+                $cut['namespaceURI'] = $reader->namespaceURI;
             }
 
             $stub->cut += count($infos) - count($cut);

--- a/src/Symfony/Component/VarDumper/Caster/XmlReaderCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/XmlReaderCaster.php
@@ -98,6 +98,14 @@ class XmlReaderCaster
                 $cut['localName'] = $reader->localName;
             }
 
+            if (\XmlReader::ATTRIBUTE === $reader->nodeType) {
+                $cut['hasValue'] = $reader->hasValue;
+
+                if ($reader->hasValue) {
+                    $cut['value'] = $reader->value;
+                }
+            }
+
             $stub->cut += count($infos) - count($cut);
 
             return $cut;

--- a/src/Symfony/Component/VarDumper/Caster/XmlReaderCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/XmlReaderCaster.php
@@ -37,7 +37,22 @@ class XmlReaderCaster
         \XmlReader::SIGNIFICANT_WHITESPACE => 'SIGNIFICANT_WHITESPACE',
         \XmlReader::END_ELEMENT => 'END_ELEMENT',
         \XmlReader::END_ENTITY => 'END_ENTITY',
-        \XmlReader::XML_DECLARATION => 'XML_DECLARATION'
+        \XmlReader::XML_DECLARATION => 'XML_DECLARATION',
+    );
+
+    private static $filteredTypes = array(
+        \XmlReader::ATTRIBUTE => true,
+        \XmlReader::ENTITY_REF => true,
+        \XmlReader::ENTITY => true,
+        \XmlReader::PI => true,
+        \XmlReader::DOC => true,
+        \XmlReader::DOC_TYPE => true,
+        \XmlReader::DOC_FRAGMENT => true,
+        \XmlReader::NOTATION => true,
+        \XmlReader::WHITESPACE => true,
+        \XmlReader::SIGNIFICANT_WHITESPACE => true,
+        \XmlReader::END_ELEMENT => true,
+        \XmlReader::END_ENTITY => true,
     );
 
     public static function castXmlReader(\XmlReader $reader, array $a, Stub $stub, $isNested)
@@ -71,6 +86,21 @@ class XmlReaderCaster
             for ($i = 0; $i < $reader->attributeCount; ++$i) {
                 $infos[Caster::PREFIX_VIRTUAL.'attributes'][] = $reader->getAttributeNo($i);
             }
+        }
+
+        if (isset(static::$filteredTypes[$reader->nodeType])) {
+            $cut = array(
+                'nodeType' => $nodeType,
+                'depth' => $reader->depth,
+            );
+
+            if ('#text' !== $reader->localName) {
+                $cut['localName'] = $reader->localName;
+            }
+
+            $stub->cut += count($infos) - count($cut);
+
+            return $cut;
         }
 
         return $a + $infos;

--- a/src/Symfony/Component/VarDumper/Caster/XmlReaderCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/XmlReaderCaster.php
@@ -1,0 +1,78 @@
+<?php
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Caster;
+
+use Symfony\Component\VarDumper\Cloner\Stub;
+
+/**
+ * Casts XmlReader class to array representation.
+ *
+ * @author Baptiste Clavié <clavie.b@gmail.com>
+ */
+class XmlReaderCaster
+{
+    private static $nodeTypes = array(
+        \XmlReader::NONE => 'NONE',
+        \XmlReader::ELEMENT => 'ELEMENT',
+        \XmlReader::ATTRIBUTE => 'ATTRIBUTE',
+        \XmlReader::TEXT => 'TEXT',
+        \XmlReader::CDATA => 'CDATA',
+        \XmlReader::ENTITY_REF => 'ENTITY_REF',
+        \XmlReader::ENTITY => 'ENTITY',
+        \XmlReader::PI => 'PI',
+        \XmlReader::COMMENT => 'COMMENT',
+        \XmlReader::DOC => 'DOC',
+        \XmlReader::DOC_TYPE => 'DOC_TYPE',
+        \XmlReader::DOC_FRAGMENT => 'DOC_FRAGMENT',
+        \XmlReader::NOTATION => 'NOTATION',
+        \XmlReader::WHITESPACE => 'WHITESPACE',
+        \XmlReader::SIGNIFICANT_WHITESPACE => 'SIGNIFICANT_WHITESPACE',
+        \XmlReader::END_ELEMENT => 'END_ELEMENT',
+        \XmlReader::END_ENTITY => 'END_ENTITY',
+        \XmlReader::XML_DECLARATION => 'XML_DECLARATION'
+    );
+
+    public static function castXmlReader(\XmlReader $reader, array $a, Stub $stub, $isNested)
+    {
+        $nodeType = new ConstStub(self::$nodeTypes[$reader->nodeType], $reader->nodeType);
+
+        $infos = array(
+            'localName' => $reader->localName,
+
+            'depth' => $reader->depth,
+
+            'attributeCount' => $reader->attributeCount,
+            'hasAttributes' => $reader->hasAttributes,
+
+            'hasValue' => $reader->hasValue,
+            'isDefault' => $reader->isDefault,
+            'isEmptyElement' => $reader->isEmptyElement,
+            'nodeType' => $nodeType,
+        );
+
+        if ($reader->hasValue && (\XmlReader::TEXT === $reader->nodeType || \XmlReader::ATTRIBUTE === $reader->nodeType)) {
+            $infos['value'] = $reader->value;
+
+            unset($infos['localName']);
+            $stub->cut += 1;
+        }
+
+        if ($reader->hasAttributes) {
+            $infos[Caster::PREFIX_VIRTUAL . 'attributes'] = array();
+
+            while ($reader->moveToNextAttribute()) {
+                $infos[Caster::PREFIX_VIRTUAL . 'attributes'][$reader->name] = $reader->value;
+            }
+        }
+
+        return $a + $infos;
+    }
+}

--- a/src/Symfony/Component/VarDumper/Caster/XmlReaderCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/XmlReaderCaster.php
@@ -66,10 +66,10 @@ class XmlReaderCaster
         }
 
         if ($reader->hasAttributes) {
-            $infos[Caster::PREFIX_VIRTUAL . 'attributes'] = array();
+            $infos[Caster::PREFIX_VIRTUAL.'attributes'] = array();
 
-            while ($reader->moveToNextAttribute()) {
-                $infos[Caster::PREFIX_VIRTUAL . 'attributes'][$reader->name] = $reader->value;
+            for ($i = 0; $i < $reader->attributeCount; ++$i) {
+                $infos[Caster::PREFIX_VIRTUAL.'attributes'][] = $reader->getAttributeNo($i);
             }
         }
 

--- a/src/Symfony/Component/VarDumper/Caster/XmlReaderCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/XmlReaderCaster.php
@@ -58,15 +58,16 @@ class XmlReaderCaster
     public static function castXmlReader(\XmlReader $reader, array $a, Stub $stub, $isNested)
     {
         $nodeType = new ConstStub(self::$nodeTypes[$reader->nodeType], $reader->nodeType);
+        $parserProperties = new EnumStub(array(
+            'LOADDTD' => $reader->getParserProperty(\XmlReader::LOADDTD),
+            'DEFAULTATTRS' => $reader->getParserProperty(\XmlReader::DEFAULTATTRS),
+            'VALIDATE' => $reader->getParserProperty(\XmlReader::VALIDATE),
+            'SUBST_ENTITIES' => $reader->getParserProperty(\XmlReader::SUBST_ENTITIES),
+        ));
 
         $infos = array(
             'nodeType' => $nodeType,
-            Caster::PREFIX_VIRTUAL.'parserProperties' => array(
-                'LOADDTD' => $reader->getParserProperty(\XmlReader::LOADDTD),
-                'DEFAULTATTRS' => $reader->getParserProperty(\XmlReader::DEFAULTATTRS),
-                'VALIDATE' => $reader->getParserProperty(\XmlReader::VALIDATE),
-                'SUBST_ENTITIES' => $reader->getParserProperty(\XmlReader::SUBST_ENTITIES),
-            ),
+            Caster::PREFIX_VIRTUAL.'parserProperties' => $parserProperties,
         );
 
         if (\XmlReader::NONE === $reader->nodeType) {
@@ -111,7 +112,7 @@ class XmlReaderCaster
                 'nodeType' => $nodeType,
                 'depth' => $reader->depth,
 
-                Caster::PREFIX_VIRTUAL.'parserProperties' => $infos[Caster::PREFIX_VIRTUAL.'parserProperties'],
+                Caster::PREFIX_VIRTUAL.'parserProperties' => $parserProperties,
             );
 
             if ('#text' !== $reader->localName) {

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -67,6 +67,8 @@ abstract class AbstractCloner implements ClonerInterface
         'DOMProcessingInstruction' => 'Symfony\Component\VarDumper\Caster\DOMCaster::castProcessingInstruction',
         'DOMXPath' => 'Symfony\Component\VarDumper\Caster\DOMCaster::castXPath',
 
+        'XmlReader' => 'Symfony\Component\VarDumper\Caster\XmlReaderCaster::castXmlReader',
+
         'ErrorException' => 'Symfony\Component\VarDumper\Caster\ExceptionCaster::castErrorException',
         'Exception' => 'Symfony\Component\VarDumper\Caster\ExceptionCaster::castException',
         'Error' => 'Symfony\Component\VarDumper\Caster\ExceptionCaster::castError',

--- a/src/Symfony/Component/VarDumper/Tests/Caster/XmlReaderCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/XmlReaderCasterTest.php
@@ -1,0 +1,222 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Tests\Caster;
+
+use Symfony\Component\VarDumper\Test\VarDumperTestTrait;
+
+/**
+ * @author Baptiste Clavié <clavie.b@gmail.com>
+ */
+class XmlReaderCasterTest extends \PHPUnit_Framework_TestCase
+{
+    use VarDumperTestTrait;
+
+    /** @var \XmlReader */
+    private $reader;
+
+    public function setUp()
+    {
+        $this->reader = new \XmlReader();
+        $this->reader->open(__DIR__.'/../Fixtures/xml_reader.xml');
+    }
+
+    public function testSimpleElementNode()
+    {
+        $dump = <<<'DUMP'
+XMLReader {
+  +localName: "foo"
+  +depth: 0
+  +attributeCount: 0
+  +hasAttributes: false
+  +hasValue: false
+  +isDefault: false
+  +isEmptyElement: false
+  +nodeType: ELEMENT
+}
+DUMP;
+
+        while ($this->reader->read() && $this->reader->nodeType !== \XmlReader::ELEMENT);
+
+        $this->assertDumpEquals($dump, $this->reader);
+    }
+
+    public function testNestedElement()
+    {
+        $dump = <<<'DUMP'
+XMLReader {
+  +localName: "bar"
+  +depth: 1
+  +attributeCount: 0
+  +hasAttributes: false
+  +hasValue: false
+  +isDefault: false
+  +isEmptyElement: false
+  +nodeType: ELEMENT
+}
+
+DUMP;
+
+        while ($this->reader->read() && $this->reader->localName !== 'bar');
+
+        $this->assertDumpEquals($dump, $this->reader);
+    }
+
+    public function testEmptyElement()
+    {
+        $dump = <<<'DUMP'
+XMLReader {
+  +localName: "bar"
+  +depth: 1
+  +attributeCount: 0
+  +hasAttributes: false
+  +hasValue: false
+  +isDefault: false
+  +isEmptyElement: true
+  +nodeType: ELEMENT
+}
+
+DUMP;
+
+        while ($this->reader->read() && $this->reader->localName !== 'bar');
+
+        $this->reader->next('bar');
+
+        $this->assertDumpEquals($dump, $this->reader);
+    }
+
+    public function testElementWithAttributes()
+    {
+        $dump = <<<'DUMP'
+XMLReader {
+  +localName: "bar"
+  +depth: 1
+  +attributeCount: 2
+  +hasAttributes: true
+  +hasValue: false
+  +isDefault: false
+  +isEmptyElement: false
+  +nodeType: ELEMENT
+  attributes: array:2 [
+    0 => "bar"
+    1 => "fubar"
+  ]
+}
+
+DUMP;
+
+        while ($this->reader->read() && $this->reader->localName !== 'bar');
+
+        $this->reader->next('bar');
+        $this->reader->next('bar');
+        $this->reader->next('bar');
+
+        $this->assertDumpEquals($dump, $this->reader);
+    }
+
+    public function testTextElement()
+    {
+        $dump = <<<'DUMP'
+XMLReader {
+  +depth: 2
+  +attributeCount: 0
+  +hasAttributes: false
+  +hasValue: true
+  +isDefault: false
+  +isEmptyElement: false
+  +nodeType: TEXT
+  +value: "With text"
+   …1
+}
+
+DUMP;
+
+        while ($this->reader->read() && $this->reader->nodeType !== \XmlReader::TEXT);
+
+        $this->assertDumpEquals($dump, $this->reader);
+    }
+
+    /** @dataProvider textFilteredProvider */
+    public function testFilteredTextElement($nodeType, $nodeTypeName, $depth)
+    {
+        $dump = <<<DUMP
+XMLReader {
+  +nodeType: $nodeTypeName
+  +depth: $depth
+   …6
+}
+
+DUMP;
+
+        while ($this->reader->read() && $this->reader->nodeType !== $nodeType);
+
+        $this->assertDumpEquals($dump, $this->reader);
+    }
+
+    public function textFilteredProvider()
+    {
+        return array(
+            'Significant Whiltespace element' => array(\XmlReader::SIGNIFICANT_WHITESPACE, 'SIGNIFICANT_WHITESPACE', 1),
+        );
+    }
+
+    /** @dataProvider elementFilteredProvider */
+    public function testFilteredElement($localName, $nodeType, $nodeTypeName, $expandType, $depth)
+    {
+        $dump = <<<DUMP
+XMLReader {
+  +nodeType: $nodeTypeName
+  +depth: $depth
+  +localName: "$localName"
+   …5
+}
+
+DUMP;
+
+        while ($this->reader->read() && $this->reader->nodeType !== $nodeType);
+
+        $this->assertDumpEquals($dump, $this->reader);
+    }
+
+    public function elementFilteredProvider()
+    {
+        return array(
+            'End Element' => array('bar', \XmlReader::END_ELEMENT, 'END_ELEMENT', 'DOMElement', 1),
+        );
+    }
+
+    public function testAttributeNode()
+    {
+        $dump = <<<'DUMP'
+XMLReader {
+  +nodeType: ATTRIBUTE
+  +depth: 2
+  +localName: "foo"
+  +hasValue: true
+  +value: "bar"
+   …4
+}
+
+DUMP;
+
+        while ($this->reader->read() && !$this->reader->hasAttributes);
+
+        $this->reader->moveToFirstAttribute();
+
+        $this->assertDumpEquals($dump, $this->reader);
+    }
+
+    public function tearDown()
+    {
+        $this->reader->close();
+    }
+}
+

--- a/src/Symfony/Component/VarDumper/Tests/Caster/XmlReaderCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/XmlReaderCasterTest.php
@@ -34,12 +34,12 @@ class XmlReaderCasterTest extends \PHPUnit_Framework_TestCase
         $dump = <<<'DUMP'
 XMLReader {
   +nodeType: ELEMENT
-  parserProperties: array:4 [
-    "LOADDTD" => false
-    "DEFAULTATTRS" => false
-    "VALIDATE" => false
-    "SUBST_ENTITIES" => false
-  ]
+  parserProperties: {
+    LOADDTD: false
+    DEFAULTATTRS: false
+    VALIDATE: false
+    SUBST_ENTITIES: false
+  }
   +localName: "foo"
   +depth: 0
   +attributeCount: 0
@@ -60,12 +60,12 @@ DUMP;
         $dump = <<<'DUMP'
 XMLReader {
   +nodeType: ELEMENT
-  parserProperties: array:4 [
-    "LOADDTD" => false
-    "DEFAULTATTRS" => false
-    "VALIDATE" => false
-    "SUBST_ENTITIES" => false
-  ]
+  parserProperties: {
+    LOADDTD: false
+    DEFAULTATTRS: false
+    VALIDATE: false
+    SUBST_ENTITIES: false
+  }
   +localName: "bar"
   +depth: 1
   +attributeCount: 0
@@ -87,12 +87,12 @@ DUMP;
         $dump = <<<'DUMP'
 XMLReader {
   +nodeType: ELEMENT
-  parserProperties: array:4 [
-    "LOADDTD" => false
-    "DEFAULTATTRS" => false
-    "VALIDATE" => false
-    "SUBST_ENTITIES" => false
-  ]
+  parserProperties: {
+    LOADDTD: false
+    DEFAULTATTRS: false
+    VALIDATE: false
+    SUBST_ENTITIES: false
+  }
   +localName: "bar"
   +depth: 1
   +attributeCount: 0
@@ -116,12 +116,12 @@ DUMP;
         $dump = <<<'DUMP'
 XMLReader {
   +nodeType: ELEMENT
-  parserProperties: array:4 [
-    "LOADDTD" => false
-    "DEFAULTATTRS" => false
-    "VALIDATE" => false
-    "SUBST_ENTITIES" => false
-  ]
+  parserProperties: {
+    LOADDTD: false
+    DEFAULTATTRS: false
+    VALIDATE: false
+    SUBST_ENTITIES: false
+  }
   +localName: "bar"
   +depth: 1
   +attributeCount: 2
@@ -151,12 +151,12 @@ DUMP;
         $dump = <<<'DUMP'
 XMLReader {
   +nodeType: TEXT
-  parserProperties: array:4 [
-    "LOADDTD" => false
-    "DEFAULTATTRS" => false
-    "VALIDATE" => false
-    "SUBST_ENTITIES" => false
-  ]
+  parserProperties: {
+    LOADDTD: false
+    DEFAULTATTRS: false
+    VALIDATE: false
+    SUBST_ENTITIES: false
+  }
   +depth: 2
   +attributeCount: 0
   +hasAttributes: false
@@ -181,12 +181,12 @@ DUMP;
 XMLReader {
   +nodeType: $nodeTypeName
   +depth: $depth
-  parserProperties: array:4 [
-    "LOADDTD" => false
-    "DEFAULTATTRS" => false
-    "VALIDATE" => false
-    "SUBST_ENTITIES" => false
-  ]
+  parserProperties: {
+    LOADDTD: false
+    DEFAULTATTRS: false
+    VALIDATE: false
+    SUBST_ENTITIES: false
+  }
    …6
 }
 
@@ -211,12 +211,12 @@ DUMP;
 XMLReader {
   +nodeType: $nodeTypeName
   +depth: $depth
-  parserProperties: array:4 [
-    "LOADDTD" => false
-    "DEFAULTATTRS" => false
-    "VALIDATE" => false
-    "SUBST_ENTITIES" => false
-  ]
+  parserProperties: {
+    LOADDTD: false
+    DEFAULTATTRS: false
+    VALIDATE: false
+    SUBST_ENTITIES: false
+  }
   +localName: "$localName"
    …5
 }
@@ -241,12 +241,12 @@ DUMP;
 XMLReader {
   +nodeType: ATTRIBUTE
   +depth: 2
-  parserProperties: array:4 [
-    "LOADDTD" => false
-    "DEFAULTATTRS" => false
-    "VALIDATE" => false
-    "SUBST_ENTITIES" => false
-  ]
+  parserProperties: {
+    LOADDTD: false
+    DEFAULTATTRS: false
+    VALIDATE: false
+    SUBST_ENTITIES: false
+  }
   +localName: "foo"
   +hasValue: true
   +value: "bar"
@@ -267,12 +267,12 @@ DUMP;
         $dump = <<<'DUMP'
 XMLReader {
   +nodeType: ELEMENT
-  parserProperties: array:4 [
-    "LOADDTD" => false
-    "DEFAULTATTRS" => false
-    "VALIDATE" => false
-    "SUBST_ENTITIES" => false
-  ]
+  parserProperties: {
+    LOADDTD: false
+    DEFAULTATTRS: false
+    VALIDATE: false
+    SUBST_ENTITIES: false
+  }
   +localName: "baz"
   +depth: 2
   +attributeCount: 0
@@ -295,12 +295,12 @@ DUMP;
         $dump = <<<'DUMP'
 XMLReader {
   +nodeType: NONE
-  parserProperties: array:4 [
-    "LOADDTD" => false
-    "DEFAULTATTRS" => false
-    "VALIDATE" => false
-    "SUBST_ENTITIES" => false
-  ]
+  parserProperties: {
+    LOADDTD: false
+    DEFAULTATTRS: false
+    VALIDATE: false
+    SUBST_ENTITIES: false
+  }
 }
 DUMP;
 

--- a/src/Symfony/Component/VarDumper/Tests/Caster/XmlReaderCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/XmlReaderCasterTest.php
@@ -150,6 +150,7 @@ DUMP;
     {
         $dump = <<<'DUMP'
 XMLReader {
+  +localName: "#text"
   +nodeType: TEXT
   +depth: 2
   +attributeCount: 0
@@ -164,7 +165,6 @@ XMLReader {
     VALIDATE: false
     SUBST_ENTITIES: false
   }
-   …1
 }
 
 DUMP;
@@ -175,10 +175,11 @@ DUMP;
     }
 
     /** @dataProvider textFilteredProvider */
-    public function testFilteredTextElement($nodeType, $nodeTypeName, $depth)
+    public function testFilteredTextElement($nodeType, $nodeTypeName, $depth, $localName)
     {
         $dump = <<<DUMP
 XMLReader {
+  +localName: "$localName"
   +nodeType: $nodeTypeName
   +depth: $depth
   parserProperties: {
@@ -187,7 +188,7 @@ XMLReader {
     VALIDATE: false
     SUBST_ENTITIES: false
   }
-   …6
+   …5
 }
 
 DUMP;
@@ -200,7 +201,7 @@ DUMP;
     public function textFilteredProvider()
     {
         return array(
-            'Significant Whiltespace element' => array(\XmlReader::SIGNIFICANT_WHITESPACE, 'SIGNIFICANT_WHITESPACE', 1),
+            'Significant Whiltespace element' => array(\XmlReader::SIGNIFICANT_WHITESPACE, 'SIGNIFICANT_WHITESPACE', 1, '#text'),
         );
     }
 
@@ -209,9 +210,9 @@ DUMP;
     {
         $dump = <<<DUMP
 XMLReader {
+  +localName: "$localName"
   +nodeType: $nodeTypeName
   +depth: $depth
-  +localName: "$localName"
   parserProperties: {
     LOADDTD: false
     DEFAULTATTRS: false
@@ -239,9 +240,10 @@ DUMP;
     {
         $dump = <<<'DUMP'
 XMLReader {
+  +localName: "foo"
   +nodeType: ATTRIBUTE
   +depth: 2
-  +localName: "foo"
+  +isDefault: false
   +hasValue: true
   +value: "bar"
   parserProperties: {
@@ -250,7 +252,6 @@ XMLReader {
     VALIDATE: false
     SUBST_ENTITIES: false
   }
-   …4
 }
 
 DUMP;
@@ -314,4 +315,3 @@ DUMP;
         $this->reader->close();
     }
 }
-

--- a/src/Symfony/Component/VarDumper/Tests/Caster/XmlReaderCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/XmlReaderCasterTest.php
@@ -33,20 +33,20 @@ class XmlReaderCasterTest extends \PHPUnit_Framework_TestCase
     {
         $dump = <<<'DUMP'
 XMLReader {
-  +nodeType: ELEMENT
-  parserProperties: {
-    LOADDTD: false
-    DEFAULTATTRS: false
-    VALIDATE: false
-    SUBST_ENTITIES: false
-  }
   +localName: "foo"
+  +nodeType: ELEMENT
   +depth: 0
   +attributeCount: 0
   +hasAttributes: false
   +hasValue: false
   +isDefault: false
   +isEmptyElement: false
+  parserProperties: {
+    LOADDTD: false
+    DEFAULTATTRS: false
+    VALIDATE: false
+    SUBST_ENTITIES: false
+  }
 }
 DUMP;
 
@@ -59,20 +59,20 @@ DUMP;
     {
         $dump = <<<'DUMP'
 XMLReader {
-  +nodeType: ELEMENT
-  parserProperties: {
-    LOADDTD: false
-    DEFAULTATTRS: false
-    VALIDATE: false
-    SUBST_ENTITIES: false
-  }
   +localName: "bar"
+  +nodeType: ELEMENT
   +depth: 1
   +attributeCount: 0
   +hasAttributes: false
   +hasValue: false
   +isDefault: false
   +isEmptyElement: false
+  parserProperties: {
+    LOADDTD: false
+    DEFAULTATTRS: false
+    VALIDATE: false
+    SUBST_ENTITIES: false
+  }
 }
 
 DUMP;
@@ -86,20 +86,20 @@ DUMP;
     {
         $dump = <<<'DUMP'
 XMLReader {
-  +nodeType: ELEMENT
-  parserProperties: {
-    LOADDTD: false
-    DEFAULTATTRS: false
-    VALIDATE: false
-    SUBST_ENTITIES: false
-  }
   +localName: "bar"
+  +nodeType: ELEMENT
   +depth: 1
   +attributeCount: 0
   +hasAttributes: false
   +hasValue: false
   +isDefault: false
   +isEmptyElement: true
+  parserProperties: {
+    LOADDTD: false
+    DEFAULTATTRS: false
+    VALIDATE: false
+    SUBST_ENTITIES: false
+  }
 }
 
 DUMP;
@@ -115,14 +115,8 @@ DUMP;
     {
         $dump = <<<'DUMP'
 XMLReader {
-  +nodeType: ELEMENT
-  parserProperties: {
-    LOADDTD: false
-    DEFAULTATTRS: false
-    VALIDATE: false
-    SUBST_ENTITIES: false
-  }
   +localName: "bar"
+  +nodeType: ELEMENT
   +depth: 1
   +attributeCount: 2
   +hasAttributes: true
@@ -133,6 +127,12 @@ XMLReader {
     0 => "bar"
     1 => "fubar"
   ]
+  parserProperties: {
+    LOADDTD: false
+    DEFAULTATTRS: false
+    VALIDATE: false
+    SUBST_ENTITIES: false
+  }
 }
 
 DUMP;
@@ -151,12 +151,6 @@ DUMP;
         $dump = <<<'DUMP'
 XMLReader {
   +nodeType: TEXT
-  parserProperties: {
-    LOADDTD: false
-    DEFAULTATTRS: false
-    VALIDATE: false
-    SUBST_ENTITIES: false
-  }
   +depth: 2
   +attributeCount: 0
   +hasAttributes: false
@@ -164,6 +158,12 @@ XMLReader {
   +isDefault: false
   +isEmptyElement: false
   +value: "With text"
+  parserProperties: {
+    LOADDTD: false
+    DEFAULTATTRS: false
+    VALIDATE: false
+    SUBST_ENTITIES: false
+  }
    …1
 }
 
@@ -211,13 +211,13 @@ DUMP;
 XMLReader {
   +nodeType: $nodeTypeName
   +depth: $depth
+  +localName: "$localName"
   parserProperties: {
     LOADDTD: false
     DEFAULTATTRS: false
     VALIDATE: false
     SUBST_ENTITIES: false
   }
-  +localName: "$localName"
    …5
 }
 
@@ -241,15 +241,15 @@ DUMP;
 XMLReader {
   +nodeType: ATTRIBUTE
   +depth: 2
+  +localName: "foo"
+  +hasValue: true
+  +value: "bar"
   parserProperties: {
     LOADDTD: false
     DEFAULTATTRS: false
     VALIDATE: false
     SUBST_ENTITIES: false
   }
-  +localName: "foo"
-  +hasValue: true
-  +value: "bar"
    …4
 }
 
@@ -266,14 +266,8 @@ DUMP;
     {
         $dump = <<<'DUMP'
 XMLReader {
-  +nodeType: ELEMENT
-  parserProperties: {
-    LOADDTD: false
-    DEFAULTATTRS: false
-    VALIDATE: false
-    SUBST_ENTITIES: false
-  }
   +localName: "baz"
+  +nodeType: ELEMENT
   +depth: 2
   +attributeCount: 0
   +hasAttributes: false
@@ -282,6 +276,12 @@ XMLReader {
   +isEmptyElement: false
   +prefix: "baz"
   +namespaceURI: "http://symfony.com"
+  parserProperties: {
+    LOADDTD: false
+    DEFAULTATTRS: false
+    VALIDATE: false
+    SUBST_ENTITIES: false
+  }
 }
 DUMP;
 

--- a/src/Symfony/Component/VarDumper/Tests/Caster/XmlReaderCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/XmlReaderCasterTest.php
@@ -262,6 +262,34 @@ DUMP;
         $this->assertDumpEquals($dump, $this->reader);
     }
 
+    public function testPrefixedElements()
+    {
+        $dump = <<<'DUMP'
+XMLReader {
+  +localName: "baz"
+  +depth: 2
+  +attributeCount: 0
+  +hasAttributes: false
+  +hasValue: false
+  +isDefault: false
+  +isEmptyElement: false
+  +nodeType: ELEMENT
+  parserProperties: array:4 [
+    "LOADDTD" => false
+    "DEFAULTATTRS" => false
+    "VALIDATE" => false
+    "SUBST_ENTITIES" => false
+  ]
+  +prefix: "baz"
+  +namespaceURI: "http://symfony.com"
+}
+DUMP;
+
+        while ($this->reader->read() && $this->reader->localName !== 'baz');
+
+        $this->assertDumpEquals($dump, $this->reader);
+    }
+
     public function tearDown()
     {
         $this->reader->close();

--- a/src/Symfony/Component/VarDumper/Tests/Caster/XmlReaderCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/XmlReaderCasterTest.php
@@ -41,6 +41,12 @@ XMLReader {
   +isDefault: false
   +isEmptyElement: false
   +nodeType: ELEMENT
+  parserProperties: array:4 [
+    "LOADDTD" => false
+    "DEFAULTATTRS" => false
+    "VALIDATE" => false
+    "SUBST_ENTITIES" => false
+  ]
 }
 DUMP;
 
@@ -61,6 +67,12 @@ XMLReader {
   +isDefault: false
   +isEmptyElement: false
   +nodeType: ELEMENT
+  parserProperties: array:4 [
+    "LOADDTD" => false
+    "DEFAULTATTRS" => false
+    "VALIDATE" => false
+    "SUBST_ENTITIES" => false
+  ]
 }
 
 DUMP;
@@ -82,6 +94,12 @@ XMLReader {
   +isDefault: false
   +isEmptyElement: true
   +nodeType: ELEMENT
+  parserProperties: array:4 [
+    "LOADDTD" => false
+    "DEFAULTATTRS" => false
+    "VALIDATE" => false
+    "SUBST_ENTITIES" => false
+  ]
 }
 
 DUMP;
@@ -105,6 +123,12 @@ XMLReader {
   +isDefault: false
   +isEmptyElement: false
   +nodeType: ELEMENT
+  parserProperties: array:4 [
+    "LOADDTD" => false
+    "DEFAULTATTRS" => false
+    "VALIDATE" => false
+    "SUBST_ENTITIES" => false
+  ]
   attributes: array:2 [
     0 => "bar"
     1 => "fubar"
@@ -133,6 +157,12 @@ XMLReader {
   +isDefault: false
   +isEmptyElement: false
   +nodeType: TEXT
+  parserProperties: array:4 [
+    "LOADDTD" => false
+    "DEFAULTATTRS" => false
+    "VALIDATE" => false
+    "SUBST_ENTITIES" => false
+  ]
   +value: "With text"
    …1
 }
@@ -151,6 +181,12 @@ DUMP;
 XMLReader {
   +nodeType: $nodeTypeName
   +depth: $depth
+  parserProperties: array:4 [
+    "LOADDTD" => false
+    "DEFAULTATTRS" => false
+    "VALIDATE" => false
+    "SUBST_ENTITIES" => false
+  ]
    …6
 }
 
@@ -175,6 +211,12 @@ DUMP;
 XMLReader {
   +nodeType: $nodeTypeName
   +depth: $depth
+  parserProperties: array:4 [
+    "LOADDTD" => false
+    "DEFAULTATTRS" => false
+    "VALIDATE" => false
+    "SUBST_ENTITIES" => false
+  ]
   +localName: "$localName"
    …5
 }
@@ -199,6 +241,12 @@ DUMP;
 XMLReader {
   +nodeType: ATTRIBUTE
   +depth: 2
+  parserProperties: array:4 [
+    "LOADDTD" => false
+    "DEFAULTATTRS" => false
+    "VALIDATE" => false
+    "SUBST_ENTITIES" => false
+  ]
   +localName: "foo"
   +hasValue: true
   +value: "bar"

--- a/src/Symfony/Component/VarDumper/Tests/Caster/XmlReaderCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/XmlReaderCasterTest.php
@@ -33,13 +33,6 @@ class XmlReaderCasterTest extends \PHPUnit_Framework_TestCase
     {
         $dump = <<<'DUMP'
 XMLReader {
-  +localName: "foo"
-  +depth: 0
-  +attributeCount: 0
-  +hasAttributes: false
-  +hasValue: false
-  +isDefault: false
-  +isEmptyElement: false
   +nodeType: ELEMENT
   parserProperties: array:4 [
     "LOADDTD" => false
@@ -47,6 +40,13 @@ XMLReader {
     "VALIDATE" => false
     "SUBST_ENTITIES" => false
   ]
+  +localName: "foo"
+  +depth: 0
+  +attributeCount: 0
+  +hasAttributes: false
+  +hasValue: false
+  +isDefault: false
+  +isEmptyElement: false
 }
 DUMP;
 
@@ -59,13 +59,6 @@ DUMP;
     {
         $dump = <<<'DUMP'
 XMLReader {
-  +localName: "bar"
-  +depth: 1
-  +attributeCount: 0
-  +hasAttributes: false
-  +hasValue: false
-  +isDefault: false
-  +isEmptyElement: false
   +nodeType: ELEMENT
   parserProperties: array:4 [
     "LOADDTD" => false
@@ -73,6 +66,13 @@ XMLReader {
     "VALIDATE" => false
     "SUBST_ENTITIES" => false
   ]
+  +localName: "bar"
+  +depth: 1
+  +attributeCount: 0
+  +hasAttributes: false
+  +hasValue: false
+  +isDefault: false
+  +isEmptyElement: false
 }
 
 DUMP;
@@ -86,13 +86,6 @@ DUMP;
     {
         $dump = <<<'DUMP'
 XMLReader {
-  +localName: "bar"
-  +depth: 1
-  +attributeCount: 0
-  +hasAttributes: false
-  +hasValue: false
-  +isDefault: false
-  +isEmptyElement: true
   +nodeType: ELEMENT
   parserProperties: array:4 [
     "LOADDTD" => false
@@ -100,6 +93,13 @@ XMLReader {
     "VALIDATE" => false
     "SUBST_ENTITIES" => false
   ]
+  +localName: "bar"
+  +depth: 1
+  +attributeCount: 0
+  +hasAttributes: false
+  +hasValue: false
+  +isDefault: false
+  +isEmptyElement: true
 }
 
 DUMP;
@@ -115,13 +115,6 @@ DUMP;
     {
         $dump = <<<'DUMP'
 XMLReader {
-  +localName: "bar"
-  +depth: 1
-  +attributeCount: 2
-  +hasAttributes: true
-  +hasValue: false
-  +isDefault: false
-  +isEmptyElement: false
   +nodeType: ELEMENT
   parserProperties: array:4 [
     "LOADDTD" => false
@@ -129,6 +122,13 @@ XMLReader {
     "VALIDATE" => false
     "SUBST_ENTITIES" => false
   ]
+  +localName: "bar"
+  +depth: 1
+  +attributeCount: 2
+  +hasAttributes: true
+  +hasValue: false
+  +isDefault: false
+  +isEmptyElement: false
   attributes: array:2 [
     0 => "bar"
     1 => "fubar"
@@ -150,12 +150,6 @@ DUMP;
     {
         $dump = <<<'DUMP'
 XMLReader {
-  +depth: 2
-  +attributeCount: 0
-  +hasAttributes: false
-  +hasValue: true
-  +isDefault: false
-  +isEmptyElement: false
   +nodeType: TEXT
   parserProperties: array:4 [
     "LOADDTD" => false
@@ -163,6 +157,12 @@ XMLReader {
     "VALIDATE" => false
     "SUBST_ENTITIES" => false
   ]
+  +depth: 2
+  +attributeCount: 0
+  +hasAttributes: false
+  +hasValue: true
+  +isDefault: false
+  +isEmptyElement: false
   +value: "With text"
    …1
 }
@@ -266,13 +266,6 @@ DUMP;
     {
         $dump = <<<'DUMP'
 XMLReader {
-  +localName: "baz"
-  +depth: 2
-  +attributeCount: 0
-  +hasAttributes: false
-  +hasValue: false
-  +isDefault: false
-  +isEmptyElement: false
   +nodeType: ELEMENT
   parserProperties: array:4 [
     "LOADDTD" => false
@@ -280,12 +273,38 @@ XMLReader {
     "VALIDATE" => false
     "SUBST_ENTITIES" => false
   ]
+  +localName: "baz"
+  +depth: 2
+  +attributeCount: 0
+  +hasAttributes: false
+  +hasValue: false
+  +isDefault: false
+  +isEmptyElement: false
   +prefix: "baz"
   +namespaceURI: "http://symfony.com"
 }
 DUMP;
 
         while ($this->reader->read() && $this->reader->localName !== 'baz');
+
+        $this->assertDumpEquals($dump, $this->reader);
+    }
+
+    public function testNone()
+    {
+        $dump = <<<'DUMP'
+XMLReader {
+  +nodeType: NONE
+  parserProperties: array:4 [
+    "LOADDTD" => false
+    "DEFAULTATTRS" => false
+    "VALIDATE" => false
+    "SUBST_ENTITIES" => false
+  ]
+}
+DUMP;
+
+        while ($this->reader->read());
 
         $this->assertDumpEquals($dump, $this->reader);
     }

--- a/src/Symfony/Component/VarDumper/Tests/Fixtures/xml_reader.xml
+++ b/src/Symfony/Component/VarDumper/Tests/Fixtures/xml_reader.xml
@@ -4,4 +4,7 @@
     <bar />
     <bar>With text</bar>
     <bar foo="bar" baz="fubar"></bar>
+    <bar xmlns:baz="http://symfony.com">
+        <baz:baz></baz:baz>
+    </bar>
 </foo>

--- a/src/Symfony/Component/VarDumper/Tests/Fixtures/xml_reader.xml
+++ b/src/Symfony/Component/VarDumper/Tests/Fixtures/xml_reader.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<foo>
+    <bar></bar>
+    <bar />
+    <bar>With text</bar>
+    <bar foo="bar" baz="fubar"></bar>
+</foo>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

Adding support for `XmlReader` objects. The thing is, with the caster as presented here, we may have noises (`#text` elements, whitespaces (significant or not) elements, ...) which may disturb the reading, but I am not sure if I should ignore those or not.

Moreover, there is only one class, but having different casters could do the trick I guess ? But then we have a lot of noise with empty results if none of the casters are satisfied (unless I missed something, allowing us to completely ignore the current object, in cases such as `XmlReader::WHITESPACE` and `XmlReader::SIGNIFICANT_WHITESPACE`). 

On attributes, I can either not touch the current state, but then I can only have indexes for attributes and no names (`<foo bar="baz">` would be rendered as `array(0 => 'baz')`), or I can modify the object (rendering `<foo bar="baz">` as `array('bar' => 'baz')`) , but as @stof said, we should not touch it, unless it is not the actual object that is modified ? I do not have enough knowledge on the var dumper to determine that point...

Open for suggestions.
- [x] Add basic XmlReaderCaster
- [x] Add XmlReaderCaster in the default casters
- [x] Add some tests
