### PR TITLE
[Console] Fix block() padding formatting after #19189

### DIFF
--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -410,9 +410,16 @@ class SymfonyStyle extends OutputStyle
             }
         }
 
+        $firstLineIndex = 0;
+        if ($padding && $this->isDecorated()) {
+            $firstLineIndex = 1;
+            array_unshift($lines, '');
+            $lines[] = '';
+        }
+
         foreach ($lines as $i => &$line) {
             if (null !== $type) {
-                $line = 0 === $i ? $type.$line : $lineIndentation.$line;
+                $line = $firstLineIndex === $i ? $type.$line : $lineIndentation.$line;
             }
 
             $line = $prefix.$line;
@@ -421,11 +428,6 @@ class SymfonyStyle extends OutputStyle
             if ($style) {
                 $line = sprintf('<%s>%s</>', $style, $line);
             }
-        }
-
-        if ($padding && $this->isDecorated()) {
-            array_unshift($lines, '');
-            $lines[] = '';
         }
 
         return $lines;

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_16.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_16.php
@@ -1,0 +1,15 @@
+<?php
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tests\Style\SymfonyStyleWithForcedLineLength;
+
+// ensure that block() output is properly formatted (even padding lines)
+return function (InputInterface $input, OutputInterface $output) {
+    $output->setDecorated(true);
+    $output = new SymfonyStyleWithForcedLineLength($input, $output);
+    $output->success(
+        'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum',
+        'TEST'
+    );
+};

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_16.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_16.txt
@@ -1,0 +1,8 @@
+
+[30;42m                                                                                                                        [39;49m
+[30;42m [OK] Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore    [39;49m
+[30;42m      magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo    [39;49m
+[30;42m      consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. [39;49m
+[30;42m      Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum     [39;49m
+[30;42m                                                                                                                        [39;49m
+


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/pull/19189#issuecomment-229735157 |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

This fixes the unformatted padding of `block()` output after #19189.
