### PR TITLE
add docblock type elements to support newly added IteratorAggregate::getIterator PhpStorm support

### DIFF
--- a/src/Symfony/Component/Console/Helper/HelperSet.php
+++ b/src/Symfony/Component/Console/Helper/HelperSet.php
@@ -20,6 +20,9 @@ use Symfony\Component\Console\Command\Command;
  */
 class HelperSet implements \IteratorAggregate
 {
+    /**
+     * @var Helper[]
+     */
     private $helpers = array();
     private $command;
 
@@ -109,6 +112,9 @@ class HelperSet implements \IteratorAggregate
         return $this->command;
     }
 
+    /**
+     * @return Helper[]
+     */
     public function getIterator()
     {
         return new \ArrayIterator($this->helpers);

--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -646,7 +646,7 @@ class Finder implements \IteratorAggregate, \Countable
      *
      * This method implements the IteratorAggregate interface.
      *
-     * @return \Iterator An iterator
+     * @return \Iterator|SplFileInfo[] An iterator
      *
      * @throws \LogicException if the in() method has not been called
      */

--- a/src/Symfony/Component/Form/ChoiceList/View/ChoiceGroupView.php
+++ b/src/Symfony/Component/Form/ChoiceList/View/ChoiceGroupView.php
@@ -47,6 +47,8 @@ class ChoiceGroupView implements \IteratorAggregate
 
     /**
      * {@inheritdoc}
+     *
+     * @return ChoiceGroupView[]|ChoiceView[]
      */
     public function getIterator()
     {

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -1022,7 +1022,7 @@ class Form implements \IteratorAggregate, FormInterface
     /**
      * Returns the iterator for this group.
      *
-     * @return \Traversable
+     * @return \Traversable|FormInterface[]
      */
     public function getIterator()
     {

--- a/src/Symfony/Component/Form/FormBuilder.php
+++ b/src/Symfony/Component/Form/FormBuilder.php
@@ -231,6 +231,8 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
 
     /**
      * {@inheritdoc}
+     *
+     * @return FormBuilderInterface[]
      */
     public function getIterator()
     {

--- a/src/Symfony/Component/Form/FormView.php
+++ b/src/Symfony/Component/Form/FormView.php
@@ -143,7 +143,7 @@ class FormView implements \ArrayAccess, \IteratorAggregate, \Countable
     /**
      * Returns an iterator to iterate over children (implements \IteratorAggregate).
      *
-     * @return \ArrayIterator The iterator
+     * @return \ArrayIterator|FormView[] The iterator
      */
     public function getIterator()
     {

--- a/src/Symfony/Component/Routing/Matcher/Dumper/DumperCollection.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/DumperCollection.php
@@ -26,7 +26,7 @@ class DumperCollection implements \IteratorAggregate
     private $parent;
 
     /**
-     * @var (DumperCollection|DumperRoute)[]
+     * @var DumperCollection[]|DumperRoute[]
      */
     private $children = array();
 
@@ -38,7 +38,7 @@ class DumperCollection implements \IteratorAggregate
     /**
      * Returns the children routes and collections.
      *
-     * @return (DumperCollection|DumperRoute)[] Array of DumperCollection|DumperRoute
+     * @return DumperCollection[]|DumperRoute[] Array of DumperCollection|DumperRoute
      */
     public function all()
     {
@@ -76,7 +76,7 @@ class DumperCollection implements \IteratorAggregate
     /**
      * Returns an iterator over the children.
      *
-     * @return \Iterator The iterator
+     * @return \Iterator|DumperCollection[]|DumperRoute[] The iterator
      */
     public function getIterator()
     {

--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -49,7 +49,7 @@ class RouteCollection implements \IteratorAggregate, \Countable
      *
      * @see all()
      *
-     * @return \ArrayIterator An \ArrayIterator object for iterating over routes
+     * @return \ArrayIterator|Route[] An \ArrayIterator object for iterating over routes
      */
     public function getIterator()
     {

--- a/src/Symfony/Component/Validator/ConstraintViolationList.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationList.php
@@ -107,6 +107,8 @@ class ConstraintViolationList implements \IteratorAggregate, ConstraintViolation
 
     /**
      * {@inheritdoc}
+     *
+     * @return \ArrayIterator|ConstraintViolationInterface[]
      */
     public function getIterator()
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | 2.7 |
| Bug fix | no |
| New feature | no |
| BC breaks | no |
| Deprecations | no |
| Tests pass | yes |
| License | MIT |

In additional to #16965 PhpStorm supports `IteratorAggregate::getIterator` now. see https://blog.jetbrains.com/phpstorm/2016/06/phpstorm-2016-2-eap-162-844/

example

```
$collection  = new \Symfony\Component\Routing\RouteCollection();
foreach ($collection as $route) {
    $route->getHost();
}
```
