### PR TITLE
Replace phpunit-bridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
         "symfony/locale": "self.version",
         "symfony/monolog-bridge": "self.version",
         "symfony/options-resolver": "self.version",
+        "symfony/phpunit-bridge": "self.version",
         "symfony/process": "self.version",
         "symfony/property-access": "self.version",
         "symfony/proxy-manager-bridge": "self.version",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

Composer is installing the phpunit-bridge twice (with different versions), im not sure its intended from a symfony-standard pov but we should avoid it by default i guess.
