### PR TITLE
[Routing] Mark getRouteCollection() as internal

### DIFF
--- a/src/Symfony/Component/Routing/RouterInterface.php
+++ b/src/Symfony/Component/Routing/RouterInterface.php
@@ -27,6 +27,10 @@ interface RouterInterface extends UrlMatcherInterface, UrlGeneratorInterface
      * Gets the RouteCollection instance associated with this Router.
      *
      * @return RouteCollection A RouteCollection instance
+     *
+     * @internal
+     *
+     * @deprecated Since Symfony 3.2, to be removed in 4.0.
      */
     public function getRouteCollection();
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/pull/19270#issuecomment-230111301 |
| License | MIT |
| Doc PR | - |

The `getRouteCollection()` method should not be used in runtime as it'll rebuild the routing cache. It should be marked as internal and removed from the interface in 4.0.

I'm not sure how to mark it as being removed from the interface, ended up deprecating it (but `Router::getRouteCollection()` isn't deprecated and shouldn't).
