### PR TITLE
Avoid phpunit 5.4 warnings on getMock (master)

### DIFF
--- a/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
@@ -93,9 +93,9 @@ abstract class ConstraintValidatorTestCase extends \PHPUnit_Framework_TestCase
 
     protected function createContext()
     {
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
-        $validator = $this->getMock('Symfony\Component\Validator\Validator\ValidatorInterface');
-        $contextualValidator = $this->getMock('Symfony\Component\Validator\Validator\ContextualValidatorInterface');
+        $translator = $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')->getMock();
+        $validator = $this->getMockBuilder('Symfony\Component\Validator\Validator\ValidatorInterface')->getMock();
+        $contextualValidator = $this->getMockBuilder('Symfony\Component\Validator\Validator\ContextualValidatorInterface')->getMock();
 
         $context = new ExecutionContext($validator, $this->root, $translator);
         $context->setGroup($this->group);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #19125 |
| License | MIT |
| Doc PR | ~ |

Avoids calling `getMock()` in phpunit 5.4 which will trigger a warning (and thus failing test suite) when used by developers as this TestCase is an extension point.

_in the other branches (opposed to #19128), this was not in the `Test` namespace yet but in `Tests`. Therefore I've only added this in the master as changed by @WouterJ in e938361cf71f78ae5affd454debfca24c31a3cd7._
