### PR TITLE
[DependencyInjection][Tests] Add missing file for tests

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/ErrorAssert.php
+++ b/src/Symfony/Bridge/PhpUnit/ErrorAssert.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit;
+
+/**
+ * Test that your code triggers expected error messages.
+ *
+ * @author Christian Flothmann <christian.flothmann@xabbuh.de>
+ */
+final class ErrorAssert
+{
+    /**
+     * @param string[] $expectedMessages Expected deprecation messages
+     * @param callable $testCode         A callable that is expected to trigger the deprecation messages
+     */
+    public static function assertDeprecationsAreTriggered($expectedMessages, $testCode)
+    {
+        if (!is_callable($testCode)) {
+            throw new \InvalidArgumentException(sprintf('The code to be tested must be a valid callable ("%s" given).', gettype($testCode)));
+        }
+
+        self::assertErrorsAreTriggered(E_USER_DEPRECATED, $expectedMessages, $testCode);
+    }
+
+    /**
+     * @param int      $expectedType     Expected triggered error type (pass one of PHP's E_* constants)
+     * @param string[] $expectedMessages Expected error messages
+     * @param callable $testCode         A callable that is expected to trigger the error messages
+     */
+    public static function assertErrorsAreTriggered($expectedType, $expectedMessages, $testCode)
+    {
+        if (!is_callable($testCode)) {
+            throw new \InvalidArgumentException(sprintf('The code to be tested must be a valid callable ("%s" given).', gettype($testCode)));
+        }
+
+        $e = null;
+        $triggeredMessages = array();
+
+        try {
+            $prevHandler = set_error_handler(function ($type, $message, $file, $line, $context) use ($expectedType, &$triggeredMessages, &$prevHandler) {
+                if ($expectedType !== $type) {
+                    return null !== $prevHandler && call_user_func($prevHandler, $type, $message, $file, $line, $context);
+                }
+                $triggeredMessages[] = $message;
+            });
+
+            call_user_func($testCode);
+        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
+        }
+        restore_error_handler();
+
+        if (null !== $e) {
+            throw $e;
+        }
+
+        \PHPUnit_Framework_Assert::assertCount(count($expectedMessages), $triggeredMessages);
+
+        foreach ($triggeredMessages as $i => $message) {
+            \PHPUnit_Framework_Assert::assertContains($expectedMessages[$i], $message);
+        }
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes (Dependancy Injection, other tests don't pass but not related) |
| Fixed tickets | #19220 |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

Add the src/Symfony/Bridge/PhpUnit/ErrorAssert.php file only available in Master but used for tests since 2.8
