### PR TITLE
Fix failing test for https://github.com/symfony/symfony/pull/19134

### DIFF
--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -29,7 +29,7 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
 
         rewind($output->getStream());
         $this->assertEquals(
-            $this->generateOutput('    0 [>---------------------------]').
+            '    0 [>---------------------------]'.
             $this->generateOutput('    1 [->--------------------------]').
             $this->generateOutput('    0 [>---------------------------]'),
             stream_get_contents($output->getStream())


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | 19134 |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

With the changes made by https://github.com/symfony/symfony/pull/19134, the `\Symfony\Component\Console\Tests\Helper\ProgressBarTest::testMultipleStart()` test fails.

This patch fixes the test for #19134.
