### PR TITLE
[MonologBridge] move HttpKernel component to require section

### DIFF
--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -17,10 +17,10 @@
     ],
     "require": {
         "php": ">=5.3.9",
-        "monolog/monolog": "~1.11"
+        "monolog/monolog": "~1.11",
+        "symfony/http-kernel": "~2.4"
     },
     "require-dev": {
-        "symfony/http-kernel": "~2.4",
         "symfony/console": "~2.4",
         "symfony/event-dispatcher": "~2.2"
     },


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #19110 |
| License | MIT |
| Doc PR |  |

Nearly every class from the bridge has (directly or indirectly) a dependency on a class from the HttpKernel component. Thus, it for me doesn't make sense to treat it as an optional dependency.
