### PR TITLE
Release v2.7.15

### DIFF
--- a/CHANGELOG-2.7.md
+++ b/CHANGELOG-2.7.md
@@ -7,6 +7,36 @@ in 2.7 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.7.0...v2.7.1
 
+* 2.7.15 (2016-06-30)
+
+ * bug #19217 [HttpKernel] Inline ValidateRequestListener logic into HttpKernel (nicolas-grekas)
+ * bug #18688 [HttpFoundation] Warning when request has both Forwarded and X-Forwarded-For (magnusnordlander)
+ * bug #19173 [Console] Decouple SymfonyStyle from TableCell (ro0NL)
+ * bug #17822 [WIP]  [Form] fix `empty_data` option in expanded `ChoiceType` (HeahDude)
+ * bug #19134 Distinguish between first and subsequent progress bar displays (rquadling)
+ * bug #19061 [FORM] fix post_max_size_message translation (alt. 2) (David Badura)
+ * bug #19100 [Console] Fixed SymfonyQuestionHelper multi-choice with defaults (sstok)
+ * bug #18924 [DoctrineBridge] Don't use object IDs in DoctrineChoiceLoader when passing a value closure (webmozart)
+ * bug #19138 [DomCrawler] No more exception on field name with strange format (guiled, fabpot)
+ * bug #18935 [Form] Consider a violation even if the form is not submitted (egeloen)
+ * bug #19127 [Form] Add exception to FormRenderer about non-unique block names (enumag)
+ * bug #19118 [Process] Fix pipes cleaning on Windows (nicolas-grekas)
+ * bug #19128 Avoid phpunit 5.4 warnings on getMock (2.7+) (iltar)
+ * bug #19114 [HttpKernel] Dont close the reponse stream in debug (nicolas-grekas)
+ * bug #19101 [Session] fix PDO transaction aborted under PostgreSQL (Tobion)
+ * bug #18501 [HttpFoundation] changed MERGE queries (hjkl)
+ * bug #19062 [HttpFoundation] Fix UPSERT for PgSql >= 9.5 (nicolas-grekas)
+ * bug #18548 [Form] minor fixes in DateTime transformers (HeahDude)
+ * bug #18732 [PropertyAccess][DX] Enhance exception that say that some methods are missing if they don't (nykopol)
+ * bug #19048 [HttpFoundation] Use UPSERT for sessions stored in PgSql >= 9.5 (nicolas-grekas)
+ * bug #19038 Fix feature detection for IE (Alsciende)
+ * bug #18915 [DependencyInjection] force enabling the external XML entity loaders (xabbuh)
+ * bug #19020 [Form] Fixed collapsed choice attributes (HeahDude)
+ * bug #19028 [Yaml] properly count skipped comment lines (xabbuh)
+ * bug #17733 [Yaml] Fix wrong line number when comments are inserted in the middle of a block. (paradajozsef)
+ * bug #18911 Fixed singular of committee (peterrehm)
+ * bug #18971 Do not inject web debug toolbar on attachments (peterrehm)
+
 * 2.7.14 (2016-06-06)
 
  * bug #18908 [DependencyInjection] force enabling the external XML entity loaders (xabbuh)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,8 +8,8 @@ Symfony is the result of the work of many people who made the code better
  - Nicolas Grekas (nicolas-grekas)
  - Bernhard Schussek (bschussek)
  - Tobias Schultze (tobion)
- - Christophe Coevoet (stof)
  - Christian Flothmann (xabbuh)
+ - Christophe Coevoet (stof)
  - Jordi Boggiano (seldaek)
  - Victor Berchet (victor)
  - Johannes S (johannes)
@@ -17,12 +17,12 @@ Symfony is the result of the work of many people who made the code better
  - Jakub Zalas (jakubzalas)
  - Ryan Weaver (weaverryan)
  - Javier Eguiluz (javier.eguiluz)
- - Hugo Hamon (hhamon)
  - Kévin Dunglas (dunglas)
+ - Hugo Hamon (hhamon)
  - Abdellatif Ait boudad (aitboudad)
  - Pascal Borreli (pborreli)
- - Joseph Bielawski (stloyd)
  - Wouter De Jong (wouterj)
+ - Joseph Bielawski (stloyd)
  - Romain Neutron (romain)
  - Karma Dordrak (drak)
  - Lukas Kahwe Smith (lsmith)
@@ -34,16 +34,16 @@ Symfony is the result of the work of many people who made the code better
  - Grégoire Pineau (lyrixx)
  - Eriksen Costa (eriksencosta)
  - Sarah Khalil (saro0h)
+ - Jules Pietri (heah)
  - Jonathan Wage (jwage)
- - Diego Saint Esteben (dosten)
  - Maxime Steinhausser (ogizanagi)
+ - Diego Saint Esteben (dosten)
  - Alexandre Salomé (alexandresalome)
  - William Durand (couac)
- - Jules Pietri (heah)
  - ornicar
+ - Francis Besset (francisbesset)
  - stealth35 ‏ (stealth35)
  - Alexander Mols (asm89)
- - Francis Besset (francisbesset)
  - Bulat Shakirzyanov (avalanche123)
  - Saša Stamenković (umpirsky)
  - Henrik Bjørnskov (henrikbjorn)
@@ -52,21 +52,21 @@ Symfony is the result of the work of many people who made the code better
  - Konstantin Kudryashov (everzet)
  - Bilal Amarni (bamarni)
  - Florin Patan (florinpatan)
- - Kevin Bond (kbond)
  - Peter Rehm (rpet)
+ - Kevin Bond (kbond)
  - Gábor Egyed (1ed)
+ - Ener-Getick (energetick)
  - Michel Weimerskirch (mweimerskirch)
  - Eric Clemmons (ericclemmons)
+ - Iltar van der Berg (kjarli)
  - Andrej Hudec (pulzarraider)
  - Christian Raue
+ - Charles Sarrazin (csarrazi)
  - Matthias Pigulla (mpdude)
  - Deni
  - Henrik Westphal (snc)
  - Dariusz Górecki (canni)
  - Arnout Boks (aboks)
- - Iltar van der Berg (kjarli)
- - Charles Sarrazin (csarrazi)
- - Ener-Getick (energetick)
  - Douglas Greenshields (shieldo)
  - Lee McDermott
  - Brandon Turner
@@ -82,49 +82,50 @@ Symfony is the result of the work of many people who made the code better
  - Antoine Hérault (herzult)
  - Arnaud Le Blanc (arnaud-lb)
  - Jérôme Tamarelle (gromnan)
+ - Paráda József (paradajozsef)
  - Michal Piotrowski (eventhorizon)
  - Tim Nagel (merk)
- - Paráda József (paradajozsef)
  - Brice BERNARD (brikou)
+ - Robin Chalas (chalas_r)
  - Alexander M. Turek (derrabus)
  - Dariusz Ruminski
  - marc.weistroff
  - Issei Murasawa (issei_m)
  - lenar
  - Włodzimierz Gajda (gajdaw)
+ - Konstantin Myakshin (koc)
+ - Baptiste Clavié (talus)
  - Alexander Schwenn (xelaris)
  - Florian Voutzinos (florianv)
- - Konstantin Myakshin (koc)
  - Colin Frei
  - Adrien Brault (adrienbrault)
  - Joshua Thijssen
- - Baptiste Clavié (talus)
  - Peter Kokot (maastermedia)
  - excelwebzone
  - Jacob Dreesen (jdreesen)
+ - Jáchym Toušek (enumag)
  - Jérémy DERUSSÉ (jderusse)
  - Vladimir Reznichenko (kalessil)
+ - Tomáš Votruba (tomas_votruba)
  - Fabien Pennequin (fabienpennequin)
  - Gordon Franke (gimler)
+ - Eric GELOEN (gelo)
  - David Buchmann (dbu)
- - Tomáš Votruba (tomas_votruba)
- - Jáchym Toušek
  - Robert Schönthal (digitalkaoz)
  - Florian Lonqueu-Brochard (florianlb)
- - Eric GELOEN (gelo)
  - Stefano Sala (stefano.sala)
  - Juti Noppornpitak (shiroyuki)
+ - Titouan Galopin (tgalopin)
  - Tigran Azatyan (tigranazatyan)
  - Sebastian Hörl (blogsh)
  - Daniel Gomes (danielcsgomes)
  - Hidenori Goto (hidenorigoto)
+ - Sebastiaan Stok (sstok)
  - Evgeniy (ewgraf)
+ - Tugdual Saunier (tucksaun)
  - Guilherme Blanco (guilhermeblanco)
  - Pablo Godel (pgodel)
- - Titouan Galopin (tgalopin)
  - Jérémie Augustin (jaugustin)
- - Sebastiaan Stok (sstok)
- - Tugdual Saunier (tucksaun)
  - Andréia Bohner (andreia)
  - Rafael Dohms (rdohms)
  - Arnaud Kleinpeter (nanocom)
@@ -141,6 +142,7 @@ Symfony is the result of the work of many people who made the code better
  - Richard van Laak (rvanlaak)
  - Matthieu Ouellette-Vachon (maoueh)
  - Michał Pipa (michal.pipa)
+ - Javier Spagnoletti (phansys)
  - Amal Raghav (kertz)
  - Jonathan Ingram (jonathaningram)
  - Artur Kotyrba
@@ -150,7 +152,6 @@ Symfony is the result of the work of many people who made the code better
  - Daniel Wehner
  - Possum
  - Dorian Villet (gnutix)
- - Javier Spagnoletti (phansys)
  - Richard Miller (mr_r_miller)
  - Mario A. Alvarez Garcia (nomack84)
  - Dennis Benkert (denderello)
@@ -179,6 +180,7 @@ Symfony is the result of the work of many people who made the code better
  - Sven Paulus (subsven)
  - Lars Strojny (lstrojny)
  - Rui Marinho (ruimarinho)
+ - Daniel Espendiller
  - Eugene Wissner
  - Julien Brochet (mewt)
  - Sergey Linnik (linniksa)
@@ -212,9 +214,7 @@ Symfony is the result of the work of many people who made the code better
  - Kristen Gilden (kgilden)
  - Dawid Nowak
  - Pierre-Yves LEBECQ (pylebecq)
- - Daniel Espendiller
  - Jakub Kucharovic (jkucharovic)
- - Robin Chalas (chalas_r)
  - Eugene Leonovich (rybakit)
  - Filippo Tessarotto
  - Joseph Rouff (rouffj)
@@ -238,6 +238,7 @@ Symfony is the result of the work of many people who made the code better
  - Roumen Damianoff (roumen)
  - Antonio J. García Lagar (ajgarlag)
  - Kim Hemsø Rasmussen (kimhemsoe)
+ - Christian Schmidt
  - Wouter Van Hecke
  - Peter Kruithof (pkruithof)
  - Michael Holm (hollo)
@@ -245,6 +246,7 @@ Symfony is the result of the work of many people who made the code better
  - Hidde Wieringa (hiddewie)
  - Chris Smith (cs278)
  - Florian Klein (docteurklein)
+ - Oleg Voronkovich
  - Manuel Kiessling (manuelkiessling)
  - Daniel Wehner
  - Atsuhiro KUBO (iteman)
@@ -294,7 +296,6 @@ Symfony is the result of the work of many people who made the code better
  - Inal DJAFAR (inalgnu)
  - Christian Gärtner (dagardner)
  - Tomasz Kowalczyk (thunderer)
- - Christian Schmidt
  - François-Xavier de Guillebon (de-gui_f)
  - Damien Alexandre (damienalexandre)
  - Felix Labrecque
@@ -322,6 +323,7 @@ Symfony is the result of the work of many people who made the code better
  - Endre Fejes
  - Tobias Naumann (tna)
  - Daniel Beyer
+ - Jhonny Lidfors (jhonne)
  - Shein Alexey
  - Baptiste Lafontaine
  - Joe Lencioni
@@ -335,7 +337,6 @@ Symfony is the result of the work of many people who made the code better
  - Ivan Kurnosov
  - Xavier HAUSHERR
  - Albert Jessurum (ajessu)
- - Oleg Voronkovich
  - Laszlo Korte
  - Pavel Batanov (scaytrase)
  - Miha Vrhovnik
@@ -355,6 +356,7 @@ Symfony is the result of the work of many people who made the code better
  - Brian King
  - Michel Salib (michelsalib)
  - geoffrey
+ - Steffen Roßkamp
  - Valentin Jonovs (valentins-jonovs)
  - Jeanmonod David (jeanmonod)
  - Jan Schumann
@@ -364,6 +366,7 @@ Symfony is the result of the work of many people who made the code better
  - Mihai Stancu
  - Olivier Dolbeau (odolbeau)
  - Jan Rosier (rosier)
+ - Magnus Nordlander (magnusnordlander)
  - vagrant
  - EdgarPE
  - Florian Pfitzer (marmelatze)
@@ -379,6 +382,7 @@ Symfony is the result of the work of many people who made the code better
  - Christian Schmidt
  - Marek Štípek (maryo)
  - Marcin Sikoń (marphi)
+ - Roland Franssen (ro0)
  - Dominik Zogg (dominik.zogg)
  - Marek Pietrzak
  - Chad Sikorra (chadsikorra)
@@ -390,6 +394,7 @@ Symfony is the result of the work of many people who made the code better
  - Zander Baldwin
  - Adam Harvey
  - Alex Bakhturin
+ - Alexander Obuhovich (aik099)
  - boombatower
  - Fabrice Bernhard (fabriceb)
  - Jérôme Macias (jeromemacias)
@@ -412,10 +417,12 @@ Symfony is the result of the work of many people who made the code better
  - ondrowan
  - Barry vd. Heuvel (barryvdh)
  - Jerzy Zawadzki (jzawadzki)
+ - Théo FIDRY (theofidry)
  - Evan S Kaufman (evanskaufman)
  - mcben
  - Jérôme Vieilledent (lolautruche)
  - Maks Slesarenko
+ - Filip Procházka (fprochazka)
  - mmoreram
  - Markus Lanthaler (lanthaler)
  - Vicent Soria Durá (vicentgodella)
@@ -440,7 +447,6 @@ Symfony is the result of the work of many people who made the code better
  - Benjamin Leveque (benji07)
  - Nate (frickenate)
  - jhonnyL
- - Jhonny Lidfors (jhonne)
  - sasezaki
  - Dawid Pakuła (zulusx)
  - Florian Rey (nervo)
@@ -503,6 +509,7 @@ Symfony is the result of the work of many people who made the code better
  - Maxime Douailin
  - Javier López (loalf)
  - Reinier Kip
+ - Geoffrey Brier (geoffrey-brier)
  - Dustin Dobervich (dustin10)
  - dantleech
  - Anne-Sophie Bachelard (annesophie)
@@ -535,9 +542,11 @@ Symfony is the result of the work of many people who made the code better
  - Arturs Vonda
  - Sascha Grossenbacher
  - Szijarto Tamas
+ - David Badura (davidbadura)
  - Catalin Dan
  - Stephan Vock
  - Benjamin Zikarsky (bzikarsky)
+ - Anton Bakai
  - Simon Schick (simonsimcity)
  - redstar504
  - Tristan Roussel
@@ -556,7 +565,7 @@ Symfony is the result of the work of many people who made the code better
  - Richard van den Brand (ricbra)
  - develop
  - Mark Sonnabaum
- - Alexander Obuhovich (aik099)
+ - Richard Quadling
  - jochenvdv
  - Arturas Smorgun (asarturas)
  - Alexander Volochnev (exelenz)
@@ -573,6 +582,7 @@ Symfony is the result of the work of many people who made the code better
  - Baldur Rensch (brensch)
  - Vladyslav Petrovych
  - Alex Xandra Albert Sim
+ - Carson Full
  - Trent Steel (trsteel88)
  - Yuen-Chi Lian
  - Besnik Br
@@ -589,6 +599,7 @@ Symfony is the result of the work of many people who made the code better
  - Leevi Graham (leevigraham)
  - Casper Valdemar Poulsen
  - Josiah (josiah)
+ - Joschi Kuphal
  - John Bohn (jbohn)
  - Marc Morera (mmoreram)
  - Andrew Hilobok (hilobok)
@@ -618,7 +629,6 @@ Symfony is the result of the work of many people who made the code better
  - Adrien Lucas (adrienlucas)
  - James Michael DuPont
  - Tom Klingenberg
- - Filip Procházka (fprochazka)
  - Christopher Hall (mythmakr)
  - Paul Kamer (pkamer)
  - Rafał Wrzeszcz (rafalwrzeszcz)
@@ -637,7 +647,6 @@ Symfony is the result of the work of many people who made the code better
  - Neil Ferreira
  - Nathanael Noblet (gnat)
  - Dmitry Parnas (parnas)
- - Théo FIDRY (theofidry)
  - Paul LE CORRE
  - DQNEO
  - Emanuele Iannone
@@ -652,7 +661,6 @@ Symfony is the result of the work of many people who made the code better
  - Matt Robinson (inanimatt)
  - Aleksey Podskrebyshev
  - Calin Mihai Pristavu
- - Steffen Roßkamp
  - David Marín Carreño (davefx)
  - Jörn Lang (j.lang)
  - Omar Yepez (oyepez003)
@@ -677,6 +685,7 @@ Symfony is the result of the work of many people who made the code better
  - Don Pinkster
  - Maksim Muruev
  - Emil Einarsson
+ - Thomas Landauer
  - Thibault Duplessis
  - Marc Abramowitz
  - Martijn Evers
@@ -697,7 +706,6 @@ Symfony is the result of the work of many people who made the code better
  - David Lima
  - Jérôme Vasseur
  - Brunet Laurent (lbrunet)
- - Magnus Nordlander (magnusnordlander)
  - Mikhail Yurasov (mym)
  - LOUARDI Abdeltif (ouardisoft)
  - Robert Gruendler (pulse00)
@@ -709,6 +717,7 @@ Symfony is the result of the work of many people who made the code better
  - Raul Fraile (raulfraile)
  - sensio
  - Patrick Kaufmann
+ - Piotr Stankowski
  - Reece Fowell (reecefowell)
  - Mátyás Somfai (smatyas)
  - stefan.r
@@ -728,6 +737,7 @@ Symfony is the result of the work of many people who made the code better
  - Pieter
  - Michael Tibben
  - Sander Marechal
+ - Andre Rømcke (andrerom)
  - Radosław Benkel
  - ttomor
  - Mei Gwilym (meigwilym)
@@ -743,6 +753,7 @@ Symfony is the result of the work of many people who made the code better
  - Danilo Silva
  - Zachary Tong (polyfractal)
  - Hryhorii Hrebiniuk
+ - Dennis Fridrich (dfridrich)
  - mcfedr (mcfedr)
  - hamza
  - dantleech
@@ -752,6 +763,7 @@ Symfony is the result of the work of many people who made the code better
  - Guillaume Royer
  - Artem (digi)
  - boite
+ - MGDSoft
  - Vadim Tyukov (vatson)
  - Sortex
  - chispita
@@ -804,10 +816,12 @@ Symfony is the result of the work of many people who made the code better
  - Benoit Garret
  - Thomas Royer (cydonia7)
  - DerManoMann
+ - Olaf Klischat
  - Jhonny Lidfors (jhonny)
  - Julien Bianchi (jubianchi)
+ - Robert Meijers
  - Marcin Chwedziak
- - Roland Franssen (ro0)
+ - hjkl
  - Tony Cosentino (tony-co)
  - Rodrigo Díez Villamuera (rodrigodiez)
  - e-ivanov
@@ -815,6 +829,7 @@ Symfony is the result of the work of many people who made the code better
  - Jeremy Bush
  - wizhippo
  - Viacheslav Sychov
+ - Carlos Ortega Huetos
  - rpg600
  - Péter Buri (burci)
  - Davide Borsatto (davide.borsatto)
@@ -834,6 +849,7 @@ Symfony is the result of the work of many people who made the code better
  - spdionis
  - Eduardo García Sanz (coma)
  - James Gilliland
+ - Rhodri Pugh (rodnaph)
  - David de Boer (ddeboer)
  - Gilles Doge (gido)
  - abulford
@@ -855,7 +871,6 @@ Symfony is the result of the work of many people who made the code better
  - Juan Traverso
  - Philipp Strube
  - Christian Sciberras
- - Anton Bakai
  - Clement Herreman (clemherreman)
  - Dan Ionut Dumitriu (danionut90)
  - Nyro (nyro)
@@ -893,7 +908,6 @@ Symfony is the result of the work of many people who made the code better
  - azine
  - Dawid Sajdak
  - Ludek Stepan
- - Geoffrey Brier
  - Aaron Stephens (astephens)
  - Craig Menning (cmenning)
  - Balázs Benyó (duplabe)
@@ -917,6 +931,7 @@ Symfony is the result of the work of many people who made the code better
  - Cédric Lahouste (rapotor)
  - Samuel Vogel (samuelvogel)
  - Berat Doğan
+ - Juanmi Rodriguez Cerón
  - Anthony Ferrara
  - Klaas Cuvelier (kcuvelier)
  - Steve Frécinaux
@@ -934,6 +949,7 @@ Symfony is the result of the work of many people who made the code better
  - Philip Frank
  - Lance McNearney
  - Giorgio Premi
+ - Ian Carroll
  - caponica
  - Matt Daum (daum)
  - Alberto Pirovano (geezmo)
@@ -945,6 +961,7 @@ Symfony is the result of the work of many people who made the code better
  - Max Summe
  - WedgeSama
  - Felds Liscia
+ - Ahmed TAILOULOUTE (ahmedtai)
  - James Halsall (jaitsu)
  - Maxime Veber (nek-)
  - Sullivan SENECHAL
@@ -968,6 +985,7 @@ Symfony is the result of the work of many people who made the code better
  - Max Romanovsky (maxromanovsky)
  - Mathieu Morlon
  - Daniel Tschinder
+ - Nykopol (nykopol)
  - Rafał Muszyński (rafmus90)
  - Timothy Anido (xanido)
  - Rick Prent
@@ -1006,6 +1024,7 @@ Symfony is the result of the work of many people who made the code better
  - Konrad Mohrfeldt
  - Lance Chen
  - Andrey Astakhov (aast)
+ - Nikolay Labinskiy (e-moe)
  - kor3k kor3k (kor3k)
  - Stelian Mocanita (stelian)
  - Flavian (2much)
@@ -1015,6 +1034,7 @@ Symfony is the result of the work of many people who made the code better
  - Hoffmann András
  - Olivier
  - pscheit
+ - Zdeněk Drahoš
  - Dan Harper
  - moldcraft
  - Ramon Kleiss (akathos)
@@ -1137,6 +1157,7 @@ Symfony is the result of the work of many people who made the code better
  - Daan van Renterghem
  - Nicole Cordes
  - Bram Van der Sype (brammm)
+ - Guile (guile)
  - Julien Moulin (lizjulien)
  - Nikita Nefedov (nikita2206)
  - Mauro Foti (skler)
@@ -1209,7 +1230,6 @@ Symfony is the result of the work of many people who made the code better
  - Haritz
  - Matthieu Prat
  - Grummfy
- - Thomas Landauer
  - Filipe Guerra
  - Gerben Wijnja
  - Rowan Manning
@@ -1260,6 +1280,7 @@ Symfony is the result of the work of many people who made the code better
  - Muriel (metalmumu)
  - Michael Pohlers (mick_the_big)
  - Cayetano Soriano Gallego (neoshadybeat)
+ - Jean Pasdeloup (pasdeloup)
  - Patrick McDougle (patrick-mcdougle)
  - Pablo Monterde Perez (plebs)
  - Jimmy Leger (redpanda)
@@ -1298,7 +1319,6 @@ Symfony is the result of the work of many people who made the code better
  - Mantas Urnieža
  - Cas
  - Dusan Kasan
- - Carson Full
  - Myke79
  - Brian Debuire
  - Piers Warmers
@@ -1332,6 +1352,7 @@ Symfony is the result of the work of many people who made the code better
  - Andras Ratz
  - andreabreu98
  - Michael Schneider
+ - Cédric Bertolini
  - n-aleha
  - Şəhriyar İmanov
  - Kaipi Yann
@@ -1358,6 +1379,7 @@ Symfony is the result of the work of many people who made the code better
  - Jon Cave
  - Sébastien HOUZE
  - Abdulkadir N. A.
+ - Ivan Menshykov
  - Yevgen Kovalienia
  - Lebnik
  - Sema
@@ -1385,8 +1407,8 @@ Symfony is the result of the work of many people who made the code better
  - Oncle Tom
  - Christian Stocker
  - Dawid Nowak
- - Richard Quadling
  - Karolis Daužickas
+ - Sergio Santoro
  - tirnanog06
  - phc
  - Дмитрий Пацура
@@ -1412,7 +1434,6 @@ Symfony is the result of the work of many people who made the code better
  - Loïc Vernet (coil)
  - Christoph Schaefer (cvschaefer)
  - Damon Jones (damon__jones)
- - David Badura (davidbadura)
  - Daniel Londero (dlondero)
  - Sebastian Landwehr (dword123)
  - Adel ELHAIBA (eadel)
@@ -1420,6 +1441,7 @@ Symfony is the result of the work of many people who made the code better
  - Elliot Anderson (elliot)
  - Sergey Zolotov (enleur)
  - Fabien D. (fabd)
+ - Carsten Eilers (fnc)
  - Sorin Gitlan (forapathy)
  - Yohan Giarelli (frequence-web)
  - Gerry Vandermaesen (gerryvdm)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -58,12 +58,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '2.7.15-DEV';
+    const VERSION = '2.7.15';
     const VERSION_ID = 20715;
     const MAJOR_VERSION = 2;
     const MINOR_VERSION = 7;
     const RELEASE_VERSION = 15;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '05/2018';
     const END_OF_LIFE = '05/2019';


### PR DESCRIPTION
Changes since last release: https://github.com/symfony/symfony/compare/v2.7.14...ec1ff36

**Changelog**
- bug #19217 [HttpKernel] Inline ValidateRequestListener logic into HttpKernel (@nicolas-grekas)
- bug #18688 [HttpFoundation] Warning when request has both Forwarded and X-Forwarded-For (@magnusnordlander)
- bug #19173 [Console] Decouple SymfonyStyle from TableCell (@ro0NL)
- bug #17822 [WIP]  [Form] fix `empty_data` option in expanded `ChoiceType` (@HeahDude)
- bug #19134 Distinguish between first and subsequent progress bar displays (@rquadling)
- bug #19061 [FORM] fix post_max_size_message translation (alt. 2) (@David Badura)
- bug #19100 [Console] Fixed SymfonyQuestionHelper multi-choice with defaults (@sstok)
- bug #18924 [DoctrineBridge] Don't use object IDs in DoctrineChoiceLoader when passing a value closure (@webmozart)
- bug #19138 [DomCrawler] No more exception on field name with strange format (@guiled, @fabpot)
- bug #18935 [Form] Consider a violation even if the form is not submitted (@egeloen)
- bug #19127 [Form] Add exception to FormRenderer about non-unique block names (@enumag)
- bug #19118 [Process] Fix pipes cleaning on Windows (@nicolas-grekas)
- bug #19128 Avoid phpunit 5.4 warnings on getMock (2.7+) (@iltar)
- bug #19114 [HttpKernel] Dont close the reponse stream in debug (@nicolas-grekas)
- bug #19101 [Session] fix PDO transaction aborted under PostgreSQL (@Tobion)
- bug #18501 [HttpFoundation] changed MERGE queries (@hjkl)
- bug #19062 [HttpFoundation] Fix UPSERT for PgSql >= 9.5 (@nicolas-grekas)
- bug #18548 [Form] minor fixes in DateTime transformers (@HeahDude)
- bug #18732 [PropertyAccess][DX] Enhance exception that say that some methods are missing if they don't (@nykopol)
- bug #19048 [HttpFoundation] Use UPSERT for sessions stored in PgSql >= 9.5 (@nicolas-grekas)
- bug #19038 Fix feature detection for IE (@Alsciende)
- bug #18915 [DependencyInjection] force enabling the external XML entity loaders (@xabbuh)
- bug #19020 [Form] Fixed collapsed choice attributes (@HeahDude)
- bug #19028 [Yaml] properly count skipped comment lines (@xabbuh)
- bug #17733 [Yaml] Fix wrong line number when comments are inserted in the middle of a block. (@paradajozsef)
- bug #18911 Fixed singular of committee (@peterrehm)
- bug #18971 Do not inject web debug toolbar on attachments (@peterrehm)
