### PR TITLE
[Serializer] Ignore first uppercase character

### DIFF
--- a/src/Symfony/Component/Serializer/NameConverter/CamelCaseToSnakeCaseNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/CamelCaseToSnakeCaseNameConverter.php
@@ -48,10 +48,11 @@ class CamelCaseToSnakeCaseNameConverter implements NameConverterInterface
 
             $len = strlen($propertyName);
             for ($i = 0; $i < $len; ++$i) {
-                if (ctype_upper($propertyName[$i]) && $i !== 0) {
-                    $snakeCasedName .= '_'.strtolower($propertyName[$i]);
+                $lcPropertyName = strtolower($propertyName[$i]);
+                if (0 !== $i && $lcPropertyName !== $propertyName[$i]) {
+                    $snakeCasedName .= '_'.$lcPropertyName;
                 } else {
-                    $snakeCasedName .= strtolower($propertyName[$i]);
+                    $snakeCasedName .= $lcPropertyName;
                 }
             }
 

--- a/src/Symfony/Component/Serializer/NameConverter/CamelCaseToSnakeCaseNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/CamelCaseToSnakeCaseNameConverter.php
@@ -48,7 +48,7 @@ class CamelCaseToSnakeCaseNameConverter implements NameConverterInterface
 
             $len = strlen($propertyName);
             for ($i = 0; $i < $len; ++$i) {
-                if (ctype_upper($propertyName[$i])) {
+                if (ctype_upper($propertyName[$i]) && $i !== 0) {
                     $snakeCasedName .= '_'.strtolower($propertyName[$i]);
                 } else {
                     $snakeCasedName .= strtolower($propertyName[$i]);

--- a/src/Symfony/Component/Serializer/Tests/NameConverter/CamelCaseToSnakeCaseNameConverterTest.php
+++ b/src/Symfony/Component/Serializer/Tests/NameConverter/CamelCaseToSnakeCaseNameConverterTest.php
@@ -48,6 +48,7 @@ class CamelCaseToSnakeCaseNameConverterTest extends \PHPUnit_Framework_TestCase
             array('coop_tilleuls', 'coopTilleuls'),
             array('_kevin_dunglas', '_kevinDunglas'),
             array('this_is_a_test', 'thisIsATest'),
+            array('first_character_no_underscore', 'FirstCharacterNoUnderscore'),
         );
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/NameConverter/CamelCaseToSnakeCaseNameConverterTest.php
+++ b/src/Symfony/Component/Serializer/Tests/NameConverter/CamelCaseToSnakeCaseNameConverterTest.php
@@ -39,7 +39,7 @@ class CamelCaseToSnakeCaseNameConverterTest extends \PHPUnit_Framework_TestCase
     public function testDenormalize($underscored, $lowerCamelCased)
     {
         $nameConverter = new CamelCaseToSnakeCaseNameConverter();
-        $this->assertEquals($nameConverter->denormalize($underscored), $lowerCamelCased);
+        $this->assertEquals($nameConverter->denormalize($underscored), lcfirst($lowerCamelCased));
     }
 
     public function attributeProvider()
@@ -49,6 +49,7 @@ class CamelCaseToSnakeCaseNameConverterTest extends \PHPUnit_Framework_TestCase
             array('_kevin_dunglas', '_kevinDunglas'),
             array('this_is_a_test', 'thisIsATest'),
             array('first_character_no_underscore', 'FirstCharacterNoUnderscore'),
+            array('tim_hovius', 'TimHovius'),
         );
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/NameConverter/CamelCaseToSnakeCaseNameConverterTest.php
+++ b/src/Symfony/Component/Serializer/Tests/NameConverter/CamelCaseToSnakeCaseNameConverterTest.php
@@ -39,7 +39,7 @@ class CamelCaseToSnakeCaseNameConverterTest extends \PHPUnit_Framework_TestCase
     public function testDenormalize($underscored, $lowerCamelCased)
     {
         $nameConverter = new CamelCaseToSnakeCaseNameConverter();
-        $this->assertEquals($nameConverter->denormalize($underscored), lcfirst($lowerCamelCased));
+        $this->assertEquals($nameConverter->denormalize($underscored), $lowerCamelCased);
     }
 
     public function attributeProvider()
@@ -48,8 +48,8 @@ class CamelCaseToSnakeCaseNameConverterTest extends \PHPUnit_Framework_TestCase
             array('coop_tilleuls', 'coopTilleuls'),
             array('_kevin_dunglas', '_kevinDunglas'),
             array('this_is_a_test', 'thisIsATest'),
-            array('first_character_no_underscore', 'FirstCharacterNoUnderscore'),
-            array('tim_hovius', 'TimHovius'),
+            array('first_character_no_underscore', 'firstCharacterNoUnderscore'),
+            array('tim_hovius', 'timHovius'),
         );
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7, 2.8, 3.0 or 3.1 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The string `CamelCaseString` was converted to `_camel_case_string`. The first character must be ignored. 
