### PR TITLE
[FrameworkBundle] Configure extended type for upload validator

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
@@ -184,7 +184,7 @@
             <tag name="form.type_extension" extended-type="Symfony\Component\Form\Extension\Core\Type\SubmitType" />
         </service>
         <service id="form.type_extension.upload.validator" class="Symfony\Component\Form\Extension\Validator\Type\UploadValidatorExtension">
-            <tag name="form.type_extension" alias="form" />
+            <tag name="form.type_extension" alias="form" extended-type="Symfony\Component\Form\Extension\Core\Type\FormType" />
             <argument type="service" id="translator"/>
             <argument type="string">%validator.translation_domain%</argument>
         </service>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

Something just broke...

```
$ bin/console -vvv

  [InvalidArgumentException]                                                                                                                                                                      
  Tagged form type extension must have the extended type configured using the extended_type/extended-type attribute, none was configured for the "form.type_extension.upload.validator" service.  

Exception trace:
 () at /var/www/html/symfony/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FormPass.php:59
 Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\FormPass->process() at /var/www/html/symfony/vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Compiler/Compiler.php:112
 Symfony\Component\DependencyInjection\Compiler\Compiler->compile() at /var/www/html/symfony/vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/ContainerBuilder.php:559
 Symfony\Component\DependencyInjection\ContainerBuilder->compile() at /var/www/html/symfony/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Kernel.php:485
 Symfony\Component\HttpKernel\Kernel->initializeContainer() at /var/www/html/symfony/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Kernel.php:117
 Symfony\Component\HttpKernel\Kernel->boot() at /var/www/html/symfony/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:68
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at /var/www/html/symfony/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:118
 Symfony\Component\Console\Application->run() at /var/www/html/symfony/bin/console:29
```
