### PR TITLE
[Console] Use InputInterface inherited doc as possible

### DIFF
--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -44,8 +44,8 @@ class ArgvInput extends Input
     /**
      * Constructor.
      *
-     * @param array           $argv       An array of parameters from the CLI (in the argv format)
-     * @param InputDefinition $definition A InputDefinition instance
+     * @param array|null           $argv       An array of parameters from the CLI (in the argv format)
+     * @param InputDefinition|null $definition A InputDefinition instance
      */
     public function __construct(array $argv = null, InputDefinition $definition = null)
     {
@@ -67,7 +67,7 @@ class ArgvInput extends Input
     }
 
     /**
-     * Processes command line arguments.
+     * {@inheritdoc}
      */
     protected function parse()
     {
@@ -251,9 +251,7 @@ class ArgvInput extends Input
     }
 
     /**
-     * Returns the first argument from the raw parameters (not parsed).
-     *
-     * @return string The value of the first argument or null otherwise
+     * {@inheritdoc}
      */
     public function getFirstArgument()
     {
@@ -267,14 +265,7 @@ class ArgvInput extends Input
     }
 
     /**
-     * Returns true if the raw parameters (not parsed) contain a value.
-     *
-     * This method is to be used to introspect the input parameters
-     * before they have been validated. It must be used carefully.
-     *
-     * @param string|array $values The value(s) to look for in the raw parameters (can be an array)
-     *
-     * @return bool true if the value is contained in the raw parameters
+     * {@inheritdoc}
      */
     public function hasParameterOption($values)
     {
@@ -292,15 +283,7 @@ class ArgvInput extends Input
     }
 
     /**
-     * Returns the value of a raw option (not parsed).
-     *
-     * This method is to be used to introspect the input parameters
-     * before they have been validated. It must be used carefully.
-     *
-     * @param string|array $values  The value(s) to look for in the raw parameters (can be an array)
-     * @param mixed        $default The default value to return if no result is found
-     *
-     * @return mixed The option value
+     * {@inheritdoc}
      */
     public function getParameterOption($values, $default = false)
     {

--- a/src/Symfony/Component/Console/Input/ArrayInput.php
+++ b/src/Symfony/Component/Console/Input/ArrayInput.php
@@ -27,8 +27,8 @@ class ArrayInput extends Input
     /**
      * Constructor.
      *
-     * @param array           $parameters An array of parameters
-     * @param InputDefinition $definition A InputDefinition instance
+     * @param array                $parameters An array of parameters
+     * @param InputDefinition|null $definition A InputDefinition instance
      */
     public function __construct(array $parameters, InputDefinition $definition = null)
     {
@@ -38,9 +38,7 @@ class ArrayInput extends Input
     }
 
     /**
-     * Returns the first argument from the raw parameters (not parsed).
-     *
-     * @return string The value of the first argument or null otherwise
+     * {@inheritdoc}
      */
     public function getFirstArgument()
     {
@@ -54,14 +52,7 @@ class ArrayInput extends Input
     }
 
     /**
-     * Returns true if the raw parameters (not parsed) contain a value.
-     *
-     * This method is to be used to introspect the input parameters
-     * before they have been validated. It must be used carefully.
-     *
-     * @param string|array $values The values to look for in the raw parameters (can be an array)
-     *
-     * @return bool true if the value is contained in the raw parameters
+     * {@inheritdoc}
      */
     public function hasParameterOption($values)
     {
@@ -81,15 +72,7 @@ class ArrayInput extends Input
     }
 
     /**
-     * Returns the value of a raw option (not parsed).
-     *
-     * This method is to be used to introspect the input parameters
-     * before they have been validated. It must be used carefully.
-     *
-     * @param string|array $values  The value(s) to look for in the raw parameters (can be an array)
-     * @param mixed        $default The default value to return if no result is found
-     *
-     * @return mixed The option value
+     * {@inheritdoc}
      */
     public function getParameterOption($values, $default = false)
     {
@@ -128,7 +111,7 @@ class ArrayInput extends Input
     }
 
     /**
-     * Processes command line arguments.
+     * {@inheritdoc}
      */
     protected function parse()
     {

--- a/src/Symfony/Component/Console/Input/Input.php
+++ b/src/Symfony/Component/Console/Input/Input.php
@@ -35,7 +35,7 @@ abstract class Input implements InputInterface
     /**
      * Constructor.
      *
-     * @param InputDefinition $definition A InputDefinition instance
+     * @param InputDefinition|null $definition A InputDefinition instance
      */
     public function __construct(InputDefinition $definition = null)
     {
@@ -48,9 +48,7 @@ abstract class Input implements InputInterface
     }
 
     /**
-     * Binds the current Input instance with the given arguments and options.
-     *
-     * @param InputDefinition $definition A InputDefinition instance
+     * {@inheritdoc}
      */
     public function bind(InputDefinition $definition)
     {
@@ -67,9 +65,7 @@ abstract class Input implements InputInterface
     abstract protected function parse();
 
     /**
-     * Validates the input.
-     *
-     * @throws \RuntimeException When not enough arguments are given
+     * {@inheritdoc}
      */
     public function validate()
     {
@@ -86,9 +82,7 @@ abstract class Input implements InputInterface
     }
 
     /**
-     * Checks if the input is interactive.
-     *
-     * @return bool Returns true if the input is interactive
+     * {@inheritdoc}
      */
     public function isInteractive()
     {
@@ -96,9 +90,7 @@ abstract class Input implements InputInterface
     }
 
     /**
-     * Sets the input interactivity.
-     *
-     * @param bool $interactive If the input should be interactive
+     * {@inheritdoc}
      */
     public function setInteractive($interactive)
     {
@@ -106,9 +98,7 @@ abstract class Input implements InputInterface
     }
 
     /**
-     * Returns the argument values.
-     *
-     * @return array An array of argument values
+     * {@inheritdoc}
      */
     public function getArguments()
     {
@@ -116,13 +106,7 @@ abstract class Input implements InputInterface
     }
 
     /**
-     * Returns the argument value for a given argument name.
-     *
-     * @param string $name The argument name
-     *
-     * @return mixed The argument value
-     *
-     * @throws \InvalidArgumentException When argument given doesn't exist
+     * {@inheritdoc}
      */
     public function getArgument($name)
     {
@@ -134,12 +118,7 @@ abstract class Input implements InputInterface
     }
 
     /**
-     * Sets an argument value by name.
-     *
-     * @param string $name  The argument name
-     * @param string $value The argument value
-     *
-     * @throws \InvalidArgumentException When argument given doesn't exist
+     * {@inheritdoc}
      */
     public function setArgument($name, $value)
     {
@@ -151,11 +130,7 @@ abstract class Input implements InputInterface
     }
 
     /**
-     * Returns true if an InputArgument object exists by name or position.
-     *
-     * @param string|int $name The InputArgument name or position
-     *
-     * @return bool true if the InputArgument object exists, false otherwise
+     * {@inheritdoc}
      */
     public function hasArgument($name)
     {
@@ -163,9 +138,7 @@ abstract class Input implements InputInterface
     }
 
     /**
-     * Returns the options values.
-     *
-     * @return array An array of option values
+     * {@inheritdoc}
      */
     public function getOptions()
     {
@@ -173,13 +146,7 @@ abstract class Input implements InputInterface
     }
 
     /**
-     * Returns the option value for a given option name.
-     *
-     * @param string $name The option name
-     *
-     * @return mixed The option value
-     *
-     * @throws \InvalidArgumentException When option given doesn't exist
+     * {@inheritdoc}
      */
     public function getOption($name)
     {
@@ -191,12 +158,7 @@ abstract class Input implements InputInterface
     }
 
     /**
-     * Sets an option value by name.
-     *
-     * @param string      $name  The option name
-     * @param string|bool $value The option value
-     *
-     * @throws \InvalidArgumentException When option given doesn't exist
+     * {@inheritdoc}
      */
     public function setOption($name, $value)
     {
@@ -208,11 +170,7 @@ abstract class Input implements InputInterface
     }
 
     /**
-     * Returns true if an InputOption object exists by name.
-     *
-     * @param string $name The InputOption name
-     *
-     * @return bool true if the InputOption object exists, false otherwise
+     * {@inheritdoc}
      */
     public function hasOption($name)
     {

--- a/src/Symfony/Component/Console/Input/InputInterface.php
+++ b/src/Symfony/Component/Console/Input/InputInterface.php
@@ -58,11 +58,9 @@ interface InputInterface
     public function bind(InputDefinition $definition);
 
     /**
-     * Validates if arguments given are correct.
+     * Validates the input.
      *
-     * Throws an exception when not enough arguments are given.
-     *
-     * @throws \RuntimeException
+     * @throws \RuntimeException When not enough arguments are given
      */
     public function validate();
 
@@ -74,11 +72,13 @@ interface InputInterface
     public function getArguments();
 
     /**
-     * Gets argument by name.
+     * Returns the argument value for a given argument name.
      *
-     * @param string $name The name of the argument
+     * @param string $name The argument name
      *
-     * @return mixed
+     * @return mixed The argument value
+     *
+     * @throws \InvalidArgumentException When argument given doesn't exist
      */
     public function getArgument($name);
 
@@ -109,11 +109,13 @@ interface InputInterface
     public function getOptions();
 
     /**
-     * Gets an option by name.
+     * Returns the option value for a given option name.
      *
-     * @param string $name The name of the option
+     * @param string $name The option name
      *
-     * @return mixed
+     * @return mixed The option value
+     *
+     * @throws \InvalidArgumentException When option given doesn't exist
      */
     public function getOption($name);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

In classes implementing `InputInterface`, the methods doc blocks are duplicated from the interface.
Sometimes descriptions are different from the interface's ones and, sometimes, the class doc is clearer. So I tried to keep always the most adapted one.
