### PR TITLE
[TwigBridge] Fix inconsistency in LintCommand help

### DIFF
--- a/src/Symfony/Bridge/Twig/Command/LintCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/LintCommand.php
@@ -65,18 +65,19 @@ class LintCommand extends Command
 The <info>%command.name%</info> command lints a template and outputs to STDOUT
 the first encountered syntax error.
 
-You can validate the syntax of a file:
+You can validate the syntax of contents passed from STDIN:
 
-<info>php %command.full_name% filename</info>
+  <info>cat filename | php %command.full_name%</info>
+
+Or the syntax of a file:
+
+  <info>php %command.full_name% filename</info>
 
 Or of a whole directory:
 
-<info>php %command.full_name% dirname</info>
-<info>php %command.full_name% dirname --format=json</info>
+  <info>php %command.full_name% dirname</info>
+  <info>php %command.full_name% dirname --format=json</info>
 
-You can also pass the template contents from STDIN:
-
-<info>cat filename | php %command.full_name%</info>
 EOF
             )
         ;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/pull/19139#discussion_r68058993 |
| License | MIT |
| Doc PR | ~ |

Actually, the `lint:yaml` command's help looks like this:

![](http://image.prntscr.com/image/95dddf38ebcf408b8e2e23cf09c3ddf6.png)

The last `Or` about STDIN is syntactically wrong, and is the only one to have a code example with indentation. This gives the same indentation for all code blocks and move the STDIN-related part as first, as proposed in https://github.com/symfony/symfony/pull/19139#discussion_r68049018 .

Now it looks like:

![](http://image.prntscr.com/image/8877349f6be746c981c2e9037d2d17ff.png)
