### PR TITLE
[WIP] [Security] Fix #2172 User switching is not available for pre-authenticated users (oldest open bug!)

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SwitchUserPreAuthenticatedTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SwitchUserPreAuthenticatedTest.php
@@ -63,10 +63,10 @@ class SwitchUserPreAuthenticatedTest extends WebTestCase
         $client = $this->createClient(array('test_case' => 'StandardFormLogin', 'root_config' => 'switchuser_preauthenticated.yml'));
         $client->followRedirects(true);
 
-        $client->setServerParameters([
+        $client->setServerParameters(array(
             'SSL_CLIENT_S_DN_Email' => $username,
-            'SSL_CLIENT_S_DN' => 'test',
-        ]);
+            'SSL_CLIENT_S_DN' => 'test'
+        ));
 
         return $client;
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SwitchUserPreAuthenticatedTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SwitchUserPreAuthenticatedTest.php
@@ -64,8 +64,8 @@ class SwitchUserPreAuthenticatedTest extends WebTestCase
         $client->followRedirects(true);
 
         $client->setServerParameters([
-            "SSL_CLIENT_S_DN_Email" => $username,
-            "SSL_CLIENT_S_DN" => 'test'
+            'SSL_CLIENT_S_DN_Email' => $username,
+            'SSL_CLIENT_S_DN' => 'test',
         ]);
 
         return $client;

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SwitchUserPreAuthenticatedTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SwitchUserPreAuthenticatedTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
+
+class SwitchUserPreAuthenticatedTest extends WebTestCase
+{
+    /**
+     * @dataProvider getTestParameters
+     */
+    public function testSwitchUser($originalUser, $targetUser, $expectedUser, $expectedStatus)
+    {
+        $client = $this->createAuthenticatedClient($originalUser);
+
+        $client->request('GET', '/profile?_switch_user='.$targetUser);
+
+        $this->assertEquals($expectedStatus, $client->getResponse()->getStatusCode());
+        $this->assertEquals($expectedUser, $client->getProfile()->getCollector('security')->getUser());
+    }
+
+    public function testSwitchedUserCannotSwitchToOther()
+    {
+        $client = $this->createAuthenticatedClient('user_can_switch');
+
+        $client->request('GET', '/profile?_switch_user=user_cannot_switch_1');
+        $client->request('GET', '/profile?_switch_user=user_cannot_switch_2');
+
+        $this->assertEquals(500, $client->getResponse()->getStatusCode());
+        $this->assertEquals('user_cannot_switch_1', $client->getProfile()->getCollector('security')->getUser());
+    }
+
+    public function testSwitchedUserExit()
+    {
+        $client = $this->createAuthenticatedClient('user_can_switch');
+
+        $client->request('GET', '/profile?_switch_user=user_cannot_switch_1');
+        $client->request('GET', '/profile?_switch_user=_exit');
+
+        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertEquals('user_can_switch', $client->getProfile()->getCollector('security')->getUser());
+    }
+
+    public function getTestParameters()
+    {
+        return array(
+            'unauthorized_user_cannot_switch' => array('user_cannot_switch_1', 'user_cannot_switch_1', 'user_cannot_switch_1', 403),
+            'authorized_user_can_switch' => array('user_can_switch', 'user_cannot_switch_1', 'user_cannot_switch_1', 200),
+            'authorized_user_cannot_switch_to_non_existent' => array('user_can_switch', 'user_does_not_exist', 'user_can_switch', 500),
+            'authorized_user_can_switch_to_himself' => array('user_can_switch', 'user_can_switch', 'user_can_switch', 200),
+        );
+    }
+
+    protected function createAuthenticatedClient($username)
+    {       
+        $client = $this->createClient(array('test_case' => 'StandardFormLogin', 'root_config' => 'switchuser_preauthenticated.yml'));
+        $client->followRedirects(true);
+
+        $client->setServerParameters([
+            "SSL_CLIENT_S_DN_Email" => $username,
+            "SSL_CLIENT_S_DN" => 'test'
+        ]);
+
+        return $client;
+    }
+
+    public static function setUpBeforeClass()
+    {
+        parent::deleteTmpDir('StandardFormLogin');
+    }
+
+    public static function tearDownAfterClass()
+    {
+        parent::deleteTmpDir('StandardFormLogin');
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SwitchUserPreAuthenticatedTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SwitchUserPreAuthenticatedTest.php
@@ -65,7 +65,7 @@ class SwitchUserPreAuthenticatedTest extends WebTestCase
 
         $client->setServerParameters(array(
             'SSL_CLIENT_S_DN_Email' => $username,
-            'SSL_CLIENT_S_DN' => 'test'
+            'SSL_CLIENT_S_DN' => 'test',
         ));
 
         return $client;

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/switchuser_preauthenticated.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/switchuser_preauthenticated.yml
@@ -1,0 +1,16 @@
+imports:
+    - { resource: ./config.yml }
+
+security:
+    providers:
+        in_memory:
+            memory:
+                users:
+                    user_can_switch:      { password: test, roles: [ROLE_USER, ROLE_ALLOWED_TO_SWITCH] }
+                    user_cannot_switch_1: { password: test, roles: [ROLE_USER] }
+                    user_cannot_switch_2: { password: test, roles: [ROLE_USER] }
+    firewalls:
+        default:
+            switch_user: true
+            form_login: false
+            x509: true

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
@@ -59,6 +59,7 @@ abstract class AbstractPreAuthenticatedListener implements ListenerInterface
             if (null !== $this->logger) {
                 $this->logger->debug('An authenticated token is already provided, bypass PreAuthenticatedListener.', array('token' => (string) $this->tokenStorage->getToken()));
             }
+
             return;
         }
 

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
@@ -54,6 +54,14 @@ abstract class AbstractPreAuthenticatedListener implements ListenerInterface
      */
     final public function handle(GetResponseEvent $event)
     {
+        $token = $this->tokenStorage->getToken();
+        if(null !== $token && false === ($token instanceof PreAuthenticatedToken) && $token->isAuthenticated()) {
+            if (null !== $this->logger) {
+                $this->logger->debug('An authenticated token is already provided, bypass PreAuthenticatedListener.', array('token' => (string) $this->tokenStorage->getToken()));
+            }
+            return;
+        }
+
         $request = $event->getRequest();
 
         try {
@@ -68,7 +76,7 @@ abstract class AbstractPreAuthenticatedListener implements ListenerInterface
             $this->logger->debug('Checking current security token.', array('token' => (string) $this->tokenStorage->getToken()));
         }
 
-        if (null !== $token = $this->tokenStorage->getToken()) {
+        if (null !== $token) {
             if ($token instanceof PreAuthenticatedToken && $this->providerKey == $token->getProviderKey() && $token->isAuthenticated() && $token->getUsername() === $user) {
                 return;
             }

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
@@ -57,7 +57,7 @@ abstract class AbstractPreAuthenticatedListener implements ListenerInterface
         $token = $this->tokenStorage->getToken();
         if(null !== $token && false === ($token instanceof PreAuthenticatedToken) && $token->isAuthenticated()) {
             if (null !== $this->logger) {
-                $this->logger->debug('An authenticated token is already provided, bypass PreAuthenticatedListener.', array('token' => (string) $this->tokenStorage->getToken()));
+                $this->logger->debug('An authenticated token is already provided, bypass PreAuthenticatedListener.', array('token' => (string) $token));
             }
 
             return;
@@ -74,7 +74,7 @@ abstract class AbstractPreAuthenticatedListener implements ListenerInterface
         }
 
         if (null !== $this->logger) {
-            $this->logger->debug('Checking current security token.', array('token' => (string) $this->tokenStorage->getToken()));
+            $this->logger->debug('Checking current security token.', array('token' => (string) $token));
         }
 
         if (null !== $token) {

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
@@ -55,7 +55,7 @@ abstract class AbstractPreAuthenticatedListener implements ListenerInterface
     final public function handle(GetResponseEvent $event)
     {
         $token = $this->tokenStorage->getToken();
-        if(null !== $token && false === ($token instanceof PreAuthenticatedToken) && $token->isAuthenticated()) {
+        if(null !== $token && !$token instanceof PreAuthenticatedToken && $token->isAuthenticated()) {
             if (null !== $this->logger) {
                 $this->logger->debug('An authenticated token is already provided, bypass PreAuthenticatedListener.', array('token' => (string) $token));
             }

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
@@ -55,7 +55,7 @@ abstract class AbstractPreAuthenticatedListener implements ListenerInterface
     final public function handle(GetResponseEvent $event)
     {
         $token = $this->tokenStorage->getToken();
-        if(null !== $token && !$token instanceof PreAuthenticatedToken && $token->isAuthenticated()) {
+        if (null !== $token && !$token instanceof PreAuthenticatedToken && $token->isAuthenticated()) {
             if (null !== $this->logger) {
                 $this->logger->debug('An authenticated token is already provided, bypass PreAuthenticatedListener.', array('token' => (string) $token));
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | maybe |
| Deprecations? | no |
| Tests pass? | no (!) |
| Fixed tickets | #2172 |
| License | MIT |
| Doc PR | no |

TODO
- [ ] gather feedback for my changes
- [ ] fix the test according to feedback

For my first PR, I tried to fix the Symfony's oldest still open bug (2011!)
New tests have been added to reproduce the bug and are now passing.

To be reviewed carefully as it deals with security.

From my understanding, the problem comes from the AbstractPreAuthenticatedListener that is not stateless: whenever a token is passed, it has to preauthenticate again.
Problem, even if another type of token is passed (like a UsernamePasswordToken), it still tries to authenticate it and as it failed it creates a new one with the current user.
This behaviour doesn't work when switching user because the new artificial user token is automatically replaced by the current preauthenticated token.

So the patch bypass this check if (and only if) a token is already there (given by context), it is already correctly authenticated, and it is of another class than PreAuthenticatedToken (to limit risks of BC break).

Problem: this new behaviour breaks (by design) the following test: 
Symfony\Component\Security\Http\Tests\Firewall\AbstractPreAuthenticatedListenerTest::testHandleWhenAuthenticationFailsWithDifferentToken

To be discussed: is this new behaviour correct (it may fix other bugs), or is there potential security issues? Should it be considered as a BC break?
