### PR TITLE
[Form] Ensure types of added FormTypes and FormTypeExtensions

### DIFF
--- a/src/Symfony/Component/Form/FormFactoryBuilder.php
+++ b/src/Symfony/Component/Form/FormFactoryBuilder.php
@@ -88,9 +88,7 @@ class FormFactoryBuilder implements FormFactoryBuilderInterface
      */
     public function addTypes(array $types)
     {
-        foreach ($types as $type) {
-            $this->types[$type->getName()] = $type;
-        }
+        array_walk($types, array($this, 'addType'));
 
         return $this;
     }
@@ -110,9 +108,7 @@ class FormFactoryBuilder implements FormFactoryBuilderInterface
      */
     public function addTypeExtensions(array $typeExtensions)
     {
-        foreach ($typeExtensions as $typeExtension) {
-            $this->typeExtensions[$typeExtension->getExtendedType()][] = $typeExtension;
-        }
+        array_walk($typeExtensions, array($this, 'addTypeExtensions'));
 
         return $this;
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

While the doc blocks for both methods `addTypes` and `addTypeExtensions` state they accept `FormTypeInterface[]` and `FormTypeExtensionInterface[]` respectively, there is no type validation. Sadly, web developers are a silly bunch and are prone to sheeplike behaviour. So they might not comply.

An example:

The abstract class `FormIntegrationTestCase.php` passes an array returned from one of its methods:

``` php
// src/Symfony/Component/Form/Test/FormIntegrationTestCase.php
protected function setUp()
{
    $this->factory = Forms::createFormFactoryBuilder()
        ->addExtensions($this->getExtensions())
        ->getFormFactory();
}
```

The Cookbook chapter _How to Unit Test your Forms_ recommends to, under certain circumstances, implement `getExtensions` like this:

``` php
protected function getExtensions()
{
    // create a type instance with the mocked dependencies
    $type = new TestedType($this->entityManager);

    return array(
        // register the type instances with the PreloadedExtension
        new PreloadedExtension(array($type), array()),
    );
}
```

— Source: http://symfony.com/doc/current/cookbook/form/unit_testing.html#testings-types-from-the-service-container

This will throw the error:

```
Error: Call to undefined method Symfony\Component\Form\PreloadedExtension::getExtendedType()
```

Instead, when applying this patch, it will throw the following which seems more sensible to me:

```
TypeError: Argument 1 passed to Symfony\Component\Form\FormFactoryBuilder::addTypeExtension() must implement interface Symfony\Component\Form\FormTypeExtensionInterface, instance of Symfony\Component\Form\PreloadedExtension given
```
