### PR TITLE
[HttpKernel] Created gateway exception classes.

### DIFF
--- a/src/Symfony/Component/HttpKernel/Exception/BadGatewayException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/BadGatewayException.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Exception;
+
+/**
+ * BadGatewayException.
+ *
+ * @author Robin van der Vleuten <robin@webstronauts.co>
+ */
+class BadGatewayException extends HttpException
+{
+    /**
+     * Constructor.
+     *
+     * @param string     $message  The internal exception message
+     * @param \Exception $previous The previous exception
+     * @param int        $code     The internal exception code
+     */
+    public function __construct($message = null, \Exception $previous = null, $code = 0)
+    {
+        parent::__construct(502, $message, $previous, array(), $code);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Exception/GatewayTimeoutException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/GatewayTimeoutException.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Exception;
+
+/**
+ * GatewayTimeoutException.
+ *
+ * @author Robin van der Vleuten <robin@webstronauts.co>
+ */
+class GatewayTimeoutException extends HttpException
+{
+    /**
+     * Constructor.
+     *
+     * @param string     $message  The internal exception message
+     * @param \Exception $previous The previous exception
+     * @param int        $code     The internal exception code
+     */
+    public function __construct($message = null, \Exception $previous = null, $code = 0)
+    {
+        parent::__construct(504, $message, $previous, array(), $code);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/BadGatewayExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/BadGatewayExceptionTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Tests\Exception;
+
+use Symfony\Component\HttpKernel\Exception\BadGatewayException;
+
+class BadGatewayExceptionTest extends HttpExceptionTest
+{
+    protected function createException()
+    {
+        return new BadGatewayException();
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/GatewayTimeoutExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/GatewayTimeoutExceptionTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Tests\Exception;
+
+use Symfony\Component\HttpKernel\Exception\GatewayTimeoutException;
+
+class GatewayTimeoutExceptionTest extends HttpExceptionTest
+{
+    protected function createException()
+    {
+        return new GatewayTimeoutException();
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Hi there,

I've created to additional http exceptions for 502 and 504 responses, which makes sense for throwing when your application acts as a "gateway" for other (api-related) services. 

Cheers,
Robin
