### PR TITLE
[Security] Log info about reloaded user only if the user objects will change

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -155,7 +155,7 @@ class ContextListener implements ListenerInterface
                 $refreshedUser = $provider->refreshUser($user);
                 $token->setUser($refreshedUser);
 
-                if (null !== $this->logger) {
+                if (spl_object_hash($user) !== spl_object_hash($refreshedUser) && null !== $this->logger) {
                     $this->logger->debug('User was reloaded from a user provider.', array('username' => $refreshedUser->getUsername(), 'provider' => get_class($provider)));
                 }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7, 2.8, 3.0, 3.1 + master |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The log information is wrong if the user provider isn't reloaded from user provider.

My use case:
I have custom user provider, that doesn't refresh user every time. User object is refreshed from database every x seconds. If the object is not refreshed from database, the object from session is used and the log information about reloaded user from provider should not occur.
