### PR TITLE
[WebProfilerBundle] Added a conflict for Http-Kernel < 3.1

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "symfony/http-kernel": "~2.8|~3.0",
+        "symfony/http-kernel": "~3.1",
         "symfony/routing": "~2.8|~3.0",
         "symfony/twig-bridge": "~2.8|~3.0"
     },


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/silexphp/Silex-WebProfiler/issues/94 |
| License | MIT |
| Doc PR | ~ |
