### PR TITLE
[travis] Fix deps=low/high patching

### DIFF
--- a/.github/travis.php
+++ b/.github/travis.php
@@ -1,19 +1,23 @@
 <?php
 
 if (4 > $_SERVER['argc']) {
-    echo "Usage: branch dir1 dir2 ... dirN\n";
+    echo "Usage: branch version dir1 dir2 ... dirN\n";
     exit(1);
 }
 
 $dirs = $_SERVER['argv'];
 array_shift($dirs);
 $branch = array_shift($dirs);
+$version = array_shift($dirs);
 
 $packages = array();
 $flags = PHP_VERSION_ID >= 50400 ? JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE : 0;
 
 foreach ($dirs as $dir) {
-    if (!`git diff --name-only $branch...HEAD -- $dir`) {
+    if (!system("git diff --name-only $branch...HEAD -- $dir", $exitStatus)) {
+        if ($exitStatus) {
+            exit($exitStatus);
+        }
         continue;
     }
     echo "$dir\n";
@@ -32,7 +36,7 @@ foreach ($dirs as $dir) {
     file_put_contents($dir.'/composer.json', $json);
     passthru("cd $dir && tar -cf package.tar --exclude='package.tar' *");
 
-    $package->version = $branch.'.x-dev';
+    $package->version = $version.'.x-dev';
     $package->dist['type'] = 'tar';
     $package->dist['url'] = 'file://'.__DIR__."/$dir/package.tar";
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ before_install:
 install:
     - if [[ ! $skip ]]; then COMPONENTS=$(find src/Symfony -mindepth 3 -type f -name phpunit.xml.dist -printf '%h\n'); fi
     # Create local composer packages for each patched components and reference them in composer.json files when cross-testing components
-    - if [[ ! $skip && $deps ]]; then php .travis.php $TRAVIS_BRANCH $COMPONENTS; fi
+    - if [[ ! $skip && $deps ]]; then git fetch origin $TRAVIS_BRANCH && php .github/travis.php FETCH_HEAD $TRAVIS_BRANCH $COMPONENTS; fi
     # For the master branch when deps=high, the version before master is checked out and tested with the locally patched components
     - if [[ $deps = high && $TRAVIS_BRANCH = master ]]; then SYMFONY_VERSION=$(git ls-remote --heads | grep -o '/[1-9].*' | tail -n 1 | sed s/.//); else SYMFONY_VERSION=$(cat composer.json | grep '^ *"dev-master". *"[1-9]' | grep -o '[0-9.]*'); fi
     - if [[ $deps = high && $TRAVIS_BRANCH = master ]]; then git fetch origin $SYMFONY_VERSION; git checkout -m FETCH_HEAD; COMPONENTS=$(find src/Symfony -mindepth 3 -type f -name phpunit.xml.dist -printf '%h\n'); ./phpunit install; fi


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Deps=low/high are broken since we added depth=1 to the git checkout on travis...
This fixes the situation and ensures it won't happen again by adding a missing error check.
