### PR TITLE
Distinguish between first and subsequent progress bar displays

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -43,6 +43,7 @@ class ProgressBar
     private $formatLineCount;
     private $messages = array();
     private $overwrite = true;
+    private $firstRun = true;
 
     private static $formatters;
     private static $formats;
@@ -522,19 +523,23 @@ class ProgressBar
     private function overwrite($message)
     {
         if ($this->overwrite) {
-            // Move the cursor to the beginning of the line
-            $this->output->write("\x0D");
+            if (!$this->isFirstRun()) {
+                // Move the cursor to the beginning of the line
+                $this->output->write("\x0D");
 
-            // Erase the line
-            $this->output->write("\x1B[2K");
+                // Erase the line
+                $this->output->write("\x1B[2K");
 
-            // Erase previous lines
-            if ($this->formatLineCount > 0) {
-                $this->output->write(str_repeat("\x1B[1A\x1B[2K", $this->formatLineCount));
+                // Erase previous lines
+                if ($this->formatLineCount > 0) {
+                    $this->output->write(str_repeat("\x1B[1A\x1B[2K", $this->formatLineCount));
+                }
             }
         } elseif ($this->step > 0) {
             $this->output->writeln('');
         }
+
+        $this->setFirstRun(false);
 
         $this->output->write($message);
     }
@@ -626,5 +631,15 @@ class ProgressBar
             'debug' => ' %current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s% %memory:6s%',
             'debug_nomax' => ' %current% [%bar%] %elapsed:6s% %memory:6s%',
         );
+    }
+
+    private function isFirstRun()
+    {
+        return $this->firstRun;
+    }
+
+    private function setFirstRun($firstRun)
+    {
+        $this->firstRun = (bool) $firstRun;
     }
 }

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -29,7 +29,7 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            $this->generateOutput('    0 [>---------------------------]').
+            '    0 [>---------------------------]'.
             $this->generateOutput('    1 [->--------------------------]').
             $this->generateOutput('    0 [>---------------------------]'),
             stream_get_contents($output->getStream())
@@ -44,7 +44,7 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            $this->generateOutput('    0 [>---------------------------]').
+            '    0 [>---------------------------]'.
             $this->generateOutput('    1 [->--------------------------]'),
             stream_get_contents($output->getStream())
         );
@@ -58,7 +58,7 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            $this->generateOutput('    0 [>---------------------------]').
+            '    0 [>---------------------------]'.
             $this->generateOutput('    5 [----->----------------------]'),
             stream_get_contents($output->getStream())
         );
@@ -73,7 +73,7 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            $this->generateOutput('    0 [>---------------------------]').
+            '    0 [>---------------------------]'.
             $this->generateOutput('    3 [--->------------------------]').
             $this->generateOutput('    5 [----->----------------------]'),
             stream_get_contents($output->getStream())
@@ -89,7 +89,7 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            $this->generateOutput('  9/10 [=========================>--]  90%').
+            '  9/10 [=========================>--]  90%'.
             $this->generateOutput(' 10/10 [============================] 100%').
             $this->generateOutput(' 11/11 [============================] 100%'),
             stream_get_contents($output->getStream())
@@ -99,7 +99,7 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
     public function testFormat()
     {
         $expected =
-            $this->generateOutput('  0/10 [>---------------------------]   0%').
+            '  0/10 [>---------------------------]   0%'.
             $this->generateOutput(' 10/10 [============================] 100%').
             $this->generateOutput(' 10/10 [============================] 100%')
         ;
@@ -156,7 +156,7 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            $this->generateOutput('  0/10 [/         ]   0%').
+            '  0/10 [/         ]   0%'.
             $this->generateOutput('  1/10 [_/        ]  10%'),
             stream_get_contents($output->getStream())
         );
@@ -169,7 +169,7 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            $this->generateOutput('  0/50 [>---------------------------]   0%'),
+            '  0/50 [>---------------------------]   0%',
             stream_get_contents($output->getStream())
         );
     }
@@ -193,7 +193,7 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            $this->generateOutput(' 50/50 [============================] 100%'),
+            ' 50/50 [============================] 100%',
             stream_get_contents($output->getStream())
         );
     }
@@ -208,7 +208,7 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            $this->generateOutput('  0/50 [>---------------------------]   0%').
+            '  0/50 [>---------------------------]   0%'.
             $this->generateOutput('  0/50 [>---------------------------]   0%').
             $this->generateOutput('  1/50 [>---------------------------]   2%').
             $this->generateOutput('  2/50 [=>--------------------------]   4%'),
@@ -230,7 +230,7 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            $this->generateOutput('  0/50 [>---------------------------]   0%').
+            '  0/50 [>---------------------------]   0%'.
             $this->generateOutput('  0/50 [>---------------------------]   0%').
             $this->generateOutput('  1/50 [>---------------------------]   2%').
             $this->generateOutput('  2/50 [=>--------------------------]'),
@@ -247,7 +247,7 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            $this->generateOutput(' 0/50 [>---------------------------]').
+            ' 0/50 [>---------------------------]'.
             $this->generateOutput(' 1/50 [>---------------------------]'),
             stream_get_contents($output->getStream())
         );
@@ -264,7 +264,7 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            $this->generateOutput('  0/50 [>---------------------------]   0%').
+            '  0/50 [>---------------------------]   0%'.
             $this->generateOutput('  0/50 [>---------------------------]   0%').
             $this->generateOutput('  1/50 [>---------------------------]   2%').
             $this->generateOutput(' 15/50 [========>-------------------]  30%').
@@ -339,7 +339,7 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            $this->generateOutput('    0 [>---------------------------]').
+            '    0 [>---------------------------]'.
             $this->generateOutput('    3 [■■■>------------------------]'),
             stream_get_contents($output->getStream())
         );
@@ -354,7 +354,7 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            $this->generateOutput('  0/50 [>---------------------------]   0%').
+            '  0/50 [>---------------------------]   0%'.
             $this->generateOutput(' 25/50 [==============>-------------]  50%').
             $this->generateOutput(''),
             stream_get_contents($output->getStream())
@@ -371,7 +371,7 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            $this->generateOutput('   0/200 [>---------------------------]   0%').
+            '   0/200 [>---------------------------]   0%'.
             $this->generateOutput('   0/200 [>---------------------------]   0%').
             $this->generateOutput(' 199/200 [===========================>]  99%').
             $this->generateOutput(' 200/200 [============================] 100%'),
@@ -471,9 +471,9 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            $this->generateOutput(' 0/2 [>---------------------------]   0%')."\n".
-            $this->generateOutput(' 0/3 [#---------------------------]   0%')."\n".
-            rtrim($this->generateOutput('    0 [>---------------------------]')).
+            ' 0/2 [>---------------------------]   0%'."\n".
+            ' 0/3 [#---------------------------]   0%'."\n".
+            rtrim('    0 [>---------------------------]').
 
             "\033[2A".
             $this->generateOutput(' 1/2 [==============>-------------]  50%')."\n".
@@ -511,7 +511,7 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            rtrim($this->generateOutput('    0 [>---------------------------]')).
+            rtrim('    0 [>---------------------------]').
             rtrim($this->generateOutput('    1 [->--------------------------]')).
             rtrim($this->generateOutput('    2 [-->-------------------------]')).
             rtrim($this->generateOutput('    3 [--->------------------------]')).
@@ -534,7 +534,7 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            $this->generateOutput(' 3 [>---------------------------]').
+            ' 3 [>---------------------------]'.
             $this->generateOutput(' 2 [=========>------------------]').
             $this->generateOutput(' 0 [============================]'),
             stream_get_contents($output->getStream())
@@ -553,7 +553,7 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            $this->generateOutput(">---------------------------\nfoobar").
+            ">---------------------------\nfoobar".
             $this->generateOutput("=========>------------------\nfoobar").
             "\x0D\x1B[2K\x1B[1A\x1B[2K".
             $this->generateOutput("============================\nfoobar"),
@@ -588,11 +588,11 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            $this->generateOutput(
+
                 " \033[44;37m Starting the demo... fingers crossed  \033[0m\n".
                 '  0/15 '.$progress.str_repeat($empty, 26)."   0%\n".
                 " \xf0\x9f\x8f\x81  < 1 sec                        \033[44;37m 0 B \033[0m"
-            ).
+            .
             $this->generateOutput(
                 " \033[44;37m Looks good to me...                   \033[0m\n".
                 '  4/15 '.str_repeat($done, 7).$progress.str_repeat($empty, 19)."  26%\n".
@@ -614,7 +614,7 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
         $bar->start();
         rewind($output->getStream());
         $this->assertEquals(
-            $this->generateOutput('    0 [>---------------------------]'),
+            '    0 [>---------------------------]',
             stream_get_contents($output->getStream())
         );
 
@@ -623,7 +623,7 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
         $bar->start();
         rewind($output->getStream());
         $this->assertEquals(
-            $this->generateOutput('  0/10 [>---------------------------]   0%'),
+            '  0/10 [>---------------------------]   0%',
             stream_get_contents($output->getStream())
         );
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #19133 |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

Fixes https://github.com/symfony/symfony/issues/19133

When a progress bar is first displayed, if it is multi-line, previously output lines are erased, depending upon the number of lines in the progress bar.

This patch fixes that be distinguishing between the first display (no erasing of previous output) and subsequent displays of the progress bar.
