### PR TITLE
Do not put any empty div if label is disabled

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_horizontal_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_horizontal_layout.html.twig
@@ -9,9 +9,7 @@
 
 {% block form_label -%}
 {% spaceless %}
-    {% if label is same as(false) %}
-        <div class="{{ block('form_label_class') }}"></div>
-    {% else %}
+    {% if label is not same as(false) %}
         {% set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' ' ~ block('form_label_class'))|trim}) %}
         {{- parent() -}}
     {% endif %}
@@ -77,5 +75,9 @@ col-sm-2
 {% endblock reset_row %}
 
 {% block form_group_class -%}
-col-sm-10
+    {%- if label is same as(false) -%}
+        col-sm-12
+    {%- else -%}
+        col-sm-10
+    {%- endif -%}
 {%- endblock form_group_class %}

--- a/src/Symfony/Component/Form/Tests/AbstractBootstrap3HorizontalLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractBootstrap3HorizontalLayoutTest.php
@@ -100,6 +100,16 @@ abstract class AbstractBootstrap3HorizontalLayoutTest extends AbstractBootstrap3
         );
     }
 
+    public function testLabelNoDivIfFalse()
+    {
+        $this->assertEmpty(
+            $this->renderLabel(
+                $this->factory->createNamed('name', 'date', null, array('label' => false))->createView()
+            ),
+            'The label should not be rendered'
+        );
+    }
+
     public function testStartTag()
     {
         $form = $this->factory->create('form', null, array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18850, #18474 |
| License | MIT |
| Doc PR | N/A |

This produces wrong alignments especially for form collections.

This PR is an alternative to #18504, fixing both #18850 and #18474 issues.

@lyrixx what do you think of this? Maybe I'm forgetting some edge cases, please tell me so we can discuss about it! :+1: 

cc @jongotlin
## Application

With the following form type configuration:

``` php
$builder
    ->add('name', null, [
        'label' => 'form.name',
        'translation_domain' => 'global',
        'text_suffix' => '@'.$domain->getName(),
    ])
    ->add('destinations', CollectionType::class, [
        'label' => 'domain.form.mailalias_destinations',
        'translation_domain' => 'front',
        'allow_add' => true,
        'allow_delete' => true,
        'prototype' => true,
        'by_reference' => false,
        'entry_options' => [
            'label' => false,
            'text_prefix' => '@',
        ],
    ])
;
```

The actual rendering looks like this:

![image](https://cloud.githubusercontent.com/assets/1698357/16498588/cc4b1dde-3efc-11e6-85b1-34bfbfcd1f19.png)

Thanks to this PR, it's now:

![image](https://cloud.githubusercontent.com/assets/1698357/16498601/d56f743c-3efc-11e6-8251-e52d55a45af5.png)
