### PR TITLE
Response headers fix

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -307,7 +307,7 @@ class Response
         }
 
         // Check if we need to send extra expire info headers
-        if ('1.0' == $this->getProtocolVersion() && 'no-cache' == $this->headers->get('Cache-Control')) {
+        if ('1.0' == $this->getProtocolVersion() && false !== strpos($this->headers->get('Cache-Control'), 'no-cache')) {
             $this->headers->set('pragma', 'no-cache');
             $this->headers->set('expires', -1);
         }

--- a/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
@@ -281,7 +281,7 @@ class ResponseHeaderBag extends HeaderBag
     protected function computeCacheControlValue()
     {
         if (!$this->cacheControl && !$this->has('ETag') && !$this->has('Last-Modified') && !$this->has('Expires')) {
-            return 'no-cache';
+            return 'no-cache, private';
         }
 
         if (!$this->cacheControl) {

--- a/src/Symfony/Component/HttpFoundation/Tests/HeaderBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/HeaderBagTest.php
@@ -171,6 +171,15 @@ class HeaderBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(10, $bag->getCacheControlDirective('max-age'));
     }
 
+    public function testCacheControlClone()
+    {
+        $headers = array('foo' => 'bar');
+        $bag1 = new HeaderBag($headers);
+        $bag2 = new HeaderBag($bag1->all());
+
+        $this->assertEquals($bag1->all(), $bag2->all());
+    }
+
     public function testGetIterator()
     {
         $headers = array('foo' => 'bar', 'hello' => 'world', 'third' => 'charm');

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
@@ -34,7 +34,7 @@ class ResponseHeaderBagTest extends \PHPUnit_Framework_TestCase
         return array(
             array(
                 array('fOo' => 'BAR'),
-                array('fOo' => array('BAR'), 'Cache-Control' => array('no-cache')),
+                array('fOo' => array('BAR'), 'Cache-Control' => array('no-cache, private')),
             ),
             array(
                 array('ETag' => 'xyzzy'),
@@ -42,23 +42,23 @@ class ResponseHeaderBagTest extends \PHPUnit_Framework_TestCase
             ),
             array(
                 array('Content-MD5' => 'Q2hlY2sgSW50ZWdyaXR5IQ=='),
-                array('Content-MD5' => array('Q2hlY2sgSW50ZWdyaXR5IQ=='), 'Cache-Control' => array('no-cache')),
+                array('Content-MD5' => array('Q2hlY2sgSW50ZWdyaXR5IQ=='), 'Cache-Control' => array('no-cache, private')),
             ),
             array(
                 array('P3P' => 'CP="CAO PSA OUR"'),
-                array('P3P' => array('CP="CAO PSA OUR"'), 'Cache-Control' => array('no-cache')),
+                array('P3P' => array('CP="CAO PSA OUR"'), 'Cache-Control' => array('no-cache, private')),
             ),
             array(
                 array('WWW-Authenticate' => 'Basic realm="WallyWorld"'),
-                array('WWW-Authenticate' => array('Basic realm="WallyWorld"'), 'Cache-Control' => array('no-cache')),
+                array('WWW-Authenticate' => array('Basic realm="WallyWorld"'), 'Cache-Control' => array('no-cache, private')),
             ),
             array(
                 array('X-UA-Compatible' => 'IE=edge,chrome=1'),
-                array('X-UA-Compatible' => array('IE=edge,chrome=1'), 'Cache-Control' => array('no-cache')),
+                array('X-UA-Compatible' => array('IE=edge,chrome=1'), 'Cache-Control' => array('no-cache, private')),
             ),
             array(
                 array('X-XSS-Protection' => '1; mode=block'),
-                array('X-XSS-Protection' => array('1; mode=block'), 'Cache-Control' => array('no-cache')),
+                array('X-XSS-Protection' => array('1; mode=block'), 'Cache-Control' => array('no-cache, private')),
             ),
         );
     }
@@ -66,7 +66,7 @@ class ResponseHeaderBagTest extends \PHPUnit_Framework_TestCase
     public function testCacheControlHeader()
     {
         $bag = new ResponseHeaderBag(array());
-        $this->assertEquals('no-cache', $bag->get('Cache-Control'));
+        $this->assertEquals('no-cache, private', $bag->get('Cache-Control'));
         $this->assertTrue($bag->hasCacheControlDirective('no-cache'));
 
         $bag = new ResponseHeaderBag(array('Cache-Control' => 'public'));
@@ -111,6 +111,14 @@ class ResponseHeaderBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('private, must-revalidate', $bag->get('Cache-Control'));
     }
 
+    public function testCacheControlClone()
+    {
+        $headers = array('foo' => 'bar');
+        $bag1 = new ResponseHeaderBag($headers);
+        $bag2 = new ResponseHeaderBag($bag1->allPreserveCase());
+        $this->assertEquals($bag1->allPreserveCase(), $bag2->allPreserveCase());
+    }
+
     public function testToStringIncludesCookieHeaders()
     {
         $bag = new ResponseHeaderBag(array());
@@ -135,7 +143,7 @@ class ResponseHeaderBagTest extends \PHPUnit_Framework_TestCase
     public function testReplace()
     {
         $bag = new ResponseHeaderBag(array());
-        $this->assertEquals('no-cache', $bag->get('Cache-Control'));
+        $this->assertEquals('no-cache, private', $bag->get('Cache-Control'));
         $this->assertTrue($bag->hasCacheControlDirective('no-cache'));
 
         $bag->replace(array('Cache-Control' => 'public'));
@@ -146,12 +154,12 @@ class ResponseHeaderBagTest extends \PHPUnit_Framework_TestCase
     public function testReplaceWithRemove()
     {
         $bag = new ResponseHeaderBag(array());
-        $this->assertEquals('no-cache', $bag->get('Cache-Control'));
+        $this->assertEquals('no-cache, private', $bag->get('Cache-Control'));
         $this->assertTrue($bag->hasCacheControlDirective('no-cache'));
 
         $bag->remove('Cache-Control');
         $bag->replace(array());
-        $this->assertEquals('no-cache', $bag->get('Cache-Control'));
+        $this->assertEquals('no-cache, private', $bag->get('Cache-Control'));
         $this->assertTrue($bag->hasCacheControlDirective('no-cache'));
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -33,7 +33,7 @@ class ResponseTest extends ResponseTestCase
         $response = new Response();
         $response = explode("\r\n", $response);
         $this->assertEquals('HTTP/1.0 200 OK', $response[0]);
-        $this->assertEquals('Cache-Control: no-cache', $response[1]);
+        $this->assertEquals('Cache-Control: no-cache, private', $response[1]);
     }
 
     public function testClone()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes/no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #16171, #16307 |
| License | MIT |
| Doc PR | n/a |

To fix the inconsistency mentioned in #16171, I think the "best" solution would be to add `private` when cache-control is not set, which was the intention but was forgotten.

I propose to make the fix in 3.2 only as it might be a BC break.
