### PR TITLE
[2.8] update tests to use the new error assertion helper

### DIFF
--- a/phpunit
+++ b/phpunit
@@ -56,7 +56,7 @@ if (!file_exists("$PHPUNIT_DIR/phpunit-$PHPUNIT_VERSION/phpunit") || md5_file(__
     if (5.1 <= $PHPUNIT_VERSION && $PHPUNIT_VERSION < 5.4) {
         passthru("$COMPOSER require --no-update phpunit/phpunit-mock-objects \"~3.1.0\"");
     }
-    passthru("$COMPOSER require --dev --no-update symfony/phpunit-bridge \">=3.1@dev\"");
+    passthru("$COMPOSER require --dev --no-update symfony/phpunit-bridge \">=3.2@dev\"");
     passthru("$COMPOSER install --prefer-dist --no-progress --ansi", $exit);
     if ($exit) {
         exit($exit);

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Yaml\Tests;
 
+use Symfony\Bridge\PhpUnit\ErrorAssert;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\Yaml\Parser;
 
@@ -930,27 +931,14 @@ EOF;
      */
     public function testColonInMappingValueException()
     {
-        $yaml = <<<EOF
+        $parser = $this->parser;
+
+        ErrorAssert::assertDeprecationsAreTriggered('Using a colon in the unquoted mapping value "bar: baz" in line 1 is deprecated since Symfony 2.8 and will throw a ParseException in 3.0.', function () use ($parser) {
+            $yaml = <<<EOF
 foo: bar: baz
 EOF;
-
-        $deprecations = array();
-        set_error_handler(function ($type, $msg) use (&$deprecations) {
-            if (E_USER_DEPRECATED !== $type) {
-                restore_error_handler();
-
-                return call_user_func_array('PHPUnit_Util_ErrorHandler::handleError', func_get_args());
-            }
-
-            $deprecations[] = $msg;
+            $parser->parse($yaml);
         });
-
-        $this->parser->parse($yaml);
-
-        restore_error_handler();
-
-        $this->assertCount(1, $deprecations);
-        $this->assertContains('Using a colon in the unquoted mapping value "bar: baz" in line 1 is deprecated since Symfony 2.8 and will throw a ParseException in 3.0.', $deprecations[0]);
     }
 
     public function testColonInMappingValueExceptionNotTriggeredByColonInComment()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
