### PR TITLE
[PropertyAccess] consistency in createPropertyAccessor

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccess.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccess.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\PropertyAccess;
 
+use Psr\Cache\CacheItemPoolInterface;
+
 /**
  * Entry point of the PropertyAccess component.
  *
@@ -19,39 +21,30 @@ namespace Symfony\Component\PropertyAccess;
 final class PropertyAccess
 {
     /**
-     * Creates a property accessor with the default configuration.
+     * Creates a property accessor.
      *
-     * @param bool $throwExceptionOnInvalidIndex
-     * @param bool $magicCall
+     * For dealing with several property accessor configured differently, use
+     * the createPropertyAccessorBuilder() method instead.
+     *
+     * @param bool                        $throwExceptionOnInvalidIndex
+     * @param bool                        $magicCall
+     * @param CacheItemPoolInterface|null $cacheItemPool
      *
      * @return PropertyAccessor The new property accessor
      */
-    public static function createPropertyAccessor($throwExceptionOnInvalidIndex = false, $magicCall = false)
+    public static function createPropertyAccessor($magicCall = false, $throwExceptionOnInvalidIndex = false, CacheItemPoolInterface $cacheItemPool = null)
     {
-        return self::createPropertyAccessorBuilder($throwExceptionOnInvalidIndex, $magicCall)->getPropertyAccessor();
+        return new PropertyAccessor($magicCall, $throwExceptionOnInvalidIndex, $cacheItemPool);
     }
 
     /**
      * Creates a property accessor builder.
      *
-     * @param bool $enableExceptionOnInvalidIndex
-     * @param bool $enableMagicCall
-     *
      * @return PropertyAccessorBuilder The new property accessor builder
      */
-    public static function createPropertyAccessorBuilder($enableExceptionOnInvalidIndex = false, $enableMagicCall = false)
+    public static function createPropertyAccessorBuilder()
     {
-        $propertyAccessorBuilder = new PropertyAccessorBuilder();
-
-        if ($enableExceptionOnInvalidIndex) {
-            $propertyAccessorBuilder->enableExceptionOnInvalidIndex();
-        }
-
-        if ($enableMagicCall) {
-            $propertyAccessorBuilder->enableMagicCall();
-        }
-
-        return $propertyAccessorBuilder;
+        return new PropertyAccessorBuilder();
     }
 
     /**

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessTest.php
@@ -13,24 +13,24 @@ namespace Symfony\Component\PropertyAccess\Tests;
 
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
+use Psr\Cache\CacheItemPoolInterface;
 
 /**
- * @author Robin Chalas <robin.chalas@gmail.com
+ * @author Robin Chalas <robin.chalas@gmail.com>
  */
 final class PropertyAccessTest extends \PHPUnit_Framework_TestCase
 {
     public function testCreatePropertyAccessor()
     {
         $this->assertInstanceOf(PropertyAccessor::class, PropertyAccess::createPropertyAccessor());
-    }
 
-    public function testCreatePropertyAccessorWithExceptionOnInvalidIndex()
-    {
+        // magicCall enabling
         $this->assertInstanceOf(PropertyAccessor::class, PropertyAccess::createPropertyAccessor(true));
-    }
 
-    public function testCreatePropertyAccessorWithMagicCallEnabled()
-    {
+        // throwExceptionOnInvalidIndex enabling
         $this->assertInstanceOf(PropertyAccessor::class, PropertyAccess::createPropertyAccessor(false, true));
+
+        // cacheItemPool enabling
+        $this->assertInstanceOf(PropertyAccessor::class, PropertyAccess::createPropertyAccessor(false, false, $this->getMock(CacheItemPoolInterface::class)));
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/6640 |

This adds the missing `$cacheItemPool` argument to `PropertyAccess::createPropertyAccessor()` next to #18977 . 
Also, rather than using the PropertyAccessorBuilder to get a PropertyAccessor instance and make one method call per argument (feature enabling), it directly calls `new PropertyAccessor` with all the method arguments passed.

About @Tobion [comment in 18977](https://github.com/symfony/symfony/pull/18977#issuecomment-225431996)  Please have a look to the [doc PR](https://github.com/symfony/symfony-docs/pull/6640), it now presents all features enabling from `createPropertyAccessor` arguments and documents the `PropertyAccessorBuilder` as the right way to get multiple property accessors independently configured.
