### PR TITLE
add ORCID validator

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Orcid.php
+++ b/src/Symfony/Component/Validator/Constraints/Orcid.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
+ *
+ * @author Dominic Bordelon <dominicbordelon@gmail.com>
+ */
+class Orcid extends Constraint
+{
+    const TOO_SHORT_ERROR = '29424315-1b99-41fc-9b13-b75d1c0a8639';
+    const TOO_LONG_ERROR = 'c22ce7be-7160-4b19-97e2-600b34bf5fea';
+    const MISSING_HYPHENS_ERROR = '3a2a78ab-9062-4c93-b541-a35b4b9bdf17';
+    const INVALID_CHARACTERS_ERROR = 'bdf57e2c-3ad7-4b4d-ad46-a8a255792aea';
+    const INVALID_CASE_ERROR = '459fac90-10ac-4fec-9fc1-11f411ee5cd2';
+    const CHECKSUM_FAILED_ERROR = '2f5b06bc-9e9d-4de4-b504-631f7ed30ecf';
+
+    protected static $errorNames = array(
+        self::TOO_SHORT_ERROR => 'TOO_SHORT_ERROR',
+        self::TOO_LONG_ERROR => 'TOO_LONG_ERROR',
+        self::MISSING_HYPHENS_ERROR => 'MISSING_HYPHEN_ERROR',
+        self::INVALID_CHARACTERS_ERROR => 'INVALID_CHARACTERS_ERROR',
+        self::INVALID_CASE_ERROR => 'INVALID_CASE_ERROR',
+        self::CHECKSUM_FAILED_ERROR => 'CHECKSUM_FAILED_ERROR',
+    );
+
+    public $message = 'This value is not a valid ORCID.';
+    public $caseSensitive = false;
+    public $requireHyphens = false;
+}

--- a/src/Symfony/Component/Validator/Constraints/OrcidValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/OrcidValidator.php
@@ -44,10 +44,9 @@ class OrcidValidator extends ConstraintValidator
         $value = (string) $value;
         $canonical = $value;
 
-
         // http://orcid.org/0000-0001-5000-0007
         // ORCIDs are sometimes expressed as URIs
-        if (substr($canonical, 0, 17) === "http://orcid.org/") {
+        if (substr($canonical, 0, 17) === 'http://orcid.org/') {
             $canonical = substr($canonical, 17);
         }
 
@@ -125,7 +124,7 @@ class OrcidValidator extends ConstraintValidator
         $givenCheckDigit = ($canonical{15} === 'x' || $canonical{15} === 'X') ? 10 : (int) $canonical{15};
 
         $sum = 0;
-        for ($i = 0; $i < 15; $i++) {
+        for ($i = 0; $i < 15; ++$i) {
             $sum = ($sum + $canonical{$i}) * 2;
         }
         $remainder = $sum % 11;
@@ -137,6 +136,5 @@ class OrcidValidator extends ConstraintValidator
                 ->setCode(Orcid::CHECKSUM_FAILED_ERROR)
                 ->addViolation();
         }
-
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/OrcidValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/OrcidValidator.php
@@ -1,0 +1,142 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+/**
+ * Validates whether the value is a valid ORCID (Open Researcher and Contributor ID).
+ *
+ * @author Dominic Bordelon <dominicbordelon@gmail.com
+ *
+ * @see http://orcid.org/
+ */
+class OrcidValidator extends ConstraintValidator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof Orcid) {
+            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Orcid');
+        }
+
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString'))) {
+            throw new UnexpectedTypeException($value, 'string');
+        }
+
+        $value = (string) $value;
+        $canonical = $value;
+
+
+        // http://orcid.org/0000-0001-5000-0007
+        // ORCIDs are sometimes expressed as URIs
+        if (substr($canonical, 0, 17) === "http://orcid.org/") {
+            $canonical = substr($canonical, 17);
+        }
+
+        // 0000-0001-5000-0007
+        //     ^    ^    ^
+        $readabilityHyphensPresent = (isset($canonical{4}) && '-' === $canonical{4} &&
+                                      isset($canonical{9}) && '-' === $canonical{9} &&
+                                      isset($canonical{14}) && '-' === $canonical{14});
+
+        if ($readabilityHyphensPresent) {
+            // remove hyphens
+            $canonical = substr($canonical, 0, 4).substr($canonical, 5, 4).substr($canonical, 10, 4).substr($canonical, 15);
+        } elseif ($constraint->requireHyphens) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Orcid::MISSING_HYPHENS_ERROR)
+                ->addViolation();
+
+            return;
+        }
+
+        $length = strlen($canonical);
+
+        if ($length < 16) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Orcid::TOO_SHORT_ERROR)
+                ->addViolation();
+
+            return;
+        }
+
+        if ($length > 16) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Orcid::TOO_LONG_ERROR)
+                ->addViolation();
+
+            return;
+        }
+
+        // 000000015000000X
+        // ^^^^^^^^^^^^^^^ digits only
+        if (!ctype_digit(substr($canonical, 0, 15))) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Orcid::INVALID_CHARACTERS_ERROR)
+                ->addViolation();
+
+            return;
+        }
+
+        // 000000015000000X
+        //                ^ digit, x, or X
+        if (!ctype_digit($canonical{15}) && 'x' !== $canonical{15} && 'X' !== $canonical{15}) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Orcid::INVALID_CHARACTERS_ERROR)
+                ->addViolation();
+
+            return;
+        }
+
+        // 000000015000000X
+        //                ^ case-sensitive?
+        if ($constraint->caseSensitive && 'x' === $canonical{15}) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Orcid::INVALID_CASE_ERROR)
+                ->addViolation();
+
+            return;
+        }
+
+        $givenCheckDigit = ($canonical{15} === 'x' || $canonical{15} === 'X') ? 10 : (int) $canonical{15};
+
+        $sum = 0;
+        for ($i = 0; $i < 15; $i++) {
+            $sum = ($sum + $canonical{$i}) * 2;
+        }
+        $remainder = $sum % 11;
+        $calculatedChecksum = (12 - $remainder) % 11;
+
+        if ($givenCheckDigit !==  $calculatedChecksum) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(Orcid::CHECKSUM_FAILED_ERROR)
+                ->addViolation();
+        }
+
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/OrcidValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/OrcidValidatorTest.php
@@ -1,0 +1,191 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\Orcid;
+use Symfony\Component\Validator\Constraints\OrcidValidator;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+/**
+ * @see http://orcid.org/
+ */
+class OrcidValidatorTest extends ConstraintValidatorTestCase
+{
+    protected function createValidator()
+    {
+        return new OrcidValidator();
+    }
+
+    public function getValidLowerCasedOrcid()
+    {
+        return array(
+            array('0000-0002-5060-860x'),
+            array('0000-0003-1497-153x'),
+            array('0000-0002-4752-937x'),
+            array('0000-0003-0242-271x'),
+            array('0000-0002-7934-453x'),
+            array('6416-1779-1877-482x'),
+            array('8806-8538-5539-947x'),
+        );
+    }
+
+    public function getValidNonHyphenatedOrcid()
+    {
+        return array(
+            array('000000028930008X'),
+            array('0000000271028233'),
+            array('0000000197839598'),
+            array('0000000286629074'),
+            array('0000000276958771'),
+            array('4323660338597675'),
+            array('4977785501386669'),
+        );
+    }
+
+    public function getFullValidOrcid()
+    {
+        return array(
+            array('0000-0002-1072-0023'),
+            array('0000-0002-0767-5639'),
+            array('0000-0002-1992-2596'),
+            array('0000-0002-8968-428X'),
+            array('0000-0003-2171-7580'),
+            array('0000-0002-0704-6816'),
+            array('2128-7213-5528-3868'),
+            array('7385-7401-0622-3537'),
+        );
+    }
+
+    public function getValidOrcid()
+    {
+        return array_merge(
+            $this->getValidLowerCasedOrcid(),
+            $this->getValidNonHyphenatedOrcid(),
+            $this->getFullValidOrcid()
+        );
+    }
+
+    public function getInvalidOrcid()
+    {
+        return array(
+            array(0, Orcid::TOO_SHORT_ERROR),
+            array('5478', Orcid::TOO_SHORT_ERROR),
+            array('0000-0001-9672-186A', Orcid::INVALID_CHARACTERS_ERROR),
+            array('0000-0002-5069-0325', Orcid::CHECKSUM_FAILED_ERROR),
+            array('0000-0002-6182-2774', Orcid::CHECKSUM_FAILED_ERROR),
+            array('0000-0002-3506-8890', Orcid::CHECKSUM_FAILED_ERROR),
+            array('1595-6914-7121-3503', Orcid::CHECKSUM_FAILED_ERROR),
+            array('7075-1299-0098-3944', Orcid::CHECKSUM_FAILED_ERROR),
+        );
+    }
+
+    public function testNullIsValid()
+    {
+        $constraint = new Orcid();
+
+        $this->validator->validate(null, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testEmptyStringIsValid()
+    {
+        $constraint = new Orcid();
+
+        $this->validator->validate('', $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testURIExpressionIsValid()
+    {
+        $constraint = new Orcid();
+
+        $this->validator->validate('http://orcid.org/0000-0002-8968-428X', $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
+     */
+    public function testExpectsStringCompatibleType()
+    {
+        $constraint = new Orcid();
+        $this->validator->validate(new \stdClass(), $constraint);
+    }
+
+    /**
+     * @dataProvider getValidLowerCasedOrcid
+     */
+    public function testCaseSensitiveOrcids($orcid)
+    {
+        $constraint = new Orcid(array(
+            'caseSensitive' => true,
+            'message' => 'myMessage',
+        ));
+
+        $this->validator->validate($orcid, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"'.$orcid.'"')
+            ->setCode(Orcid::INVALID_CASE_ERROR)
+            ->assertRaised();
+    }
+
+    /**
+     * @dataProvider getValidNonHyphenatedOrcid
+     */
+    public function testRequireHyphenOrcids($orcid)
+    {
+        $constraint = new Orcid(array(
+            'requireHyphens' => true,
+            'message' => 'myMessage',
+        ));
+
+        $this->validator->validate($orcid, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"'.$orcid.'"')
+            ->setCode(Orcid::MISSING_HYPHENS_ERROR)
+            ->assertRaised();
+    }
+
+    /**
+     * @dataProvider getValidOrcid
+     */
+    public function testValidOrcid($orcid)
+    {
+        $constraint = new Orcid();
+
+        $this->validator->validate($orcid, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @dataProvider getInvalidOrcid
+     */
+    public function testInvalidOrcid($orcid, $code)
+    {
+        $constraint = new Orcid(array(
+            'message' => 'myMessage',
+        ));
+
+        $this->validator->validate($orcid, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"'.$orcid.'"')
+            ->setCode($code)
+            ->assertRaised();
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

I found myself in need of a validator for ORCIDs (Open Researcher and Contributor IDs, http://orcid.org/), so I did this. Based very heavily on the existing ISSN validator.
