### PR TITLE
[HttpKernel] Clarify deprecation of non-scalar values in surrogate fragment renderer

### DIFF
--- a/UPGRADE-3.1.md
+++ b/UPGRADE-3.1.md
@@ -95,9 +95,9 @@ FrameworkBundle
 HttpKernel
 ----------
 
- * Passing objects as URI attributes to the ESI and SSI renderers has been
+ * Passing non-scalar values as URI attributes to the ESI and SSI renderers has been
    deprecated and will be removed in Symfony 4.0. The inline fragment
-   renderer should be used with object attributes.
+   renderer should be used with non-scalar attributes.
 
  * The `ControllerResolver::getArguments()` method has been deprecated and will
    be removed in 4.0. If you have your own `ControllerResolverInterface`

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -84,9 +84,9 @@ FrameworkBundle
 HttpKernel
 ----------
 
- * Possibility to pass objects as URI attributes to the ESI and SSI renderers
-   has been removed. The inline fragment renderer should be used with object
-   attributes.
+ * Possibility to pass non-scalar values as URI attributes to the ESI and SSI
+   renderers has been removed. The inline fragment renderer should be used with
+   non-scalar attributes.
 
  * The `ControllerResolver::getArguments()` method has been removed. If you
    have your own `ControllerResolverInterface` implementation, you should

--- a/src/Symfony/Component/HttpKernel/Fragment/AbstractSurrogateFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/AbstractSurrogateFragmentRenderer.php
@@ -65,7 +65,7 @@ abstract class AbstractSurrogateFragmentRenderer extends RoutableFragmentRendere
     {
         if (!$this->surrogate || !$this->surrogate->hasSurrogateCapability($request)) {
             if ($uri instanceof ControllerReference && $this->containsNonScalars($uri->attributes)) {
-                @trigger_error('Passing objects as part of URI attributes to the ESI and SSI rendering strategies is deprecated since version 3.1, and will be removed in 4.0. Use a different rendering strategy or pass scalar values.', E_USER_DEPRECATED);
+                @trigger_error('Passing non-scalar values as part of URI attributes to the ESI and SSI rendering strategies is deprecated since version 3.1, and will be removed in 4.0. Use a different rendering strategy or pass scalar values.', E_USER_DEPRECATED);
             }
 
             return $this->inlineStrategy->render($uri, $request, $options);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #19262 |
| License | MIT |
| Doc PR | ~ |
