### PR TITLE
[Validator][Choice] Make strict the default option for choice validation

### DIFF
--- a/UPGRADE-3.2.md
+++ b/UPGRADE-3.2.md
@@ -70,3 +70,19 @@ Validator
        // ...
    }
    ```
+   
+ * Setting the strict option of the `Choice` Constraint to `false` has been  
+   deprecated and the option will be changed to `true` as of 4.0.
+
+   ```php
+   // ...
+   use Symfony\Component\Validator\Constraints as Assert;
+
+   class MyEntity
+   {
+       /**
+        * @Assert\Choice(choices={"MR", "MRS"}, strict=true)
+        */
+       private $salutation;
+   }
+   ```

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -261,3 +261,7 @@ Validator
        // ...
    }
    ```
+   
+ * The default value of the strict option of the `Choice` Constraint has been
+   changed to `true` as of 4.0. If you need the the previous behaviour ensure to 
+   set the option to `false`.

--- a/src/Symfony/Component/Validator/Constraints/Choice.php
+++ b/src/Symfony/Component/Validator/Constraints/Choice.php
@@ -34,7 +34,7 @@ class Choice extends Constraint
     public $choices;
     public $callback;
     public $multiple = false;
-    public $strict = false;
+    public $strict = true;
     public $min;
     public $max;
     public $message = 'The value you selected is not a valid choice.';

--- a/src/Symfony/Component/Validator/Constraints/Choice.php
+++ b/src/Symfony/Component/Validator/Constraints/Choice.php
@@ -34,7 +34,7 @@ class Choice extends Constraint
     public $choices;
     public $callback;
     public $multiple = false;
-    public $strict = true;
+    public $strict = false;
     public $min;
     public $max;
     public $message = 'The value you selected is not a valid choice.';

--- a/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
@@ -57,6 +57,10 @@ class ChoiceValidator extends ConstraintValidator
             $choices = $constraint->choices;
         }
 
+        if (false === $constraint->strict) {
+            @trigger_error('Setting the strict option of the Choice constraint to false is deprecated since version 3.2 and will be removed in 4.0.', E_USER_DEPRECATED);
+        }
+
         if ($constraint->multiple) {
             foreach ($value as $_value) {
                 if (!in_array($_value, $choices, $constraint->strict)) {

--- a/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
@@ -245,6 +245,9 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
+    /**
+     * @group legacy
+     */
     public function testNonStrict()
     {
         $constraint = new Choice(array(
@@ -286,6 +289,9 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
+    /**
+     * @group legacy
+     */
     public function testNonStrictWithMultipleChoices()
     {
         $constraint = new Choice(array(

--- a/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
@@ -40,6 +40,7 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
         $constraint = new Choice(array(
             'choices' => array('foo', 'bar'),
             'multiple' => true,
+            'strict' => true,
         ));
 
         $this->validator->validate('asdf', $constraint);
@@ -47,7 +48,15 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new Choice(array('choices' => array('foo', 'bar'))));
+        $this->validator->validate(
+            null,
+            new Choice(
+                array(
+                    'choices' => array('foo', 'bar'),
+                    'strict' => true,
+                )
+            )
+        );
 
         $this->assertNoViolation();
     }
@@ -57,7 +66,7 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
      */
     public function testChoicesOrCallbackExpected()
     {
-        $this->validator->validate('foobar', new Choice());
+        $this->validator->validate('foobar', new Choice(array('strict' => true)));
     }
 
     /**
@@ -65,12 +74,12 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
      */
     public function testValidCallbackExpected()
     {
-        $this->validator->validate('foobar', new Choice(array('callback' => 'abcd')));
+        $this->validator->validate('foobar', new Choice(array('callback' => 'abcd', 'strict' => true)));
     }
 
     public function testValidChoiceArray()
     {
-        $constraint = new Choice(array('choices' => array('foo', 'bar')));
+        $constraint = new Choice(array('choices' => array('foo', 'bar'), 'strict' => true));
 
         $this->validator->validate('bar', $constraint);
 
@@ -79,7 +88,7 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
 
     public function testValidChoiceCallbackFunction()
     {
-        $constraint = new Choice(array('callback' => __NAMESPACE__.'\choice_callback'));
+        $constraint = new Choice(array('callback' => __NAMESPACE__.'\choice_callback', 'strict' => true));
 
         $this->validator->validate('bar', $constraint);
 
@@ -88,9 +97,14 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
 
     public function testValidChoiceCallbackClosure()
     {
-        $constraint = new Choice(array('callback' => function () {
-            return array('foo', 'bar');
-        }));
+        $constraint = new Choice(
+            array(
+                'strict' => true,
+                'callback' => function () {
+                    return array('foo', 'bar');
+                },
+            )
+        );
 
         $this->validator->validate('bar', $constraint);
 
@@ -99,7 +113,7 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
 
     public function testValidChoiceCallbackStaticMethod()
     {
-        $constraint = new Choice(array('callback' => array(__CLASS__, 'staticCallback')));
+        $constraint = new Choice(array('callback' => array(__CLASS__, 'staticCallback'), 'strict' => true));
 
         $this->validator->validate('bar', $constraint);
 
@@ -111,7 +125,7 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
         // search $this for "staticCallback"
         $this->setObject($this);
 
-        $constraint = new Choice(array('callback' => 'staticCallback'));
+        $constraint = new Choice(array('callback' => 'staticCallback', 'strict' => true));
 
         $this->validator->validate('bar', $constraint);
 
@@ -123,6 +137,7 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
         $constraint = new Choice(array(
             'choices' => array('foo', 'bar', 'baz'),
             'multiple' => true,
+            'strict' => true,
         ));
 
         $this->validator->validate(array('baz', 'bar'), $constraint);
@@ -135,6 +150,7 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
         $constraint = new Choice(array(
             'choices' => array('foo', 'bar'),
             'message' => 'myMessage',
+            'strict' => true,
         ));
 
         $this->validator->validate('baz', $constraint);
@@ -152,6 +168,7 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
             // the DB or the model
             'choices' => array(),
             'message' => 'myMessage',
+            'strict' => true,
         ));
 
         $this->validator->validate('baz', $constraint);
@@ -168,6 +185,7 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
             'choices' => array('foo', 'bar'),
             'multipleMessage' => 'myMessage',
             'multiple' => true,
+            'strict' => true,
         ));
 
         $this->validator->validate(array('foo', 'baz'), $constraint);
@@ -186,6 +204,7 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
             'multiple' => true,
             'min' => 2,
             'minMessage' => 'myMessage',
+            'strict' => true,
         ));
 
         $value = array('foo');
@@ -209,6 +228,7 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
             'multiple' => true,
             'max' => 2,
             'maxMessage' => 'myMessage',
+            'strict' => true,
         ));
 
         $value = array('foo', 'bar', 'moo');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #18973 |
| License | MIT |
| Doc PR | - |

This is just the WIP as there are two options.
1. Just change default which would only possible to introduce in 4.x or in 3.2 if this BC break is considered as acceptable
2. Add a new option e.g. `strictComparison` which defaults to true in 4.x and deprecate the usage of the strict option for 3.2.
3. Just deprecate strict = false and remove the option but I would be against that as we remove flexibility which might be wanted.

As per discussion I went ahead with option 3. We can then still decide if we want to remove the option entirely or eventually reenable setting strict to false in a later release.
