### PR TITLE
Fixed BC Layer in DoctrineChoiceLoader

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/DoctrineChoiceLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/DoctrineChoiceLoader.php
@@ -75,6 +75,7 @@ class DoctrineChoiceLoader implements ChoiceLoaderInterface
             // form first to last argument as of 3.1
             $manager = $class;
             $class = $idReader;
+            $idReader = $objectLoader;
             $objectLoader = $factory;
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

in the case when the BC Layer is used $idReader is not set to the right value.
