### PR TITLE
Adds support for the SameSite attribute in cookies.

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -77,7 +77,7 @@ class Cookie
         $this->httpOnly = (bool) $httpOnly;
         $this->raw = (bool) $raw;
 
-        if (!in_array($sameSite, [self::SAMESITE_LAX, self::SAMESITE_STRICT, null])) {
+        if (!in_array($sameSite, array(self::SAMESITE_LAX, self::SAMESITE_STRICT, null))) {
             throw new \InvalidArgumentException('The sameSite parameter is not valid.');
         }
 

--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -39,7 +39,7 @@ class Cookie
      * @param bool                          $secure   Whether the cookie should only be transmitted over a secure HTTPS connection from the client
      * @param bool                          $httpOnly Whether the cookie will be made accessible only through the HTTP protocol
      * @param bool                          $raw      Whether the cookie value should be sent with no url encoding
-     * @param bool|null                   $sameSite Whether the cookie will be available for cross-site requests
+     * @param bool|null                     $sameSite Whether the cookie will be available for cross-site requests
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -28,6 +28,9 @@ class Cookie
     private $raw;
     private $sameSite;
 
+    const SAMESITE_LAX = 'lax';
+    const SAMESITE_STRICT = 'strict';
+
     /**
      * Constructor.
      *
@@ -73,6 +76,11 @@ class Cookie
         $this->secure = (bool) $secure;
         $this->httpOnly = (bool) $httpOnly;
         $this->raw = (bool) $raw;
+
+        if (!in_array($sameSite, [self::SAMESITE_LAX, self::SAMESITE_STRICT, null])) {
+            throw new \InvalidArgumentException('The sameSite parameter is not valid.');
+        }
+
         $this->sameSite = $sameSite;
     }
 

--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -110,7 +110,7 @@ class Cookie
         if (true === $this->isHttpOnly()) {
             $str .= '; httponly';
         }
-        
+
         if (false !== $this->hasSameSite()) {
             $str .= '; samesite='.$this->getSameSite();
         }
@@ -207,7 +207,7 @@ class Cookie
     {
         return $this->raw;
     }
-    
+
     /**
      * Gets the SameSite attribute.
      *
@@ -217,7 +217,7 @@ class Cookie
     {
         return $this->sameSite;
     }
-    
+
     /**
      * Checks if the cookie value should be sent with a SameSite attribute.
      *

--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -26,7 +26,7 @@ class Cookie
     protected $secure;
     protected $httpOnly;
     private $raw;
-    protected $sameSite;
+    private $sameSite;
 
     /**
      * Constructor.
@@ -39,11 +39,11 @@ class Cookie
      * @param bool                          $secure   Whether the cookie should only be transmitted over a secure HTTPS connection from the client
      * @param bool                          $httpOnly Whether the cookie will be made accessible only through the HTTP protocol
      * @param bool                          $raw      Whether the cookie value should be sent with no url encoding
-     * @param bool|string                   $sameSite Whether the cookie will be available for cross-site requests
+     * @param bool|null                   $sameSite Whether the cookie will be available for cross-site requests
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct($name, $value = null, $expire = 0, $path = '/', $domain = null, $secure = false, $httpOnly = true, $raw = false, $sameSite = false)
+    public function __construct($name, $value = null, $expire = 0, $path = '/', $domain = null, $secure = false, $httpOnly = true, $raw = false, $sameSite = null)
     {
         // from PHP source code
         if (preg_match("/[=,; \t\r\n\013\014]/", $name)) {
@@ -111,7 +111,7 @@ class Cookie
             $str .= '; httponly';
         }
 
-        if (false !== $this->hasSameSite()) {
+        if (null !== $this->getSameSite()) {
             $str .= '; samesite='.$this->getSameSite();
         }
 
@@ -211,20 +211,10 @@ class Cookie
     /**
      * Gets the SameSite attribute.
      *
-     * @return string|bool
+     * @return string|null
      */
     public function getSameSite()
     {
         return $this->sameSite;
-    }
-
-    /**
-     * Checks if the cookie value should be sent with a SameSite attribute.
-     *
-     * @return bool
-     */
-    public function hasSameSite()
-    {
-        return $this->sameSite !== false;
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -39,7 +39,7 @@ class Cookie
      * @param bool                          $secure   Whether the cookie should only be transmitted over a secure HTTPS connection from the client
      * @param bool                          $httpOnly Whether the cookie will be made accessible only through the HTTP protocol
      * @param bool                          $raw      Whether the cookie value should be sent with no url encoding
-     * @param bool|null                     $sameSite Whether the cookie will be available for cross-site requests
+     * @param string|null                   $sameSite Whether the cookie will be available for cross-site requests
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -26,6 +26,7 @@ class Cookie
     protected $secure;
     protected $httpOnly;
     private $raw;
+    protected $sameSite;
 
     /**
      * Constructor.
@@ -38,10 +39,11 @@ class Cookie
      * @param bool                          $secure   Whether the cookie should only be transmitted over a secure HTTPS connection from the client
      * @param bool                          $httpOnly Whether the cookie will be made accessible only through the HTTP protocol
      * @param bool                          $raw      Whether the cookie value should be sent with no url encoding
+     * @param bool|string                   $sameSite Whether the cookie will be available for cross-site requests
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct($name, $value = null, $expire = 0, $path = '/', $domain = null, $secure = false, $httpOnly = true, $raw = false)
+    public function __construct($name, $value = null, $expire = 0, $path = '/', $domain = null, $secure = false, $httpOnly = true, $raw = false, $sameSite = false)
     {
         // from PHP source code
         if (preg_match("/[=,; \t\r\n\013\014]/", $name)) {
@@ -71,6 +73,7 @@ class Cookie
         $this->secure = (bool) $secure;
         $this->httpOnly = (bool) $httpOnly;
         $this->raw = (bool) $raw;
+        $this->sameSite = $sameSite;
     }
 
     /**
@@ -106,6 +109,10 @@ class Cookie
 
         if (true === $this->isHttpOnly()) {
             $str .= '; httponly';
+        }
+        
+        if (false !== $this->hasSameSite()) {
+            $str .= '; samesite='.$this->getSameSite();
         }
 
         return $str;
@@ -199,5 +206,25 @@ class Cookie
     public function isRaw()
     {
         return $this->raw;
+    }
+    
+    /**
+     * Gets the SameSite attribute.
+     *
+     * @return string|bool
+     */
+    public function getSameSite()
+    {
+        return $this->sameSite;
+    }
+    
+    /**
+     * Checks if the cookie value should be sent with a SameSite attribute.
+     *
+     * @return bool
+     */
+    public function hasSameSite()
+    {
+        return $this->sameSite !== false;
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

$sameSite can be set to false, "lax", or "strict".

You can read about what the different modes do here: http://www.sjoerdlangkemper.nl/2016/04/14/preventing-csrf-with-samesite-cookie-attribute/
