### PR TITLE
Fixed typos in the expectedException annotations

### DIFF
--- a/src/Symfony/Component/Asset/Tests/PackagesTest.php
+++ b/src/Symfony/Component/Asset/Tests/PackagesTest.php
@@ -14,8 +14,6 @@ namespace Symfony\Component\Asset\Tests;
 use Symfony\Component\Asset\Package;
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\Asset\VersionStrategy\StaticVersionStrategy;
-use Symfony\Component\Asset\Exception\InvalidArgumentException;
-use Symfony\Component\Asset\Exception\LogicException;
 
 class PackagesTest extends \PHPUnit_Framework_TestCase
 {

--- a/src/Symfony/Component/Asset/Tests/PackagesTest.php
+++ b/src/Symfony/Component/Asset/Tests/PackagesTest.php
@@ -57,7 +57,7 @@ class PackagesTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException LogicException
+     * @expectedException Symfony\Component\Asset\Exception\LogicException
      */
     public function testNoDefaultPackage()
     {
@@ -66,7 +66,7 @@ class PackagesTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException Symfony\Component\Asset\Exception\InvalidArgumentException
      */
     public function testUndefinedPackage()
     {

--- a/src/Symfony/Component/Asset/Tests/PackagesTest.php
+++ b/src/Symfony/Component/Asset/Tests/PackagesTest.php
@@ -55,7 +55,7 @@ class PackagesTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Symfony\Component\Asset\Exception\LogicException
+     * @expectedException \Symfony\Component\Asset\Exception\LogicException
      */
     public function testNoDefaultPackage()
     {
@@ -64,7 +64,7 @@ class PackagesTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Symfony\Component\Asset\Exception\InvalidArgumentException
+     * @expectedException \Symfony\Component\Asset\Exception\InvalidArgumentException
      */
     public function testUndefinedPackage()
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

PHPUnit ignores any imports when resolving these. You must always reference the FQCN.
