### PR TITLE
[Serializer] Allow to use easily static constructors

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Fixtures/StaticConstructorDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/StaticConstructorDummy.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class StaticConstructorDummy
+{
+    public $foo;
+    public $bar;
+    public $quz;
+
+    public static function create($foo)
+    {
+        $dummy = new self();
+        $dummy->quz = $foo;
+
+        return $dummy;
+    }
+
+    private function __construct()
+    {
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/StaticConstructorNormalizer.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/StaticConstructorNormalizer.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+
+/**
+ * @author Guilhem N. <egetick@gmail.com>
+ */
+class StaticConstructorNormalizer extends ObjectNormalizer
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConstructor(array &$data, $class, array &$context, \ReflectionClass $reflectionClass, $allowedAttributes)
+    {
+        if (is_a($class, StaticConstructorDummy::class, true)) {
+            return new \ReflectionMethod($class, 'create');
+        }
+
+        return parent::getConstructor($data, $class, $context, $reflectionClass, $allowedAttributes);
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
@@ -9,6 +9,8 @@ use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Tests\Fixtures\AbstractNormalizerDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\ProxyDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\StaticConstructorDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\StaticConstructorNormalizer;
 
 /**
  * Provides a dummy Normalizer which extends the AbstractNormalizer.
@@ -102,5 +104,15 @@ class AbstractNormalizerTest extends \PHPUnit_Framework_TestCase
         $normalizer->denormalize(array('foo' => 'bar'), 'Symfony\Component\Serializer\Tests\Fixtures\ToBeProxyfiedDummy', null, $context);
 
         $this->assertSame('bar', $proxyDummy->getFoo());
+    }
+
+    public function testObjectWithStaticConstructor()
+    {
+        $normalizer = new StaticConstructorNormalizer();
+        $dummy = $normalizer->denormalize(array('foo' => 'baz'), StaticConstructorDummy::class);
+
+        $this->assertInstanceOf(StaticConstructorDummy::class, $dummy);
+        $this->assertEquals('baz', $dummy->quz);
+        $this->assertNull($dummy->foo);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/pull/19027#issuecomment-225527475 |
| License | MIT |
| Doc PR | - |

This PR allows to simply use static constructors to instantiate objects with the serializer by extending the default normalizers.
