### PR TITLE
Throw less misleading exception when property access not found

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -651,6 +651,8 @@ class PropertyAccessor implements PropertyAccessorInterface
             // fatal error.
 
             $object->$property = $value;
+        } elseif (self::ACCESS_TYPE_NOT_FOUND === $access[self::ACCESS_TYPE]) {
+            throw new NoSuchPropertyException(sprintf('Could not determine access type for property "%s".', $property));
         } elseif (self::ACCESS_TYPE_MAGIC === $access[self::ACCESS_TYPE]) {
             $object->{$access[self::ACCESS_NAME]}($value);
         } else {


### PR DESCRIPTION
Prevent throwing a NoSuchPropertyException with a somewhat misleading message "Neither the property "X" nor one of the methods "addX()"/"removeX()", "setX()", "x()", "__set()" or "__call()" exist and have public access in class when the access cannot be determined, for instance if the doctrine schema is not up to date. 

| Q | A |
| --- | --- |
| Branch? | 3.1 for fixes |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
