### PR TITLE
[Console] Use InputInterface inherited doc in implementations

### DIFF
--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -69,7 +69,7 @@ class ArgvInput extends Input
     }
 
     /**
-     * Processes command line arguments.
+     * {@inheritdoc}
      */
     protected function parse()
     {
@@ -253,9 +253,7 @@ class ArgvInput extends Input
     }
 
     /**
-     * Returns the first argument from the raw parameters (not parsed).
-     *
-     * @return string The value of the first argument or null otherwise
+     * {@inheritdoc}
      */
     public function getFirstArgument()
     {
@@ -269,15 +267,7 @@ class ArgvInput extends Input
     }
 
     /**
-     * Returns true if the raw parameters (not parsed) contain a value.
-     *
-     * This method is to be used to introspect the input parameters
-     * before they have been validated. It must be used carefully.
-     *
-     * @param string|array $values     The value(s) to look for in the raw parameters (can be an array)
-     * @param bool         $onlyParams Only check real parameters, skip those following an end of options (--) signal
-     *
-     * @return bool true if the value is contained in the raw parameters
+     * {@inheritdoc}
      */
     public function hasParameterOption($values, $onlyParams = false)
     {
@@ -298,16 +288,7 @@ class ArgvInput extends Input
     }
 
     /**
-     * Returns the value of a raw option (not parsed).
-     *
-     * This method is to be used to introspect the input parameters
-     * before they have been validated. It must be used carefully.
-     *
-     * @param string|array $values     The value(s) to look for in the raw parameters (can be an array)
-     * @param mixed        $default    The default value to return if no result is found
-     * @param bool         $onlyParams Only check real parameters, skip those following an end of options (--) signal
-     *
-     * @return mixed The option value
+     * {@inheritdoc}
      */
     public function getParameterOption($values, $default = false, $onlyParams = false)
     {

--- a/src/Symfony/Component/Console/Input/ArrayInput.php
+++ b/src/Symfony/Component/Console/Input/ArrayInput.php
@@ -30,8 +30,8 @@ class ArrayInput extends Input
     /**
      * Constructor.
      *
-     * @param array           $parameters An array of parameters
-     * @param InputDefinition $definition A InputDefinition instance
+     * @param array                $parameters An array of parameters
+     * @param InputDefinition|null $definition A InputDefinition instance
      */
     public function __construct(array $parameters, InputDefinition $definition = null)
     {
@@ -41,9 +41,7 @@ class ArrayInput extends Input
     }
 
     /**
-     * Returns the first argument from the raw parameters (not parsed).
-     *
-     * @return string The value of the first argument or null otherwise
+     * {@inheritdoc}
      */
     public function getFirstArgument()
     {
@@ -57,15 +55,7 @@ class ArrayInput extends Input
     }
 
     /**
-     * Returns true if the raw parameters (not parsed) contain a value.
-     *
-     * This method is to be used to introspect the input parameters
-     * before they have been validated. It must be used carefully.
-     *
-     * @param string|array $values     The values to look for in the raw parameters (can be an array)
-     * @param bool         $onlyParams Only check real parameters, skip those following an end of options (--) signal
-     *
-     * @return bool true if the value is contained in the raw parameters
+     * {@inheritdoc}
      */
     public function hasParameterOption($values, $onlyParams = false)
     {
@@ -89,16 +79,7 @@ class ArrayInput extends Input
     }
 
     /**
-     * Returns the value of a raw option (not parsed).
-     *
-     * This method is to be used to introspect the input parameters
-     * before they have been validated. It must be used carefully.
-     *
-     * @param string|array $values     The value(s) to look for in the raw parameters (can be an array)
-     * @param mixed        $default    The default value to return if no result is found
-     * @param bool         $onlyParams Only check real parameters, skip those following an end of options (--) signal
-     *
-     * @return mixed The option value
+     * {@inheritdoc}
      */
     public function getParameterOption($values, $default = false, $onlyParams = false)
     {
@@ -141,7 +122,7 @@ class ArrayInput extends Input
     }
 
     /**
-     * Processes command line arguments.
+     * {@inheritdoc}
      */
     protected function parse()
     {

--- a/src/Symfony/Component/Console/Input/Input.php
+++ b/src/Symfony/Component/Console/Input/Input.php
@@ -38,7 +38,7 @@ abstract class Input implements InputInterface
     /**
      * Constructor.
      *
-     * @param InputDefinition $definition A InputDefinition instance
+     * @param InputDefinition|null $definition A InputDefinition instance
      */
     public function __construct(InputDefinition $definition = null)
     {
@@ -51,9 +51,7 @@ abstract class Input implements InputInterface
     }
 
     /**
-     * Binds the current Input instance with the given arguments and options.
-     *
-     * @param InputDefinition $definition A InputDefinition instance
+     * {@inheritdoc}
      */
     public function bind(InputDefinition $definition)
     {
@@ -70,9 +68,7 @@ abstract class Input implements InputInterface
     abstract protected function parse();
 
     /**
-     * Validates the input.
-     *
-     * @throws RuntimeException When not enough arguments are given
+     * {@inheritdoc}
      */
     public function validate()
     {
@@ -89,9 +85,7 @@ abstract class Input implements InputInterface
     }
 
     /**
-     * Checks if the input is interactive.
-     *
-     * @return bool Returns true if the input is interactive
+     * {@inheritdoc}
      */
     public function isInteractive()
     {
@@ -99,9 +93,7 @@ abstract class Input implements InputInterface
     }
 
     /**
-     * Sets the input interactivity.
-     *
-     * @param bool $interactive If the input should be interactive
+     * {@inheritdoc}
      */
     public function setInteractive($interactive)
     {
@@ -109,9 +101,7 @@ abstract class Input implements InputInterface
     }
 
     /**
-     * Returns the argument values.
-     *
-     * @return array An array of argument values
+     * {@inheritdoc}
      */
     public function getArguments()
     {
@@ -119,13 +109,7 @@ abstract class Input implements InputInterface
     }
 
     /**
-     * Returns the argument value for a given argument name.
-     *
-     * @param string $name The argument name
-     *
-     * @return mixed The argument value
-     *
-     * @throws InvalidArgumentException When argument given doesn't exist
+     * {@inheritdoc}
      */
     public function getArgument($name)
     {
@@ -137,12 +121,7 @@ abstract class Input implements InputInterface
     }
 
     /**
-     * Sets an argument value by name.
-     *
-     * @param string $name  The argument name
-     * @param string $value The argument value
-     *
-     * @throws InvalidArgumentException When argument given doesn't exist
+     * {@inheritdoc}
      */
     public function setArgument($name, $value)
     {
@@ -154,11 +133,7 @@ abstract class Input implements InputInterface
     }
 
     /**
-     * Returns true if an InputArgument object exists by name or position.
-     *
-     * @param string|int $name The InputArgument name or position
-     *
-     * @return bool true if the InputArgument object exists, false otherwise
+     * {@inheritdoc}
      */
     public function hasArgument($name)
     {
@@ -166,9 +141,7 @@ abstract class Input implements InputInterface
     }
 
     /**
-     * Returns the options values.
-     *
-     * @return array An array of option values
+     * {@inheritdoc}
      */
     public function getOptions()
     {
@@ -176,13 +149,7 @@ abstract class Input implements InputInterface
     }
 
     /**
-     * Returns the option value for a given option name.
-     *
-     * @param string $name The option name
-     *
-     * @return mixed The option value
-     *
-     * @throws InvalidArgumentException When option given doesn't exist
+     * {@inheritdoc}
      */
     public function getOption($name)
     {
@@ -194,12 +161,7 @@ abstract class Input implements InputInterface
     }
 
     /**
-     * Sets an option value by name.
-     *
-     * @param string      $name  The option name
-     * @param string|bool $value The option value
-     *
-     * @throws InvalidArgumentException When option given doesn't exist
+     * {@inheritdoc}
      */
     public function setOption($name, $value)
     {
@@ -211,11 +173,7 @@ abstract class Input implements InputInterface
     }
 
     /**
-     * Returns true if an InputOption object exists by name.
-     *
-     * @param string $name The InputOption name
-     *
-     * @return bool true if the InputOption object exists, false otherwise
+     * {@inheritdoc}
      */
     public function hasOption($name)
     {

--- a/src/Symfony/Component/Console/Input/InputInterface.php
+++ b/src/Symfony/Component/Console/Input/InputInterface.php
@@ -60,11 +60,9 @@ interface InputInterface
     public function bind(InputDefinition $definition);
 
     /**
-     * Validates if arguments given are correct.
+     * Validates the input.
      *
-     * Throws an exception when not enough arguments are given.
-     *
-     * @throws \RuntimeException
+     * @throws \RuntimeException When not enough arguments are given
      */
     public function validate();
 
@@ -76,11 +74,13 @@ interface InputInterface
     public function getArguments();
 
     /**
-     * Gets argument by name.
+     * Returns the argument value for a given argument name.
      *
-     * @param string $name The name of the argument
+     * @param string $name The argument name
      *
-     * @return mixed
+     * @return mixed The argument value
+     *
+     * @throws \InvalidArgumentException When argument given doesn't exist
      */
     public function getArgument($name);
 
@@ -90,7 +90,7 @@ interface InputInterface
      * @param string $name  The argument name
      * @param string $value The argument value
      *
-     * @throws InvalidArgumentException When argument given doesn't exist
+     * @throws \InvalidArgumentException When argument given doesn't exist
      */
     public function setArgument($name, $value);
 
@@ -111,11 +111,13 @@ interface InputInterface
     public function getOptions();
 
     /**
-     * Gets an option by name.
+     * Returns the option value for a given option name.
      *
-     * @param string $name The name of the option
+     * @param string $name The option name
      *
-     * @return mixed
+     * @return mixed The option value
+     *
+     * @throws \InvalidArgumentException When option given doesn't exist
      */
     public function getOption($name);
 
@@ -125,7 +127,7 @@ interface InputInterface
      * @param string      $name  The option name
      * @param string|bool $value The option value
      *
-     * @throws InvalidArgumentException When option given doesn't exist
+     * @throws \InvalidArgumentException When option given doesn't exist
      */
     public function setOption($name, $value);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.0 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

In classes implementing `InputInterface`, the methods doc blocks are duplicated from the interface.
Sometimes descriptions are different from the interface's ones and, sometimes, the class doc is clearer. So I tried to keep always the most adapted one.
