### PR TITLE
[Bridge/Doctrine] Reset the EM lazy-proxy instead of the EM service

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/ManagerRegistryTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ManagerRegistryTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests;
+
+use Symfony\Bridge\Doctrine\ManagerRegistry;
+use Symfony\Bridge\ProxyManager\Tests\LazyProxy\Dumper\PhpDumperTest;
+
+class ManagerRegistryTest extends \PHPUnit_Framework_TestCase
+{
+    public static function setUpBeforeClass()
+    {
+        $test = new PhpDumperTest();
+        $test->testDumpContainerWithProxyServiceWillShareProxies();
+    }
+
+    public function testResetService()
+    {
+        $container = new \LazyServiceProjectServiceContainer();
+
+        $registry = new TestManagerRegistry('name', array(), array('defaultManager' => 'foo'), 'defaultConnection', 'defaultManager', 'proxyInterfaceName');
+        $registry->setContainer($container);
+
+        $foo = $container->get('foo');
+        $foo->bar = 123;
+        $this->assertTrue(isset($foo->bar));
+
+        $registry->resetManager();
+
+        $this->assertSame($foo, $container->get('foo'));
+        $this->assertFalse(isset($foo->bar));
+    }
+}
+
+class TestManagerRegistry extends ManagerRegistry
+{
+    public function getAliasNamespace($alias)
+    {
+        return 'Foo';
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -27,6 +27,7 @@
         "symfony/http-kernel": "~2.8|~3.0",
         "symfony/property-access": "~2.8|~3.0",
         "symfony/property-info": "~2.8|3.0",
+        "symfony/proxy-manager-bridge": "~2.8|~3.0",
         "symfony/security": "~2.8|~3.0",
         "symfony/expression-language": "~2.8|~3.0",
         "symfony/validator": "~2.8|~3.0",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | no |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This makes the entity manager resettable by resetting its proxy, which should be more robust than resetting its service.
See first comments in #19192
Ping @stof
