### PR TITLE
[PhpUnitBridge] use call_user_func() for PHP 5.3 compatibility

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/ErrorAssert.php
+++ b/src/Symfony/Bridge/PhpUnit/ErrorAssert.php
@@ -53,7 +53,7 @@ final class ErrorAssert
                 $triggeredMessages[] = $message;
             });
 
-            $testCode();
+            call_user_func($testCode);
         } catch (\Exception $e) {
         } catch (\Throwable $e) {
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Not all callables can be called directly on PHP 5.3 (for example, `array('className', 'methodName')` does not work).
