### PR TITLE
[Serializer] Argument objects

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -323,14 +323,13 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
                     }
                 } elseif ($allowed && !$ignored && (isset($data[$key]) || array_key_exists($key, $data))) {
                     $parameterData = $data[$key];
-                    if (null !== $constructorParameter->getType()) {
-                        try {
+                    try {
+                        if (null !== $constructorParameter->getClass()) {
                             $parameterClass = $constructorParameter->getClass()->getName();
-                        } catch (\ReflectionException $e) {
-                            throw new RuntimeException(sprintf('Could not determine the class of the parameter "%s".', $key), 0, $e);
+                            $parameterData = $this->serializer->deserialize($parameterData, $parameterClass, $format, $context);
                         }
-
-                        $parameterData = $this->serializer->deserialize($parameterData, $parameterClass, $format, $context);
+                    } catch (\ReflectionException $e) {
+                        throw new RuntimeException(sprintf('Could not determine the class of the parameter "%s".', $key), 0, $e);
                     }
 
                     // Don't run set for a parameter passed to the constructor

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -347,6 +347,8 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
 
                 if ($constructorParameter->isDefaultValueAvailable()) {
                     $params[] = $constructorParameter->getDefaultValue();
+
+                    continue;
                 }
 
                 throw new RuntimeException(

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -274,6 +274,8 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
      */
     protected function instantiateObject(array &$data, $class, array &$context, \ReflectionClass $reflectionClass, $allowedAttributes)
     {
+        @trigger_error(sprintf('"%s()" has been deprecated sin Symfony 3.1 and will be removed in version 4.0. Use "%s::instantiateComplexObject()" instead.', __METHOD__, __CLASS__));
+
         return $this->instantiateComplexObject($data, $class, $context, $reflectionClass, $allowedAttributes);
     }
 

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -332,8 +332,14 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
                     }
                 } elseif ($allowed && !$ignored && (isset($data[$key]) || array_key_exists($key, $data))) {
                     $parameterData = $data[$key];
-                    if (null !== $constructorParameter->getClass()) {
-                        $parameterData = $this->serializer->deserialize($parameterData, $constructorParameter->getClass()->getName(), $format, $context);
+                    if (null !== $constructorParameter->getType()) {
+                        try {
+                            $parameterClass = $constructorParameter->getClass()->getName();
+                        } catch (\ReflectionException $e) {
+                            throw new RuntimeException(sprintf('Could not determine the class of the parameter "%s".', $key), 0, $e);
+                        }
+
+                        $parameterData = $this->serializer->deserialize($parameterData, $parameterClass, $format, $context);
                     }
 
                     // Don't run set for a parameter passed to the constructor

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -274,7 +274,7 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
      */
     protected function instantiateObject(array &$data, $class, array &$context, \ReflectionClass $reflectionClass, $allowedAttributes)
     {
-        @trigger_error(sprintf('"%s()" has been deprecated sin Symfony 3.1 and will be removed in version 4.0. Use "%s::instantiateComplexObject()" instead.', __METHOD__, __CLASS__));
+        @trigger_error(sprintf('"%s()" has been deprecated since Symfony 3.1 and will be removed in version 4.0. Use "%s::instantiateComplexObject()" instead.', __METHOD__, __CLASS__), E_USER_DEPRECATED);
 
         return $this->instantiateComplexObject($data, $class, $context, $reflectionClass, $allowedAttributes);
     }

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -319,9 +319,13 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
                         $params = array_merge($params, $data[$paramName]);
                     }
                 } elseif ($allowed && !$ignored && (isset($data[$key]) || array_key_exists($key, $data))) {
-                    $params[] = $data[$key];
-                    // don't run set for a parameter passed to the constructor
-                    unset($data[$key]);
+                    $parameterData = $data[$key];
+                    if (null !== $constructogrParameter->getClass()) {
+                        $parameterData = $this->serializer->denormalize($parameterData, $constructorParameter->getClass()->getName(), null, $context);
+                    }
+
+                    // Don't run set for a parameter passed to the constructor
+                    $params[] = $parameterData;
                 } elseif ($constructorParameter->isDefaultValueAvailable()) {
                     $params[] = $constructorParameter->getDefaultValue();
                 } else {

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -335,7 +335,7 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
                 if ($allowed && !$ignored && (isset($data[$key]) || array_key_exists($key, $data))) {
                     $parameterData = $data[$key];
                     if (null !== $constructorParameter->getClass()) {
-                        $parameterData = $this->serializer->deserialize($parameterData, $constructorParameter->getClass()->getName(), null, $context);
+                        $parameterData = $this->serializer->deserialize($parameterData, $constructorParameter->getClass()->getName(), $format, $context);
                     }
 
                     // Don't run set for a parameter passed to the constructor

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -281,12 +281,13 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
      * @param array            $context
      * @param \ReflectionClass $reflectionClass
      * @param array|bool       $allowedAttributes
+     * @param string|null      $format
      *
      * @return object
      *
      * @throws RuntimeException
      */
-    protected function instantiateObject(array &$data, $class, array &$context, \ReflectionClass $reflectionClass, $allowedAttributes)
+    protected function instantiateObject(array &$data, $class, array &$context, \ReflectionClass $reflectionClass, $allowedAttributes, $format = null)
     {
         if (
             isset($context[static::OBJECT_TO_POPULATE]) &&
@@ -320,12 +321,13 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
                     }
                 } elseif ($allowed && !$ignored && (isset($data[$key]) || array_key_exists($key, $data))) {
                     $parameterData = $data[$key];
-                    if (null !== $constructogrParameter->getClass()) {
+                    if (null !== $constructorParameter->getClass()) {
                         $parameterData = $this->serializer->denormalize($parameterData, $constructorParameter->getClass()->getName(), null, $context);
                     }
 
                     // Don't run set for a parameter passed to the constructor
                     $params[] = $parameterData;
+                    unset($data[$key]);
                 } elseif ($constructorParameter->isDefaultValueAvailable()) {
                     $params[] = $constructorParameter->getDefaultValue();
                 } else {

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -269,17 +269,6 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
     }
 
     /**
-     * @see instantiateComplexObject
-     * @deprecated Since 3.1, will be removed in 4.0. Use instantiateComplexObject instead.
-     */
-    protected function instantiateObject(array &$data, $class, array &$context, \ReflectionClass $reflectionClass, $allowedAttributes)
-    {
-        @trigger_error(sprintf('"%s()" has been deprecated since Symfony 3.1 and will be removed in version 4.0. Use "%s::instantiateComplexObject()" instead.', __METHOD__, __CLASS__), E_USER_DEPRECATED);
-
-        return $this->instantiateComplexObject($data, $class, $context, $reflectionClass, $allowedAttributes);
-    }
-
-    /**
      * Instantiates an object using constructor parameters when needed.
      *
      * This method also allows to denormalize data into an existing object if
@@ -298,8 +287,10 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
      *
      * @throws RuntimeException
      */
-    protected function instantiateComplexObject(array &$data, $class, array &$context, \ReflectionClass $reflectionClass, $allowedAttributes, $format = null)
+    protected function instantiateObject(array &$data, $class, array &$context, \ReflectionClass $reflectionClass, $allowedAttributes/*, $format = null*/)
     {
+        $format = func_num_args() >= 6 ? func_get_arg(5) : null;
+
         if (
             isset($context[static::OBJECT_TO_POPULATE]) &&
             is_object($context[static::OBJECT_TO_POPULATE]) &&

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -175,7 +175,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         $normalizedData = $this->prepareForDenormalization($data);
 
         $reflectionClass = new \ReflectionClass($class);
-        $object = $this->instantiateObject($normalizedData, $class, $context, $reflectionClass, $allowedAttributes);
+        $object = $this->instantiateObject($normalizedData, $class, $context, $reflectionClass, $allowedAttributes, $format);
 
         foreach ($normalizedData as $attribute => $value) {
             if ($this->nameConverter) {

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -175,7 +175,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         $normalizedData = $this->prepareForDenormalization($data);
 
         $reflectionClass = new \ReflectionClass($class);
-        $object = $this->instantiateComplexObject($normalizedData, $class, $context, $reflectionClass, $allowedAttributes, $format);
+        $object = $this->instantiateObject($normalizedData, $class, $context, $reflectionClass, $allowedAttributes, $format);
 
         foreach ($normalizedData as $attribute => $value) {
             if ($this->nameConverter) {

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -175,7 +175,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         $normalizedData = $this->prepareForDenormalization($data);
 
         $reflectionClass = new \ReflectionClass($class);
-        $object = $this->instantiateObject($normalizedData, $class, $context, $reflectionClass, $allowedAttributes, $format);
+        $object = $this->instantiateComplexObject($normalizedData, $class, $context, $reflectionClass, $allowedAttributes, $format);
 
         foreach ($normalizedData as $attribute => $value) {
             if ($this->nameConverter) {

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -47,7 +47,7 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
         $normalizedData = $this->prepareForDenormalization($data);
 
         $reflectionClass = new \ReflectionClass($class);
-        $object = $this->instantiateComplexObject($normalizedData, $class, $context, $reflectionClass, $allowedAttributes, $format);
+        $object = $this->instantiateObject($normalizedData, $class, $context, $reflectionClass, $allowedAttributes, $format);
 
         $classMethods = get_class_methods($object);
         foreach ($normalizedData as $attribute => $value) {

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -47,7 +47,7 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
         $normalizedData = $this->prepareForDenormalization($data);
 
         $reflectionClass = new \ReflectionClass($class);
-        $object = $this->instantiateObject($normalizedData, $class, $context, $reflectionClass, $allowedAttributes);
+        $object = $this->instantiateComplexObject($normalizedData, $class, $context, $reflectionClass, $allowedAttributes, $format);
 
         $classMethods = get_class_methods($object);
         foreach ($normalizedData as $attribute => $value) {

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DenormalizerDecoratorSerializer.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DenormalizerDecoratorSerializer.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * @author Théo FIDRY <theo.fidry@gmail.com>
+ */
+class DenormalizerDecoratorSerializer implements SerializerInterface
+{
+    private $normalizer;
+
+    /**
+     * @param NormalizerInterface|DenormalizerInterface $normalizer
+     */
+    public function __construct($normalizer)
+    {
+        if (false === $normalizer instanceof NormalizerInterface && false === $normalizer instanceof DenormalizerInterface) {
+            throw new \InvalidArgumentException();
+        }
+        
+        $this->normalizer = $normalizer;
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize($data, $format, array $context = array())
+    {
+        return $this->normalizer->normalize($data, $format, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deserialize($data, $type, $format, array $context = array())
+    {
+        return $this->normalizer->denormalize($data, $type, $format, $context);
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DenormalizerDecoratorSerializer.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DenormalizerDecoratorSerializer.php
@@ -21,10 +21,10 @@ class DenormalizerDecoratorSerializer implements SerializerInterface
         if (false === $normalizer instanceof NormalizerInterface && false === $normalizer instanceof DenormalizerInterface) {
             throw new \InvalidArgumentException();
         }
-        
+
         $this->normalizer = $normalizer;
     }
-    
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -32,10 +32,10 @@ class AbstractObjectNormalizerTest extends \PHPUnit_Framework_TestCase
     {
         $data = array('foo' => 'foo', 'bar' => 'bar', 'baz' => 'baz');
         $class = __NAMESPACE__.'\Dummy';
-        $context = [];
-        
+        $context = array();
+
         $normalizer = new AbstractObjectNormalizerDummy();
-        $normalizer->instantiateObject($data, $class, $context, new \ReflectionClass($class), []);
+        $normalizer->instantiateObject($data, $class, $context, new \ReflectionClass($class), array());
     }
 }
 
@@ -63,8 +63,6 @@ class AbstractObjectNormalizerDummy extends AbstractObjectNormalizer
     {
         return parent::instantiateObject($data, $class, $context, $reflectionClass, $allowedAttributes);
     }
-
-
 }
 
 class Dummy

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -24,6 +24,19 @@ class AbstractObjectNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($normalizedData->bar);
         $this->assertSame('baz', $normalizedData->baz);
     }
+
+    /**
+     * @group legacy
+     */
+    public function testInstantiateObjectDenormalizer()
+    {
+        $data = array('foo' => 'foo', 'bar' => 'bar', 'baz' => 'baz');
+        $class = __NAMESPACE__.'\Dummy';
+        $context = [];
+        
+        $normalizer = new AbstractObjectNormalizerDummy();
+        $normalizer->instantiateObject($data, $class, $context, new \ReflectionClass($class), []);
+    }
 }
 
 class AbstractObjectNormalizerDummy extends AbstractObjectNormalizer
@@ -45,6 +58,13 @@ class AbstractObjectNormalizerDummy extends AbstractObjectNormalizer
     {
         return in_array($attribute, array('foo', 'baz'));
     }
+
+    public function instantiateObject(array &$data, $class, array &$context, \ReflectionClass $reflectionClass, $allowedAttributes)
+    {
+        return parent::instantiateObject($data, $class, $context, $reflectionClass, $allowedAttributes);
+    }
+
+
 }
 
 class Dummy

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -180,6 +180,27 @@ class ObjectNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('rab', $obj->getInner()->bar);
     }
 
+    /**
+     * @expectedException \Symfony\Component\Serializer\Exception\RuntimeException
+     * @expectedExceptionMessage Could not determine the class of the parameter "unknown".
+     */
+    public function testConstructorWithUnknownObjectTypeHintDenormalize()
+    {
+        $data = array(
+            'id' => 10,
+            'unknown' => array(
+                'foo' => 'oof',
+                'bar' => 'rab',
+            ),
+        );
+
+        $normalizer = new ObjectNormalizer();
+        $serializer = new DenormalizerDecoratorSerializer($normalizer);
+        $normalizer->setSerializer($serializer);
+
+        $normalizer->denormalize($data, DummyWithConstructorInexistingObject::class);
+    }
+
     public function testGroupsNormalize()
     {
         $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
@@ -825,5 +846,12 @@ class DummyWithConstructorObject
     public function getInner()
     {
         return $this->inner;
+    }
+}
+
+class DummyWithConstructorInexistingObject
+{
+    public function __construct($id, Unknown $unknown)
+    {
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -157,6 +157,24 @@ class ObjectNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $obj->bar);
     }
 
+    public function testConstructorWithObjectTypeHintDenormalize()
+    {
+        $data = [
+            'id' => 10,
+            'inner' => [
+                'foo' => 'oof',
+                'bar' => 'rab',
+            ],
+        ];
+
+        $obj = $this->normalizer->denormalize($data, DummyWithConstructorObject::class);
+        $this->assertInstanceOf(DummyWithConstructorObject::class, $obj);
+        $this->assertEquals(10, $obj->getId);
+        $this->assertInstanceOf(ObjectInner::class, $obj->getInner());
+        $this->assertEquals('foo', $obj->getInner()->foo);
+        $this->assertEquals('bar', $obj->getInner()->bar);
+    }
+
     public function testGroupsNormalize()
     {
         $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
@@ -780,5 +798,27 @@ class FormatAndContextAwareNormalizer extends ObjectNormalizer
         }
 
         return false;
+    }
+}
+
+class DummyWithConstructorObject
+{
+    private $id;
+    private $inner;
+
+    public function __construct($id, ObjectInner $inner)
+    {
+        $this->id = $id;
+        $this->inner = $inner;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getInner()
+    {
+        return $this->inner;
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -159,13 +159,13 @@ class ObjectNormalizerTest extends \PHPUnit_Framework_TestCase
 
     public function testConstructorWithObjectTypeHintDenormalize()
     {
-        $data = [
+        $data = array(
             'id' => 10,
-            'inner' => [
+            'inner' => array(
                 'foo' => 'oof',
                 'bar' => 'rab',
-            ],
-        ];
+            ),
+        );
 
         $obj = $this->normalizer->denormalize($data, DummyWithConstructorObject::class);
         $this->assertInstanceOf(DummyWithConstructorObject::class, $obj);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Tests\Fixtures\CircularReferenceDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\DenormalizerDecoratorSerializer;
 use Symfony\Component\Serializer\Tests\Fixtures\MaxDepthDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\SiblingHolder;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
@@ -167,12 +168,16 @@ class ObjectNormalizerTest extends \PHPUnit_Framework_TestCase
             ),
         );
 
-        $obj = $this->normalizer->denormalize($data, DummyWithConstructorObject::class);
+        $normalizer = new ObjectNormalizer();
+        $serializer = new DenormalizerDecoratorSerializer($normalizer);
+        $normalizer->setSerializer($serializer);
+
+        $obj = $normalizer->denormalize($data, DummyWithConstructorObject::class);
         $this->assertInstanceOf(DummyWithConstructorObject::class, $obj);
-        $this->assertEquals(10, $obj->getId);
+        $this->assertEquals(10, $obj->getId());
         $this->assertInstanceOf(ObjectInner::class, $obj->getInner());
-        $this->assertEquals('foo', $obj->getInner()->foo);
-        $this->assertEquals('bar', $obj->getInner()->bar);
+        $this->assertEquals('oof', $obj->getInner()->foo);
+        $this->assertEquals('rab', $obj->getInner()->bar);
     }
 
     public function testGroupsNormalize()

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -16,8 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9",
-        "symfony/property-access": "^3.1"
+        "php": ">=5.5.9"
     },
     "require-dev": {
         "symfony/yaml": "~2.8|~3.0",

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -21,6 +21,7 @@
     "require-dev": {
         "symfony/yaml": "~2.8|~3.0",
         "symfony/config": "~2.8|~3.0",
+        "symfony/property-access": "~2.8|~3.0",
         "symfony/http-foundation": "~2.8|~3.0",
         "symfony/cache": "~3.1",
         "symfony/property-info": "~2.8|~3.0",

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -16,12 +16,12 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9"
+        "php": ">=5.5.9",
+        "symfony/property-access": "^3.1"
     },
     "require-dev": {
         "symfony/yaml": "~2.8|~3.0",
         "symfony/config": "~2.8|~3.0",
-        "symfony/property-access": "~2.8|~3.0",
         "symfony/http-foundation": "~2.8|~3.0",
         "symfony/cache": "~3.1",
         "symfony/property-info": "~2.8|~3.0",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | TODO |
| Fixed tickets | none |
| License | MIT |
| Doc PR | TODO |

Assuming with have the two following entities:

``` php
namespace AppBundle\Entity;

class Dummy
{
    public function __construct(int $id, string $name, string $email, AnotherDummy $anotherDummy)
    {
        $this->id = $id;
        $this->name = $name;
        $this->email = $email;
        $this->anotherDummy = $anotherDummy;
    }
}

class AnotherDummy
{
    public function __construct(int $id, string $uuid, bool $isEnabled)
    {
        $this->id = $id;
        $this->uuid = $uuid;
        $this->isEnabled = $isEnabled;
    }
}
```

Doing the following will fail:

``` php
$serializer->denormalize(
    [
        'id' => $i,
        'name' => 'dummy',
        'email' => 'du@ex.com',
        'another_dummy' => [
            'id' => 1000 + $i,
            'uuid' => 'azerty',
            'is_enabled' => true,
        ],
    ],
    \AppBundle\Entity\Dummy::class
);
```

with a type error, because the 4th argument passed to `Dummy::__construct()` will be an array. The following patch checks if the type of the argument is an object, and if it is tries to denormalize that object as well.

I'm not sure if it's me missing something or this is a use case that has been omitted (willingly or not), but if it's a valuable patch I would be happy to work on finishing it. 
