### PR TITLE
[HttpKernel] Add convenient method ArgumentResolver:: getDefaultArgumentValueResolvers

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver.php
@@ -36,12 +36,7 @@ final class ArgumentResolver implements ArgumentResolverInterface
     public function __construct(ArgumentMetadataFactoryInterface $argumentMetadataFactory = null, array $argumentValueResolvers = array())
     {
         $this->argumentMetadataFactory = $argumentMetadataFactory ?: new ArgumentMetadataFactory();
-        $this->argumentValueResolvers = $argumentValueResolvers ?: array(
-            new RequestAttributeValueResolver(),
-            new RequestValueResolver(),
-            new DefaultValueResolver(),
-            new VariadicValueResolver(),
-        );
+        $this->argumentValueResolvers = $argumentValueResolvers ?: self::getDefaultArgumentValueResolvers();
     }
 
     /**
@@ -83,5 +78,15 @@ final class ArgumentResolver implements ArgumentResolverInterface
         }
 
         return $arguments;
+    }
+
+    public static function getDefaultArgumentValueResolvers()
+    {
+        return array(
+            new RequestAttributeValueResolver(),
+            new RequestValueResolver(),
+            new DefaultValueResolver(),
+            new VariadicValueResolver(),
+        );
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

I realized while implementing my own `ArgumentValueResolver` that registering a new one is not easy, you have to give the whole list of resolver instead of pushing your one in the stack.
