### PR TITLE
[Security] Allow LDAP loadUser override

### DIFF
--- a/src/Symfony/Component/Security/Core/User/LdapUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/LdapUserProvider.php
@@ -111,7 +111,7 @@ class LdapUserProvider implements UserProviderInterface
      *
      * @return User
      */
-    private function loadUser($username, Entry $entry)
+    protected function loadUser($username, Entry $entry)
     {
         $password = $this->getPassword($entry);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Back to 3.0, one could extend `Symfony\Component\Security\Core\User\LdapUserProvider` and override how User objects are created.
Among several improvements, #17560 changed `loadUser` signature but also visibility to `private` which disallow any overriding.
Even if the signature BC break is legitimate, we should still be able to override this method IMHO, which is not possible with a private visibility.
This PRs introduces a `protected` visibility to allow again overriding.
