### PR TITLE
[Routing] Allow non-string requirements with BC+FC

### DIFF
--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -108,7 +108,7 @@ class RouteCompiler implements RouteCompilerInterface
                 $tokens[] = array('text', $precedingText);
             }
 
-            $regexp = $route->getRequirement($varName);
+            $regexp = $route->getRequirement($varName, true);
             if (null === $regexp) {
                 $followingPattern = (string) substr($pattern, $pos);
                 // Find the next static character after the variable that functions as a separator. By default, this separator and '/'
@@ -132,6 +132,8 @@ class RouteCompiler implements RouteCompilerInterface
                     // directly adjacent, e.g. '/{x}{y}'.
                     $regexp .= '+';
                 }
+            } elseif (!is_string($regexp)) {
+                throw new \InvalidArgumentException(sprintf('Routing requirement for "%s" must be a string.', $varName));
             }
 
             $tokens[] = array('variable', $isSeparator ? $precedingChar : '', $regexp, $varName);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12430 |
| License | MIT |
| Doc PR | - |

Drupal is using route requirements for things like general access control. See e.g.
https://github.com/drupal/drupal/blob/8.1.x/core/modules/node/node.routing.yml

This may be a mistake, but from a semantic pov, the yaml reads good. From a BC perspective also, drupal can't change that. This is creating a DX issue where e.g. `true` has to be written as `'TRUE'` because we allow only string requirements.
Yet, this restriction is perfectly legal for reqs that are used in host&path patterns. But since one can add requirements that do not match any pattern, the string check on them is not _that_ useful.

This PR is a POC for accepting any type of requirements, provided they aren't used in patterns.
It is double opt-in so that BC and FC is at its best.

WDYT? Worth writing tests?
