### PR TITLE
Handle REQUEST_URI containing host and path

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ApacheRequest.php
+++ b/src/Symfony/Component/HttpFoundation/ApacheRequest.php
@@ -23,7 +23,11 @@ class ApacheRequest extends Request
      */
     protected function prepareRequestUri()
     {
-        return $this->server->get('REQUEST_URI');
+        $requestUri = $this->server->get('REQUEST_URI');
+        $parsedRequest = parse_url($requestUri);
+        // Make sure to return only path.
+        // Proxies can set REQUEST_URI to contain host and path.
+        return $parsedRequest['path'];
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/ApacheRequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ApacheRequestTest.php
@@ -33,6 +33,16 @@ class ApacheRequestTest extends \PHPUnit_Framework_TestCase
         return array(
             array(
                 array(
+                    'REQUEST_URI' => 'http://example.com/foo/app_dev.php/bar',
+                    'SCRIPT_NAME' => '/foo/app_dev.php',
+                    'PATH_INFO' => '/bar',
+                ),
+                '/foo/app_dev.php/bar',
+                '/foo/app_dev.php',
+                '/bar',
+            ),
+            array(
+                array(
                     'REQUEST_URI' => '/foo/app_dev.php/bar',
                     'SCRIPT_NAME' => '/foo/app_dev.php',
                     'PATH_INFO' => '/bar',


### PR DESCRIPTION
In some scenarios proxies may send the complete URL in the `request_uri` field. And this breaks routing.
http://tools.ietf.org/html/rfc2616#section-5.1.2

```
   The absoluteURI form is REQUIRED when the request is being made to a
   proxy. The proxy is requested to forward the request or service it
   from a valid cache, and return the response. Note that the proxy MAY
   forward the request on to another proxy or directly to the server
```

| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
