### PR TITLE
sync min email validator version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,7 @@
         "monolog/monolog": "~1.11",
         "ircmaxell/password-compat": "~1.0",
         "ocramius/proxy-manager": "~0.4|~1.0|~2.0",
-        "egulias/email-validator": "~1.2"
+        "egulias/email-validator": "~1.2,>=1.2.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

I stumbled upon this while trying to run the min deps version tests while installing everything from the global `composer.json` file. In the Validator component, we already have this present for a long time sine b1b5cca41c9d325c94117c60679190b0348527d8.
