### PR TITLE
[Console] Fix formatting of SymfonyStyle::comment()

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_1.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_1.txt
@@ -1,3 +1,3 @@
 
- // This service is an alias for the service [32mservice_1[39m                                                                  
+[39;49m // [39;49mThis service is an alias for the service [32mservice_1[39m                                                                  
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_2.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_2.txt
@@ -1,3 +1,3 @@
 
- // This service is an alias for the service [32mservice_2[39m                                                                  
+[39;49m // [39;49mThis service is an alias for the service [32mservice_2[39m                                                                  
 

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -66,53 +66,10 @@ class SymfonyStyle extends OutputStyle
      */
     public function block($messages, $type = null, $style = null, $prefix = ' ', $padding = false)
     {
-        $this->autoPrependBlock();
         $messages = is_array($messages) ? array_values($messages) : array($messages);
-        $indentLength = 0;
-        $lines = array();
 
-        if (null !== $type) {
-            $typePrefix = sprintf('[%s] ', $type);
-            $indentLength = strlen($typePrefix);
-            $lineIndentation = str_repeat(' ', $indentLength);
-        }
-
-        // wrap and add newlines for each element
-        foreach ($messages as $key => $message) {
-            $message = OutputFormatter::escape($message);
-            $lines = array_merge($lines, explode(PHP_EOL, wordwrap($message, $this->lineLength - Helper::strlen($prefix) - $indentLength, PHP_EOL, true)));
-
-            // prefix each line with a number of spaces equivalent to the type length
-            if (null !== $type) {
-                foreach ($lines as &$line) {
-                    $line = $lineIndentation === substr($line, 0, $indentLength) ? $line : $lineIndentation.$line;
-                }
-            }
-
-            if (count($messages) > 1 && $key < count($messages) - 1) {
-                $lines[] = '';
-            }
-        }
-
-        if (null !== $type) {
-            $lines[0] = substr_replace($lines[0], $typePrefix, 0, $indentLength);
-        }
-
-        if ($padding && $this->isDecorated()) {
-            array_unshift($lines, '');
-            $lines[] = '';
-        }
-
-        foreach ($lines as &$line) {
-            $line = sprintf('%s%s', $prefix, $line);
-            $line .= str_repeat(' ', $this->lineLength - Helper::strlenWithoutDecoration($this->getFormatter(), $line));
-
-            if ($style) {
-                $line = sprintf('<%s>%s</>', $style, $line);
-            }
-        }
-
-        $this->writeln($lines);
+        $this->autoPrependBlock();
+        $this->writeln($this->createBlock($messages, $type, $style, $prefix, $padding, true));
         $this->newLine();
     }
 
@@ -177,11 +134,10 @@ class SymfonyStyle extends OutputStyle
     public function comment($message)
     {
         $messages = is_array($message) ? array_values($message) : array($message);
-        foreach ($messages as &$message) {
-            $message = $this->getFormatter()->format($message);
-        }
 
-        $this->block($messages, null, null, ' // ');
+        $this->autoPrependBlock();
+        $this->writeln($this->createBlock($messages, null, null, '<fg=default;bg=default> // </>'));
+        $this->newLine();
     }
 
     /**
@@ -436,5 +392,51 @@ class SymfonyStyle extends OutputStyle
         return array_map(function ($value) {
             return substr($value, -4);
         }, array_merge(array($this->bufferedOutput->fetch()), (array) $messages));
+    }
+
+    private function createBlock($messages, $type = null, $style = null, $prefix = ' ', $padding = false, $escape = false)
+    {
+        $indentLength = 0;
+        $prefixLength = Helper::strlenWithoutDecoration($this->getFormatter(), $prefix);
+        $lines = array();
+
+        if (null !== $type) {
+            $type = sprintf('[%s] ', $type);
+            $indentLength = strlen($type);
+            $lineIndentation = str_repeat(' ', $indentLength);
+        }
+
+        // wrap and add newlines for each element
+        foreach ($messages as $key => $message) {
+            if ($escape) {
+                $message = OutputFormatter::escape($message);
+            }
+
+            $lines = array_merge($lines, explode(PHP_EOL, wordwrap($message, $this->lineLength - $prefixLength - $indentLength, PHP_EOL, true)));
+
+            if (count($messages) > 1 && $key < count($messages) - 1) {
+                $lines[] = '';
+            }
+        }
+
+        foreach ($lines as $i => &$line) {
+            if (null !== $type) {
+                $line = 0 === $i ? $type.$line : $lineIndentation.$line;
+            }
+
+            $line = $prefix.$line;
+            $line .= str_repeat(' ', $this->lineLength - Helper::strlenWithoutDecoration($this->getFormatter(), $line));
+
+            if ($style) {
+                $line = sprintf('<%s>%s</>', $style, $line);
+            }
+        }
+
+        if ($padding && $this->isDecorated()) {
+            array_unshift($lines, '');
+            $lines[] = '';
+        }
+
+        return $lines;
     }
 }

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_13.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_13.php
@@ -1,0 +1,15 @@
+<?php
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tests\Style\SymfonyStyleWithForcedLineLength;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+// ensure that nested tags have no effect on the color of the '//' prefix
+return function (InputInterface $input, OutputInterface $output) {
+    $output->setDecorated(true);
+    $output = new SymfonyStyle($input, $output);
+    $output->comment(
+        'Lorem ipsum dolor sit <comment>amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</comment> Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum'
+    );
+};

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_14.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_14.php
@@ -1,0 +1,17 @@
+<?php
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tests\Style\SymfonyStyleWithForcedLineLength;
+
+// ensure that block() behaves properly with a prefix and without type
+return function (InputInterface $input, OutputInterface $output) {
+    $output = new SymfonyStyleWithForcedLineLength($input, $output);
+    $output->block(
+        'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum',
+        null,
+        null,
+        '$ ',
+        true
+    );
+};

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_15.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_15.php
@@ -1,0 +1,14 @@
+<?php
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tests\Style\SymfonyStyleWithForcedLineLength;
+
+// ensure that block() behaves properly with a type and without prefix
+return function (InputInterface $input, OutputInterface $output) {
+    $output = new SymfonyStyleWithForcedLineLength($input, $output);
+    $output->block(
+        'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum',
+        'TEST'
+    );
+};

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_13.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_13.txt
@@ -1,0 +1,7 @@
+
+[39;49m // [39;49mLorem ipsum dolor sit [33mamet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et             [39m
+[39;49m // [39;49m[33mdolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea       [39m
+[39;49m // [39;49m[33mcommodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla     [39m
+[39;49m // [39;49m[33mpariatur.[39m Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim            
+[39;49m // [39;49mid est laborum                                                                                                      
+

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_14.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_14.txt
@@ -1,0 +1,6 @@
+
+$ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna  
+$ aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.   
+$ Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint 
+$ occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum                        
+

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_15.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_15.txt
@@ -1,0 +1,7 @@
+
+ [TEST] Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore  
+        magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo  
+        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla         
+        pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est 
+        laborum                                                                                                         
+


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #19172 |
| License | MIT |
| Doc PR | n/a |

This:

``` php
$io->comment('Lorem ipsum dolor sit amet, consectetur adipisicing elit, <comment>sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat </comment>cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.');
```

Before outputs:

![](http://image.prntscr.com/image/1d2ea9de42024b53a77120c482be51d4.png)

After:

![](http://image.prntscr.com/image/36de23ec14b64804b0cbae7a431185be.png)

This moves the lines-cutting logic from `block()` into a specific `createBlock`, used from both `comment()` and `block()`, sort as `comment()` can take messages containing nested tags and outputs a correctly formatted block without escaping tags.
