### PR TITLE
[Routing] Add a 'has' method to the RouteCollection

### DIFF
--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -90,6 +90,18 @@ class RouteCollection implements \IteratorAggregate, \Countable
     }
 
     /**
+     * Returns whether a route with the given name exists.
+     *
+     * @param string $name The route name
+     *
+     * @return bool
+     */
+    public function has($name)
+    {
+        return isset($this->routes[$name]);
+    }
+
+    /**
      * Gets a route by name.
      *
      * @param string $name The route name

--- a/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
@@ -199,6 +199,22 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $collection1->getIterator(), '->addCollection() removes previous routes when adding new routes with the same name');
     }
 
+    public function testHas()
+    {
+        $collection = new RouteCollection();
+        $collection->add('x', new Route('/x'));
+        $childCollection = new RouteCollection();
+        $childCollection->add('y', new Route('/y'));
+        $collection->addCollection($childCollection);
+        $collection->add('$péß^a|', new Route('/special'));
+
+        $this->assertTrue($collection->has('y'), '->has() handles correct route in child collection');
+        $this->assertTrue($collection->has('$péß^a|'), '->has() can handle special characters');
+        $this->assertFalse($childCollection->has('x'), '->has() does not check the route defined in parent collection');
+        $this->assertFalse($collection->has('non-existent'), '->has() returns false when route does not exist');
+        $this->assertFalse($collection->has(0), '->has() does not disclose internal child RouteCollection');
+    }
+
     public function testGet()
     {
         $collection1 = new RouteCollection();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This method is usefull when you want just to check whether a route exists:

``` php
if ($router->getRouteCollection()->has('some_route')) {
    // ...
}
```
