### PR TITLE
[Console] Consistent table header cell format for symfony styleguide

### DIFF
--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -691,7 +691,6 @@ class Table
             ->setHorizontalBorderChar('-')
             ->setVerticalBorderChar(' ')
             ->setCrossingChar(' ')
-            ->setCellHeaderFormat('%s')
         ;
 
         return array(

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -17,7 +17,6 @@ use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Helper\SymfonyQuestionHelper;
 use Symfony\Component\Console\Helper\Table;
-use Symfony\Component\Console\Helper\TableCell;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -230,17 +229,6 @@ class SymfonyStyle extends OutputStyle
      */
     public function table(array $headers, array $rows)
     {
-        array_walk_recursive($headers, function (&$value) {
-            if ($value instanceof TableCell) {
-                $value = new TableCell(sprintf('<info>%s</>', $value), array(
-                    'colspan' => $value->getColspan(),
-                    'rowspan' => $value->getRowspan(),
-                ));
-            } else {
-                $value = sprintf('<info>%s</>', $value);
-            }
-        });
-
         $table = new Table($this);
         $table->setHeaders($headers);
         $table->setRows($rows);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | yes? |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no? |
| Tests pass? | yes |
| Fixed tickets | #19123 |
| License | MIT |
| Doc PR | ~ |

Looks like a bug/regression to me ;-) however im not totally sure why `->setCellHeaderFormat('%s')` was added that explicitly. Seems like [nobody knows](https://github.com/symfony/symfony/issues/19123) :)
