### PR TITLE
[FrameworkBundle] Deprecate the service serializer.mapping.cache.doctrine.apc

### DIFF
--- a/UPGRADE-3.2.md
+++ b/UPGRADE-3.2.md
@@ -29,6 +29,12 @@ Form
    }
    ```
 
+FrameworkBundle
+---------------
+
+  * The service `serializer.mapping.cache.doctrine.apc` is deprecated. APCu should now
+    be automatically used when available.
+
 Validator
 ---------
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -114,9 +114,9 @@ FrameworkBundle
     - `"form.type.submit"`
     - `"form.type.reset"`
 
- * The `framework.serializer.cache` option and the service
-   `serializer.mapping.cache.apc` have been removed. APCu should now
-   be automatically used when available.
+ * The `framework.serializer.cache` option and the services
+   `serializer.mapping.cache.apc` and `serializer.mapping.cache.doctrine.apc`
+   have been removed. APCu should now be automatically used when available.
 
 HttpKernel
 ----------

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
@@ -42,10 +42,11 @@
             <call method="setNamespace">
                 <argument>%serializer.mapping.cache.prefix%</argument>
             </call>
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.2 and will be removed in 4.0. APCu should now be automatically used when available.</deprecated>
         </service>
 
         <service id="serializer.mapping.cache.apc" parent="serializer.mapping.cache.doctrine.apc">
-            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0. Use "serializer.mapping.cache.doctrine.apc" instead</deprecated>
+            <deprecated>The "%service_id%" service is deprecated since Symfony 3.1 and will be removed in 4.0. APCu should now be automatically used when available.</deprecated>
         </service>
 
         <!-- Encoders -->


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This PR deprecates the service `serializer.mapping.cache.doctrine.apc` introduced in 3.1 as the cache component is now the recommended way.
This PR contains https://github.com/symfony/symfony/pull/19235.
