### PR TITLE
[ClassLoader] Add ClassCollectionLoader::inline() to generate inlined-classes files

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ClassCacheCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ClassCacheCacheWarmer.php
@@ -21,6 +21,13 @@ use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
  */
 class ClassCacheCacheWarmer implements CacheWarmerInterface
 {
+    private $declaredClasses;
+
+    public function __construct(array $declaredClasses = null)
+    {
+        $this->declaredClasses = $declaredClasses;
+    }
+
     /**
      * Warms up the cache.
      *
@@ -37,8 +44,9 @@ class ClassCacheCacheWarmer implements CacheWarmerInterface
         if (file_exists($cacheDir.'/classes.php')) {
             return;
         }
+        $declared = null !== $this->declaredClasses ? $this->declaredClasses : array_merge(get_declared_classes(), get_declared_interfaces(), get_declared_traits());
 
-        ClassCollectionLoader::load(include($classmap), $cacheDir, 'classes', false);
+        ClassCollectionLoader::inline(include($classmap), $cacheDir.'/classes.php', $declared);
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -170,15 +170,23 @@ class FrameworkExtension extends Extension
         }
 
         $this->addClassesToCompile(array(
+            'Symfony\\Component\\Config\\ConfigCache',
             'Symfony\\Component\\Config\\FileLocator',
 
             'Symfony\\Component\\Debug\\ErrorHandler',
 
+            'Symfony\\Component\\DependencyInjection\\ContainerAwareInterface',
+            'Symfony\\Component\\DependencyInjection\\Container',
+
             'Symfony\\Component\\EventDispatcher\\Event',
             'Symfony\\Component\\EventDispatcher\\ContainerAwareEventDispatcher',
 
+            'Symfony\\Component\\HttpFoundation\\Response',
+            'Symfony\\Component\\HttpFoundation\\ResponseHeaderBag',
+
             'Symfony\\Component\\HttpKernel\\EventListener\\ResponseListener',
             'Symfony\\Component\\HttpKernel\\EventListener\\RouterListener',
+            'Symfony\\Component\\HttpKernel\\Bundle\\Bundle',
             'Symfony\\Component\\HttpKernel\\Controller\\ControllerResolver',
             'Symfony\\Component\\HttpKernel\\Controller\\ArgumentResolver',
             'Symfony\\Component\\HttpKernel\\ControllerMetadata\\ArgumentMetadata',
@@ -189,13 +197,18 @@ class FrameworkExtension extends Extension
             'Symfony\\Component\\HttpKernel\\Event\\GetResponseEvent',
             'Symfony\\Component\\HttpKernel\\Event\\GetResponseForControllerResultEvent',
             'Symfony\\Component\\HttpKernel\\Event\\GetResponseForExceptionEvent',
+            'Symfony\\Component\\HttpKernel\\HttpKernel',
             'Symfony\\Component\\HttpKernel\\KernelEvents',
             'Symfony\\Component\\HttpKernel\\Config\\FileLocator',
 
             'Symfony\\Bundle\\FrameworkBundle\\Controller\\ControllerNameParser',
             'Symfony\\Bundle\\FrameworkBundle\\Controller\\ControllerResolver',
+
             // Cannot be included because annotations will parse the big compiled class file
             // 'Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller',
+
+            // cannot be included as commands are discovered based on the path to this class via Reflection
+            // 'Symfony\\Bundle\\FrameworkBundle\\FrameworkBundle',
         ));
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -24,6 +24,17 @@
 
         <service id="kernel.class_cache.cache_warmer" class="Symfony\Bundle\FrameworkBundle\CacheWarmer\ClassCacheCacheWarmer">
             <tag name="kernel.cache_warmer" />
+            <argument type="collection">
+                <argument>Doctrine\Common\Annotations\AnnotationRegistry</argument>
+                <argument>Symfony\Component\HttpFoundation\ParameterBag</argument>
+                <argument>Symfony\Component\HttpFoundation\HeaderBag</argument>
+                <argument>Symfony\Component\HttpFoundation\FileBag</argument>
+                <argument>Symfony\Component\HttpFoundation\ServerBag</argument>
+                <argument>Symfony\Component\HttpFoundation\Request</argument>
+                <argument>Symfony\Component\HttpKernel\Kernel</argument>
+                <argument>Symfony\Component\ClassLoader\ClassCollectionLoader</argument>
+                <argument>Symfony\Component\ClassLoader\ApcClassLoader</argument>
+            </argument>
         </service>
 
         <service id="cache_clearer" class="Symfony\Component\HttpKernel\CacheClearer\ChainCacheClearer">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ClassCacheCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ClassCacheCacheWarmerTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\CacheWarmer;
+
+use Symfony\Bundle\FrameworkBundle\CacheWarmer\ClassCacheCacheWarmer;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\DeclaredClass;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\WarmedClass;
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+
+class ClassCacheCacheWarmerTest extends TestCase
+{
+    public function testWithDeclaredClasses()
+    {
+        $this->assertTrue(class_exists(WarmedClass::class, true));
+
+        $dir = sys_get_temp_dir();
+        @unlink($dir.'/classes.php');
+        file_put_contents($dir.'/classes.map', sprintf('<?php return %s;', var_export(array(WarmedClass::class), true)));
+
+        $warmer = new ClassCacheCacheWarmer(array(DeclaredClass::class));
+
+        $warmer->warmUp($dir);
+
+        $this->assertSame(<<<'EOTXT'
+<?php 
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures
+{
+class WarmedClass extends DeclaredClass
+{
+}
+}
+EOTXT
+            , file_get_contents($dir.'/classes.php')
+        );
+
+        @unlink($dir.'/classes.map');
+        @unlink($dir.'/classes.php');
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/DeclaredClass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/DeclaredClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures;
+
+class DeclaredClass
+{
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/WarmedClass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/WarmedClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures;
+
+class WarmedClass extends DeclaredClass
+{
+}

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.5.9",
         "symfony/asset": "~2.8|~3.0",
         "symfony/cache": "~3.1",
-        "symfony/class-loader": "~2.8|~3.0",
+        "symfony/class-loader": "~3.2",
         "symfony/dependency-injection": "~3.2",
         "symfony/config": "~2.8|~3.0",
         "symfony/event-dispatcher": "~2.8|~3.0",

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/DeclaredClass.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/DeclaredClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\ClassLoader\Tests\Fixtures;
+
+class DeclaredClass implements DeclaredInterface
+{
+}

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/DeclaredInterface.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/DeclaredInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\ClassLoader\Tests\Fixtures;
+
+interface DeclaredInterface
+{
+}

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/WarmedClass.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/WarmedClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\ClassLoader\Tests\Fixtures;
+
+class WarmedClass extends DeclaredClass implements WarmedInterface
+{
+}

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/WarmedInterface.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/WarmedInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\ClassLoader\Tests\Fixtures;
+
+interface WarmedInterface
+{
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Unfortunately, can't be tested because the method relies too much on side effects.
Coupled with https://github.com/sensiolabs/SensioDistributionBundle/pull/272, allows inlining `ClassCollectionLoader` itself into the `bootstrap.php.cache` file.
