### PR TITLE
[2.7][meta/CS] no_extra_consecutive_blank_lines results

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -31,5 +31,7 @@ return Symfony\CS\Config\Config::create()
             ->notPath('src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/Resources/Custom/_name_entry_label.html.php')
             // explicit heredoc test
             ->notPath('src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Resources/views/translation.html.php')
+            // fixture test
+            ->notPath('src/Symfony/Component/Debug/Resources/ext/tests/003.phpt')
     )
 ;

--- a/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
@@ -102,20 +102,16 @@ class XmlReferenceDumper
                             case 'Symfony\Component\Config\Definition\ScalarNode':
                                 $prototypeValue = 'scalar value';
                                 break;
-
                             case 'Symfony\Component\Config\Definition\FloatNode':
                             case 'Symfony\Component\Config\Definition\IntegerNode':
                                 $prototypeValue = 'numeric value';
                                 break;
-
                             case 'Symfony\Component\Config\Definition\BooleanNode':
                                 $prototypeValue = 'true|false';
                                 break;
-
                             case 'Symfony\Component\Config\Definition\EnumNode':
                                 $prototypeValue = implode('|', array_map('json_encode', $prototype->getValues()));
                                 break;
-
                             default:
                                 $prototypeValue = 'value';
                         }

--- a/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
@@ -60,12 +60,10 @@ class SymfonyQuestionHelper extends QuestionHelper
                 $text = sprintf(' <info>%s</info>:', $text);
 
                 break;
-
             case $question instanceof ConfirmationQuestion:
                 $text = sprintf(' <info>%s (yes/no)</info> [<comment>%s</comment>]:', $text, $default ? 'yes' : 'no');
 
                 break;
-
             case $question instanceof ChoiceQuestion && $question->isMultiSelect():
                 $choices = $question->getChoices();
                 $default = explode(',', $default);
@@ -77,13 +75,11 @@ class SymfonyQuestionHelper extends QuestionHelper
                 $text = sprintf(' <info>%s</info> [<comment>%s</comment>]:', $text, implode(', ', $default));
 
                 break;
-
             case $question instanceof ChoiceQuestion:
                 $choices = $question->getChoices();
                 $text = sprintf(' <info>%s</info> [<comment>%s</comment>]:', $text, $choices[$default]);
 
                 break;
-
             default:
                 $text = sprintf(' <info>%s</info> [<comment>%s</comment>]:', $text, $default);
         }

--- a/src/Symfony/Component/Console/Helper/TableHelper.php
+++ b/src/Symfony/Component/Console/Helper/TableHelper.php
@@ -58,15 +58,12 @@ class TableHelper extends Helper
             case self::LAYOUT_BORDERLESS:
                 $this->table->setStyle('borderless');
                 break;
-
             case self::LAYOUT_COMPACT:
                 $this->table->setStyle('compact');
                 break;
-
             case self::LAYOUT_DEFAULT:
                 $this->table->setStyle('default');
                 break;
-
             default:
                 throw new \InvalidArgumentException(sprintf('Invalid table layout "%s".', $layout));
         }

--- a/src/Symfony/Component/CssSelector/XPath/Extension/FunctionExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/FunctionExtension.php
@@ -98,7 +98,6 @@ class FunctionExtension extends AbstractExtension
         }
 
         return $xpath->addCondition(implode(' and ', $conditions));
-
         // todo: handle an+b, odd, even
         // an+b means every-a, plus b, e.g., 2n+1 means odd
         // 0n+b means b

--- a/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
@@ -37,7 +37,6 @@ class GetAttrNode extends Node
                     ->raw($this->nodes['attribute']->attributes['value'])
                 ;
                 break;
-
             case self::METHOD_CALL:
                 $compiler
                     ->compile($this->nodes['node'])
@@ -48,7 +47,6 @@ class GetAttrNode extends Node
                     ->raw(')')
                 ;
                 break;
-
             case self::ARRAY_CALL:
                 $compiler
                     ->compile($this->nodes['node'])
@@ -71,7 +69,6 @@ class GetAttrNode extends Node
                 $property = $this->nodes['attribute']->attributes['value'];
 
                 return $obj->$property;
-
             case self::METHOD_CALL:
                 $obj = $this->nodes['node']->evaluate($functions, $values);
                 if (!is_object($obj)) {
@@ -79,7 +76,6 @@ class GetAttrNode extends Node
                 }
 
                 return call_user_func_array(array($obj, $this->nodes['attribute']->attributes['value']), $this->nodes['arguments']->evaluate($functions, $values));
-
             case self::ARRAY_CALL:
                 $array = $this->nodes['node']->evaluate($functions, $values);
                 if (!is_array($array) && !$array instanceof \ArrayAccess) {

--- a/src/Symfony/Component/ExpressionLanguage/Parser.php
+++ b/src/Symfony/Component/ExpressionLanguage/Parser.php
@@ -183,15 +183,12 @@ class Parser
                     case 'true':
                     case 'TRUE':
                         return new Node\ConstantNode(true);
-
                     case 'false':
                     case 'FALSE':
                         return new Node\ConstantNode(false);
-
                     case 'null':
                     case 'NULL':
                         return new Node\ConstantNode(null);
-
                     default:
                         if ('(' === $this->stream->current->value) {
                             if (false === isset($this->functions[$token->value])) {
@@ -214,13 +211,11 @@ class Parser
                         }
                 }
                 break;
-
             case Token::NUMBER_TYPE:
             case Token::STRING_TYPE:
                 $this->stream->next();
 
                 return new Node\ConstantNode($token->value);
-
             default:
                 if ($token->test(Token::PUNCTUATION_TYPE, '[')) {
                     $node = $this->parseArrayExpression();

--- a/src/Symfony/Component/Form/Extension/HttpFoundation/EventListener/BindRequestListener.php
+++ b/src/Symfony/Component/Form/Extension/HttpFoundation/EventListener/BindRequestListener.php
@@ -58,7 +58,6 @@ class BindRequestListener implements EventSubscriberInterface
                     : $request->query->get($name, $default);
 
                 break;
-
             default:
                 if ('' === $name) {
                     // Form bound without name

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
@@ -95,67 +95,49 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
                     case 'boolean':
                     case 'bool':
                         return new TypeGuess('checkbox', array(), Guess::MEDIUM_CONFIDENCE);
-
                     case 'double':
                     case 'float':
                     case 'numeric':
                     case 'real':
                         return new TypeGuess('number', array(), Guess::MEDIUM_CONFIDENCE);
-
                     case 'integer':
                     case 'int':
                     case 'long':
                         return new TypeGuess('integer', array(), Guess::MEDIUM_CONFIDENCE);
-
                     case '\DateTime':
                         return new TypeGuess('date', array(), Guess::MEDIUM_CONFIDENCE);
-
                     case 'string':
                         return new TypeGuess('text', array(), Guess::LOW_CONFIDENCE);
                 }
                 break;
-
             case 'Symfony\Component\Validator\Constraints\Country':
                 return new TypeGuess('country', array(), Guess::HIGH_CONFIDENCE);
-
             case 'Symfony\Component\Validator\Constraints\Date':
                 return new TypeGuess('date', array('input' => 'string'), Guess::HIGH_CONFIDENCE);
-
             case 'Symfony\Component\Validator\Constraints\DateTime':
                 return new TypeGuess('datetime', array('input' => 'string'), Guess::HIGH_CONFIDENCE);
-
             case 'Symfony\Component\Validator\Constraints\Email':
                 return new TypeGuess('email', array(), Guess::HIGH_CONFIDENCE);
-
             case 'Symfony\Component\Validator\Constraints\File':
             case 'Symfony\Component\Validator\Constraints\Image':
                 return new TypeGuess('file', array(), Guess::HIGH_CONFIDENCE);
-
             case 'Symfony\Component\Validator\Constraints\Language':
                 return new TypeGuess('language', array(), Guess::HIGH_CONFIDENCE);
-
             case 'Symfony\Component\Validator\Constraints\Locale':
                 return new TypeGuess('locale', array(), Guess::HIGH_CONFIDENCE);
-
             case 'Symfony\Component\Validator\Constraints\Time':
                 return new TypeGuess('time', array('input' => 'string'), Guess::HIGH_CONFIDENCE);
-
             case 'Symfony\Component\Validator\Constraints\Url':
                 return new TypeGuess('url', array(), Guess::HIGH_CONFIDENCE);
-
             case 'Symfony\Component\Validator\Constraints\Ip':
                 return new TypeGuess('text', array(), Guess::MEDIUM_CONFIDENCE);
-
             case 'Symfony\Component\Validator\Constraints\Length':
             case 'Symfony\Component\Validator\Constraints\Regex':
                 return new TypeGuess('text', array(), Guess::LOW_CONFIDENCE);
-
             case 'Symfony\Component\Validator\Constraints\Range':
                 return new TypeGuess('number', array(), Guess::LOW_CONFIDENCE);
-
             case 'Symfony\Component\Validator\Constraints\Count':
                 return new TypeGuess('collection', array(), Guess::LOW_CONFIDENCE);
-
             case 'Symfony\Component\Validator\Constraints\True':
             case 'Symfony\Component\Validator\Constraints\False':
             case 'Symfony\Component\Validator\Constraints\IsTrue':
@@ -197,13 +179,11 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
                     return new ValueGuess($constraint->max, Guess::HIGH_CONFIDENCE);
                 }
                 break;
-
             case 'Symfony\Component\Validator\Constraints\Type':
                 if (in_array($constraint->type, array('double', 'float', 'numeric', 'real'))) {
                     return new ValueGuess(null, Guess::MEDIUM_CONFIDENCE);
                 }
                 break;
-
             case 'Symfony\Component\Validator\Constraints\Range':
                 if (is_numeric($constraint->max)) {
                     return new ValueGuess(strlen((string) $constraint->max), Guess::LOW_CONFIDENCE);
@@ -227,7 +207,6 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
                     return new ValueGuess(sprintf('.{%s,}', (string) $constraint->min), Guess::LOW_CONFIDENCE);
                 }
                 break;
-
             case 'Symfony\Component\Validator\Constraints\Regex':
                 $htmlPattern = $constraint->getHtmlPattern();
 
@@ -235,13 +214,11 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
                     return new ValueGuess($htmlPattern, Guess::HIGH_CONFIDENCE);
                 }
                 break;
-
             case 'Symfony\Component\Validator\Constraints\Range':
                 if (is_numeric($constraint->min)) {
                     return new ValueGuess(sprintf('.{%s,}', strlen((string) $constraint->min)), Guess::LOW_CONFIDENCE);
                 }
                 break;
-
             case 'Symfony\Component\Validator\Constraints\Type':
                 if (in_array($constraint->type, array('double', 'float', 'numeric', 'real'))) {
                     return new ValueGuess(null, Guess::MEDIUM_CONFIDENCE);

--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -206,19 +206,14 @@ class JsonResponse extends Response
         switch (json_last_error()) {
             case JSON_ERROR_DEPTH:
                 return 'Maximum stack depth exceeded.';
-
             case JSON_ERROR_STATE_MISMATCH:
                 return 'Underflow or the modes mismatch.';
-
             case JSON_ERROR_CTRL_CHAR:
                 return 'Unexpected control character found.';
-
             case JSON_ERROR_SYNTAX:
                 return 'Syntax error, malformed JSON.';
-
             case JSON_ERROR_UTF8:
                 return 'Malformed UTF-8 characters, possibly incorrectly encoded.';
-
             default:
                 return 'Unknown error.';
         }

--- a/src/Symfony/Component/Process/Exception/ProcessTimedOutException.php
+++ b/src/Symfony/Component/Process/Exception/ProcessTimedOutException.php
@@ -58,10 +58,8 @@ class ProcessTimedOutException extends RuntimeException
         switch ($this->timeoutType) {
             case self::TYPE_GENERAL:
                 return $this->process->getTimeout();
-
             case self::TYPE_IDLE:
                 return $this->process->getIdleTimeout();
-
             default:
                 throw new \LogicException(sprintf('Unknown timeout type "%d".', $this->timeoutType));
         }

--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
@@ -108,12 +108,10 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
             switch ($result) {
                 case VoterInterface::ACCESS_GRANTED:
                     return true;
-
                 case VoterInterface::ACCESS_DENIED:
                     ++$deny;
 
                     break;
-
                 default:
                     break;
             }
@@ -153,12 +151,10 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
                     ++$grant;
 
                     break;
-
                 case VoterInterface::ACCESS_DENIED:
                     ++$deny;
 
                     break;
-
                 default:
                     ++$abstain;
 
@@ -199,10 +195,8 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
                         ++$grant;
 
                         break;
-
                     case VoterInterface::ACCESS_DENIED:
                         return false;
-
                     default:
                         break;
                 }

--- a/src/Symfony/Component/Security/Http/Session/SessionAuthenticationStrategy.php
+++ b/src/Symfony/Component/Security/Http/Session/SessionAuthenticationStrategy.php
@@ -45,7 +45,6 @@ class SessionAuthenticationStrategy implements SessionAuthenticationStrategyInte
         switch ($this->strategy) {
             case self::NONE:
                 return;
-
             case self::MIGRATE:
                 // Destroying the old session is broken in php 5.4.0 - 5.4.10
                 // See php bug #63379
@@ -53,12 +52,10 @@ class SessionAuthenticationStrategy implements SessionAuthenticationStrategyInte
                 $request->getSession()->migrate($destroy);
 
                 return;
-
             case self::INVALIDATE:
                 $request->getSession()->invalidate();
 
                 return;
-
             default:
                 throw new \RuntimeException(sprintf('Invalid session authentication strategy "%s"', $this->strategy));
         }

--- a/src/Symfony/Component/Templating/Asset/UrlPackage.php
+++ b/src/Symfony/Component/Templating/Asset/UrlPackage.php
@@ -75,10 +75,8 @@ class UrlPackage extends Package
         switch ($count = count($this->baseUrls)) {
             case 0:
                 return '';
-
             case 1:
                 return $this->baseUrls[0];
-
             default:
                 return $this->baseUrls[fmod(hexdec(substr(hash('sha256', $path), 0, 10)), $count)];
         }

--- a/src/Symfony/Component/Translation/PluralizationRules.php
+++ b/src/Symfony/Component/Translation/PluralizationRules.php
@@ -72,7 +72,6 @@ class PluralizationRules
             case 'zh':
                 return 0;
                 break;
-
             case 'af':
             case 'bn':
             case 'bg':
@@ -124,7 +123,6 @@ class PluralizationRules
             case 'ur':
             case 'zu':
                 return ($number == 1) ? 0 : 1;
-
             case 'am':
             case 'bh':
             case 'fil':
@@ -139,7 +137,6 @@ class PluralizationRules
             case 'ti':
             case 'wa':
                 return (($number == 0) || ($number == 1)) ? 0 : 1;
-
             case 'be':
             case 'bs':
             case 'hr':
@@ -147,41 +144,29 @@ class PluralizationRules
             case 'sr':
             case 'uk':
                 return (($number % 10 == 1) && ($number % 100 != 11)) ? 0 : ((($number % 10 >= 2) && ($number % 10 <= 4) && (($number % 100 < 10) || ($number % 100 >= 20))) ? 1 : 2);
-
             case 'cs':
             case 'sk':
                 return ($number == 1) ? 0 : ((($number >= 2) && ($number <= 4)) ? 1 : 2);
-
             case 'ga':
                 return ($number == 1) ? 0 : (($number == 2) ? 1 : 2);
-
             case 'lt':
                 return (($number % 10 == 1) && ($number % 100 != 11)) ? 0 : ((($number % 10 >= 2) && (($number % 100 < 10) || ($number % 100 >= 20))) ? 1 : 2);
-
             case 'sl':
                 return ($number % 100 == 1) ? 0 : (($number % 100 == 2) ? 1 : ((($number % 100 == 3) || ($number % 100 == 4)) ? 2 : 3));
-
             case 'mk':
                 return ($number % 10 == 1) ? 0 : 1;
-
             case 'mt':
                 return ($number == 1) ? 0 : ((($number == 0) || (($number % 100 > 1) && ($number % 100 < 11))) ? 1 : ((($number % 100 > 10) && ($number % 100 < 20)) ? 2 : 3));
-
             case 'lv':
                 return ($number == 0) ? 0 : ((($number % 10 == 1) && ($number % 100 != 11)) ? 1 : 2);
-
             case 'pl':
                 return ($number == 1) ? 0 : ((($number % 10 >= 2) && ($number % 10 <= 4) && (($number % 100 < 12) || ($number % 100 > 14))) ? 1 : 2);
-
             case 'cy':
                 return ($number == 1) ? 0 : (($number == 2) ? 1 : ((($number == 8) || ($number == 11)) ? 2 : 3));
-
             case 'ro':
                 return ($number == 1) ? 0 : ((($number == 0) || (($number % 100 > 0) && ($number % 100 < 20))) ? 1 : 2);
-
             case 'ar':
                 return ($number == 0) ? 0 : (($number == 1) ? 1 : (($number == 2) ? 2 : ((($number % 100 >= 3) && ($number % 100 <= 10)) ? 3 : ((($number % 100 >= 11) && ($number % 100 <= 99)) ? 4 : 5))));
-
             default:
                 return 0;
         }

--- a/src/Symfony/Component/Validator/Constraints/IpValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IpValidator.php
@@ -47,47 +47,36 @@ class IpValidator extends ConstraintValidator
             case Ip::V4:
                $flag = FILTER_FLAG_IPV4;
                break;
-
             case Ip::V6:
                $flag = FILTER_FLAG_IPV6;
                break;
-
             case Ip::V4_NO_PRIV:
                $flag = FILTER_FLAG_IPV4 | FILTER_FLAG_NO_PRIV_RANGE;
                break;
-
             case Ip::V6_NO_PRIV:
                $flag = FILTER_FLAG_IPV6 | FILTER_FLAG_NO_PRIV_RANGE;
                break;
-
             case Ip::ALL_NO_PRIV:
                $flag = FILTER_FLAG_NO_PRIV_RANGE;
                break;
-
             case Ip::V4_NO_RES:
                $flag = FILTER_FLAG_IPV4 | FILTER_FLAG_NO_RES_RANGE;
                break;
-
             case Ip::V6_NO_RES:
                $flag = FILTER_FLAG_IPV6 | FILTER_FLAG_NO_RES_RANGE;
                break;
-
             case Ip::ALL_NO_RES:
                $flag = FILTER_FLAG_NO_RES_RANGE;
                break;
-
             case Ip::V4_ONLY_PUBLIC:
                $flag = FILTER_FLAG_IPV4 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE;
                break;
-
             case Ip::V6_ONLY_PUBLIC:
                $flag = FILTER_FLAG_IPV6 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE;
                break;
-
             case Ip::ALL_ONLY_PUBLIC:
                $flag = FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE;
                break;
-
             default:
                 $flag = null;
                 break;

--- a/src/Symfony/Component/VarDumper/Caster/CutStub.php
+++ b/src/Symfony/Component/VarDumper/Caster/CutStub.php
@@ -30,13 +30,11 @@ class CutStub extends Stub
                 $this->class = get_class($value);
                 $this->cut = -1;
                 break;
-
             case 'array':
                 $this->type = self::TYPE_ARRAY;
                 $this->class = self::ARRAY_ASSOC;
                 $this->cut = $this->value = count($value);
                 break;
-
             case 'resource':
             case 'unknown type':
                 $this->type = self::TYPE_RESOURCE;
@@ -44,7 +42,6 @@ class CutStub extends Stub
                 $this->class = @get_resource_type($value);
                 $this->cut = -1;
                 break;
-
             case 'string':
                 $this->type = self::TYPE_STRING;
                 $this->class = preg_match('//u', $value) ? self::STRING_UTF8 : self::STRING_BINARY;

--- a/src/Symfony/Component/VarDumper/Cloner/Data.php
+++ b/src/Symfony/Component/VarDumper/Cloner/Data.php
@@ -174,7 +174,6 @@ class Data
                 case Stub::TYPE_STRING:
                     $dumper->dumpString($cursor, $item->value, Stub::STRING_BINARY === $item->class, $cut);
                     break;
-
                 case Stub::TYPE_ARRAY:
                     $item = clone $item;
                     $item->type = $item->class;
@@ -191,7 +190,6 @@ class Data
                     }
                     $dumper->leaveHash($cursor, $item->type, $item->class, $withChildren, $cut);
                     break;
-
                 default:
                     throw new \RuntimeException(sprintf('Unexpected Stub type: %s', $item->type));
             }

--- a/src/Symfony/Component/VarDumper/Cloner/VarCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/VarCloner.php
@@ -110,10 +110,8 @@ class VarCloner extends AbstractCloner
                             $stub->value = iconv_substr($v, 0, $maxString, 'UTF-8');
                         }
                         break;
-
                     case 'integer':
                         break;
-
                     case 'array':
                         if ($v) {
                             $stub = $arrayRefs[$len] = new Stub();
@@ -139,7 +137,6 @@ class VarCloner extends AbstractCloner
                             $stub->value = $zval['array_count'] ?: count($a);
                         }
                         break;
-
                     case 'object':
                         if (empty($objRefs[$h = $zval['object_handle'] ?: ($hashMask ^ hexdec(substr(spl_object_hash($v), $hashOffset, PHP_INT_SIZE)))])) {
                             $stub = new Stub();
@@ -175,7 +172,6 @@ class VarCloner extends AbstractCloner
                             $a = null;
                         }
                         break;
-
                     case 'resource':
                     case 'unknown type':
                         if (empty($resRefs[$h = (int) $v])) {

--- a/src/Symfony/Component/VarDumper/Dumper/AbstractDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/AbstractDumper.php
@@ -206,12 +206,10 @@ abstract class AbstractDumper implements DataDumperInterface, DumperInterface
                 case $s[$i] < "\x80":
                     $s[$j] = $s[$i];
                     break;
-
                 case $s[$i] < "\xC0":
                     $s[$j] = "\xC2";
                     $s[++$j] = $s[$i];
                     break;
-
                 default:
                     $s[$j] = "\xC3";
                     $s[++$j] = chr(ord($s[$i]) - 64);

--- a/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
@@ -120,7 +120,6 @@ class CliDumper extends AbstractDumper
             case 'integer':
                 $style = 'num';
                 break;
-
             case 'double':
                 $style = 'num';
 
@@ -136,15 +135,12 @@ class CliDumper extends AbstractDumper
                         break;
                 }
                 break;
-
             case 'NULL':
                 $value = 'null';
                 break;
-
             case 'boolean':
                 $value = $value ? 'true' : 'false';
                 break;
-
             default:
                 $attr['value'] = isset($value[0]) && !preg_match('//u', $value) ? $this->utf8Encode($value) : $value;
                 $value = isset($type[0]) && !preg_match('//u', $type) ? $this->utf8Encode($type) : $type;
@@ -324,7 +320,6 @@ class CliDumper extends AbstractDumper
                         $this->line .= $bin.'"'.$this->style($style, $key).'" => ';
                     }
                     break;
-
                 case Cursor::HASH_RESOURCE:
                     $key = "\0~\0".$key;
                     // No break;
@@ -436,7 +431,6 @@ class CliDumper extends AbstractDumper
                         case '--color=force':
                         case '--color=always':
                             return static::$defaultColors = true;
-
                         case '--no-ansi':
                         case '--color=no':
                         case '--color=none':


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

This is an acceptance test for the configuration of PHP-CS-Fixer 2.x fixer `NoExtraConsecutiveBlankLinesFixer`.
Configuration options are; no blank line after token of kind:
- `break`
- `continue`
- `return`
- `throw`
- `use`
- `}`

(note: if the tokens are part of an one line statement the rule is not applied)

and;
- no consecutive blank lines (`extra`)

Please let me know what style (and thereby configuration) the SF community prefers.

For discussion about the fixer itself and for reference: https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2010

The goal is not to see this PR merged (as merging conflict it the future makes it not worth it).
