### PR TITLE
[Validator] Deprecate Symfony\Component\Validator\Mapping\Cache\DoctrineCache

### DIFF
--- a/UPGRADE-3.2.md
+++ b/UPGRADE-3.2.md
@@ -58,3 +58,30 @@ Validator
        // ...
    }
    ```
+
+ * `Symfony\Component\Validator\Mapping\Cache\DoctrineCache` has been deprecated
+   in favor of `Symfony\Component\Validator\Mapping\Cache\Psr6Cache`.
+
+   Before:
+   ```php
+   use Doctrine\Common\Cache\ApcCache;
+   use Symfony\Component\Validator\Mapping\Cache\DoctrineCache;
+
+   $cache = new DoctrineCache(new ApcCache());
+   ```
+
+   After:
+   ```php
+   use Symfony\Component\Cache\Adapter\ApcuAdapter;
+   use Symfony\Component\Validator\Mapping\Cache\Psr6Cache;
+
+   $cache = new Psr6Cache(new ApcuAdapter());
+
+   // or
+
+   use Doctrine\Common\Cache\ApcCache;
+   use Symfony\Component\Cache\Adapter\DoctrineAdapter;
+   use Symfony\Component\Validator\Mapping\Cache\Psr6Cache;
+
+   $cache = new Psr6Cache(new DoctrineAdapter(new ApcCache()));
+   ```

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -260,3 +260,29 @@ Validator
        // ...
    }
    ```
+  * `Symfony\Component\Validator\Mapping\Cache\DoctrineCache` has been removed
+    in favor of `Symfony\Component\Validator\Mapping\Cache\Psr6Cache`.
+
+    Before:
+    ```php
+    use Doctrine\Common\Cache\ApcCache;
+    use Symfony\Component\Validator\Mapping\Cache\DoctrineCache;
+
+    $cache = new DoctrineCache(new ApcCache());
+    ```
+
+    After:
+    ```php
+    use Symfony\Component\Cache\Adapter\ApcuAdapter;
+    use Symfony\Component\Validator\Mapping\Cache\Psr6Cache;
+
+    $cache = new Psr6Cache(new ApcuAdapter());
+
+    // or
+
+    use Doctrine\Common\Cache\ApcCache;
+    use Symfony\Component\Cache\Adapter\DoctrineAdapter;
+    use Symfony\Component\Validator\Mapping\Cache\Psr6Cache;
+
+    $cache = new Psr6Cache(new DoctrineAdapter(new ApcCache()));
+    ```

--- a/src/Symfony/Component/Validator/Mapping/Cache/DoctrineCache.php
+++ b/src/Symfony/Component/Validator/Mapping/Cache/DoctrineCache.php
@@ -12,12 +12,16 @@
 namespace Symfony\Component\Validator\Mapping\Cache;
 
 use Doctrine\Common\Cache\Cache;
+use Symfony\Component\Cache\Adapter\DoctrineAdapter;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 /**
  * Adapts a Doctrine cache to a CacheInterface.
  *
  * @author Florian Voutzinos <florian@voutzinos.com>
+ *
+ * @deprecated since 3.2, to be removed in 4.0. Use {@link Psr6Cache}
+ *             with {@link DoctrineAdapter} instead.
  */
 final class DoctrineCache implements CacheInterface
 {
@@ -30,6 +34,7 @@ final class DoctrineCache implements CacheInterface
      */
     public function __construct(Cache $cache)
     {
+        @trigger_error(sprintf('%s is deprecated since version 3.2 and will be removed in 4.0. Use %s with %s instead.', __CLASS__, Psr6Cache::class, DoctrineAdapter::class), E_USER_DEPRECATED);
         $this->cache = $cache;
     }
 

--- a/src/Symfony/Component/Validator/Tests/Mapping/Cache/DoctrineCacheTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Cache/DoctrineCacheTest.php
@@ -12,12 +12,18 @@
 namespace Symfony\Component\Validator\Tests\Mapping\Cache;
 
 use Doctrine\Common\Cache\ArrayCache;
+use Symfony\Bridge\PhpUnit\ErrorAssert;
 use Symfony\Component\Validator\Mapping\Cache\DoctrineCache;
 
 class DoctrineCacheTest extends AbstractCacheTest
 {
     protected function setUp()
     {
-        $this->cache = new DoctrineCache(new ArrayCache());
+        ErrorAssert::assertDeprecationsAreTriggered(
+            array(sprintf('%s is deprecated since version 3.2', DoctrineCache::class)),
+            function () {
+                $this->cache = new DoctrineCache(new ArrayCache());
+            }
+        );
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

As the Cache component is now available and as it allows to do most of the time as much as the doctrine cache provider and as at worst it allows to use a doctrine provider, imo we should deprecate this cache implementation dedicated to doctrine in favor of the one dedicated to psr6.
