### PR TITLE
[FrameworkBundle] Output where a service is injected during debug

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -202,6 +202,7 @@ EOF
 
     /**
      * Find all services where the service $name is used.
+     * Can be either by the constructor, by a setter or by a public property.
      *
      * @param ContainerBuilder $builder
      * @param string           $name
@@ -215,6 +216,19 @@ EOF
         foreach ($builder->getDefinitions() as $service => $definition) {
             foreach ($definition->getArguments() as $argument) {
                 if ($argument instanceof Reference && (string) $argument === $name) {
+                    $usages[] = $service;
+                }
+            }
+            foreach ($definition->getMethodCalls() as $methodCall) {
+                $methodParameters = $methodCall[1];
+                foreach ($methodParameters as $methodParameter) {
+                    if ($methodParameter instanceof Reference && (string) $methodParameter === $name) {
+                        $usages[] = $service;
+                    }
+                }
+            }
+            foreach ($definition->getProperties() as $property) {
+                if ($property instanceof Reference && (string) $property === $name) {
                     $usages[] = $service;
                 }
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -107,7 +107,7 @@ EOF
             $options = array('tag' => $tag, 'show_private' => $input->getOption('show-private'));
         } elseif ($name = $input->getArgument('name')) {
             $name = $this->findProperServiceName($input, $io, $object, $name);
-            $options = array('id' => $name, 'injections' => $this->findServiceIdsInjections($object, $name));
+            $options = array('id' => $name, 'usages' => $this->findServiceIdsUsages($object, $name));
         } else {
             $options = array('show_private' => $input->getOption('show-private'));
         }
@@ -201,26 +201,26 @@ EOF
     }
 
     /**
-     * Find all services where the service $name has been injected.
+     * Find all services where the service $name is used.
      *
      * @param ContainerBuilder $builder
      * @param string           $name
      *
      * @return array
      */
-    private function findServiceIdsInjections(ContainerBuilder $builder, $name)
+    private function findServiceIdsUsages(ContainerBuilder $builder, $name)
     {
-        $injections = array();
+        $usages = array();
 
         foreach ($builder->getDefinitions() as $service => $definition) {
             foreach ($definition->getArguments() as $argument) {
                 if ($argument instanceof Reference && (string) $argument === $name) {
-                    $injections[] = $service;
+                    $usages[] = $service;
                 }
             }
         }
 
-        return $injections;
+        return $usages;
     }
 
     private function findServiceIdsContaining(ContainerBuilder $builder, $name)

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -20,7 +20,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * A console command for retrieving information about services.
@@ -107,7 +106,7 @@ EOF
             $options = array('tag' => $tag, 'show_private' => $input->getOption('show-private'));
         } elseif ($name = $input->getArgument('name')) {
             $name = $this->findProperServiceName($input, $io, $object, $name);
-            $options = array('id' => $name, 'usages' => $this->findServiceIdsUsages($object, $name));
+            $options = array('id' => $name);
         } else {
             $options = array('show_private' => $input->getOption('show-private'));
         }
@@ -198,43 +197,6 @@ EOF
         $default = 1 === count($matchingServices) ? $matchingServices[0] : null;
 
         return $io->choice('Select one of the following services to display its information', $matchingServices, $default);
-    }
-
-    /**
-     * Find all services where the service $name is used.
-     * Can be either by the constructor, by a setter or by a public property.
-     *
-     * @param ContainerBuilder $builder
-     * @param string           $name
-     *
-     * @return array
-     */
-    private function findServiceIdsUsages(ContainerBuilder $builder, $name)
-    {
-        $usages = array();
-
-        foreach ($builder->getDefinitions() as $service => $definition) {
-            foreach ($definition->getArguments() as $argument) {
-                if ($argument instanceof Reference && (string) $argument === $name) {
-                    $usages[] = $service;
-                }
-            }
-            foreach ($definition->getMethodCalls() as $methodCall) {
-                $methodParameters = $methodCall[1];
-                foreach ($methodParameters as $methodParameter) {
-                    if ($methodParameter instanceof Reference && (string) $methodParameter === $name) {
-                        $usages[] = $service;
-                    }
-                }
-            }
-            foreach ($definition->getProperties() as $property) {
-                if ($property instanceof Reference && (string) $property === $name) {
-                    $usages[] = $service;
-                }
-            }
-        }
-
-        return $usages;
     }
 
     private function findServiceIdsContaining(ContainerBuilder $builder, $name)

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -17,6 +17,7 @@ use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
@@ -54,7 +55,7 @@ abstract class Descriptor implements DescriptorInterface
                 $this->describeContainerTags($object, $options);
                 break;
             case $object instanceof ContainerBuilder && isset($options['id']):
-                $this->describeContainerService($this->resolveServiceDefinition($object, $options['id']), $options);
+                $this->describeContainerService($object, $this->resolveServiceDefinition($object, $options['id']), $options);
                 break;
             case $object instanceof ContainerBuilder && isset($options['parameter']):
                 $this->describeContainerParameter($object->getParameter($options['parameter']), $options);
@@ -138,10 +139,11 @@ abstract class Descriptor implements DescriptorInterface
      * Common options are:
      * * name: name of described service
      *
+     * @param ContainerBuilder        $builder
      * @param Definition|Alias|object $service
      * @param array                   $options
      */
-    abstract protected function describeContainerService($service, array $options = array());
+    abstract protected function describeContainerService(ContainerBuilder $builder, $service, array $options = array());
 
     /**
      * Describes container services.
@@ -295,6 +297,42 @@ abstract class Descriptor implements DescriptorInterface
         return $definitions;
     }
 
+    /**
+     * Find all services where the service $name is used.
+     * Can be either by the constructor, by a setter or by a public property.
+     *
+     * @param ContainerBuilder $builder
+     * @param string           $name
+     *
+     * @return array
+     */
+    protected function findServiceIdsUsages(ContainerBuilder $builder, $name)
+    {
+        $usages = array();
+
+        foreach ($builder->getDefinitions() as $service => $definition) {
+            foreach ($definition->getArguments() as $argument) {
+                if ($argument instanceof Reference && (string) $argument === $name) {
+                    $usages[] = $service;
+                }
+            }
+            foreach ($definition->getMethodCalls() as $methodCall) {
+                $methodParameters = $methodCall[1];
+                foreach ($methodParameters as $methodParameter) {
+                    if ($methodParameter instanceof Reference && (string) $methodParameter === $name) {
+                        $usages[] = $service;
+                    }
+                }
+            }
+            foreach ($definition->getProperties() as $property) {
+                if ($property instanceof Reference && (string) $property === $name) {
+                    $usages[] = $service;
+                }
+            }
+        }
+
+        return $usages;
+    }
     protected function sortParameters(ParameterBag $parameters)
     {
         $parameters = $parameters->all();

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -311,6 +311,10 @@ abstract class Descriptor implements DescriptorInterface
         $usages = array();
 
         foreach ($builder->getDefinitions() as $service => $definition) {
+            if ($name === $service) {
+                continue;
+            }
+
             foreach ($definition->getArguments() as $argument) {
                 if ($argument instanceof Reference && (string) $argument === $name) {
                     $usages[] = $service;
@@ -333,6 +337,7 @@ abstract class Descriptor implements DescriptorInterface
 
         return $usages;
     }
+
     protected function sortParameters(ParameterBag $parameters)
     {
         $parameters = $parameters->all();

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -77,7 +77,7 @@ class JsonDescriptor extends Descriptor
     /**
      * {@inheritdoc}
      */
-    protected function describeContainerService($service, array $options = array())
+    protected function describeContainerService(ContainerBuilder $builder, $service, array $options = array())
     {
         if (!isset($options['id'])) {
             throw new \InvalidArgumentException('An "id" option must be provided.');
@@ -86,7 +86,7 @@ class JsonDescriptor extends Descriptor
         if ($service instanceof Alias) {
             $this->writeData($this->getContainerAliasData($service), $options);
         } elseif ($service instanceof Definition) {
-            $this->writeData($this->getContainerDefinitionData($service), $options);
+            $this->writeData($this->getContainerDefinitionDataWithUsages($builder, $service, $options['id'], false), $options);
         } else {
             $this->writeData(get_class($service), $options);
         }
@@ -108,7 +108,7 @@ class JsonDescriptor extends Descriptor
                 $data['aliases'][$serviceId] = $this->getContainerAliasData($service);
             } elseif ($service instanceof Definition) {
                 if (($showPrivate || $service->isPublic())) {
-                    $data['definitions'][$serviceId] = $this->getContainerDefinitionData($service);
+                    $data['definitions'][$serviceId] = $this->getContainerDefinitionDataWithUsages($builder, $service, $serviceId, false);
                 }
             } else {
                 $data['services'][$serviceId] = get_class($service);
@@ -260,6 +260,22 @@ class JsonDescriptor extends Descriptor
                 }
             }
         }
+
+        return $data;
+    }
+
+    /**
+     * @param ContainerBuilder $builder
+     * @param Definition       $definition
+     * @param string           $serviceId
+     * @param bool             $omitTags
+     *
+     * @return array
+     */
+    private function getContainerDefinitionDataWithUsages(ContainerBuilder $builder, Definition $definition, $serviceId, $omitTags = false)
+    {
+        $data = $this->getContainerDefinitionData($definition, $omitTags);
+        $data['usages'] = $this->findServiceIdsUsages($builder, $serviceId);
 
         return $data;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -324,6 +324,13 @@ class TextDescriptor extends Descriptor
             }
         }
 
+        $injections = '-';
+        if (isset($options['injections']) && !empty($options['injections'])) {
+            $injections = implode(', ', $options['injections']);
+        }
+
+        $tableRows[] = array('Injected Into', $injections);
+
         $options['output']->table($tableHeaders, $tableRows);
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
@@ -98,6 +98,8 @@ class ObjectsProvider
     {
         $definition1 = new Definition('Full\\Qualified\\Class1');
         $definition2 = new Definition('Full\\Qualified\\Class2');
+        $definition3 = new Definition('Full\\Qualified\\Class3');
+        $definition4 = new Definition('Full\\Qualified\\Class4');
 
         return array(
             'definition_1' => $definition1
@@ -117,6 +119,12 @@ class ObjectsProvider
                 ->addTag('tag2')
                 ->addMethodCall('setMailer', array(new Reference('mailer')))
                 ->setFactory(array(new Reference('factory.service'), 'get')),
+            'definition_3' => $definition3
+                ->setArguments(array(new Reference('definition_1'))),
+            'definition_4' => $definition4
+                ->setArguments(array(new Reference('definition_1')))
+                ->addMethodCall('setFoo', array(new Reference('definition_2')))
+                ->setProperty('bar', new Reference('definition_3')),
         );
     }
 
@@ -133,7 +141,9 @@ class ObjectsProvider
         $eventDispatcher = new EventDispatcher();
 
         $eventDispatcher->addListener('event1', 'global_function', 255);
-        $eventDispatcher->addListener('event1', function () { return 'Closure'; }, -1);
+        $eventDispatcher->addListener('event1', function () {
+            return 'Closure';
+        }, -1);
         $eventDispatcher->addListener('event2', new CallableClass());
 
         return array('event_dispatcher_1' => $eventDispatcher);
@@ -147,7 +157,9 @@ class ObjectsProvider
             'callable_3' => array(new CallableClass(), 'method'),
             'callable_4' => 'Symfony\\Bundle\\FrameworkBundle\\Tests\\Console\\Descriptor\\CallableClass::staticMethod',
             'callable_5' => array('Symfony\\Bundle\\FrameworkBundle\\Tests\\Console\\Descriptor\\ExtendedCallableClass', 'parent::staticMethod'),
-            'callable_6' => function () { return 'Closure'; },
+            'callable_6' => function () {
+                return 'Closure';
+            },
             'callable_7' => new CallableClass(),
         );
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.json
@@ -14,7 +14,41 @@
 
             ],
             "autowire": false,
-            "autowiring_types": []
+            "autowiring_types": [],
+            "usages": ["definition_3", "definition_4"]
+        },
+        "definition_3":{
+            "class": "Full\\Qualified\\Class3",
+            "public": true,
+            "synthetic": false,
+            "lazy": false,
+            "shared": true,
+            "abstract": false,
+            "file": null,
+            "tags": [
+
+            ],
+            "autowire": false,
+            "autowiring_types": [],
+            "usages": ["definition_4"]
+        },
+        "definition_4":{
+            "class": "Full\\Qualified\\Class4",
+            "public": true,
+            "synthetic": false,
+            "lazy": false,
+            "shared": true,
+            "abstract": false,
+            "file": null,
+            "tags": [
+
+            ],
+            "calls": [
+                "setFoo"
+            ],
+            "autowire": false,
+            "autowiring_types": [],
+            "usages": []
         }
     },
     "aliases": {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.md
@@ -16,6 +16,35 @@ definition_1
 - Autowired: no
 - Factory Class: `Full\Qualified\FactoryClass`
 - Factory Method: `get`
+- Usages:
+    - `definition_3`
+    - `definition_4`
+
+definition_3
+~~~~~~~~~~~~
+
+- Class: `Full\Qualified\Class3`
+- Public: yes
+- Synthetic: no
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowired: no
+- Usages:
+    - `definition_4`
+
+definition_4
+~~~~~~~~~~~~
+
+- Class: `Full\Qualified\Class4`
+- Public: yes
+- Synthetic: no
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowired: no
+- Call: `setFoo`
+- Usages: -
 
 
 Aliases

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.txt
@@ -8,6 +8,8 @@
   alias_1             alias for "service_1"                                   
   alias_2             alias for "service_2"                                   
   definition_1        Full\Qualified\Class1                                   
+  definition_3        Full\Qualified\Class3                                   
+  definition_4        Full\Qualified\Class4                                   
   service_container   Symfony\Component\DependencyInjection\ContainerBuilder  
  ------------------- -------------------------------------------------------- 
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.xml
@@ -4,6 +4,21 @@
   <alias id="alias_2" service="service_2" public="false"/>
   <definition id="definition_1" class="Full\Qualified\Class1" public="true" synthetic="false" lazy="true" shared="true" abstract="true" autowired="false" file="">
     <factory class="Full\Qualified\FactoryClass" method="get"/>
+    <usages>
+      <usage>definition_3</usage>
+      <usage>definition_4</usage>
+    </usages>
+  </definition>
+  <definition id="definition_3" class="Full\Qualified\Class3" public="true" synthetic="false" lazy="false" shared="true" abstract="false" autowired="false" file="">
+    <usages>
+      <usage>definition_4</usage>
+    </usages>
+  </definition>
+  <definition id="definition_4" class="Full\Qualified\Class4" public="true" synthetic="false" lazy="false" shared="true" abstract="false" autowired="false" file="">
+    <calls>
+      <call method="setFoo"/>
+    </calls>
+    <usages/>
   </definition>
   <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerBuilder"/>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.json
@@ -14,7 +14,8 @@
 
             ],
             "autowire": false,
-            "autowiring_types": []
+            "autowiring_types": [],
+            "usages": ["definition_3", "definition_4"]
         },
         "definition_2": {
             "class": "Full\\Qualified\\Class2",
@@ -51,7 +52,41 @@
                 "setMailer"
             ],
             "autowire": false,
-            "autowiring_types": []
+            "autowiring_types": [],
+            "usages": ["definition_4"]
+        },
+        "definition_3":{
+            "class": "Full\\Qualified\\Class3",
+            "public": true,
+            "synthetic": false,
+            "lazy": false,
+            "shared": true,
+            "abstract": false,
+            "file": null,
+            "tags": [
+
+            ],
+            "autowire": false,
+            "autowiring_types": [],
+            "usages": ["definition_4"]
+        },
+        "definition_4":{
+            "class": "Full\\Qualified\\Class4",
+            "public": true,
+            "synthetic": false,
+            "lazy": false,
+            "shared": true,
+            "abstract": false,
+            "file": null,
+            "tags": [
+
+            ],
+            "calls": [
+                "setFoo"
+            ],
+            "autowire": false,
+            "autowiring_types": [],
+            "usages": []
         }
     },
     "aliases": {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.md
@@ -16,6 +16,9 @@ definition_1
 - Autowired: no
 - Factory Class: `Full\Qualified\FactoryClass`
 - Factory Method: `get`
+- Usages:
+    - `definition_3`
+    - `definition_4`
 
 definition_2
 ~~~~~~~~~~~~
@@ -37,6 +40,34 @@ definition_2
 - Tag: `tag1`
     - Attr3: val3
 - Tag: `tag2`
+- Usages:
+    - `definition_4`
+
+definition_3
+~~~~~~~~~~~~
+
+- Class: `Full\Qualified\Class3`
+- Public: yes
+- Synthetic: no
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowired: no
+- Usages:
+    - `definition_4`
+
+definition_4
+~~~~~~~~~~~~
+
+- Class: `Full\Qualified\Class4`
+- Public: yes
+- Synthetic: no
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowired: no
+- Call: `setFoo`
+- Usages: -
 
 
 Aliases

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.txt
@@ -9,6 +9,8 @@
   alias_2             alias for "service_2"                                   
   definition_1        Full\Qualified\Class1                                   
   definition_2        Full\Qualified\Class2                                   
+  definition_3        Full\Qualified\Class3                                   
+  definition_4        Full\Qualified\Class4                                   
   service_container   Symfony\Component\DependencyInjection\ContainerBuilder  
  ------------------- -------------------------------------------------------- 
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_services.xml
@@ -4,6 +4,10 @@
   <alias id="alias_2" service="service_2" public="false"/>
   <definition id="definition_1" class="Full\Qualified\Class1" public="true" synthetic="false" lazy="true" shared="true" abstract="true" autowired="false" file="">
     <factory class="Full\Qualified\FactoryClass" method="get"/>
+    <usages>
+      <usage>definition_3</usage>
+      <usage>definition_4</usage>
+    </usages>
   </definition>
   <definition id="definition_2" class="Full\Qualified\Class2" public="false" synthetic="true" lazy="false" shared="true" abstract="false" autowired="false" file="/path/to/file">
     <factory service="factory.service" method="get"/>
@@ -20,6 +24,20 @@
       </tag>
       <tag name="tag2"/>
     </tags>
+    <usages>
+      <usage>definition_4</usage>
+    </usages>
+  </definition>
+  <definition id="definition_3" class="Full\Qualified\Class3" public="true" synthetic="false" lazy="false" shared="true" abstract="false" autowired="false" file="">
+    <usages>
+      <usage>definition_4</usage>
+    </usages>
+  </definition>
+  <definition id="definition_4" class="Full\Qualified\Class4" public="true" synthetic="false" lazy="false" shared="true" abstract="false" autowired="false" file="">
+    <calls>
+      <call method="setFoo"/>
+    </calls>
+    <usages/>
   </definition>
   <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerBuilder"/>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tag1.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tag1.json
@@ -35,7 +35,8 @@
                 "setMailer"
             ],
             "autowire": false,
-            "autowiring_types": []
+            "autowiring_types": [],
+            "usages": ["definition_4"]
         }
     },
     "aliases": [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tag1.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tag1.md
@@ -24,3 +24,5 @@ definition_2
 - Tag: `tag1`
     - Attr3: val3
 - Tag: `tag2`
+- Usages:
+    - `definition_4`

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tag1.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_tag1.xml
@@ -15,5 +15,8 @@
       </tag>
       <tag name="tag2"/>
     </tags>
+    <usages>
+      <usage>definition_4</usage>
+    </usages>
   </definition>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_3.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_3.json
@@ -1,0 +1,14 @@
+{
+    "class": "Full\\Qualified\\Class3",
+    "public": true,
+    "synthetic": false,
+    "lazy": false,
+    "shared": true,
+    "abstract": false,
+    "file": null,
+    "tags": [
+
+    ],
+    "autowire": false,
+    "autowiring_types": []
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_3.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_3.md
@@ -1,0 +1,7 @@
+- Class: `Full\Qualified\Class3`
+- Public: yes
+- Synthetic: no
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowired: no

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_3.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_3.txt
@@ -1,0 +1,15 @@
+ ------------------ ----------------------- 
+ [32m Option           [39m [32m Value                 [39m 
+ ------------------ ----------------------- 
+  Service ID         -                      
+  Class              Full\Qualified\Class3  
+  Tags               -                      
+  Public             yes                    
+  Synthetic          no                     
+  Lazy               no                     
+  Shared             yes                    
+  Abstract           no                     
+  Autowired          no                     
+  Autowiring Types   -                      
+ ------------------ ----------------------- 
+

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_3.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_3.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definition class="Full\Qualified\Class3" public="true" synthetic="false" lazy="false" shared="true" abstract="false" autowired="false" file=""/>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_4.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_4.json
@@ -1,0 +1,17 @@
+{
+    "class": "Full\\Qualified\\Class4",
+    "public": true,
+    "synthetic": false,
+    "lazy": false,
+    "shared": true,
+    "abstract": false,
+    "file": null,
+    "tags": [
+
+    ],
+    "calls": [
+        "setFoo"
+    ],
+    "autowire": false,
+    "autowiring_types": []
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_4.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_4.md
@@ -1,0 +1,8 @@
+- Class: `Full\Qualified\Class4`
+- Public: yes
+- Synthetic: no
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowired: no
+- Call: `setFoo`

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_4.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_4.txt
@@ -1,0 +1,16 @@
+ ------------------ ----------------------- 
+ [32m Option           [39m [32m Value                 [39m 
+ ------------------ ----------------------- 
+  Service ID         -                      
+  Class              Full\Qualified\Class4  
+  Tags               -                      
+  Calls              setFoo                 
+  Public             yes                    
+  Synthetic          no                     
+  Lazy               no                     
+  Shared             yes                    
+  Abstract           no                     
+  Autowired          no                     
+  Autowiring Types   -                      
+ ------------------ ----------------------- 
+

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_4.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_4.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definition class="Full\Qualified\Class4" public="true" synthetic="false" lazy="false" shared="true" abstract="false" autowired="false" file="">
+  <calls>
+    <call method="setFoo"/>
+  </calls>
+</definition>


### PR DESCRIPTION
## Todo

- [x] JSON
- [x] TXT
- [x] MD
- [X] XML
- [x] skip current definition
- [x] ask if output's definition needs the usages

## Goal

The goal of this PR is to be able to know where a service is injected when using `bin/console debug:container service_name`.

Imagine the following services:

```
services:
    bar:
        class: StdClass
        tags:
            - { name: 'tag1' }
    foo_constructor:
        class: StdClass
        arguments:
            - '@bar'
    foo_setter:
        class: FooSetter
        calls:
            - [setBar, ['@bar']]
    foo_property:
        class: FooProperty
        properties:
            bar: '@bar'
```

The command `bin/console debug:container bar` will output:
![sf1](https://cloud.githubusercontent.com/assets/3691804/21174371/0bdaabc8-c1dd-11e6-8d8c-c1656ec6bfa1.png)

The command `bin/console debug:container foo_constructor` will output:
![sf2](https://cloud.githubusercontent.com/assets/3691804/21174385/20a4cf20-c1dd-11e6-94ba-ef4cc685eed8.png)

| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | almost... |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
