### PR TITLE
[RFC][Filesystem] Test filesystem with stringish objects

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -37,7 +37,7 @@ class Filesystem
      */
     public function copy($originFile, $targetFile, $overwriteNewerFiles = false)
     {
-        if (stream_is_local($originFile) && !is_file($originFile)) {
+        if (stream_is_local((string) $originFile) && !is_file($originFile)) {
             throw new FileNotFoundException(sprintf('Failed to copy "%s" because file does not exist.', $originFile), 0, null, $originFile);
         }
 
@@ -71,7 +71,7 @@ class Filesystem
             // Like `cp`, preserve executable permission bits
             @chmod($targetFile, fileperms($targetFile) | (fileperms($originFile) & 0111));
 
-            if (stream_is_local($originFile) && $bytesCopied !== ($bytesOrigin = filesize($originFile))) {
+            if (stream_is_local((string) $originFile) && $bytesCopied !== ($bytesOrigin = filesize($originFile))) {
                 throw new IOException(sprintf('Failed to copy the whole content of "%s" to "%s" (%g of %g bytes copied).', $originFile, $targetFile, $bytesCopied, $bytesOrigin), 0, null, $originFile);
             }
         }

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Filesystem\Tests;
 
+use Symfony\Component\Filesystem\Tests\Fixtures\StringishObject;
+
 /**
  * Test class for Filesystem.
  */
@@ -26,6 +28,17 @@ class FilesystemTest extends FilesystemTestCase
         $this->filesystem->copy($sourceFilePath, $targetFilePath);
 
         $this->assertFileExists($targetFilePath);
+        $this->assertEquals('SOURCE FILE', file_get_contents($targetFilePath));
+
+        // stringish variant
+        $sourceFilePath = new StringishObject($sourceFilePath.'_v2');
+        $targetFilePath = new StringishObject($targetFilePath.'_v2');
+
+        file_put_contents($sourceFilePath, 'SOURCE FILE');
+
+        $this->filesystem->copy($sourceFilePath, $targetFilePath);
+
+        $this->assertFileExists((string) $targetFilePath);
         $this->assertEquals('SOURCE FILE', file_get_contents($targetFilePath));
     }
 

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -198,53 +198,67 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertEquals(file_get_contents($sourceFilePath), file_get_contents($targetFilePath));
     }
 
-    public function testMkdirCreatesDirectoriesRecursively()
+    public function provideSubDirectoryPaths()
     {
-        $directory = $this->workspace
-            .DIRECTORY_SEPARATOR.'directory'
-            .DIRECTORY_SEPARATOR.'sub_directory';
+        $workspace = $this->createWorkspace();
 
+        return array(
+            array($workspace.DIRECTORY_SEPARATOR.'directory'.DIRECTORY_SEPARATOR.'sub_directory'),
+            array(new StringishObject($workspace.DIRECTORY_SEPARATOR.'directory'.DIRECTORY_SEPARATOR.'sub_directory')),
+        );
+    }
+
+    /**
+     * @dataProvider provideSubDirectoryPaths
+     */
+    public function testMkdirCreatesDirectoriesRecursively($directory)
+    {
         $this->filesystem->mkdir($directory);
 
         $this->assertTrue(is_dir($directory));
     }
 
-    public function testMkdirCreatesDirectoriesFromArray()
+    public function provideDirectoryCollectionPaths()
     {
-        $basePath = $this->workspace.DIRECTORY_SEPARATOR;
-        $directories = array(
-            $basePath.'1', $basePath.'2', $basePath.'3',
+        $workspace = $this->createWorkspace();
+        $files = array(
+            $workspace.DIRECTORY_SEPARATOR.'1', $workspace.DIRECTORY_SEPARATOR.'2', new StringishObject($workspace.DIRECTORY_SEPARATOR.'3'),
         );
 
-        $this->filesystem->mkdir($directories);
-
-        $this->assertTrue(is_dir($basePath.'1'));
-        $this->assertTrue(is_dir($basePath.'2'));
-        $this->assertTrue(is_dir($basePath.'3'));
-    }
-
-    public function testMkdirCreatesDirectoriesFromTraversableObject()
-    {
-        $basePath = $this->workspace.DIRECTORY_SEPARATOR;
-        $directories = new \ArrayObject(array(
-            $basePath.'1', $basePath.'2', $basePath.'3',
-        ));
-
-        $this->filesystem->mkdir($directories);
-
-        $this->assertTrue(is_dir($basePath.'1'));
-        $this->assertTrue(is_dir($basePath.'2'));
-        $this->assertTrue(is_dir($basePath.'3'));
+        return array(
+            array($files),
+            array(new \ArrayObject($files)),
+        );
     }
 
     /**
+     * @dataProvider provideDirectoryCollectionPaths
+     */
+    public function testMkdirCreatesDirectoriesFromIterable($directories)
+    {
+        $this->filesystem->mkdir($directories);
+
+        foreach ($directories as $directory) {
+            $this->assertTrue(is_dir($directory));
+        }
+    }
+
+    public function providePaths()
+    {
+        $workspace = $this->createWorkspace();
+
+        return array(
+            array($workspace.DIRECTORY_SEPARATOR.'1'),
+            array(new StringishObject($workspace.DIRECTORY_SEPARATOR.'2')),
+        );
+    }
+
+    /**
+     * @dataProvider providePaths
      * @expectedException \Symfony\Component\Filesystem\Exception\IOException
      */
-    public function testMkdirCreatesDirectoriesFails()
+    public function testMkdirCreatesDirectoriesFails($dir)
     {
-        $basePath = $this->workspace.DIRECTORY_SEPARATOR;
-        $dir = $basePath.'2';
-
         file_put_contents($dir, '');
 
         $this->filesystem->mkdir($dir);

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -198,18 +198,18 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertEquals(file_get_contents($sourceFilePath), file_get_contents($targetFilePath));
     }
 
-    public function provideSubDirectoryPaths()
+    public function provideSubPaths()
     {
         $workspace = $this->createWorkspace();
 
         return array(
-            array($workspace.DIRECTORY_SEPARATOR.'directory'.DIRECTORY_SEPARATOR.'sub_directory'),
-            array(new StringishObject($workspace.DIRECTORY_SEPARATOR.'directory'.DIRECTORY_SEPARATOR.'sub_directory')),
+            array($workspace.DIRECTORY_SEPARATOR.'1'.DIRECTORY_SEPARATOR.'2'),
+            array(new StringishObject($workspace.DIRECTORY_SEPARATOR.'1'.DIRECTORY_SEPARATOR.'2')),
         );
     }
 
     /**
-     * @dataProvider provideSubDirectoryPaths
+     * @dataProvider provideSubPaths
      */
     public function testMkdirCreatesDirectoriesRecursively($directory)
     {
@@ -218,7 +218,7 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertTrue(is_dir($directory));
     }
 
-    public function provideDirectoryCollectionPaths()
+    public function provideIterablePaths()
     {
         $workspace = $this->createWorkspace();
         $files = array(
@@ -232,7 +232,7 @@ class FilesystemTest extends FilesystemTestCase
     }
 
     /**
-     * @dataProvider provideDirectoryCollectionPaths
+     * @dataProvider provideIterablePaths
      */
     public function testMkdirCreatesDirectoriesFromIterable($directories)
     {
@@ -264,51 +264,35 @@ class FilesystemTest extends FilesystemTestCase
         $this->filesystem->mkdir($dir);
     }
 
-    public function testTouchCreatesEmptyFile()
+    /**
+     * @dataProvider providePaths
+     */
+    public function testTouchCreatesEmptyFile($file)
     {
-        $file = $this->workspace.DIRECTORY_SEPARATOR.'1';
-
         $this->filesystem->touch($file);
 
-        $this->assertFileExists($file);
+        $this->assertFileExists((string) $file);
     }
 
     /**
+     * @dataProvider provideSubPaths
      * @expectedException \Symfony\Component\Filesystem\Exception\IOException
      */
-    public function testTouchFails()
+    public function testTouchFails($file)
     {
-        $file = $this->workspace.DIRECTORY_SEPARATOR.'1'.DIRECTORY_SEPARATOR.'2';
-
         $this->filesystem->touch($file);
     }
 
-    public function testTouchCreatesEmptyFilesFromArray()
+    /**
+     * @dataProvider provideIterablePaths
+     */
+    public function testTouchCreatesEmptyFilesFromIterable($files)
     {
-        $basePath = $this->workspace.DIRECTORY_SEPARATOR;
-        $files = array(
-            $basePath.'1', $basePath.'2', $basePath.'3',
-        );
-
         $this->filesystem->touch($files);
 
-        $this->assertFileExists($basePath.'1');
-        $this->assertFileExists($basePath.'2');
-        $this->assertFileExists($basePath.'3');
-    }
-
-    public function testTouchCreatesEmptyFilesFromTraversableObject()
-    {
-        $basePath = $this->workspace.DIRECTORY_SEPARATOR;
-        $files = new \ArrayObject(array(
-            $basePath.'1', $basePath.'2', $basePath.'3',
-        ));
-
-        $this->filesystem->touch($files);
-
-        $this->assertFileExists($basePath.'1');
-        $this->assertFileExists($basePath.'2');
-        $this->assertFileExists($basePath.'3');
+        foreach ($files as $file) {
+            $this->assertFileExists((string) $file);
+        }
     }
 
     public function testRemoveCleansFilesAndDirectoriesIteratively()

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTestCase.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTestCase.php
@@ -30,6 +30,11 @@ class FilesystemTestCase extends \PHPUnit_Framework_TestCase
     protected $workspace = null;
 
     /**
+     * @var array
+     */
+    protected $workspacesToRemove = array();
+
+    /**
      * @var null|bool Flag for hard links on Windows
      */
     private static $linkOnWindows = null;
@@ -84,7 +89,7 @@ class FilesystemTestCase extends \PHPUnit_Framework_TestCase
             $this->longPathNamesWindows = array();
         }
 
-        $this->filesystem->remove($this->workspace);
+        $this->filesystem->remove($this->workspacesToRemove);
         umask($this->umask);
     }
 
@@ -95,6 +100,7 @@ class FilesystemTestCase extends \PHPUnit_Framework_TestCase
     {
         $workspace = sys_get_temp_dir().'/'.microtime(true).'.'.mt_rand();
         mkdir($workspace, 0777, true);
+        $this->workspacesToRemove[] = $workspace;
 
         return realpath($workspace);
     }

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTestCase.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTestCase.php
@@ -98,7 +98,7 @@ class FilesystemTestCase extends \PHPUnit_Framework_TestCase
      */
     protected function createWorkspace()
     {
-        $workspace = sys_get_temp_dir().'/'.microtime(true).'.'.mt_rand();
+        $workspace = sys_get_temp_dir().DIRECTORY_SEPARATOR.microtime(true).'.'.mt_rand();
         mkdir($workspace, 0777, true);
         $this->workspacesToRemove[] = $workspace;
 

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTestCase.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTestCase.php
@@ -72,9 +72,7 @@ class FilesystemTestCase extends \PHPUnit_Framework_TestCase
     {
         $this->umask = umask(0);
         $this->filesystem = new Filesystem();
-        $this->workspace = sys_get_temp_dir().'/'.microtime(true).'.'.mt_rand();
-        mkdir($this->workspace, 0777, true);
-        $this->workspace = realpath($this->workspace);
+        $this->workspace = $this->createWorkspace();
     }
 
     protected function tearDown()
@@ -88,6 +86,17 @@ class FilesystemTestCase extends \PHPUnit_Framework_TestCase
 
         $this->filesystem->remove($this->workspace);
         umask($this->umask);
+    }
+
+    /**
+     * @return string
+     */
+    protected function createWorkspace()
+    {
+        $workspace = sys_get_temp_dir().'/'.microtime(true).'.'.mt_rand();
+        mkdir($workspace, 0777, true);
+
+        return realpath($workspace);
     }
 
     /**

--- a/src/Symfony/Component/Filesystem/Tests/Fixtures/StringishObject.php
+++ b/src/Symfony/Component/Filesystem/Tests/Fixtures/StringishObject.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Tests\Fixtures;
+
+/**
+ * Represents a stringish object (i.e. an object implementing __toString())
+ */
+class StringishObject
+{
+    private $value;
+
+    /**
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->value;
+    }
+}

--- a/src/Symfony/Component/Filesystem/Tests/Fixtures/StringishObject.php
+++ b/src/Symfony/Component/Filesystem/Tests/Fixtures/StringishObject.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Filesystem\Tests\Fixtures;
 
 /**
- * Represents a stringish object (i.e. an object implementing __toString())
+ * Represents a stringish object (i.e. an object implementing __toString()).
  */
 class StringishObject
 {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7? |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #19075 |
| License | MIT |
| Doc PR | ~ |

A quick proof of concept that the `Filesystem` component works with stringish objects (objects implementing `__toString`, e.g. `\SplFileInfo`).

Also tested `$filesystem->remove($finder)` and that just works as expected. Should we update the tests so it can be officially supported?
