### PR TITLE
[CS] Respect PSR2 4.2

### DIFF
--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Fixtures/includes/foo.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Fixtures/includes/foo.php
@@ -2,9 +2,14 @@
 
 class ProxyManagerBridgeFooClass
 {
-    public $foo, $moo;
+    public $foo;
+    public $moo;
 
-    public $bar = null, $initialized = false, $configured = false, $called = false, $arguments = array();
+    public $bar = null;
+    public $initialized = false;
+    public $configured = false;
+    public $called = false;
+    public $arguments = array();
 
     public function __construct($arguments = array())
     {

--- a/src/Symfony/Component/Console/Tests/Input/InputDefinitionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputDefinitionTest.php
@@ -19,7 +19,10 @@ class InputDefinitionTest extends \PHPUnit_Framework_TestCase
 {
     protected static $fixtures;
 
-    protected $foo, $bar, $foo1, $foo2;
+    protected $foo;
+    protected $bar;
+    protected $foo1;
+    protected $foo2;
 
     public static function setUpBeforeClass()
     {

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -599,7 +599,9 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
 class ProjectServiceContainer extends Container
 {
-    public $__bar, $__foo_bar, $__foo_baz;
+    public $__bar;
+    public $__foo_bar;
+    public $__foo_baz;
     public $synchronized;
 
     public function __construct()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/foo.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/foo.php
@@ -4,9 +4,14 @@ namespace Bar;
 
 class FooClass
 {
-    public $foo, $moo;
+    public $foo;
+    public $moo;
 
-    public $bar = null, $initialized = false, $configured = false, $called = false, $arguments = array();
+    public $bar = null;
+    public $initialized = false;
+    public $configured = false;
+    public $called = false;
+    public $arguments = array();
 
     public function __construct($arguments = array())
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | 2.7 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

http://www.php-fig.org/psr/psr-2/#4-2-properties

I'm writing a [new fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/1889) (`single_class_element_per_statement`), which intends to avoid multiple class elements in one statement.
This PR is a POC about the result of this fixer, so I'd like to know what do you think about, since it will be also added to the `@Symfony` ruleset.
Please note that class constants are considered too, but here isn't any offending code about that.

Example output:

```
$ ./php-cs-fixer.phar fix . --rules=single_class_element_per_statement -vvv
   1) src/Symfony/Component/Console/Tests/Input/InputDefinitionTest.php (single_class_element_per_statement)
   2) src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php (single_class_element_per_statement)
   3) src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/foo.php (single_class_element_per_statement)
   4) src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/Fixtures/includes/foo.php (single_class_element_per_statement)
```
