### PR TITLE
Automatic logout after changing password on another session

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Provider/DaoAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/DaoAuthenticationProvider.php
@@ -75,7 +75,7 @@ class DaoAuthenticationProvider extends UserAuthenticationProvider
     protected function retrieveUser($username, UsernamePasswordToken $token)
     {
         $user = $token->getUser();
-        if ($user instanceof UserInterface) {
+        if ($user instanceof UserInterface && $token->isAuthenticated()) {
             return $user;
         }
 

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -110,9 +110,9 @@ abstract class AbstractToken implements TokenInterface
 
         if ($changed) {
             $this->setAuthenticated(false);
+        } else {
+            $this->user = $user;
         }
-
-        $this->user = $user;
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/DaoAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/DaoAuthenticationProviderTest.php
@@ -78,6 +78,10 @@ class DaoAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
               ->method('getUser')
               ->will($this->returnValue($user))
         ;
+        $token->expects($this->once())
+              ->method('isAuthenticated')
+              ->will($this->returnValue(true))
+        ;
 
         $provider = new DaoAuthenticationProvider($userProvider, $this->getMock('Symfony\\Component\\Security\\Core\\User\\UserCheckerInterface'), 'key', $this->getMock('Symfony\\Component\\Security\\Core\\Encoder\\EncoderFactoryInterface'));
         $reflection = new \ReflectionMethod($provider, 'retrieveUser');
@@ -260,7 +264,7 @@ class DaoAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
 
     protected function getSupportedToken()
     {
-        $mock = $this->getMock('Symfony\\Component\\Security\\Core\\Authentication\\Token\\UsernamePasswordToken', array('getCredentials', 'getUser', 'getProviderKey'), array(), '', false);
+        $mock = $this->getMock('Symfony\\Component\\Security\\Core\\Authentication\\Token\\UsernamePasswordToken', array('getCredentials', 'getUser', 'getProviderKey', 'isAuthenticated'), array(), '', false);
         $mock
             ->expects($this->any())
             ->method('getProviderKey')

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/AbstractTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/AbstractTokenTest.php
@@ -65,9 +65,11 @@ class AbstractTokenTest extends \PHPUnit_Framework_TestCase
         $token->setUser('fabien');
         $this->assertEquals('fabien', $token->getUsername());
 
+        $token = $this->getToken(array('ROLE_FOO'));
         $token->setUser(new TestUser('fabien'));
         $this->assertEquals('fabien', $token->getUsername());
 
+        $token = $this->getToken(array('ROLE_FOO'));
         $user = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
         $user->expects($this->once())->method('getUsername')->will($this->returnValue('fabien'));
         $token->setUser($user);

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Firewall;
 
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Http\Authorization\AccessDeniedHandlerInterface;
 use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface;
@@ -200,6 +201,15 @@ class ExceptionListener
 
             if (null !== $this->logger) {
                 $this->logger->info('The security token was removed due to an AccountStatusException.', array('exception' => $authException));
+            }
+        }
+
+        if ($authException instanceof BadCredentialsException) {
+            // remove the security token to prevent infinite redirect loops
+            $this->tokenStorage->setToken(null);
+
+            if (null !== $this->logger) {
+                $this->logger->info('The security token was removed due to a BadCredentialsException.', array('exception' => $authException));
             }
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17023 |
| License | MIT |
| Doc PR | none |

Although this PR does not break BC, the change in AbstractToken that relates to setUser functionality is highly volatile and should be thoughtfully inspected for possible regressions.

The flow that causes this bug:
1. [ContextListener L161](https://github.com/symfony/symfony/blob/3.1/src/Symfony/Component/Security/Http/Firewall/ContextListener.php#L161) sets the refreshed User in the token (while checking and marking the token as not authenticated [AbstractToken L112](https://github.com/symfony/symfony/blob/3.1/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php#L112)). This as a consequence leads to the fact that the user data from the unserialized session data is lost and cannot be used anymore later on.
2. After Firewall listener trigger, [DaoAuthenticationProvider](https://github.com/symfony/symfony/blob/3.1/src/Symfony/Component/Security/Core/Authentication/Provider/DaoAuthenticationProvider.php) is invoked. It fetches the user from the token (the already refreshed user) and runs the checks [UserAuthenticationProvider 85-87](https://github.com/symfony/symfony/blob/3.1/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php#L85).
3. The _checkPreAuth_ [L85](https://github.com/symfony/symfony/blob/3.1/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php#L85) and _checkPostAuth_ [L87](https://github.com/symfony/symfony/blob/3.1/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php#L87) are ok as they use the most recent version of the user (refreshed user). _checkAuthentication_ [L86](https://github.com/symfony/symfony/blob/3.1/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php#L86) on the other hand is intended for comparing the old user (from the token) and the new user (the refreshed one), but as the user was overwritten on step 1, this check always returns true [(DaoAuthenticationProvider checkAuthentication method)](https://github.com/symfony/symfony/blob/3.1/src/Symfony/Component/Security/Core/Authentication/Provider/DaoAuthenticationProvider.php#L56).

As a result the user remains logged in although the serialized data from the session he has, contains an old password. After first refresh of the page, his session data is overwritten with fresh data from the refreshed user.
