### PR TITLE
[Console] Add default behavior for the %message% placeholder in the ProgressBar

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -42,7 +42,7 @@ class ProgressBar
     private $stepWidth;
     private $percent = 0.0;
     private $formatLineCount;
-    private $messages;
+    private $messages = array();
     private $overwrite = true;
 
     private static $formatters;
@@ -140,11 +140,24 @@ class ProgressBar
         return isset(self::$formats[$name]) ? self::$formats[$name] : null;
     }
 
+    /**
+     * Set message.
+     *
+     * @param string $message Message
+     * @param string $name    Name for a message which is used as placeholder
+     */
     public function setMessage($message, $name = 'message')
     {
         $this->messages[$name] = $message;
     }
 
+    /**
+     * Get message.
+     *
+     * @param string $name Name for a message which is used as placeholder
+     *
+     * @return mixed
+     */
     public function getMessage($name = 'message')
     {
         return $this->messages[$name];
@@ -563,23 +576,38 @@ class ProgressBar
             'percent' => function (ProgressBar $bar) {
                 return floor($bar->getProgressPercent() * 100);
             },
+            'message' => function (ProgressBar $bar) {
+                $message = '';
+
+                if (isset($bar->messages['message'])) {
+                    $message = $bar->getMessage();
+
+                    if (0 !== strlen($message) && ' ' !== substr($message, 0, 1)) {
+                        // If message does not start with space, then add 1 space at the beginning of the message
+                        // to separate the message from the [%bar%] placeholder
+                        $message = ' '.$message;
+                    }
+                }
+
+                return $message;
+            },
         );
     }
 
     private static function initFormats()
     {
         return array(
-            'normal' => ' %current%/%max% [%bar%] %percent:3s%%',
-            'normal_nomax' => ' %current% [%bar%]',
+            'normal' => ' %current%/%max% [%bar%]%message% %percent:3s%%',
+            'normal_nomax' => ' %current% [%bar%]%message%',
 
-            'verbose' => ' %current%/%max% [%bar%] %percent:3s%% %elapsed:6s%',
-            'verbose_nomax' => ' %current% [%bar%] %elapsed:6s%',
+            'verbose' => ' %current%/%max% [%bar%]%message% %percent:3s%% %elapsed:6s%',
+            'verbose_nomax' => ' %current% [%bar%]%message% %elapsed:6s%',
 
-            'very_verbose' => ' %current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s%',
-            'very_verbose_nomax' => ' %current% [%bar%] %elapsed:6s%',
+            'very_verbose' => ' %current%/%max% [%bar%]%message% %percent:3s%% %elapsed:6s%/%estimated:-6s%',
+            'very_verbose_nomax' => ' %current% [%bar%]%message% %elapsed:6s%',
 
-            'debug' => ' %current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s% %memory:6s%',
-            'debug_nomax' => ' %current% [%bar%] %elapsed:6s% %memory:6s%',
+            'debug' => ' %current%/%max% [%bar%]%message% %percent:3s%% %elapsed:6s%/%estimated:-6s% %memory:6s%',
+            'debug_nomax' => ' %current% [%bar%]%message% %elapsed:6s% %memory:6s%',
         );
     }
 }

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -636,6 +636,87 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @param string $format         Format
+     * @param string $expectedOutput Expected output
+     *
+     * @dataProvider defaultBehaviorForMessagePlaceholderProvider
+     */
+    public function testDefaultBehaviorForMessagePlaceholder($format, $expectedOutput)
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream(), 4);
+        $bar->setFormat($format);
+        $bar->setMessage('Text without a space at the beginning');
+        $bar->start();
+        $bar->setMessage(' Text with a space at the beginning');
+        $bar->advance();
+        $bar->setMessage('  Text with two spaces at the beginning');
+        $bar->advance();
+        $bar->setMessage('');
+        $bar->advance();
+        $bar->setMessage('Finish');
+        $bar->finish();
+        rewind($output->getStream());
+        $this->assertEquals($expectedOutput, stream_get_contents($output->getStream()));
+    }
+
+    public function defaultBehaviorForMessagePlaceholderProvider()
+    {
+        $data = array();
+        $data[] = array(
+            'normal',
+            $this->generateOutput(' 0/4 [>---------------------------] Text without a space at the beginning   0%').
+            $this->generateOutput(' 1/4 [=======>--------------------] Text with a space at the beginning  25%').
+            $this->generateOutput(' 2/4 [==============>-------------]  Text with two spaces at the beginning  50%').
+            $this->generateOutput(' 3/4 [=====================>------]  75%').
+            $this->generateOutput(' 4/4 [============================] Finish 100%'),
+        );
+        $data[] = array(
+            'normal_nomax',
+            $this->generateOutput(' 0 [>---------------------------] Text without a space at the beginning').
+            $this->generateOutput(' 1 [=======>--------------------] Text with a space at the beginning').
+            $this->generateOutput(' 2 [==============>-------------]  Text with two spaces at the beginning').
+            $this->generateOutput(' 3 [=====================>------]').
+            $this->generateOutput(' 4 [============================] Finish'),
+        );
+        // As this test is very lightweight, it should be executed less than 1 second
+        // So `elapsed` and `estimated` placeholders are `< 1 sec` here
+        $data[] = array(
+            'verbose',
+            $this->generateOutput(' 0/4 [>---------------------------] Text without a space at the beginning   0% < 1 sec').
+            $this->generateOutput(' 1/4 [=======>--------------------] Text with a space at the beginning  25% < 1 sec').
+            $this->generateOutput(' 2/4 [==============>-------------]  Text with two spaces at the beginning  50% < 1 sec').
+            $this->generateOutput(' 3/4 [=====================>------]  75% < 1 sec').
+            $this->generateOutput(' 4/4 [============================] Finish 100% < 1 sec'),
+        );
+        $data[] = array(
+            'verbose_nomax',
+            $this->generateOutput(' 0 [>---------------------------] Text without a space at the beginning < 1 sec').
+            $this->generateOutput(' 1 [=======>--------------------] Text with a space at the beginning < 1 sec').
+            $this->generateOutput(' 2 [==============>-------------]  Text with two spaces at the beginning < 1 sec').
+            $this->generateOutput(' 3 [=====================>------] < 1 sec').
+            $this->generateOutput(' 4 [============================] Finish < 1 sec'),
+        );
+        $data[] = array(
+            'very_verbose',
+            $this->generateOutput(' 0/4 [>---------------------------] Text without a space at the beginning   0% < 1 sec/< 1 sec').
+            $this->generateOutput(' 1/4 [=======>--------------------] Text with a space at the beginning  25% < 1 sec/< 1 sec').
+            $this->generateOutput(' 2/4 [==============>-------------]  Text with two spaces at the beginning  50% < 1 sec/< 1 sec').
+            $this->generateOutput(' 3/4 [=====================>------]  75% < 1 sec/< 1 sec').
+            $this->generateOutput(' 4/4 [============================] Finish 100% < 1 sec/< 1 sec'),
+        );
+        $data[] = array(
+            'very_verbose_nomax',
+            $this->generateOutput(' 0 [>---------------------------] Text without a space at the beginning < 1 sec').
+            $this->generateOutput(' 1 [=======>--------------------] Text with a space at the beginning < 1 sec').
+            $this->generateOutput(' 2 [==============>-------------]  Text with two spaces at the beginning < 1 sec').
+            $this->generateOutput(' 3 [=====================>------] < 1 sec').
+            $this->generateOutput(' 4 [============================] Finish < 1 sec'),
+        );
+        // `debug` and `debug_nomax` are not tested because memory usage can be different on different systems and versions
+        return $data;
+    }
+
+    /**
      * Provides each defined format.
      *
      * @return array


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/pull/18746 the same patch which was rejected because wrong branch (2.7) was selected |
| License | MIT |
| Doc PR | If this patch be accepted then current docs will be actual and no update needed. Otherwise documentation should be updated a bit because now it contains wrong example of default behavior, described in https://github.com/symfony/symfony-docs/issues/6544 |

> The description I totally copy pasted from the previous PR https://github.com/symfony/symfony/pull/18746

When I was reading the documentation for the ProgressBar helper http://symfony.com/doc/current/components/console/helpers/progressbar.html I found a nice feature - showing messages by using `%message%` placeholder. But when I tried the example from the docs, I found that it does not work as expected. 

So this code will give the next output

``` php
protected function execute(InputInterface $input, OutputInterface $output)
{
    $bar = new ProgressBar($output, 4);

    $bar->setMessage('Starting the demo...');
    $bar->start();

    sleep(1);

    $bar->setMessage('First message...');
    $bar->advance();

    sleep(1);

    $bar->setMessage('Second message...');
    $bar->advance();

    sleep(1);

    $bar->setMessage('Third message...');
    $bar->advance();

    sleep(1);

    $bar->setMessage('Finish...');
    $bar->finish();

    $output->writeln('');
}
```

![example1](https://cloud.githubusercontent.com/assets/815865/15176301/20e44a48-1773-11e6-97f2-208b0503b9e0.gif)

So as you see no message is displayed. That is because all built-in formats do not have a `%message%` placeholder. You can check the master branch https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Console/Helper/ProgressBar.php#L569 to be sure. Same is in the older versions.

Or you can just quickly look at the `initFormats()` which I copy-pasted here:

``` php
private static function initFormats()
{
    return array(
        'normal' => ' %current%/%max% [%bar%] %percent:3s%%',
        'normal_nomax' => ' %current% [%bar%]',

        'verbose' => ' %current%/%max% [%bar%] %percent:3s%% %elapsed:6s%',
        'verbose_nomax' => ' %current% [%bar%] %elapsed:6s%',

        'very_verbose' => ' %current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s%',
        'very_verbose_nomax' => ' %current% [%bar%] %elapsed:6s%',

        'debug' => ' %current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s% %memory:6s%',
        'debug_nomax' => ' %current% [%bar%] %elapsed:6s% %memory:6s%',
    );
}
```

> For example ProgressIndicator has the `%message%` placeholder https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Console/Helper/ProgressIndicator.php#L314

So that's why out of box without customizing your format - messages won't be shown. For example in the current implementation of the ProgressBar if I want to display the message I have to add the next code:

``` php
$bar = new ProgressBar($output, 4);
// I just take the `normal` format and add %message% placeholder there
$bar->setFormatDefinition('normal_customized', ' %current%/%max% [%bar%] %message% %percent:3s%%');
$bar->setFormat('normal_customized');

// End with the code from my previous example...
```

And it works...

![2](https://cloud.githubusercontent.com/assets/815865/15176806/97bff408-1775-11e6-9e0d-91ebe0aa76ae.gif)

But as I described here https://github.com/symfony/symfony-docs/issues/6544 It is not clear from the docs. After the reading of docs I thought that message should be displayed out of box without customizing the output.

After that I investigated the code of ProgressBar and found the cause.

So I see two ways how to solve it.
1) Leave the code as it is now and fix the docs. But I think it is not best choice, because user still needs to add custom format every time when they need to display a simple message.
2) Add the default behavior for the `%message%` placeholder which doesn't break the backwards compatibility.

So in this patch I propose a small tweak. I propose to add a placeholder formatter for `%message%` placeholder. It will check if there is a message with name `message` in the array of messages - then it will take it, otherwise - it will ignore it.
Also I propose to add a `%message%` to all built-in formats, e.g.
`'normal' => ' %current%/%max% [%bar%]%message% %percent:3s%%',`
But don't surround it with spaces, so in this case if user doesn't set the custom message, the message placeholder formatter will convert it to the empty string, so it behaves like in the current implementation.
If user adds a custom message `$bar->setMessage('Starting');` the formatter will replace placeholder with the current text.
There is one additional tweak I have added there. As the `%message%` placeholder is set next to the `[%bar%]` without a space, if user adds the message without at least one space at the beginning, the progress bar will look a bit ugly
`4/4 [============================]Finish... 100%`
To prevent it I decided to add a space to the beginning of the message, if message doesn't start with a space. So in my implementation if user sets the message like this

``` php
$bar->setMessage('Finish'); // without a space at the beginning
```

The output will be next (with extra space)

```
 4/4 [============================] Finish 100%
```

If user manually adds some spaces at the beginning then no extra space will be added.

``` php
// user sets a space at the beginning, so no extra space added
$bar->setMessage(' Finish');
// outputs the:  4/4 [============================] Finish 100%

// user sets two spaces, so only two spaces are shown, no more extra space
$bar->setMessage('  Finish');
// outputs the:  4/4 [============================]  Finish 100%

// same with different number of spaces
$bar->setMessage('    Finish');
// outputs the:  4/4 [============================]    Finish 100%
```

So with the changes which I propose to the ProgressBar the next code will give the next output

``` php
protected function execute(InputInterface $input, OutputInterface $output)
{
    $bar = new ProgressBar($output, 4);

    $bar->setMessage('Starting the demo...');
    $bar->start();

    sleep(1);

    $bar->setMessage(' First message...');
    $bar->advance();

    sleep(1);

    $bar->setMessage('  Second message...');
    $bar->advance();

    sleep(1);

    $bar->setMessage('');
    $bar->advance();

    sleep(1);

    $bar->setMessage('Finish...');
    $bar->finish();

    $output->writeln('');
}
```

![3](https://cloud.githubusercontent.com/assets/815865/15178035/ed0417a4-177b-11e6-9895-faf6bd71ede4.gif)

I didn't update existing tests, because this patch doesn't break them. But I added new tests to check the default behavior of the `%message%` placeholder.

That's all. Waiting for your feedback.
