### PR TITLE
[HttpFoundation] add a handler to store sessions in a PSR-6 cache

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/CachePoolSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/CachePoolSessionHandler.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Cache\InvalidArgumentException;
+
+/**
+ * Stores PHP sessions in a {@see CacheItemPoolInterface PSR-6 cache item pool}.
+ *
+ * @author Christian Flothmann <christian.flothmann@xabbuh.de>
+ */
+class CachePoolSessionHandler implements \SessionHandlerInterface
+{
+    private $cachePool;
+    private $expiresAfter;
+
+    /**
+     * Creates a session handler that wraps a cache item pool using the given options.
+     *
+     * Available options are:
+     *  * expires_after: The maximum lifetime of a session in seconds
+     *
+     * @param CacheItemPoolInterface $cachePool
+     * @param array                  $options
+     */
+    public function __construct(CacheItemPoolInterface $cachePool, array $options = array())
+    {
+        if (count($diff = array_diff(array_keys($options), array('expires_after'))) > 0) {
+            throw new \InvalidArgumentException(sprintf('The following options are not supported "%s".', implode('", "', $diff)));
+        }
+
+        $this->cachePool = $cachePool;
+        $this->expiresAfter = isset($options['expires_after']) ? (int) $options['expires_after'] : (int) ini_get('session.gc_maxlifetime');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function open($savePath, $sessionId)
+    {
+        try {
+            $this->cachePool->getItem($sessionId);
+
+            return true;
+        } catch (InvalidArgumentException $e) {
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function close()
+    {
+        // there is nothing like a close operation for PSR-6 cache pools
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function read($sessionId)
+    {
+        try {
+            $item = $this->cachePool->getItem($sessionId);
+
+            return $item->isHit() ? $item->get() : '';
+        } catch (InvalidArgumentException $e) {
+            return '';
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function write($sessionId, $sessionData)
+    {
+        try {
+            $item = $this->cachePool->getItem($sessionId);
+            $item->set($sessionData);
+            $item->expiresAfter($this->expiresAfter);
+
+            return $this->cachePool->save($item);
+        } catch (InvalidArgumentException $e) {
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function destroy($sessionId)
+    {
+        try {
+            return $this->cachePool->deleteItem($sessionId);
+        } catch (InvalidArgumentException $e) {
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function gc($maxLifetime)
+    {
+        // cache pools must implement garbage collection on their own
+        return true;
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/CachePoolSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/CachePoolSessionHandlerTest.php
@@ -1,0 +1,240 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
+
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Cache\InvalidArgumentException as BaseInvalidArgumentException;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\CachePoolSessionHandler;
+
+class CachePoolSessionHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $cachePool;
+
+    /**
+     * @var CachePoolSessionHandler
+     */
+    private $sessionHandler;
+
+    protected function setUp()
+    {
+        $this->cachePool = $this->getMock(CacheItemPoolInterface::class);
+        $this->sessionHandler = new CachePoolSessionHandler($this->cachePool, array());
+    }
+
+    public function testOpenSucceeds()
+    {
+        $this->assertTrue($this->sessionHandler->open('save-path', 'id'));
+    }
+
+    public function testOpenReturnsFalseIfTheCacheItemCannotBeRead()
+    {
+        $this->cachePoolThrowsException('getItem');
+
+        $this->assertFalse($this->sessionHandler->open('save-path', 'id'));
+    }
+
+    public function testClose()
+    {
+        $this->assertTrue($this->sessionHandler->close());
+    }
+
+    public function testReadReturnsCachedDataOnSuccess()
+    {
+        $this->cachePoolReturnsItemWithHit();
+
+        $this->assertSame('data', $this->sessionHandler->read('id'));
+    }
+
+    public function testReadReturnsEmptyStringIfNoCacheItemWasFound()
+    {
+        $this->cachePoolReturnsItemWithoutHit();
+
+        $this->assertSame('', $this->sessionHandler->read('id'));
+    }
+
+    public function testReadReturnsEmptyStringIfTheCacheItemCannotBeRead()
+    {
+        $this->cachePoolThrowsException('getItem');
+
+        $this->assertSame('', $this->sessionHandler->read('id'));
+    }
+
+    public function testWriteReturnsTrueWhenTheCacheItemCouldBeSaved()
+    {
+        $this->cachePoolReturnsItemWithHit();
+        $this
+            ->cachePool
+            ->expects($this->once())
+            ->method('save')
+            ->willReturn(true)
+        ;
+
+        $this->assertTrue($this->sessionHandler->write('id', 'data'));
+    }
+
+    public function testWriteReturnsFalseWhenTheCacheItemCouldNotBeSaved()
+    {
+        $this->cachePoolReturnsItemWithHit();
+        $this
+            ->cachePool
+            ->expects($this->once())
+            ->method('save')
+            ->willReturn(false)
+        ;
+
+        $this->assertFalse($this->sessionHandler->write('id', 'data'));
+    }
+
+    public function testWriteReturnsFalseWhenTheCachePoolThrowsAnException()
+    {
+        $this->cachePoolThrowsException('getItem');
+
+        $this->assertFalse($this->sessionHandler->write('id', 'data'));
+    }
+
+    public function testWriteRespectsCustomMaxLifetime()
+    {
+        $this->sessionHandler = new CachePoolSessionHandler($this->cachePool, array('expires_after' => 86400));
+        $item = $this->cachePoolReturnsItemWithHit();
+        $item
+            ->expects($this->atLeastOnce())
+            ->method('expiresAfter')
+            ->with(86400)
+        ;
+        $this
+            ->cachePool
+            ->expects($this->once())
+            ->method('save')
+            ->willReturn(true)
+        ;
+
+        $this->assertTrue($this->sessionHandler->write('id', 'data'));
+    }
+
+    public function testDestroyReturnsTrueWhenTheCacheItemWasRemoved()
+    {
+        $this
+            ->cachePool
+            ->expects($this->once())
+            ->method('deleteItem')
+            ->willReturn(true)
+        ;
+
+        $this->assertTrue($this->sessionHandler->destroy('id'));
+    }
+
+    public function testDestroyReturnsFalseWhenTheCacheItemWasNotRemoved()
+    {
+        $this
+            ->cachePool
+            ->expects($this->once())
+            ->method('deleteItem')
+            ->willReturn(false)
+        ;
+
+        $this->assertFalse($this->sessionHandler->destroy('id'));
+    }
+
+    public function testDestroyReturnsFalseWhenTheCachePoolThrowsAnException()
+    {
+        $this->cachePoolThrowsException('deleteItem');
+
+        $this->assertFalse($this->sessionHandler->destroy('id'));
+    }
+
+    public function testGcSucceeds()
+    {
+        $this->assertTrue($this->sessionHandler->gc(1000));
+    }
+
+    /**
+     * @dataProvider getOptionFixtures
+     */
+    public function testSupportedOptions($options, $supported)
+    {
+        try {
+            new CachePoolSessionHandler($this->cachePool, $options);
+
+            $this->assertTrue($supported);
+        } catch (\InvalidArgumentException $e) {
+            $this->assertFalse($supported);
+        }
+    }
+
+    public function getOptionFixtures()
+    {
+        return array(
+            array(array('prefix' => 'session'), false),
+            array(array('expires_after' => 100), true),
+            array(array('expires_after' => 100, 'foo' => 'bar'), false),
+        );
+    }
+
+    private function cachePoolReturnsItemWithHit()
+    {
+        $item = $this->getMock(CacheItemInterface::class);
+        $item
+            ->expects($this->any())
+            ->method('isHit')
+            ->willReturn(true)
+        ;
+        $item
+            ->expects($this->any())
+            ->method('get')
+            ->willReturn('data')
+        ;
+        $this
+            ->cachePool
+            ->expects($this->any())
+            ->method('getItem')
+            ->with('id')
+            ->willReturn($item)
+        ;
+
+        return $item;
+    }
+
+    private function cachePoolReturnsItemWithoutHit()
+    {
+        $item = $this->getMock(CacheItemInterface::class);
+        $item
+            ->expects($this->any())
+            ->method('isHit')
+            ->willReturn(false)
+        ;
+        $this
+            ->cachePool
+            ->expects($this->any())
+            ->method('getItem')
+            ->with('id')
+            ->willReturn($item)
+        ;
+    }
+
+    private function cachePoolThrowsException($method)
+    {
+        $this
+            ->cachePool
+            ->expects($this->any())
+            ->method($method)
+            ->willThrowException($this->getMock(InvalidArgumentException::class))
+        ;
+    }
+}
+
+class InvalidArgumentException extends \Exception implements BaseInvalidArgumentException
+{
+}

--- a/src/Symfony/Component/HttpFoundation/composer.json
+++ b/src/Symfony/Component/HttpFoundation/composer.json
@@ -20,6 +20,7 @@
         "symfony/polyfill-mbstring": "~1.1"
     },
     "require-dev": {
+        "psr/cache": "~1.0",
         "symfony/expression-language": "~2.8|~3.0"
     },
     "autoload": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | TODO |

Currently, we ship a set of specific session storage handlers with the HttpFoundation aimed to support different storage backends. I suggest to add a new handler that is capable to work with an arbitrary PSR-6 cache item pool to be able to use other backends currently not supported by the core.
