### PR TITLE
[Console] Reference changes that ease command testing in changelog

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+3.2.0
+------
+
+* added `setInputs()` method to CommandTester for ease testing of commands expecting inputs
+* added `setStream()` and `getStream()` methods to Input (implement StreamableInputInterface)
+* added StreamableInputInterface
+
 3.1.0
 -----
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

I totally forget to do it in the corresponding PRs,
I used `3.2.0` even if not yet released, hope that is correct.
