### PR TITLE
Add new FormType "SignedType” 

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
+++ b/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
@@ -76,6 +76,7 @@ class CoreExtension extends AbstractExtension
             new Type\SubmitType(),
             new Type\ResetType(),
             new Type\CurrencyType(),
+            new Type\SignedType(),
         );
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToSignedTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToSignedTransformer.php
@@ -72,7 +72,7 @@ class ValueToSignedTransformer implements DataTransformerInterface
 
         $newSignature = $this->calculateSignature($array[$this->fieldKey]);
 
-        if (!$this->checkSignature($array[$this->signedKey], $newSignature)) {
+        if (!hash_equals($array[$this->signedKey], $newSignature)) {
             throw new TransformationFailedException(
                 'The signature does not match with the provided data.'
             );
@@ -99,37 +99,5 @@ class ValueToSignedTransformer implements DataTransformerInterface
         }
 
         return hash_final($ctx);
-    }
-
-    /**
-     * Check two signature with protection on timing attack.
-     *
-     * @param $signatureA
-     * @param $signatureB
-     *
-     * @return bool
-     */
-    protected static function checkSignature($signatureA, $signatureB)
-    {
-        if (!is_string($signatureA) || !is_string($signatureB)) {
-            return false;
-        }
-
-        /*
-         * Trying to avoid timing attack due to the behavior of string equality condition (==)
-         *
-         * In certain cases, information can be leaked by using a timing attack.
-         * It takes advantage of the == operator only comparing until it finds a difference in the two strings. To prevent it, you have two options.
-         */
-        if (($len = strlen($signatureA)) != strlen($signatureB)) {
-            return false;
-        }
-
-        $status = 0;
-        for ($i = 0; $i < $len; ++$i) {
-            $status |= ord($signatureA[$i]) ^ ord($signatureB[$i]);
-        }
-
-        return $status === 0;
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToSignedTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToSignedTransformer.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Core\DataTransformer;
+
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
+/**
+ * @author William Pottier <developer@william-pottier.fr>
+ */
+class ValueToSignedTransformer implements DataTransformerInterface
+{
+    private $fieldKey;
+
+    private $signedKey;
+
+    private $secret;
+
+    private $algo;
+
+    public function __construct($fieldKey, $signedKey, $secret, $algo = 'sha512')
+    {
+        $this->fieldKey = $fieldKey;
+        $this->signedKey = $signedKey;
+        $this->secret = $secret;
+        $this->algo = $algo;
+    }
+
+    /**
+     * Sign the given value and return an array with the value and the signature.
+     *
+     * @param mixed $value The value
+     *
+     * @return array The array
+     */
+    public function transform($value)
+    {
+        return array(
+            $this->fieldKey => $value,
+            $this->signedKey => $this->calculateSignature($value),
+        );
+    }
+
+    /**
+     * Extracts the value and check signature from an array.
+     *
+     * @param array $array
+     *
+     * @return mixed The value
+     *
+     * @throws TransformationFailedException If the given value is not an array or
+     *                                       if the given array can not be transformed.
+     */
+    public function reverseTransform($array)
+    {
+        if (!is_array($array)) {
+            throw new TransformationFailedException('Expected an array.');
+        }
+
+        if (!array_key_exists($this->fieldKey, $array) || !array_key_exists($this->signedKey, $array)) {
+            throw new TransformationFailedException('Expected an array with data and signature.');
+        }
+
+        $newSignature = $this->calculateSignature($array[$this->fieldKey]);
+
+        if (!$this->checkSignature($array[$this->signedKey], $newSignature)) {
+            throw new TransformationFailedException(
+                'The signature does not match with the provided data.'
+            );
+        }
+
+        return $array[$this->fieldKey];
+    }
+
+    /**
+     * Calculate signature for the provided data based on the configured algo & secret.
+     *
+     * @return string the calculated signature
+     */
+    protected function calculateSignature($value)
+    {
+        $ctx = hash_init($this->algo, HASH_HMAC, $this->secret);
+
+        if (!is_array($value)) {
+            $value = array($value);
+        }
+
+        foreach ($value as $valueElement) {
+            hash_update($ctx, $valueElement);
+        }
+
+        return hash_final($ctx);
+    }
+
+    /**
+     * Check two signature with protection on timing attack.
+     *
+     * @param $signatureA
+     * @param $signatureB
+     *
+     * @return bool
+     */
+    protected static function checkSignature($signatureA, $signatureB)
+    {
+        if (!is_string($signatureA) || !is_string($signatureB)) {
+            return false;
+        }
+
+        /*
+         * Trying to avoid timing attack due to the behavior of string equality condition (==)
+         *
+         * In certain cases, information can be leaked by using a timing attack.
+         * It takes advantage of the == operator only comparing until it finds a difference in the two strings. To prevent it, you have two options.
+         */
+        if (($len = strlen($signatureA)) != strlen($signatureB)) {
+            return false;
+        }
+
+        $status = 0;
+        for ($i = 0; $i < $len; ++$i) {
+            $status |= ord($signatureA[$i]) ^ ord($signatureB[$i]);
+        }
+
+        return $status === 0;
+    }
+}

--- a/src/Symfony/Component/Form/Extension/Core/Type/SignedType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/SignedType.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Core\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\DataTransformer\ValueToSignedTransformer;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @author William Pottier <developer@william-pottier.fr>
+ */
+class SignedType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setRequired('signature_secret');
+
+        $resolver->setDefaults(array(
+            'type' => __NAMESPACE__.'\HiddenType',
+            'options' => array(),
+            'field_name' => 'data',
+            'error_bubbling' => false,
+            'signature_name' => 'signature',
+            'signature_algorithm' => 'sha512',
+        ));
+
+        $resolver->setAllowedTypes('options', 'array');
+        $resolver->setAllowedTypes('field_name', 'string');
+        $resolver->setAllowedTypes('signature_secret', 'string');
+        $resolver->setAllowedTypes('signature_name', 'string');
+        $resolver->setAllowedTypes('signature_algorithm', 'string');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->addViewTransformer(new ValueToSignedTransformer(
+                $options['field_name'],
+                $options['signature_name'],
+                $options['signature_secret'],
+                $options['signature_algorithm']
+            ))
+            ->add($options['field_name'], $options['type'], $options['options'])
+            ->add($options['signature_name'], HiddenType::class)
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'signed';
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ValueToSignedTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ValueToSignedTransformerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Core\DataTransformer;
+
+use Symfony\Component\Form\Extension\Core\DataTransformer\ValueToSignedTransformer;
+
+class ValueToSignedTransformerTest extends \PHPUnit_Framework_TestCase
+{
+    private $transformer;
+
+    protected function setUp()
+    {
+        $this->transformer = new ValueToSignedTransformer('data', 'signature', 'ThisIsSecret', 'sha512');
+    }
+
+    protected function tearDown()
+    {
+        $this->transformer = null;
+    }
+
+    public function testTransform()
+    {
+        $output = array(
+            'data' => 'foobar',
+            'signature' => 'e643b257dce7856e96027a0df2e58fa91d9a3d01517a3010af7adcc212aa286eb1e13ad62c441367c8a55f7970e078d1998dfbeab6ebf1d80990e27cd98cb81c',
+        );
+
+        $this->assertSame($output, $this->transformer->transform('foobar'));
+    }
+
+    public function testReverseTransform()
+    {
+        $input = array(
+            'data' => 'foobar',
+            'signature' => 'e643b257dce7856e96027a0df2e58fa91d9a3d01517a3010af7adcc212aa286eb1e13ad62c441367c8a55f7970e078d1998dfbeab6ebf1d80990e27cd98cb81c',
+        );
+
+        $this->assertSame('foobar', $this->transformer->reverseTransform($input));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
+     */
+    public function testReverseTransformCheckSignature()
+    {
+        $input = array(
+            'data' => 'foobar2',
+            'signature' => 'e643b257dce7856e96027a0df2e58fa91d9a3d01517a3010af7adcc212aa286eb1e13ad62c441367c8a55f7970e078d1998dfbeab6ebf1d80990e27cd98cb81c',
+        );
+
+        $this->transformer->reverseTransform($input);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
+     */
+    public function testReverseTransformExpectArray()
+    {
+        $this->transformer->reverseTransform('foobar2');
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/SignedTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/SignedTypeTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Core\Type;
+
+class SignedTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
+{
+    protected $form;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\SignedType', null, array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\HiddenType',
+            'signature_secret' => 'ThisIsSecret',
+        ));
+        $this->form->setData(null);
+    }
+
+    public function testSetData()
+    {
+        $this->form->setData('foobar');
+
+        $this->assertEquals('foobar', $this->form['data']->getData());
+        $this->assertEquals(
+            'e643b257dce7856e96027a0df2e58fa91d9a3d01517a3010af7adcc212aa286eb1e13ad62c441367c8a55f7970e078d1998dfbeab6ebf1d80990e27cd98cb81c',
+            $this->form['signature']->getData()
+        );
+    }
+
+    public function testSetOptions()
+    {
+        $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\SignedType', null, array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+            'options' => array('label' => 'Global'),
+            'signature_secret' => 'ThisIsSecret',
+        ));
+
+        $this->assertEquals('Global', $form['data']->getConfig()->getOption('label'));
+        $this->assertTrue($form['data']->isRequired());
+    }
+
+    public function testSubmitInvalidSign()
+    {
+        $input = array('data' => 'foo', 'signature' => 'bar');
+
+        $this->form->submit($input);
+
+        $this->assertEquals('foo', $this->form['data']->getViewData());
+        $this->assertEquals('bar', $this->form['signature']->getViewData());
+        $this->assertFalse($this->form->isSynchronized());
+        $this->assertEquals($input, $this->form->getViewData());
+        $this->assertNull($this->form->getData());
+    }
+
+    public function testSubmitValidSign()
+    {
+        $input = array(
+            'data' => 'foobar',
+            'signature' => 'e643b257dce7856e96027a0df2e58fa91d9a3d01517a3010af7adcc212aa286eb1e13ad62c441367c8a55f7970e078d1998dfbeab6ebf1d80990e27cd98cb81c',
+        );
+
+        $this->form->submit($input);
+
+        $this->assertEquals('foobar', $this->form['data']->getViewData());
+        $this->assertEquals(
+            'e643b257dce7856e96027a0df2e58fa91d9a3d01517a3010af7adcc212aa286eb1e13ad62c441367c8a55f7970e078d1998dfbeab6ebf1d80990e27cd98cb81c',
+            $this->form['signature']->getViewData()
+        );
+        $this->assertTrue($this->form->isSynchronized());
+        $this->assertEquals($input, $this->form->getViewData());
+        $this->assertEquals('foobar', $this->form->getData());
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" for new features |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | to be done |

Add new FormType "SignedType”  to pass data through form submission and ensure user didn't change it.
The field will be associated with an hidden field "signature". The signature is calculated by creating a secret protected hash (secret only known by the server). On submission the DataTransformer calculate a new signature of the submitted data and check with the sign passed in the form. As the secret remain on the server side the user cannot forge a valid signature to reflect the data change.

This type works with any FormType underlying data but the main purpose is to use it with hidden or collection of hidden type.

Sample usage : 

``` php
$builder
            ->add('invitations', SignedType::class, [
                'type' => CollectionType::class,
                'field_name' => 'field',
                'signature_name' => 'hash',
                'signature_secret' => $options['secret'],
                'signature_algorithm' => 'sha512'
                'options' => [
                    'entry_type' => HiddenType::class,
                ],
            ]);
```
