### PR TITLE
[YAML] Fixed parsing problem with nested DateTime lists

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -398,7 +398,7 @@ class Inline
                     $value = self::parseScalar($sequence, $flags, array(',', ']'), array('"', "'"), $i, true, $references);
 
                     // the value can be an array if a reference has been resolved to an array var
-                    if (!is_array($value) && !$isQuoted && false !== strpos($value, ': ')) {
+                    if (!is_array($value) && !$value instanceof \DateTimeInterface && !$isQuoted && false !== strpos($value, ': ')) {
                         // embedded mapping?
                         try {
                             $pos = 0;

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -549,6 +549,22 @@ class InlineTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider getTimestampTests
+     */
+    public function testParseNestedTimestampListAsDateTimeObject($yaml, $year, $month, $day, $hour, $minute, $second)
+    {
+        $expected = new \DateTime($yaml);
+        $expected->setTimeZone(new \DateTimeZone('UTC'));
+        $expected->setDate($year, $month, $day);
+        $expected->setTime($hour, $minute, $second);
+
+        $expectedNested = array('nested' => array($expected));
+        $yamlNested = "{nested: [$yaml]}";
+
+        $this->assertEquals($expectedNested, Inline::parse($yamlNested, Yaml::PARSE_DATETIME));
+    }
+
+    /**
      * @dataProvider getDateTimeDumpTests
      */
     public function testDumpDateTime($dateTime, $expected)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

---

Without this fix, DateTime-aware parsing of a YAML source containing nested lists of dates result in an error. Consider this:

``` php
$data = ['date' => ['annivesary' => new \DateTime('now')]];
$yaml = Yaml::dump($data);
var_dump($yaml);

$parsed = Yaml::parse($yaml, Yaml::PARSE_DATETIME);
print_r($parsed);
```

Everything is fine, result is:

```
string(48) "date:
    annivesary: 2016-06-11T11:26:30+02:00
"
Array
(
    [date] => Array
        (
            [annivesary] => DateTime Object
                (
                    [date] => 2016-06-11 11:26:30.000000
                    [timezone_type] => 1
                    [timezone] => +02:00
                )

        )

)
```

But making the `anniversary` a list of dates

``` php
$data = ['date' => ['annivesary' => [new \DateTime('now')]]];
$yaml = Yaml::dump($data);
var_dump($yaml);

$parsed = Yaml::parse($yaml, Yaml::PARSE_DATETIME);
print_r($parsed);
```

will result in:

```
string(50) "date:
    annivesary: [2016-06-11T12:00:05+02:00]
"
PHP Warning:  strpos() expects parameter 1 to be string, object given in [...]\vendor\symfony\yaml\Inline.php on line 382
PHP Catchable fatal error:  Object of class DateTime could not be converted to string in [...]\vendor\symfony\yaml\Inline.php on line 386
```

(I didn't capture the error messages with the most recent master branch, so line numbers differ somewhat)
