### PR TITLE
Change some conditions from equal to identical

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
@@ -202,13 +202,13 @@ abstract class AbstractDoctrineExtension extends Extension
             if ($container->hasDefinition($mappingService)) {
                 $mappingDriverDef = $container->getDefinition($mappingService);
                 $args = $mappingDriverDef->getArguments();
-                if ($driverType == 'annotation') {
+                if ($driverType === 'annotation') {
                     $args[1] = array_merge(array_values($driverPaths), $args[1]);
                 } else {
                     $args[0] = array_merge(array_values($driverPaths), $args[0]);
                 }
                 $mappingDriverDef->setArguments($args);
-            } elseif ($driverType == 'annotation') {
+            } elseif ($driverType === 'annotation') {
                 $mappingDriverDef = new Definition('%'.$this->getObjectManagerElementName('metadata.'.$driverType.'.class%'), array(
                     new Reference($this->getObjectManagerElementName('metadata.annotation_reader')),
                     array_values($driverPaths),

--- a/src/Symfony/Bridge/Doctrine/HttpFoundation/DbalSessionHandler.php
+++ b/src/Symfony/Bridge/Doctrine/HttpFoundation/DbalSessionHandler.php
@@ -163,7 +163,7 @@ class DbalSessionHandler implements \SessionHandlerInterface
                 // Oracle has a bug that will intermittently happen if you
                 // have only 1 bind on a CLOB field for 2 different statements
                 // (INSERT and UPDATE in this case)
-                if ('oracle' == $this->con->getDatabasePlatform()->getName()) {
+                if ('oracle' === $this->con->getDatabasePlatform()->getName()) {
                     $mergeStmt->bindParam(':data2', $encoded, \PDO::PARAM_STR);
                 }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -177,7 +177,7 @@ EOF
                 $extractedMessagesCount += $domainMessagesCount;
             }
 
-            if ($input->getOption('output-format') == 'xlf') {
+            if ($input->getOption('output-format') === 'xlf') {
                 $io->comment('Xliff output version is <info>1.2</info>');
             }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerResolver.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerResolver.php
@@ -55,10 +55,10 @@ class ControllerResolver extends BaseControllerResolver
     {
         if (false === strpos($controller, '::')) {
             $count = substr_count($controller, ':');
-            if (2 == $count) {
+            if (2 === $count) {
                 // controller in the a:b:c notation then
                 $controller = $this->parser->parse($controller);
-            } elseif (1 == $count) {
+            } elseif (1 === $count) {
                 // controller in the service:method notation
                 list($service, $method) = explode(':', $controller, 2);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/date_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/date_widget.html.php
@@ -1,4 +1,4 @@
-<?php if ($widget == 'single_text'): ?>
+<?php if ($widget === 'single_text'): ?>
     <?php echo $view['form']->block($form, 'form_widget_simple'); ?>
 <?php else: ?>
     <div <?php echo $view['form']->block($form, 'widget_container_attributes') ?>>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/datetime_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/datetime_widget.html.php
@@ -1,4 +1,4 @@
-<?php if ($widget == 'single_text'): ?>
+<?php if ($widget === 'single_text'): ?>
     <?php echo $view['form']->block($form, 'form_widget_simple'); ?>
 <?php else: ?>
     <div <?php echo $view['form']->block($form, 'widget_container_attributes') ?>>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/time_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/time_widget.html.php
@@ -1,7 +1,7 @@
-<?php if ($widget == 'single_text'): ?>
+<?php if ($widget === 'single_text'): ?>
     <?php echo $view['form']->block($form, 'form_widget_simple'); ?>
 <?php else: ?>
-    <?php $vars = $widget == 'text' ? array('attr' => array('size' => 1)) : array() ?>
+    <?php $vars = $widget === 'text' ? array('attr' => array('size' => 1)) : array() ?>
     <div <?php echo $view['form']->block($form, 'widget_container_attributes') ?>>
         <?php
             // There should be no spaces between the colons and the widgets, that's why

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/Fixtures/StubTemplateNameParser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/Fixtures/StubTemplateNameParser.php
@@ -30,7 +30,7 @@ class StubTemplateNameParser implements TemplateNameParserInterface
     {
         list($bundle, $controller, $template) = explode(':', $name, 3);
 
-        if ($template[0] == '_') {
+        if ($template[0] === '_') {
             $path = $this->rootTheme.'/Custom/'.$template;
         } elseif ($bundle === 'TestBundle') {
             $path = $this->rootTheme.'/'.$controller.'/'.$template;

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/GuardAuthenticationFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/GuardAuthenticationFactory.php
@@ -109,7 +109,7 @@ class GuardAuthenticationFactory implements SecurityFactoryInterface
         }
 
         $authenticatorIds = $config['authenticators'];
-        if (count($authenticatorIds) == 1) {
+        if (count($authenticatorIds) === 1) {
             // if there is only one authenticator, use that as the entry point
             return array_shift($authenticatorIds);
         }

--- a/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
@@ -99,7 +99,7 @@ class ExceptionController
     protected function findTemplate(Request $request, $format, $code, $showException)
     {
         $name = $showException ? 'exception' : 'error';
-        if ($showException && 'html' == $format) {
+        if ($showException && 'html' === $format) {
             $name = 'exception_full';
         }
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
@@ -60,7 +60,7 @@ class ProfilerControllerTest extends \PHPUnit_Framework_TestCase
             ->expects($this->exactly(2))
             ->method('loadProfile')
             ->will($this->returnCallback(function ($token) {
-                if ('found' == $token) {
+                if ('found' === $token) {
                     return new Profile($token);
                 }
             }))

--- a/src/Symfony/Component/Asset/PathPackage.php
+++ b/src/Symfony/Component/Asset/PathPackage.php
@@ -39,7 +39,7 @@ class PathPackage extends Package
         if (!$basePath) {
             $this->basePath = '/';
         } else {
-            if ('/' != $basePath[0]) {
+            if ('/' !== $basePath[0]) {
                 $basePath = '/'.$basePath;
             }
 

--- a/src/Symfony/Component/Asset/UrlPackage.php
+++ b/src/Symfony/Component/Asset/UrlPackage.php
@@ -81,7 +81,7 @@ class UrlPackage extends Package
 
         $url = $this->getVersionStrategy()->applyVersion($path);
 
-        if ($url && '/' != $url[0]) {
+        if ($url && '/' !== $url[0]) {
             $url = '/'.$url;
         }
 

--- a/src/Symfony/Component/Asset/VersionStrategy/StaticVersionStrategy.php
+++ b/src/Symfony/Component/Asset/VersionStrategy/StaticVersionStrategy.php
@@ -46,7 +46,7 @@ class StaticVersionStrategy implements VersionStrategyInterface
     {
         $versionized = sprintf($this->format, ltrim($path, '/'), $this->getVersion($path));
 
-        if ($path && '/' == $path[0]) {
+        if ($path && '/' === $path[0]) {
             return '/'.$versionized;
         }
 

--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -299,7 +299,7 @@ abstract class Client
             $server['HTTP_HOST'] = $this->extractHost($uri);
         }
 
-        $server['HTTPS'] = 'https' == parse_url($uri, PHP_URL_SCHEME);
+        $server['HTTPS'] = 'https' === parse_url($uri, PHP_URL_SCHEME);
 
         $this->internalRequest = new Request($uri, $method, $parameters, $files, $this->cookieJar->allValues($uri), $server, $content);
 
@@ -543,7 +543,7 @@ abstract class Client
         }
 
         // anchor?
-        if (!$uri || '#' == $uri[0]) {
+        if (!$uri || '#' === $uri[0]) {
             return preg_replace('/#.*?$/', '', $currentUri).$uri;
         }
 
@@ -577,7 +577,7 @@ abstract class Client
     {
         $server['HTTP_HOST'] = $this->extractHost($uri);
         $scheme = parse_url($uri, PHP_URL_SCHEME);
-        $server['HTTPS'] = null === $scheme ? $server['HTTPS'] : 'https' == $scheme;
+        $server['HTTPS'] = null === $scheme ? $server['HTTPS'] : 'https' === $scheme;
         unset($server['HTTP_IF_NONE_MATCH'], $server['HTTP_IF_MODIFIED_SINCE']);
 
         return $server;

--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -160,7 +160,7 @@ class Cookie
 
             if ('secure' === strtolower($part)) {
                 // Ignore the secure flag if the original URI is not given or is not HTTPS
-                if (!$url || !isset($urlParts['scheme']) || 'https' != $urlParts['scheme']) {
+                if (!$url || !isset($urlParts['scheme']) || 'https' !== $urlParts['scheme']) {
                     continue;
                 }
 

--- a/src/Symfony/Component/BrowserKit/CookieJar.php
+++ b/src/Symfony/Component/BrowserKit/CookieJar.php
@@ -213,7 +213,7 @@ class CookieJar
                 }
 
                 foreach ($namedCookies as $cookie) {
-                    if ($cookie->isSecure() && 'https' != $parts['scheme']) {
+                    if ($cookie->isSecure() && 'https' !== $parts['scheme']) {
                         continue;
                     }
 

--- a/src/Symfony/Component/BrowserKit/History.php
+++ b/src/Symfony/Component/BrowserKit/History.php
@@ -49,7 +49,7 @@ class History
      */
     public function isEmpty()
     {
-        return count($this->stack) == 0;
+        return count($this->stack) === 0;
     }
 
     /**
@@ -93,7 +93,7 @@ class History
      */
     public function current()
     {
-        if (-1 == $this->position) {
+        if (-1 === $this->position) {
             throw new \LogicException('The page history is empty.');
         }
 

--- a/src/Symfony/Component/Config/Definition/Dumper/YamlReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/YamlReferenceDumper.php
@@ -122,7 +122,7 @@ class YamlReferenceDumper
             $comments[] = 'Example: '.$example;
         }
 
-        $default = (string) $default != '' ? ' '.$default : '';
+        $default = (string) $default !== '' ? ' '.$default : '';
         $comments = count($comments) ? '# '.implode(', ', $comments) : '';
 
         $text = rtrim(sprintf('%-20s %s %s', $node->getName().':', $default, $comments), ' ');

--- a/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
@@ -250,7 +250,7 @@ class PrototypedArrayNode extends ArrayNode
                     }
 
                     // if only "value" is left
-                    if (1 == count($v) && isset($v['value'])) {
+                    if (1 === count($v) && isset($v['value'])) {
                         $v = $v['value'];
                     }
                 }

--- a/src/Symfony/Component/Config/Util/XmlUtils.php
+++ b/src/Symfony/Component/Config/Util/XmlUtils.php
@@ -203,7 +203,7 @@ class XmlUtils
                 return true;
             case 'false' === $lowercaseValue:
                 return false;
-            case isset($value[1]) && '0b' == $value[0].$value[1]:
+            case isset($value[1]) && '0b' === $value[0].$value[1]:
                 return bindec($value);
             case is_numeric($value):
                 return '0x' === $value[0].$value[1] ? hexdec($value) : (float) $value;

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -482,7 +482,7 @@ class Application
             $message = sprintf('There are no commands defined in the "%s" namespace.', $namespace);
 
             if ($alternatives = $this->findAlternatives($namespace, $allNamespaces)) {
-                if (1 == count($alternatives)) {
+                if (1 === count($alternatives)) {
                     $message .= "\n\nDid you mean this?\n    ";
                 } else {
                     $message .= "\n\nDid you mean one of these?\n    ";
@@ -529,7 +529,7 @@ class Application
             $message = sprintf('Command "%s" is not defined.', $name);
 
             if ($alternatives = $this->findAlternatives($name, $allCommands)) {
-                if (1 == count($alternatives)) {
+                if (1 === count($alternatives)) {
                     $message .= "\n\nDid you mean this?\n    ";
                 } else {
                     $message .= "\n\nDid you mean one of these?\n    ";

--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -145,7 +145,7 @@ class OutputFormatter implements OutputFormatterInterface
             $pos = $match[1];
             $text = $match[0];
 
-            if (0 != $pos && '\\' == $message[$pos - 1]) {
+            if (0 != $pos && '\\' === $message[$pos - 1]) {
                 continue;
             }
 
@@ -154,7 +154,7 @@ class OutputFormatter implements OutputFormatterInterface
             $offset = $pos + strlen($text);
 
             // opening tag?
-            if ($open = '/' != $text[1]) {
+            if ($open = '/' !== $text[1]) {
                 $tag = $matches[1][$i][0];
             } else {
                 $tag = isset($matches[3][$i][0]) ? $matches[3][$i][0] : '';
@@ -210,9 +210,9 @@ class OutputFormatter implements OutputFormatterInterface
         foreach ($matches as $match) {
             array_shift($match);
 
-            if ('fg' == $match[0]) {
+            if ('fg' === $match[0]) {
                 $style->setForeground($match[1]);
-            } elseif ('bg' == $match[0]) {
+            } elseif ('bg' === $match[0]) {
                 $style->setBackground($match[1]);
             } else {
                 try {

--- a/src/Symfony/Component/Console/Helper/Helper.php
+++ b/src/Symfony/Component/Console/Helper/Helper.php
@@ -77,7 +77,7 @@ abstract class Helper implements HelperInterface
                 if ((isset($timeFormats[$index + 1]) && $secs < $timeFormats[$index + 1][0])
                     || $index == count($timeFormats) - 1
                 ) {
-                    if (2 == count($format)) {
+                    if (2 === count($format)) {
                         return $format[1];
                     }
 

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -78,7 +78,7 @@ class ArgvInput extends Input
         while (null !== $token = array_shift($this->parsed)) {
             if ($parseOptions && '' == $token) {
                 $this->parseArgument($token);
-            } elseif ($parseOptions && '--' == $token) {
+            } elseif ($parseOptions && '--' === $token) {
                 $parseOptions = false;
             } elseif ($parseOptions && 0 === strpos($token, '--')) {
                 $this->parseLongOption($token);

--- a/src/Symfony/Component/DependencyInjection/Exception/ParameterNotFoundException.php
+++ b/src/Symfony/Component/DependencyInjection/Exception/ParameterNotFoundException.php
@@ -53,7 +53,7 @@ class ParameterNotFoundException extends InvalidArgumentException
         }
 
         if ($this->alternatives) {
-            if (1 == count($this->alternatives)) {
+            if (1 === count($this->alternatives)) {
                 $this->message .= ' Did you mean this: "';
             } else {
                 $this->message .= ' Did you mean one of these: "';

--- a/src/Symfony/Component/DependencyInjection/Exception/ServiceNotFoundException.php
+++ b/src/Symfony/Component/DependencyInjection/Exception/ServiceNotFoundException.php
@@ -30,7 +30,7 @@ class ServiceNotFoundException extends InvalidArgumentException
         }
 
         if ($alternatives) {
-            if (1 == count($alternatives)) {
+            if (1 === count($alternatives)) {
                 $msg .= ' Did you mean this: "';
             } else {
                 $msg .= ' Did you mean one of these: "';

--- a/src/Symfony/Component/DependencyInjection/Extension/Extension.php
+++ b/src/Symfony/Component/DependencyInjection/Extension/Extension.php
@@ -65,7 +65,7 @@ abstract class Extension implements ExtensionInterface, ConfigurationExtensionIn
     public function getAlias()
     {
         $className = get_class($this);
-        if (substr($className, -9) != 'Extension') {
+        if (substr($className, -9) !== 'Extension') {
             throw new BadMethodCallException('This extension does not follow the naming convention; you must overwrite the getAlias() method.');
         }
         $classBaseName = substr(strrchr($className, '\\'), 1, -9);

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -353,7 +353,7 @@ class XmlFileLoader extends FileLoader
             }
 
             // parameter keys are case insensitive
-            if ('parameter' == $name && $lowercase) {
+            if ('parameter' === $name && $lowercase) {
                 $key = strtolower($key);
             }
 
@@ -367,9 +367,9 @@ class XmlFileLoader extends FileLoader
                 case 'service':
                     $onInvalid = $arg->getAttribute('on-invalid');
                     $invalidBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE;
-                    if ('ignore' == $onInvalid) {
+                    if ('ignore' === $onInvalid) {
                         $invalidBehavior = ContainerInterface::IGNORE_ON_INVALID_REFERENCE;
-                    } elseif ('null' == $onInvalid) {
+                    } elseif ('null' === $onInvalid) {
                         $invalidBehavior = ContainerInterface::NULL_ON_INVALID_REFERENCE;
                     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
@@ -306,7 +306,7 @@ class ProjectServiceContainer extends Container
         if ($this->has('foobaz')) {
             $instance->setBar($this->get('foobaz', ContainerInterface::NULL_ON_INVALID_REFERENCE));
         }
-        $instance->setBar(($this->get('foo')->foo() . (($this->hasparameter('foo')) ? ($this->getParameter('foo')) : ('default'))));
+        $instance->setBar(($this->get("foo")->foo() . (($this->hasparameter("foo")) ? ($this->getParameter("foo")) : ("default"))));
 
         return $instance;
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
@@ -306,7 +306,7 @@ class ProjectServiceContainer extends Container
         if ($this->has('foobaz')) {
             $instance->setBar($this->get('foobaz', ContainerInterface::NULL_ON_INVALID_REFERENCE));
         }
-        $instance->setBar(($this->get("foo")->foo() . (($this->hasparameter("foo")) ? ($this->getParameter("foo")) : ("default"))));
+        $instance->setBar(($this->get('foo')->foo() . (($this->hasparameter('foo')) ? ($this->getParameter('foo')) : ('default'))));
 
         return $instance;
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -291,7 +291,7 @@ class ProjectServiceContainer extends Container
 
         $instance->setBar($this->get('foo'));
         $instance->setBar(NULL);
-        $instance->setBar(($this->get('foo')->foo() . (($this->hasparameter('foo')) ? ($this->getParameter('foo')) : ('default'))));
+        $instance->setBar(($this->get("foo")->foo() . (($this->hasparameter("foo")) ? ($this->getParameter("foo")) : ("default"))));
 
         return $instance;
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -291,7 +291,7 @@ class ProjectServiceContainer extends Container
 
         $instance->setBar($this->get('foo'));
         $instance->setBar(NULL);
-        $instance->setBar(($this->get("foo")->foo() . (($this->hasparameter("foo")) ? ($this->getParameter("foo")) : ("default"))));
+        $instance->setBar(($this->get('foo')->foo() . (($this->hasparameter('foo')) ? ($this->getParameter('foo')) : ('default'))));
 
         return $instance;
     }

--- a/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
@@ -214,7 +214,7 @@ class ChoiceFormField extends FormField
         $this->options = array();
         $this->multiple = false;
 
-        if ('input' == $this->node->nodeName) {
+        if ('input' === $this->node->nodeName) {
             $this->type = strtolower($this->node->getAttribute('type'));
             $optionValue = $this->buildOptionValue($this->node);
             $this->options[] = $optionValue;

--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -403,7 +403,7 @@ class Form extends Link implements \ArrayAccess
 
         // add submitted button if it has a valid name
         if ('form' !== $this->button->nodeName && $this->button->hasAttribute('name') && $this->button->getAttribute('name')) {
-            if ('input' == $this->button->nodeName && 'image' == strtolower($this->button->getAttribute('type'))) {
+            if ('input' === $this->button->nodeName && 'image' === strtolower($this->button->getAttribute('type'))) {
                 $name = $this->button->getAttribute('name');
                 $this->button->setAttribute('value', '0');
 
@@ -452,9 +452,9 @@ class Form extends Link implements \ArrayAccess
         }
 
         $nodeName = $node->nodeName;
-        if ('select' == $nodeName || 'input' == $nodeName && 'checkbox' == strtolower($node->getAttribute('type'))) {
+        if ('select' === $nodeName || 'input' === $nodeName && 'checkbox' === strtolower($node->getAttribute('type'))) {
             $this->set(new Field\ChoiceFormField($node));
-        } elseif ('input' == $nodeName && 'radio' == strtolower($node->getAttribute('type'))) {
+        } elseif ('input' === $nodeName && 'radio' === strtolower($node->getAttribute('type'))) {
             // there may be other fields with the same name that are no choice
             // fields already registered (see https://github.com/symfony/symfony/issues/11689)
             if ($this->has($node->getAttribute('name')) && $this->get($node->getAttribute('name')) instanceof ChoiceFormField) {
@@ -462,11 +462,11 @@ class Form extends Link implements \ArrayAccess
             } else {
                 $this->set(new Field\ChoiceFormField($node));
             }
-        } elseif ('input' == $nodeName && 'file' == strtolower($node->getAttribute('type'))) {
+        } elseif ('input' === $nodeName && 'file' === strtolower($node->getAttribute('type'))) {
             $this->set(new Field\FileFormField($node));
-        } elseif ('input' == $nodeName && !in_array(strtolower($node->getAttribute('type')), array('submit', 'button', 'image'))) {
+        } elseif ('input' === $nodeName && !in_array(strtolower($node->getAttribute('type')), array('submit', 'button', 'image'))) {
             $this->set(new Field\InputFormField($node));
-        } elseif ('textarea' == $nodeName) {
+        } elseif ('textarea' === $nodeName) {
             $this->set(new Field\TextareaFormField($node));
         }
     }

--- a/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
@@ -169,7 +169,7 @@ class TraceableEventDispatcherTest extends \PHPUnit_Framework_TestCase
         $loop = 1;
         $dispatcher->addListener('foo', $listener1 = function () use ($dispatcher, &$loop) {
             ++$loop;
-            if (2 == $loop) {
+            if (2 === $loop) {
                 $dispatcher->dispatch('foo');
             }
         });

--- a/src/Symfony/Component/ExpressionLanguage/Lexer.php
+++ b/src/Symfony/Component/ExpressionLanguage/Lexer.php
@@ -36,7 +36,7 @@ class Lexer
         $end = strlen($expression);
 
         while ($cursor < $end) {
-            if (' ' == $expression[$cursor]) {
+            if (' ' === $expression[$cursor]) {
                 ++$cursor;
 
                 continue;

--- a/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/BinaryNode.php
@@ -45,7 +45,7 @@ class BinaryNode extends Node
     {
         $operator = $this->attributes['operator'];
 
-        if ('matches' == $operator) {
+        if ('matches' === $operator) {
             $compiler
                 ->raw('preg_match(')
                 ->compile($this->nodes['right'])

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -226,7 +226,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
 
     public function testFollowLinks()
     {
-        if ('\\' == DIRECTORY_SEPARATOR) {
+        if ('\\' === DIRECTORY_SEPARATOR) {
             $this->markTestSkipped('symlinks are not supported on Windows');
         }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
@@ -144,7 +144,7 @@ class CheckboxTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         // present a binary status field as a checkbox
         $transformer = new CallbackTransformer(
             function ($value) {
-                return 'checked' == $value;
+                return 'checked' === $value;
             },
             function ($value) {
                 return $value ? 'checked' : 'unchecked';

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1028,7 +1028,7 @@ class Request
         $scheme = $this->getScheme();
         $port = $this->getPort();
 
-        if (('http' == $scheme && $port == 80) || ('https' == $scheme && $port == 443)) {
+        if (('http' === $scheme && $port == 80) || ('https' === $scheme && $port == 443)) {
             return $this->getHost();
         }
 
@@ -1547,7 +1547,7 @@ class Request
      */
     public function isNoCache()
     {
-        return $this->headers->hasCacheControlDirective('no-cache') || 'no-cache' == $this->headers->get('Pragma');
+        return $this->headers->hasCacheControlDirective('no-cache') || 'no-cache' === $this->headers->get('Pragma');
     }
 
     /**
@@ -1679,7 +1679,7 @@ class Request
      */
     public function isXmlHttpRequest()
     {
-        return 'XMLHttpRequest' == $this->headers->get('X-Requested-With');
+        return 'XMLHttpRequest' === $this->headers->get('X-Requested-With');
     }
 
     /*
@@ -1761,7 +1761,7 @@ class Request
                 $seg = $segs[$index];
                 $baseUrl = '/'.$seg.$baseUrl;
                 ++$index;
-            } while ($last > $index && (false !== $pos = strpos($path, $baseUrl)) && 0 != $pos);
+            } while ($last > $index && strpos($path, $baseUrl));
         }
 
         // Does the baseUrl have anything in common with the request_uri?

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -302,7 +302,7 @@ class Response
         }
 
         // Fix protocol
-        if ('HTTP/1.0' != $request->server->get('SERVER_PROTOCOL')) {
+        if ('HTTP/1.0' !== $request->server->get('SERVER_PROTOCOL')) {
             $this->setProtocolVersion('1.1');
         }
 
@@ -1170,7 +1170,7 @@ class Response
      */
     protected function ensureIEOverSSLCompatibility(Request $request)
     {
-        if (false !== stripos($this->headers->get('Content-Disposition'), 'attachment') && preg_match('/MSIE (.*?);/i', $request->server->get('HTTP_USER_AGENT'), $match) == 1 && true === $request->isSecure()) {
+        if (false !== stripos($this->headers->get('Content-Disposition'), 'attachment') && preg_match('/MSIE (.*?);/i', $request->server->get('HTTP_USER_AGENT'), $match) === 1 && true === $request->isSecure()) {
             if ((int) preg_replace('/(MSIE )(.*?);/', '$2', $match[0]) < 9) {
                 $this->headers->remove('Cache-Control');
             }

--- a/src/Symfony/Component/HttpFoundation/ServerBag.php
+++ b/src/Symfony/Component/HttpFoundation/ServerBag.php
@@ -68,7 +68,7 @@ class ServerBag extends ParameterBag
                 if (0 === stripos($authorizationHeader, 'basic ')) {
                     // Decode AUTHORIZATION header into PHP_AUTH_USER and PHP_AUTH_PW when authorization header is basic
                     $exploded = explode(':', base64_decode(substr($authorizationHeader, 6)), 2);
-                    if (count($exploded) == 2) {
+                    if (count($exploded) === 2) {
                         list($headers['PHP_AUTH_USER'], $headers['PHP_AUTH_PW']) = $exploded;
                     }
                 } elseif (empty($this->parameters['PHP_AUTH_DIGEST']) && (0 === stripos($authorizationHeader, 'digest '))) {

--- a/src/Symfony/Component/HttpFoundation/Tests/File/MimeType/MimeTypeTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/MimeType/MimeTypeTest.php
@@ -70,7 +70,7 @@ class MimeTypeTest extends \PHPUnit_Framework_TestCase
         touch($path);
         @chmod($path, 0333);
 
-        if (substr(sprintf('%o', fileperms($path)), -4) == '0333') {
+        if (substr(sprintf('%o', fileperms($path)), -4) === '0333') {
             $this->setExpectedException('Symfony\Component\HttpFoundation\File\Exception\AccessDeniedException');
             MimeTypeGuesser::getInstance()->guess($path);
         } else {

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -388,7 +388,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
                 $expires = $expires->getTimestamp();
             } else {
                 $tmp = strtotime($expires);
-                if (false === $tmp || -1 == $tmp) {
+                if (false === $tmp || -1 === $tmp) {
                     throw new \InvalidArgumentException(sprintf('The "expires" cookie parameter is not valid (%s).', $expires));
                 }
                 $expires = $tmp;

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
@@ -902,11 +902,11 @@ class HttpCacheTest extends HttpCacheTestCase
     public function testInvalidatesCachedResponsesOnPost()
     {
         $this->setNextResponse(200, array(), 'Hello World', function ($request, $response) {
-            if ('GET' == $request->getMethod()) {
+            if ('GET' === $request->getMethod()) {
                 $response->setStatusCode(200);
                 $response->headers->set('Cache-Control', 'public, max-age=500');
                 $response->setContent('Hello World');
-            } elseif ('POST' == $request->getMethod()) {
+            } elseif ('POST' === $request->getMethod()) {
                 $response->setStatusCode(303);
                 $response->headers->set('Location', '/');
                 $response->headers->remove('Cache-Control');

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/Hour2400Transformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/Hour2400Transformer.php
@@ -33,9 +33,9 @@ class Hour2400Transformer extends HourTransformer
      */
     public function normalizeHour($hour, $marker = null)
     {
-        if ('AM' == $marker) {
+        if ('AM' === $marker) {
             $hour = 0;
-        } elseif ('PM' == $marker) {
+        } elseif ('PM' === $marker) {
             $hour = 12;
         }
 

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/Hour2401Transformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/Hour2401Transformer.php
@@ -36,9 +36,9 @@ class Hour2401Transformer extends HourTransformer
      */
     public function normalizeHour($hour, $marker = null)
     {
-        if ((null === $marker && 24 === $hour) || 'AM' == $marker) {
+        if ((null === $marker && 24 === $hour) || 'AM' === $marker) {
             $hour = 0;
-        } elseif ('PM' == $marker) {
+        } elseif ('PM' === $marker) {
             $hour = 12;
         }
 

--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/TimeZoneTransformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/TimeZoneTransformer.php
@@ -84,7 +84,7 @@ class TimeZoneTransformer extends Transformer
         if (preg_match('/GMT(?P<signal>[+-])(?P<hours>\d{2}):?(?P<minutes>\d{2})/', $formattedTimeZone, $matches)) {
             $hours = (int) $matches['hours'];
             $minutes = (int) $matches['minutes'];
-            $signal = $matches['signal'] == '-' ? '+' : '-';
+            $signal = $matches['signal'] === '-' ? '+' : '-';
 
             if (0 < $minutes) {
                 throw new NotImplementedException(sprintf(

--- a/src/Symfony/Component/Routing/Loader/ObjectRouteLoader.php
+++ b/src/Symfony/Component/Routing/Loader/ObjectRouteLoader.php
@@ -45,7 +45,7 @@ abstract class ObjectRouteLoader extends Loader
     public function load($resource, $type = null)
     {
         $parts = explode(':', $resource);
-        if (count($parts) != 2) {
+        if (count($parts) !== 2) {
             throw new \InvalidArgumentException(sprintf('Invalid resource "%s" passed to the "service" route loader: use the format "service_name:methodName"', $resource));
         }
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
@@ -83,7 +83,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
             // baz5
             if (preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-                if ($this->context->getMethod() !== 'POST') {
+                if ($this->context->getMethod() != 'POST') {
                     $allow[] = 'POST';
                     goto not_baz5;
                 }
@@ -94,7 +94,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
             // baz.baz6
             if (preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-                if ($this->context->getMethod() !== 'PUT') {
+                if ($this->context->getMethod() != 'PUT') {
                     $allow[] = 'PUT';
                     goto not_bazbaz6;
                 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
@@ -83,7 +83,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
             // baz5
             if (preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-                if ($this->context->getMethod() != 'POST') {
+                if ($this->context->getMethod() !== 'POST') {
                     $allow[] = 'POST';
                     goto not_baz5;
                 }
@@ -94,7 +94,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
             // baz.baz6
             if (preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-                if ($this->context->getMethod() != 'PUT') {
+                if ($this->context->getMethod() !== 'PUT') {
                     $allow[] = 'PUT';
                     goto not_bazbaz6;
                 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
@@ -91,7 +91,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
             // baz5
             if (preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-                if ($this->context->getMethod() !== 'POST') {
+                if ($this->context->getMethod() != 'POST') {
                     $allow[] = 'POST';
                     goto not_baz5;
                 }
@@ -102,7 +102,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
             // baz.baz6
             if (preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-                if ($this->context->getMethod() !== 'PUT') {
+                if ($this->context->getMethod() != 'PUT') {
                     $allow[] = 'PUT';
                     goto not_bazbaz6;
                 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
@@ -91,7 +91,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
             // baz5
             if (preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-                if ($this->context->getMethod() != 'POST') {
+                if ($this->context->getMethod() !== 'POST') {
                     $allow[] = 'POST';
                     goto not_baz5;
                 }
@@ -102,7 +102,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
             // baz.baz6
             if (preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-                if ($this->context->getMethod() != 'PUT') {
+                if ($this->context->getMethod() !== 'PUT') {
                     $allow[] = 'PUT';
                     goto not_bazbaz6;
                 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
@@ -41,7 +41,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         }
 
         // with-condition
-        if ($pathinfo === '/with-condition' && ($context->getMethod() === 'GET')) {
+        if ($pathinfo === '/with-condition' && ($context->getMethod() == "GET")) {
             return array('_route' => 'with-condition');
         }
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
@@ -41,7 +41,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         }
 
         // with-condition
-        if ($pathinfo === '/with-condition' && ($context->getMethod() == "GET")) {
+        if ($pathinfo === '/with-condition' && ($context->getMethod() === 'GET')) {
             return array('_route' => 'with-condition');
         }
 

--- a/src/Symfony/Component/Stopwatch/Stopwatch.php
+++ b/src/Symfony/Component/Stopwatch/Stopwatch.php
@@ -76,7 +76,7 @@ class Stopwatch
     {
         $this->stop('__section__');
 
-        if (1 == count($this->activeSections)) {
+        if (1 === count($this->activeSections)) {
             throw new \LogicException('There is no started section to stop.');
         }
 

--- a/src/Symfony/Component/Templating/Loader/FilesystemLoader.php
+++ b/src/Symfony/Component/Templating/Loader/FilesystemLoader.php
@@ -105,10 +105,10 @@ class FilesystemLoader extends Loader
      */
     protected static function isAbsolutePath($file)
     {
-        if ($file[0] == '/' || $file[0] == '\\'
+        if ($file[0] === '/' || $file[0] === '\\'
             || (strlen($file) > 3 && ctype_alpha($file[0])
-                && $file[1] == ':'
-                && ($file[2] == '\\' || $file[2] == '/')
+                && $file[1] === ':'
+                && ($file[2] === '\\' || $file[2] === '/')
             )
             || null !== parse_url($file, PHP_URL_SCHEME)
         ) {

--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -445,7 +445,7 @@ class PhpEngine implements EngineInterface, \ArrayAccess
                  * @return string the escaped value
                  */
                 function ($value) {
-                    if ('UTF-8' != $this->getCharset()) {
+                    if ('UTF-8' !== $this->getCharset()) {
                         $value = iconv($this->getCharset(), 'UTF-8', $value);
                     }
 
@@ -467,7 +467,7 @@ class PhpEngine implements EngineInterface, \ArrayAccess
                         throw new \InvalidArgumentException('The string to escape is not a valid UTF-8 string.');
                     }
 
-                    if ('UTF-8' != $this->getCharset()) {
+                    if ('UTF-8' !== $this->getCharset()) {
                         $value = iconv('UTF-8', $this->getCharset(), $value);
                     }
 

--- a/src/Symfony/Component/Translation/PluralizationRules.php
+++ b/src/Symfony/Component/Translation/PluralizationRules.php
@@ -146,7 +146,7 @@ class PluralizationRules
             case 'ru':
             case 'sr':
             case 'uk':
-                return (($number % 10 == 1) && ($number % 100 != 11)) ? 0 : ((($number % 10 >= 2) && ($number % 10 <= 4) && (($number % 100 < 10) || ($number % 100 >= 20))) ? 1 : 2);
+                return (($number % 10 === 1) && ($number % 100 !== 11)) ? 0 : ((($number % 10 >= 2) && ($number % 10 <= 4) && (($number % 100 < 10) || ($number % 100 >= 20))) ? 1 : 2);
 
             case 'cs':
             case 'sk':
@@ -156,19 +156,19 @@ class PluralizationRules
                 return ($number == 1) ? 0 : (($number == 2) ? 1 : 2);
 
             case 'lt':
-                return (($number % 10 == 1) && ($number % 100 != 11)) ? 0 : ((($number % 10 >= 2) && (($number % 100 < 10) || ($number % 100 >= 20))) ? 1 : 2);
+                return (($number % 10 === 1) && ($number % 100 !== 11)) ? 0 : ((($number % 10 >= 2) && (($number % 100 < 10) || ($number % 100 >= 20))) ? 1 : 2);
 
             case 'sl':
-                return ($number % 100 == 1) ? 0 : (($number % 100 == 2) ? 1 : ((($number % 100 == 3) || ($number % 100 == 4)) ? 2 : 3));
+                return ($number % 100 === 1) ? 0 : (($number % 100 === 2) ? 1 : ((($number % 100 === 3) || ($number % 100 === 4)) ? 2 : 3));
 
             case 'mk':
-                return ($number % 10 == 1) ? 0 : 1;
+                return ($number % 10 === 1) ? 0 : 1;
 
             case 'mt':
                 return ($number == 1) ? 0 : ((($number == 0) || (($number % 100 > 1) && ($number % 100 < 11))) ? 1 : ((($number % 100 > 10) && ($number % 100 < 20)) ? 2 : 3));
 
             case 'lv':
-                return ($number == 0) ? 0 : ((($number % 10 == 1) && ($number % 100 != 11)) ? 1 : 2);
+                return ($number == 0) ? 0 : ((($number % 10 === 1) && ($number % 100 !== 11)) ? 1 : 2);
 
             case 'pl':
                 return ($number == 1) ? 0 : ((($number % 10 >= 2) && ($number % 10 <= 4) && (($number % 100 < 12) || ($number % 100 > 14))) ? 1 : 2);

--- a/src/Symfony/Component/Validator/Constraints/Collection.php
+++ b/src/Symfony/Component/Validator/Constraints/Collection.php
@@ -63,7 +63,7 @@ class Collection extends Composite
         foreach ($this->fields as $fieldName => $field) {
             // the XmlFileLoader and YamlFileLoader pass the field Optional
             // and Required constraint as an array with exactly one element
-            if (is_array($field) && count($field) == 1) {
+            if (is_array($field) && count($field) === 1) {
                 $this->fields[$fieldName] = $field = $field[0];
             }
 

--- a/src/Symfony/Component/Validator/Constraints/TypeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TypeValidator.php
@@ -34,7 +34,7 @@ class TypeValidator extends ConstraintValidator
         }
 
         $type = strtolower($constraint->type);
-        $type = $type == 'boolean' ? 'bool' : $constraint->type;
+        $type = $type === 'boolean' ? 'bool' : $constraint->type;
         $isFunction = 'is_'.$type;
         $ctypeFunction = 'ctype_'.$type;
 

--- a/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintAValidator.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintAValidator.php
@@ -28,7 +28,7 @@ class ConstraintAValidator extends ConstraintValidator
 
     public function validate($value, Constraint $constraint)
     {
-        if ('VALID' != $value) {
+        if ('VALID' !== $value) {
             $this->context->addViolation('message', array('param' => 'value'));
 
             return;

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -350,7 +350,7 @@ class Inline
         $output = substr($match[0], 1, strlen($match[0]) - 2);
 
         $unescaper = new Unescaper();
-        if ('"' == $scalar[$i]) {
+        if ('"' === $scalar[$i]) {
             $output = $unescaper->unescapeDoubleQuotedString($output);
         } else {
             $output = $unescaper->unescapeSingleQuotedString($output);

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -116,7 +116,7 @@ class Parser
 
             $isRef = $mergeNode = false;
             if (preg_match('#^\-((?P<leadspaces>\s+)(?P<value>.+?))?\s*$#u', $this->currentLine, $values)) {
-                if ($context && 'mapping' == $context) {
+                if ($context && 'mapping' === $context) {
                     throw new ParseException('You cannot define a sequence item when in a mapping', $this->getRealCurrentLineNb() + 1, $this->currentLine);
                 }
                 $context = 'sequence';
@@ -148,7 +148,7 @@ class Parser
                     $this->refs[$isRef] = end($data);
                 }
             } elseif (preg_match('#^(?P<key>'.Inline::REGEX_QUOTED_STRING.'|[^ \'"\[\{].*?) *\:(\s+(?P<value>.+?))?\s*$#u', $this->currentLine, $values) && (false === strpos($values['key'], ' #') || in_array($values['key'][0], array('"', "'")))) {
-                if ($context && 'sequence' == $context) {
+                if ($context && 'sequence' === $context) {
                     throw new ParseException('You cannot define a mapping item when in a sequence', $this->currentLineNb + 1, $this->currentLine);
                 }
                 $context = 'mapping';
@@ -782,7 +782,7 @@ class Parser
 
         // remove leading comments
         $trimmedValue = preg_replace('#^(\#.*?\n)+#s', '', $value, -1, $count);
-        if ($count == 1) {
+        if ($count === 1) {
             // items have been removed, update the offset
             $this->offset += substr_count($value, "\n") - substr_count($trimmedValue, "\n");
             $value = $trimmedValue;
@@ -790,7 +790,7 @@ class Parser
 
         // remove start of the document marker (---)
         $trimmedValue = preg_replace('#^\-\-\-.*?\n#s', '', $value, -1, $count);
-        if ($count == 1) {
+        if ($count === 1) {
             // items have been removed, update the offset
             $this->offset += substr_count($value, "\n") - substr_count($trimmedValue, "\n");
             $value = $trimmedValue;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

In PHP any string, that does not started from number is equal (==) 0.
Example:

``` php
var_dump(0 == '+'); // true
var_dump(0 == '*'); // true
var_dump(0 == '&'); // true
var_dump(0 == 'foo'); // true

var_dump(0 != '&'); // false
```

To avoid this behavior is better to use identical operator (===)
Also, === is faster than ==

Also, for **[HttpFoundation / Request]** I make logic easier

from

```
(false !== $pos = strpos($path, $baseUrl)) && 0 != $pos)
// result is not false and is not 0
```

to

```
strpos($path, $baseUrl)
// it is mean, result is true
```

PS helps to avoid some bugs in future.
