### PR TITLE
[VarDumper] `$var` param isn't used in `dump()`

### DIFF
--- a/src/Symfony/Component/VarDumper/Resources/functions/dump.php
+++ b/src/Symfony/Component/VarDumper/Resources/functions/dump.php
@@ -15,7 +15,7 @@ if (!function_exists('dump')) {
     /**
      * @author Nicolas Grekas <p@tchwork.com>
      */
-    function dump($var)
+    function dump()
     {
         foreach (func_get_args() as $var) {
             VarDumper::dump($var);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes? |
| License | MIT |

This isn't a new feature, but it's also not really a bug fix. It's just a cosmetic issue. There is an unused variable in the `dump()` function. Since the variable is overwritten in the loop, it's not needed as a parameter in the function.
