### PR TITLE
removed @since

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterMappingsPass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterMappingsPass.php
@@ -118,8 +118,6 @@ abstract class RegisterMappingsPass implements CompilerPassInterface
      * @param string               $registerAliasMethodName Name of Configuration class method to
      *                                                      register alias.
      * @param string[]             $aliasMap                Map of alias to namespace
-     *
-     * @since Support for bundle alias was added in Symfony 2.6
      */
     public function __construct($driver, array $namespaces, array $managerParameters, $driverPattern, $enabledParameter = false, $configurationPattern = '', $registerAliasMethodName = '', array $aliasMap = array())
     {

--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/IdReader.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/IdReader.php
@@ -18,8 +18,6 @@ use Symfony\Component\Form\Exception\RuntimeException;
 /**
  * A utility for reading object IDs.
  *
- * @since  1.0
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @internal This class is meant for internal use only.

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/LegacyUniqueEntityValidatorLegacyApiTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/LegacyUniqueEntityValidatorLegacyApiTest.php
@@ -14,8 +14,6 @@ namespace Symfony\Bridge\Doctrine\Tests\Validator\Constraints;
 use Symfony\Component\Validator\Validation;
 
 /**
- * @since  2.5.4
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  * @group  legacy
  */

--- a/src/Symfony/Component/Form/Extension/Csrf/CsrfProvider/CsrfProviderAdapter.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/CsrfProvider/CsrfProviderAdapter.php
@@ -21,8 +21,6 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
  * Adapter for using old CSRF providers where the new {@link CsrfTokenManagerInterface}
  * is expected.
  *
- * @since  2.4
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @deprecated since version 2.4, to be removed in 3.0.

--- a/src/Symfony/Component/Form/Extension/Csrf/CsrfProvider/CsrfTokenManagerAdapter.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/CsrfProvider/CsrfTokenManagerAdapter.php
@@ -17,8 +17,6 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 /**
  * Adapter for using the new token generator with the old interface.
  *
- * @since  2.4
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @deprecated since version 2.4, to be removed in 3.0.

--- a/src/Symfony/Component/Form/Extension/DataCollector/DataCollectorExtension.php
+++ b/src/Symfony/Component/Form/Extension/DataCollector/DataCollectorExtension.php
@@ -17,8 +17,6 @@ use Symfony\Component\Form\AbstractExtension;
 /**
  * Extension for collecting data of the forms on a page.
  *
- * @since  2.4
- *
  * @author Robert Schönthal <robert.schoenthal@gmail.com>
  * @author Bernhard Schussek <bschussek@gmail.com>
  */

--- a/src/Symfony/Component/Form/Extension/DataCollector/EventListener/DataCollectorListener.php
+++ b/src/Symfony/Component/Form/Extension/DataCollector/EventListener/DataCollectorListener.php
@@ -20,8 +20,6 @@ use Symfony\Component\Form\FormEvents;
  * Listener that invokes a data collector for the {@link FormEvents::POST_SET_DATA}
  * and {@link FormEvents::POST_SUBMIT} events.
  *
- * @since  2.4
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class DataCollectorListener implements EventSubscriberInterface

--- a/src/Symfony/Component/Form/Extension/DataCollector/FormDataCollector.php
+++ b/src/Symfony/Component/Form/Extension/DataCollector/FormDataCollector.php
@@ -20,8 +20,6 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 /**
  * Data collector for {@link FormInterface} instances.
  *
- * @since  2.4
- *
  * @author Robert Schönthal <robert.schoenthal@gmail.com>
  * @author Bernhard Schussek <bschussek@gmail.com>
  */

--- a/src/Symfony/Component/Form/Extension/DataCollector/FormDataCollectorInterface.php
+++ b/src/Symfony/Component/Form/Extension/DataCollector/FormDataCollectorInterface.php
@@ -18,8 +18,6 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 /**
  * Collects and structures information about forms.
  *
- * @since  2.4
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 interface FormDataCollectorInterface extends DataCollectorInterface

--- a/src/Symfony/Component/Form/Extension/DataCollector/FormDataExtractor.php
+++ b/src/Symfony/Component/Form/Extension/DataCollector/FormDataExtractor.php
@@ -19,8 +19,6 @@ use Symfony\Component\Validator\ConstraintViolationInterface;
 /**
  * Default implementation of {@link FormDataExtractorInterface}.
  *
- * @since  2.4
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class FormDataExtractor implements FormDataExtractorInterface

--- a/src/Symfony/Component/Form/Extension/DataCollector/FormDataExtractorInterface.php
+++ b/src/Symfony/Component/Form/Extension/DataCollector/FormDataExtractorInterface.php
@@ -17,8 +17,6 @@ use Symfony\Component\Form\FormView;
 /**
  * Extracts arrays of information out of forms.
  *
- * @since  2.4
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 interface FormDataExtractorInterface

--- a/src/Symfony/Component/Form/Extension/DataCollector/Proxy/ResolvedTypeDataCollectorProxy.php
+++ b/src/Symfony/Component/Form/Extension/DataCollector/Proxy/ResolvedTypeDataCollectorProxy.php
@@ -21,8 +21,6 @@ use Symfony\Component\Form\ResolvedFormTypeInterface;
 /**
  * Proxy that invokes a data collector when creating a form and its view.
  *
- * @since  2.4
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class ResolvedTypeDataCollectorProxy implements ResolvedFormTypeInterface

--- a/src/Symfony/Component/Form/Extension/DataCollector/Proxy/ResolvedTypeFactoryDataCollectorProxy.php
+++ b/src/Symfony/Component/Form/Extension/DataCollector/Proxy/ResolvedTypeFactoryDataCollectorProxy.php
@@ -20,8 +20,6 @@ use Symfony\Component\Form\ResolvedFormTypeInterface;
  * Proxy that wraps resolved types into {@link ResolvedTypeDataCollectorProxy}
  * instances.
  *
- * @since  2.4
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class ResolvedTypeFactoryDataCollectorProxy implements ResolvedFormTypeFactoryInterface

--- a/src/Symfony/Component/Form/Extension/DataCollector/Type/DataCollectorTypeExtension.php
+++ b/src/Symfony/Component/Form/Extension/DataCollector/Type/DataCollectorTypeExtension.php
@@ -19,8 +19,6 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * Type extension for collecting data of a form with this type.
  *
- * @since  2.4
- *
  * @author Robert Schönthal <robert.schoenthal@gmail.com>
  * @author Bernhard Schussek <bschussek@gmail.com>
  */

--- a/src/Symfony/Component/Form/FormErrorIterator.php
+++ b/src/Symfony/Component/Form/FormErrorIterator.php
@@ -27,8 +27,6 @@ use Symfony\Component\Form\Exception\BadMethodCallException;
  * flatten the recursive structure into a flat list of errors.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
- *
- * @since 2.5
  */
 class FormErrorIterator implements \RecursiveIterator, \SeekableIterator, \ArrayAccess, \Countable
 {

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -102,9 +102,6 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
      *
      * @return FormErrorIterator An iterator over the {@link FormError}
      *                           instances that where added to this form
-     *
-     * @since 2.5 Since version 2.5 this method returns a
-     *            {@link FormErrorIterator} instance instead of an array
      */
     public function getErrors($deep = false, $flatten = true);
 

--- a/src/Symfony/Component/Form/Test/FormPerformanceTestCase.php
+++ b/src/Symfony/Component/Form/Test/FormPerformanceTestCase.php
@@ -62,8 +62,6 @@ abstract class FormPerformanceTestCase extends FormIntegrationTestCase
     }
 
     /**
-     * @since Method available since Release 2.3.0
-     *
      * @return int
      */
     public function getMaxRunningTime()

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/LegacyFormValidatorLegacyApiTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/LegacyFormValidatorLegacyApiTest.php
@@ -14,8 +14,6 @@ namespace Symfony\Component\Form\Tests\Extension\Validator\Constraints;
 use Symfony\Component\Validator\Validation;
 
 /**
- * @since  2.5.3
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  * @group  legacy
  */

--- a/src/Symfony/Component/Form/Util/OrderedHashMap.php
+++ b/src/Symfony/Component/Form/Util/OrderedHashMap.php
@@ -63,8 +63,6 @@ namespace Symfony\Component\Form\Util;
  *     }
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
- *
- * @since 2.2.6
  */
 class OrderedHashMap implements \ArrayAccess, \IteratorAggregate, \Countable
 {
@@ -93,8 +91,6 @@ class OrderedHashMap implements \ArrayAccess, \IteratorAggregate, \Countable
      * Creates a new map.
      *
      * @param array $elements The elements to insert initially
-     *
-     * @since 2.2.6
      */
     public function __construct(array $elements = array())
     {
@@ -104,8 +100,6 @@ class OrderedHashMap implements \ArrayAccess, \IteratorAggregate, \Countable
 
     /**
      * {@inheritdoc}
-     *
-     * @since 2.2.6
      */
     public function offsetExists($key)
     {
@@ -114,8 +108,6 @@ class OrderedHashMap implements \ArrayAccess, \IteratorAggregate, \Countable
 
     /**
      * {@inheritdoc}
-     *
-     * @since 2.2.6
      */
     public function offsetGet($key)
     {
@@ -128,8 +120,6 @@ class OrderedHashMap implements \ArrayAccess, \IteratorAggregate, \Countable
 
     /**
      * {@inheritdoc}
-     *
-     * @since 2.2.6
      */
     public function offsetSet($key, $value)
     {
@@ -151,8 +141,6 @@ class OrderedHashMap implements \ArrayAccess, \IteratorAggregate, \Countable
 
     /**
      * {@inheritdoc}
-     *
-     * @since 2.2.6
      */
     public function offsetUnset($key)
     {
@@ -170,8 +158,6 @@ class OrderedHashMap implements \ArrayAccess, \IteratorAggregate, \Countable
 
     /**
      * {@inheritdoc}
-     *
-     * @since 2.2.6
      */
     public function getIterator()
     {
@@ -180,8 +166,6 @@ class OrderedHashMap implements \ArrayAccess, \IteratorAggregate, \Countable
 
     /**
      * {@inheritdoc}
-     *
-     * @since 2.2.6
      */
     public function count()
     {

--- a/src/Symfony/Component/Form/Util/OrderedHashMapIterator.php
+++ b/src/Symfony/Component/Form/Util/OrderedHashMapIterator.php
@@ -17,8 +17,6 @@ namespace Symfony\Component\Form\Util;
  * This class is internal and should not be used.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
- *
- * @since 2.2.6
  */
 class OrderedHashMapIterator implements \Iterator
 {
@@ -69,8 +67,6 @@ class OrderedHashMapIterator implements \Iterator
      *                              This array is managed by the corresponding
      *                              {@link OrderedHashMap} instance to support
      *                              recognizing the deletion of elements.
-     *
-     * @since 2.2.6
      */
     public function __construct(array &$elements, array &$orderedKeys, array &$managedCursors)
     {
@@ -85,8 +81,6 @@ class OrderedHashMapIterator implements \Iterator
     /**
      * Removes the iterator's cursors from the managed cursors of the
      * corresponding {@link OrderedHashMap} instance.
-     *
-     * @since 2.2.6
      */
     public function __destruct()
     {
@@ -96,9 +90,7 @@ class OrderedHashMapIterator implements \Iterator
     }
 
     /**
-     *{@inheritdoc}
-     *
-     * @since 2.2.6
+     * {@inheritdoc}
      */
     public function current()
     {
@@ -107,8 +99,6 @@ class OrderedHashMapIterator implements \Iterator
 
     /**
      * {@inheritdoc}
-     *
-     * @since 2.2.6
      */
     public function next()
     {
@@ -124,9 +114,7 @@ class OrderedHashMapIterator implements \Iterator
     }
 
     /**
-     *{@inheritdoc}
-     *
-     * @since 2.2.6
+     * {@inheritdoc}
      */
     public function key()
     {
@@ -134,9 +122,7 @@ class OrderedHashMapIterator implements \Iterator
     }
 
     /**
-     *{@inheritdoc}
-     *
-     * @since 2.2.6
+     * {@inheritdoc}
      */
     public function valid()
     {
@@ -144,9 +130,7 @@ class OrderedHashMapIterator implements \Iterator
     }
 
     /**
-     *{@inheritdoc}
-     *
-     * @since 2.2.6
+     * {@inheritdoc}
      */
     public function rewind()
     {

--- a/src/Symfony/Component/Security/Core/Tests/Validator/Constraints/LegacyUserPasswordValidatorTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Validator/Constraints/LegacyUserPasswordValidatorTest.php
@@ -14,8 +14,6 @@ namespace Symfony\Component\Security\Core\Tests\Validator\Constraints;
 use Symfony\Component\Validator\Validation;
 
 /**
- * @since  2.5.4
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  * @group  legacy
  */

--- a/src/Symfony/Component/Security/Csrf/CsrfTokenManagerInterface.php
+++ b/src/Symfony/Component/Security/Csrf/CsrfTokenManagerInterface.php
@@ -14,8 +14,6 @@ namespace Symfony\Component\Security\Csrf;
 /**
  * Manages CSRF tokens.
  *
- * @since  2.4
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 interface CsrfTokenManagerInterface

--- a/src/Symfony/Component/Security/Csrf/TokenGenerator/TokenGeneratorInterface.php
+++ b/src/Symfony/Component/Security/Csrf/TokenGenerator/TokenGeneratorInterface.php
@@ -14,8 +14,6 @@ namespace Symfony\Component\Security\Csrf\TokenGenerator;
 /**
  * Generates CSRF tokens.
  *
- * @since  2.4
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 interface TokenGeneratorInterface

--- a/src/Symfony/Component/Security/Csrf/TokenGenerator/UriSafeTokenGenerator.php
+++ b/src/Symfony/Component/Security/Csrf/TokenGenerator/UriSafeTokenGenerator.php
@@ -17,8 +17,6 @@ use Symfony\Component\Security\Core\Util\SecureRandom;
 /**
  * Generates CSRF tokens.
  *
- * @since  2.4
- *
  * @author Bernhard Schussek <bernhard.schussek@symfony.com>
  */
 class UriSafeTokenGenerator implements TokenGeneratorInterface

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/NativeSessionTokenStorage.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/NativeSessionTokenStorage.php
@@ -16,8 +16,6 @@ use Symfony\Component\Security\Csrf\Exception\TokenNotFoundException;
 /**
  * Token storage that uses PHP's native session handling.
  *
- * @since  2.4
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class NativeSessionTokenStorage implements TokenStorageInterface

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/SessionTokenStorage.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/SessionTokenStorage.php
@@ -17,8 +17,6 @@ use Symfony\Component\Security\Csrf\Exception\TokenNotFoundException;
 /**
  * Token storage that uses a Symfony Session object.
  *
- * @since  2.4
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class SessionTokenStorage implements TokenStorageInterface

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/TokenStorageInterface.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/TokenStorageInterface.php
@@ -14,8 +14,6 @@ namespace Symfony\Component\Security\Csrf\TokenStorage;
 /**
  * Stores CSRF tokens.
  *
- * @since  2.4
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 interface TokenStorageInterface

--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -207,8 +207,6 @@ abstract class Constraint
      * @throws InvalidOptionsException If an invalid option name is given
      *
      * @internal This method should not be used or overwritten in userland code.
-     *
-     * @since 2.6
      */
     public function __get($option)
     {
@@ -296,8 +294,6 @@ abstract class Constraint
      * @internal This method may be replaced by an implementation of
      *           {@link \Serializable} in the future. Please don't use or
      *           overwrite it.
-     *
-     * @since 2.6
      */
     public function __sleep()
     {

--- a/src/Symfony/Component/Validator/Constraints/Callback.php
+++ b/src/Symfony/Component/Validator/Constraints/Callback.php
@@ -23,8 +23,6 @@ class Callback extends Constraint
 {
     /**
      * @var string|callable
-     *
-     * @since 2.4
      */
     public $callback;
 

--- a/src/Symfony/Component/Validator/Constraints/Composite.php
+++ b/src/Symfony/Component/Validator/Constraints/Composite.php
@@ -24,8 +24,6 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
  * let {@link getCompositeOption()} return the name of the property which
  * contains the nested constraints.
  *
- * @since  2.6
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 abstract class Composite extends Constraint

--- a/src/Symfony/Component/Validator/Constraints/Traverse.php
+++ b/src/Symfony/Component/Validator/Constraints/Traverse.php
@@ -17,8 +17,6 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 /**
  * @Annotation
  *
- * @since  2.5
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class Traverse extends Constraint

--- a/src/Symfony/Component/Validator/Context/ExecutionContext.php
+++ b/src/Symfony/Component/Validator/Context/ExecutionContext.php
@@ -27,8 +27,6 @@ use Symfony\Component\Validator\Violation\ConstraintViolationBuilder;
 /**
  * The context used and created by {@link ExecutionContextFactory}.
  *
- * @since  2.5
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @see ExecutionContextInterface

--- a/src/Symfony/Component/Validator/Context/ExecutionContextFactory.php
+++ b/src/Symfony/Component/Validator/Context/ExecutionContextFactory.php
@@ -17,8 +17,6 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 /**
  * Creates new {@link ExecutionContext} instances.
  *
- * @since  2.5
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @internal You should not instantiate or use this class. Code against

--- a/src/Symfony/Component/Validator/Context/ExecutionContextFactoryInterface.php
+++ b/src/Symfony/Component/Validator/Context/ExecutionContextFactoryInterface.php
@@ -19,8 +19,6 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  * You can use a custom factory if you want to customize the execution context
  * that is passed through the validation run.
  *
- * @since  2.5
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 interface ExecutionContextFactoryInterface

--- a/src/Symfony/Component/Validator/Context/ExecutionContextInterface.php
+++ b/src/Symfony/Component/Validator/Context/ExecutionContextInterface.php
@@ -56,8 +56,6 @@ use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
  * cannot store a context and expect that the methods still return the same
  * results later on.
  *
- * @since  2.5
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 interface ExecutionContextInterface extends LegacyExecutionContextInterface

--- a/src/Symfony/Component/Validator/Context/LegacyExecutionContext.php
+++ b/src/Symfony/Component/Validator/Context/LegacyExecutionContext.php
@@ -20,8 +20,6 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 /**
  * An execution context that is compatible with the legacy API (< 2.5).
  *
- * @since  2.5
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @deprecated since version 2.5, to be removed in 3.0.

--- a/src/Symfony/Component/Validator/Context/LegacyExecutionContextFactory.php
+++ b/src/Symfony/Component/Validator/Context/LegacyExecutionContextFactory.php
@@ -22,8 +22,6 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  *
  * Implemented for backward compatibility with Symfony < 2.5.
  *
- * @since  2.5
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @deprecated since version 2.5, to be removed in 3.0.

--- a/src/Symfony/Component/Validator/Exception/UnsupportedMetadataException.php
+++ b/src/Symfony/Component/Validator/Exception/UnsupportedMetadataException.php
@@ -12,8 +12,6 @@
 namespace Symfony\Component\Validator\Exception;
 
 /**
- * @since  2.5
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class UnsupportedMetadataException extends InvalidArgumentException

--- a/src/Symfony/Component/Validator/Mapping/CascadingStrategy.php
+++ b/src/Symfony/Component/Validator/Mapping/CascadingStrategy.php
@@ -27,8 +27,6 @@ namespace Symfony\Component\Validator\Mapping;
  * Although the constants currently represent a boolean switch, they are
  * implemented as bit mask in order to allow future extensions.
  *
- * @since  2.5
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @see TraversalStrategy

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadataInterface.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadataInterface.php
@@ -24,8 +24,6 @@ use Symfony\Component\Validator\PropertyMetadataContainerInterface as LegacyProp
  * by a group sequence for that class and whether instances of that class
  * should be traversed or not.
  *
- * @since  2.5
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @see MetadataInterface

--- a/src/Symfony/Component/Validator/Mapping/Factory/MetadataFactoryInterface.php
+++ b/src/Symfony/Component/Validator/Mapping/Factory/MetadataFactoryInterface.php
@@ -16,8 +16,6 @@ use Symfony\Component\Validator\MetadataFactoryInterface as LegacyMetadataFactor
 /**
  * Returns {@link \Symfony\Component\Validator\Mapping\MetadataInterface} instances for values.
  *
- * @since  2.5
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 interface MetadataFactoryInterface extends LegacyMetadataFactoryInterface

--- a/src/Symfony/Component/Validator/Mapping/GenericMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/GenericMetadata.php
@@ -23,8 +23,6 @@ use Symfony\Component\Validator\ValidationVisitorInterface;
  *
  * This class supports serialization and cloning.
  *
- * @since  2.5
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class GenericMetadata implements MetadataInterface

--- a/src/Symfony/Component/Validator/Mapping/MetadataInterface.php
+++ b/src/Symfony/Component/Validator/Mapping/MetadataInterface.php
@@ -24,8 +24,6 @@ use Symfony\Component\Validator\MetadataInterface as LegacyMetadataInterface;
  * against their class' metadata and whether traversable objects should be
  * traversed or not.
  *
- * @since  2.5
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @see CascadingStrategy

--- a/src/Symfony/Component/Validator/Mapping/PropertyMetadataInterface.php
+++ b/src/Symfony/Component/Validator/Mapping/PropertyMetadataInterface.php
@@ -24,8 +24,6 @@ use Symfony\Component\Validator\PropertyMetadataInterface as LegacyPropertyMetad
  * should be validated against their class' metadata and whether traversable
  * objects should be traversed or not.
  *
- * @since  2.5
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @see MetadataInterface

--- a/src/Symfony/Component/Validator/Mapping/TraversalStrategy.php
+++ b/src/Symfony/Component/Validator/Mapping/TraversalStrategy.php
@@ -23,8 +23,6 @@ namespace Symfony\Component\Validator\Mapping;
  *
  * The traversal strategy is ignored for arrays. Arrays are always iterated.
  *
- * @since  2.1
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @see CascadingStrategy

--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractConstraintValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractConstraintValidatorTest.php
@@ -24,8 +24,6 @@ use Symfony\Component\Validator\Mapping\PropertyMetadata;
 use Symfony\Component\Validator\Validation;
 
 /**
- * @since 2.5.3
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 abstract class AbstractConstraintValidatorTest extends \PHPUnit_Framework_TestCase

--- a/src/Symfony/Component/Validator/Tests/Constraints/CompositeTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CompositeTest.php
@@ -32,8 +32,6 @@ class ConcreteComposite extends Composite
 }
 
 /**
- * @since  2.6
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class CompositeTest extends \PHPUnit_Framework_TestCase

--- a/src/Symfony/Component/Validator/Tests/Fixtures/StubGlobalExecutionContext.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/StubGlobalExecutionContext.php
@@ -16,8 +16,6 @@ use Symfony\Component\Validator\GlobalExecutionContextInterface;
 use Symfony\Component\Validator\ValidationVisitorInterface;
 
 /**
- * @since 2.5.3
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @deprecated since version 2.5, to be removed in 3.0

--- a/src/Symfony/Component/Validator/Tests/Validator/Abstract2Dot5ApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/Abstract2Dot5ApiTest.php
@@ -29,8 +29,6 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 /**
  * Verifies that a validator satisfies the API of Symfony 2.5+.
  *
- * @since  2.5
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 abstract class Abstract2Dot5ApiTest extends AbstractValidatorTest

--- a/src/Symfony/Component/Validator/Tests/Validator/AbstractLegacyApiTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/AbstractLegacyApiTest.php
@@ -23,8 +23,6 @@ use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
 /**
  * Verifies that a validator satisfies the API of Symfony < 2.5.
  *
- * @since  2.5
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  * @group legacy
  */

--- a/src/Symfony/Component/Validator/Tests/Validator/AbstractValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/AbstractValidatorTest.php
@@ -23,8 +23,6 @@ use Symfony\Component\Validator\Tests\Fixtures\GroupSequenceProviderEntity;
 use Symfony\Component\Validator\Tests\Fixtures\Reference;
 
 /**
- * @since  2.5
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 abstract class AbstractValidatorTest extends \PHPUnit_Framework_TestCase

--- a/src/Symfony/Component/Validator/Util/PropertyPath.php
+++ b/src/Symfony/Component/Validator/Util/PropertyPath.php
@@ -16,8 +16,6 @@ namespace Symfony\Component\Validator\Util;
  *
  * For more extensive functionality, use Symfony's PropertyAccess component.
  *
- * @since  2.5
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class PropertyPath

--- a/src/Symfony/Component/Validator/Validator/ContextualValidatorInterface.php
+++ b/src/Symfony/Component/Validator/Validator/ContextualValidatorInterface.php
@@ -17,8 +17,6 @@ use Symfony\Component\Validator\ConstraintViolationListInterface;
 /**
  * A validator in a specific execution context.
  *
- * @since  2.5
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 interface ContextualValidatorInterface

--- a/src/Symfony/Component/Validator/Validator/LegacyValidator.php
+++ b/src/Symfony/Component/Validator/Validator/LegacyValidator.php
@@ -16,8 +16,6 @@ namespace Symfony\Component\Validator\Validator;
 /**
  * A validator that supports both the API of Symfony < 2.5 and Symfony 2.5+.
  *
- * @since  2.5
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @see \Symfony\Component\Validator\ValidatorInterface

--- a/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
@@ -33,8 +33,6 @@ use Symfony\Component\Validator\Util\PropertyPath;
 /**
  * Recursive implementation of {@link ContextualValidatorInterface}.
  *
- * @since  2.5
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class RecursiveContextualValidator implements ContextualValidatorInterface

--- a/src/Symfony/Component/Validator/Validator/RecursiveValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveValidator.php
@@ -24,8 +24,6 @@ use Symfony\Component\Validator\ValidatorInterface as LegacyValidatorInterface;
 /**
  * Recursive implementation of {@link ValidatorInterface}.
  *
- * @since  2.5
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class RecursiveValidator implements ValidatorInterface, LegacyValidatorInterface

--- a/src/Symfony/Component/Validator/Validator/ValidatorInterface.php
+++ b/src/Symfony/Component/Validator/Validator/ValidatorInterface.php
@@ -19,8 +19,6 @@ use Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface;
 /**
  * Validates PHP values against constraints.
  *
- * @since  2.5
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 interface ValidatorInterface extends MetadataFactoryInterface

--- a/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilder.php
+++ b/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilder.php
@@ -20,8 +20,6 @@ use Symfony\Component\Validator\Util\PropertyPath;
 /**
  * Default implementation of {@link ConstraintViolationBuilderInterface}.
  *
- * @since  2.5
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @internal You should not instantiate or use this class. Code against

--- a/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilderInterface.php
+++ b/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilderInterface.php
@@ -19,8 +19,6 @@ namespace Symfony\Component\Validator\Violation;
  * Finally, call {@link addViolation()} to add the violation to the current
  * execution context.
  *
- * @since  2.5
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 interface ConstraintViolationBuilderInterface


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

`@since` is not an annotation we use in Symfony, so let's remove the exiting ones.
