### PR TITLE
[Routing] rename boolean and integer to bool and int

### DIFF
--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 3.2.0
 -----
 
- * Added support for `boolean`, `integer`, `float`, `string`, `list` and `map` defaults.
+ * Added support for `bool`, `int`, `float`, `string`, `list` and `map` defaults in XML configurations.
   
 2.8.0
 -----

--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -261,9 +261,9 @@ class XmlFileLoader extends FileLoader
             return $this->parseDefaultNode($child, $path);
         }
 
-        // If the default element doesn't contain a nested "boolean", "integer",
-        // "float", "string", "list" or "map" element, the element contents will
-        // be treated as the string value of the associated default option.
+        // If the default element doesn't contain a nested "bool", "int", "float",
+        // "string", "list", or "map" element, the element contents will be treated
+        // as the string value of the associated default option.
         return trim($element->textContent);
     }
 
@@ -284,9 +284,9 @@ class XmlFileLoader extends FileLoader
         }
 
         switch ($node->localName) {
-            case 'boolean':
+            case 'bool':
                 return 'true' === trim($node->nodeValue) || '1' === trim($node->nodeValue);
-            case 'integer':
+            case 'int':
                 return (int) trim($node->nodeValue);
             case 'float':
                 return (float) trim($node->nodeValue);
@@ -325,7 +325,7 @@ class XmlFileLoader extends FileLoader
 
                 return $map;
             default:
-                throw new \InvalidArgumentException(sprintf('Unknown tag "%s" used in file "%s". Expected "boolean", "integer", "float", "string", "list" or "map".', $node->localName, $path));
+                throw new \InvalidArgumentException(sprintf('Unknown tag "%s" used in file "%s". Expected "bool", "int", "float", "string", "list", or "map".', $node->localName, $path));
         }
     }
 

--- a/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
+++ b/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
@@ -56,8 +56,8 @@
 
   <xsd:complexType name="default" mixed="true">
     <xsd:choice minOccurs="0" maxOccurs="1">
-      <xsd:element name="boolean" type="xsd:boolean" />
-      <xsd:element name="integer" type="xsd:integer" />
+      <xsd:element name="bool" type="xsd:boolean" />
+      <xsd:element name="int" type="xsd:integer" />
       <xsd:element name="float" type="xsd:float" />
       <xsd:element name="string" type="xsd:string" />
       <xsd:element name="list" type="list" />
@@ -76,8 +76,8 @@
 
   <xsd:complexType name="list">
     <xsd:choice minOccurs="0" maxOccurs="unbounded">
-      <xsd:element name="boolean" nillable="true" type="xsd:boolean" />
-      <xsd:element name="integer" nillable="true" type="xsd:integer" />
+      <xsd:element name="bool" nillable="true" type="xsd:boolean" />
+      <xsd:element name="int" nillable="true" type="xsd:integer" />
       <xsd:element name="float" nillable="true" type="xsd:float" />
       <xsd:element name="string" nillable="true" type="xsd:string" />
       <xsd:element name="list" nillable="true" type="list" />
@@ -87,8 +87,8 @@
 
   <xsd:complexType name="map">
       <xsd:choice minOccurs="0" maxOccurs="unbounded">
-          <xsd:element name="boolean" nillable="true" type="map-boolean-entry" />
-          <xsd:element name="integer" nillable="true" type="map-integer-entry" />
+          <xsd:element name="bool" nillable="true" type="map-bool-entry" />
+          <xsd:element name="int" nillable="true" type="map-int-entry" />
           <xsd:element name="float" nillable="true" type="map-float-entry" />
           <xsd:element name="string" nillable="true" type="map-string-entry" />
           <xsd:element name="list" nillable="true" type="map-list-entry" />
@@ -96,7 +96,7 @@
       </xsd:choice>
   </xsd:complexType>
 
-  <xsd:complexType name="map-boolean-entry">
+  <xsd:complexType name="map-bool-entry">
     <xsd:simpleContent>
       <xsd:extension base="xsd:boolean">
         <xsd:attribute name="key" type="xsd:string" use="required" />
@@ -104,7 +104,7 @@
     </xsd:simpleContent>
   </xsd:complexType>
 
-  <xsd:complexType name="map-integer-entry">
+  <xsd:complexType name="map-int-entry">
     <xsd:simpleContent>
       <xsd:extension base="xsd:integer">
         <xsd:attribute name="key" type="xsd:string" use="required" />

--- a/src/Symfony/Component/Routing/Tests/Fixtures/list_defaults.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/list_defaults.xml
@@ -10,8 +10,8 @@
         </default>
         <default key="values">
             <list>
-                <boolean>true</boolean>
-                <integer>1</integer>
+                <bool>true</bool>
+                <int>1</int>
                 <float>3.5</float>
                 <string>foo</string>
             </list>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/list_in_list_defaults.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/list_in_list_defaults.xml
@@ -11,8 +11,8 @@
         <default key="values">
             <list>
                 <list>
-                    <boolean>true</boolean>
-                    <integer>1</integer>
+                    <bool>true</bool>
+                    <int>1</int>
                     <float>3.5</float>
                     <string>foo</string>
                 </list>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/list_in_map_defaults.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/list_in_map_defaults.xml
@@ -11,8 +11,8 @@
         <default key="values">
             <map>
                 <list key="list">
-                    <boolean>true</boolean>
-                    <integer>1</integer>
+                    <bool>true</bool>
+                    <int>1</int>
                     <float>3.5</float>
                     <string>foo</string>
                 </list>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/list_null_values.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/list_null_values.xml
@@ -10,8 +10,8 @@
         </default>
         <default key="list">
             <list>
-                <boolean xsi:nil="true" />
-                <integer xsi:nil="true" />
+                <bool xsi:nil="true" />
+                <int xsi:nil="true" />
                 <float xsi:nil="1" />
                 <string xsi:nil="true" />
                 <list xsi:nil="true" />

--- a/src/Symfony/Component/Routing/Tests/Fixtures/map_defaults.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/map_defaults.xml
@@ -10,8 +10,8 @@
         </default>
         <default key="values">
             <map>
-                <boolean key="public">true</boolean>
-                <integer key="page">1</integer>
+                <bool key="public">true</bool>
+                <int key="page">1</int>
                 <float key="price">3.5</float>
                 <string key="title">foo</string>
             </map>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/map_in_list_defaults.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/map_in_list_defaults.xml
@@ -11,8 +11,8 @@
         <default key="values">
             <list>
                 <map>
-                    <boolean key="public">true</boolean>
-                    <integer key="page">1</integer>
+                    <bool key="public">true</bool>
+                    <int key="page">1</int>
                     <float key="price">3.5</float>
                     <string key="title">foo</string>
                 </map>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/map_in_map_defaults.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/map_in_map_defaults.xml
@@ -11,8 +11,8 @@
         <default key="values">
             <map>
                 <map key="map">
-                    <boolean key="public">true</boolean>
-                    <integer key="page">1</integer>
+                    <bool key="public">true</bool>
+                    <int key="page">1</int>
                     <float key="price">3.5</float>
                     <string key="title">foo</string>
                 </map>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/map_null_values.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/map_null_values.xml
@@ -10,8 +10,8 @@
         </default>
         <default key="map">
             <map>
-                <boolean key="boolean" xsi:nil="true" />
-                <integer key="integer" xsi:nil="true" />
+                <bool key="boolean" xsi:nil="true" />
+                <int key="integer" xsi:nil="true" />
                 <float key="float" xsi:nil="true" />
                 <string key="string" xsi:nil="1" />
                 <list key="list" xsi:nil="true" />

--- a/src/Symfony/Component/Routing/Tests/Fixtures/namespaceprefix.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/namespaceprefix.xml
@@ -10,7 +10,7 @@
         <r2:requirement xmlns:r2="http://symfony.com/schema/routing" key="_locale">en|fr|de</r2:requirement>
         <r:option key="compiler_class">RouteCompiler</r:option>
         <r:default key="page">
-            <r3:integer xmlns:r3="http://symfony.com/schema/routing">1</r3:integer>
+            <r3:int xmlns:r3="http://symfony.com/schema/routing">1</r3:int>
         </r:default>
     </r:route>
 </r:routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/scalar_defaults.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/scalar_defaults.xml
@@ -10,22 +10,22 @@
         </default>
         <default key="slug" xsi:nil="true" />
         <default key="published">
-            <boolean>true</boolean>
+            <bool>true</bool>
         </default>
         <default key="page">
-            <integer>1</integer>
+            <int>1</int>
         </default>
         <default key="price">
             <float>3.5</float>
         </default>
         <default key="archived">
-            <boolean>false</boolean>
+            <bool>false</bool>
         </default>
         <default key="free">
-            <boolean>1</boolean>
+            <bool>1</bool>
         </default>
         <default key="locked">
-            <boolean>0</boolean>
+            <bool>0</bool>
         </default>
         <default key="foo" xsi:nil="true" />
         <default key="bar" xsi:nil="1" />


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/pull/11394#issuecomment-228075328 |
| License | MIT |
| Doc PR |  |

This addresses @Tobion's comment in https://github.com/symfony/symfony/pull/11394#issuecomment-228075328.

@symfony/deciders What do you think? Should we change the element names to how we use the types in PHP code or should we stick with XML element names that rather match the types as defined by the XML schema?
