### PR TITLE
[Routing] UrlGenerator: add a method 'hasRoute' to check whether a route exists

### DIFF
--- a/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
+++ b/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
@@ -124,7 +124,7 @@ EOF;
     }
 
     /**
-     * Generates PHP code representing the `hasRoute` method that implements the UrlGeneratorInterface.
+     * Generates PHP code representing the `hasRoute` method that implements the RoutePresenceCheckableInterface.
      *
      * @return string PHP code
      */

--- a/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
+++ b/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
@@ -68,6 +68,8 @@ class {$options['class']} extends {$options['base_class']}
     }
 
 {$this->generateGenerateMethod()}
+
+{$this->generateHasRouteMethod()}
 }
 
 EOF;
@@ -117,6 +119,21 @@ EOF;
         list($variables, $defaults, $requirements, $tokens, $hostTokens, $requiredSchemes) = self::$declaredRoutes[$name];
 
         return $this->doGenerate($variables, $defaults, $requirements, $tokens, $parameters, $name, $referenceType, $hostTokens, $requiredSchemes);
+    }
+EOF;
+    }
+
+    /**
+     * Generates PHP code representing the `getRoutes` method that implements the UrlGeneratorInterface.
+     *
+     * @return string PHP code
+     */
+    private function generateHasRouteMethod()
+    {
+        return <<<'EOF'
+    public function hasRoute($name)
+    {
+        return isset(self::$declaredRoutes[$name]);
     }
 EOF;
     }

--- a/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
+++ b/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
@@ -124,7 +124,7 @@ EOF;
     }
 
     /**
-     * Generates PHP code representing the `getRoutes` method that implements the UrlGeneratorInterface.
+     * Generates PHP code representing the `hasRoute` method that implements the UrlGeneratorInterface.
      *
      * @return string PHP code
      */

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -11,12 +11,12 @@
 
 namespace Symfony\Component\Routing\Generator;
 
-use Psr\Log\LoggerInterface;
-use Symfony\Component\Routing\Exception\InvalidParameterException;
-use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
-use Symfony\Component\Routing\Exception\RouteNotFoundException;
-use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\Exception\InvalidParameterException;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
+use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\RoutePresenceCheckableInterface;
 
 /**

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -124,6 +124,14 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
     /**
      * {@inheritdoc}
      */
+    public function hasRoute($name)
+    {
+        return isset($this->routes[$name]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function generate($name, $parameters = array(), $referenceType = self::ABSOLUTE_PATH)
     {
         if (null === $route = $this->routes->get($name)) {

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -11,12 +11,13 @@
 
 namespace Symfony\Component\Routing\Generator;
 
-use Symfony\Component\Routing\RouteCollection;
-use Symfony\Component\Routing\RequestContext;
-use Symfony\Component\Routing\Exception\InvalidParameterException;
-use Symfony\Component\Routing\Exception\RouteNotFoundException;
-use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Routing\Exception\InvalidParameterException;
+use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\RoutePresenceCheckableInterface;
 
 /**
  * UrlGenerator can generate a URL or a path for any route in the RouteCollection
@@ -25,7 +26,7 @@ use Psr\Log\LoggerInterface;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Tobias Schultze <http://tobion.de>
  */
-class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInterface
+class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInterface, RoutePresenceCheckableInterface
 {
     /**
      * @var RouteCollection
@@ -122,11 +123,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
     }
 
     /**
-     * Returns whether a route with the given name exists.
-     *
-     * @param string $name The route name
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function hasRoute($name)
     {

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -122,7 +122,11 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
     }
 
     /**
-     * {@inheritdoc}
+     * Returns whether a route with the given name exists.
+     *
+     * @param string $name The route name
+     *
+     * @return bool
      */
     public function hasRoute($name)
     {

--- a/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
@@ -83,4 +83,13 @@ interface UrlGeneratorInterface extends RequestContextAwareInterface
      *                                             it does not match the requirement
      */
     public function generate($name, $parameters = array(), $referenceType = self::ABSOLUTE_PATH);
+
+    /**
+     * Returns whether a route with the given name exists.
+     *
+     * @param string $name The route name
+     *
+     * @return bool
+     */
+    public function hasRoute($name);
 }

--- a/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
@@ -83,13 +83,4 @@ interface UrlGeneratorInterface extends RequestContextAwareInterface
      *                                             it does not match the requirement
      */
     public function generate($name, $parameters = array(), $referenceType = self::ABSOLUTE_PATH);
-
-    /**
-     * Returns whether a route with the given name exists.
-     *
-     * @param string $name The route name
-     *
-     * @return bool
-     */
-    public function hasRoute($name);
 }

--- a/src/Symfony/Component/Routing/RoutePresenceCheckableInterface.php
+++ b/src/Symfony/Component/Routing/RoutePresenceCheckableInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing;
+
+/**
+ * Interface for checking a route presence.
+ *
+ * @author Oleg Voronkovich <oleg-voronkovich@yandex.ru>
+ */
+interface RoutePresenceCheckableInterface
+{
+    /**
+     * Returns whether a route with the given name exists.
+     *
+     * @param string $name The route name
+     *
+     * @return bool
+     */
+    public function hasRoute($name);
+}

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -11,20 +11,19 @@
 
 namespace Symfony\Component\Routing;
 
-use Psr\Log\LoggerInterface;
-use Symfony\Component\Config\ConfigCacheFactory;
-use Symfony\Component\Config\ConfigCacheFactoryInterface;
-use Symfony\Component\Config\ConfigCacheInterface;
 use Symfony\Component\Config\Loader\LoaderInterface;
-use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
-use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Config\ConfigCacheInterface;
+use Symfony\Component\Config\ConfigCacheFactoryInterface;
+use Symfony\Component\Config\ConfigCacheFactory;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\Generator\ConfigurableRequirementsInterface;
-use Symfony\Component\Routing\Generator\Dumper\GeneratorDumperInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Routing\Matcher\Dumper\MatcherDumperInterface;
+use Symfony\Component\Routing\Generator\Dumper\GeneratorDumperInterface;
 use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
 use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
-use Symfony\Component\Routing\RoutePresenceCheckableInterface;
+use Symfony\Component\Routing\Matcher\Dumper\MatcherDumperInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
 
 /**
  * The Router class is an example of the integration of all pieces of the

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -229,6 +229,14 @@ class Router implements RouterInterface, RequestMatcherInterface
     /**
      * {@inheritdoc}
      */
+    public function hasRoute($name)
+    {
+        return $this->getGenerator()->hasRoute($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function generate($name, $parameters = array(), $referenceType = self::ABSOLUTE_PATH)
     {
         return $this->getGenerator()->generate($name, $parameters, $referenceType);

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -227,7 +227,11 @@ class Router implements RouterInterface, RequestMatcherInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Returns whether a route with the given name exists.
+     *
+     * @param string $name The route name
+     *
+     * @return bool
      */
     public function hasRoute($name)
     {

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -11,19 +11,20 @@
 
 namespace Symfony\Component\Routing;
 
-use Symfony\Component\Config\Loader\LoaderInterface;
-use Symfony\Component\Config\ConfigCacheInterface;
-use Symfony\Component\Config\ConfigCacheFactoryInterface;
-use Symfony\Component\Config\ConfigCacheFactory;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Config\ConfigCacheFactory;
+use Symfony\Component\Config\ConfigCacheFactoryInterface;
+use Symfony\Component\Config\ConfigCacheInterface;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\ConfigurableRequirementsInterface;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\Generator\Dumper\GeneratorDumperInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\Matcher\Dumper\MatcherDumperInterface;
 use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
 use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
-use Symfony\Component\Routing\Matcher\Dumper\MatcherDumperInterface;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+use Symfony\Component\Routing\RoutePresenceCheckableInterface;
 
 /**
  * The Router class is an example of the integration of all pieces of the
@@ -31,7 +32,7 @@ use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class Router implements RouterInterface, RequestMatcherInterface
+class Router implements RouterInterface, RequestMatcherInterface, RoutePresenceCheckableInterface
 {
     /**
      * @var UrlMatcherInterface|null
@@ -231,10 +232,16 @@ class Router implements RouterInterface, RequestMatcherInterface
      *
      * @param string $name The route name
      *
+     * @throws \RuntimeException When an url generator does not implement the RoutePresenceCheckableInterface
+     *
      * @return bool
      */
     public function hasRoute($name)
     {
+        if (!$this->getGenerator() instanceof RoutePresenceCheckableInterface) {
+            throw new \RuntimeException('The current implementaion of an url generator does not support the RoutePresenceCheckableInterface.');
+        }
+
         return $this->getGenerator()->hasRoute($name);
     }
 

--- a/src/Symfony/Component/Routing/Tests/Generator/Dumper/PhpGeneratorDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/Dumper/PhpGeneratorDumperTest.php
@@ -177,4 +177,17 @@ class PhpGeneratorDumperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($absoluteUrl, 'https://localhost/app.php/testing');
         $this->assertEquals($relativeUrl, '/app.php/testing');
     }
+
+    public function testHasRoute()
+    {
+        $this->routeCollection->add('Test', new Route('/test'));
+
+        file_put_contents($this->testTmpFilepath, $this->generatorDumper->dump(array('class' => 'HasRouteUrlGenerator')));
+        include $this->testTmpFilepath;
+
+        $projectUrlGenerator = new \HasRouteUrlGenerator(new RequestContext());
+
+        $this->assertTrue($projectUrlGenerator->hasRoute('Test'));
+        $this->assertFalse($projectUrlGenerator->hasRoute('non-existent'));
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.4 |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This method is usefull when you want just to check whether a route exists:

``` php
if ($router->hasRoute('homepage')) {
    // ...
}
```

See https://github.com/symfony/symfony/pull/19270 and https://github.com/symfony/symfony-docs/issues/6710
