### PR TITLE
[Form] - fixed bug - name in ButtonBuilder

### DIFF
--- a/src/Symfony/Component/Form/ButtonBuilder.php
+++ b/src/Symfony/Component/Form/ButtonBuilder.php
@@ -62,11 +62,12 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      */
     public function __construct($name, array $options = array())
     {
-        if (empty($name) && 0 != $name) {
+        $name = (string) $name;
+        if ('' === $name) {
             throw new InvalidArgumentException('Buttons cannot have empty names.');
         }
 
-        $this->name = (string) $name;
+        $this->name = $name;
         $this->options = $options;
     }
 

--- a/src/Symfony/Component/Form/Tests/ButtonBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/ButtonBuilderTest.php
@@ -19,20 +19,19 @@ use Symfony\Component\Form\Exception\InvalidArgumentException;
  */
 class ButtonBuilderTest extends \PHPUnit_Framework_TestCase
 {
-
     /**
      * @return array
      */
     public function getValidNames()
     {
-        return [
-            ['reset'],
-            ['submit'],
-            ['foo'],
-            ['0'],
-            [0],
-            ['button[]'],
-        ];
+        return array(
+            array('reset'),
+            array('submit'),
+            array('foo'),
+            array('0'),
+            array(0),
+            array('button[]'),
+        );
     }
 
     /**
@@ -50,11 +49,11 @@ class ButtonBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function getInvalidNames()
     {
-        return [
-            [''],
-            [false],
-            [null],
-        ];
+        return array(
+            array(''),
+            array(false),
+            array(null),
+        );
     }
 
     /**
@@ -67,5 +66,4 @@ class ButtonBuilderTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException(InvalidArgumentException::class, 'Buttons cannot have empty names.');
         new ButtonBuilder($name);
     }
-
 }

--- a/src/Symfony/Component/Form/Tests/ButtonBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/ButtonBuilderTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Form\Tests;
 
 use Symfony\Component\Form\ButtonBuilder;
-use Symfony\Component\Form\Exception\InvalidArgumentException;
 
 /**
  * @author Alexander Cheprasov <cheprasov.84@ya.ru>
@@ -41,7 +40,7 @@ class ButtonBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidNames($name)
     {
-        $this->assertInstanceOf(ButtonBuilder::class, new ButtonBuilder($name));
+        $this->assertInstanceOf('\Symfony\Component\Form\ButtonBuilder', new ButtonBuilder($name));
     }
 
     /**
@@ -63,7 +62,10 @@ class ButtonBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidNames($name)
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Buttons cannot have empty names.');
+        $this->setExpectedException(
+            '\Symfony\Component\Form\Exception\InvalidArgumentException',
+            'Buttons cannot have empty names.'
+        );
         new ButtonBuilder($name);
     }
 }

--- a/src/Symfony/Component/Form/Tests/ButtonBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/ButtonBuilderTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests;
+
+use Symfony\Component\Form\ButtonBuilder;
+use Symfony\Component\Form\Exception\InvalidArgumentException;
+
+/**
+ * @author Alexander Cheprasov <cheprasov.84@ya.ru>
+ */
+class ButtonBuilderTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @return array
+     */
+    public function getValidNames()
+    {
+        return [
+            ['reset'],
+            ['submit'],
+            ['foo'],
+            ['0'],
+            [0],
+            ['button[]'],
+        ];
+    }
+
+    /**
+     * @dataProvider getValidNames
+     *
+     * @param string $name
+     */
+    public function testValidNames($name)
+    {
+        $this->assertInstanceOf(ButtonBuilder::class, new ButtonBuilder($name));
+    }
+
+    /**
+     * @return array
+     */
+    public function getInvalidNames()
+    {
+        return [
+            [''],
+            [false],
+            [null],
+        ];
+    }
+
+    /**
+     * @dataProvider getInvalidNames
+     *
+     * @param string $name
+     */
+    public function testInvalidNames($name)
+    {
+        $this->setExpectedException(InvalidArgumentException::class, 'Buttons cannot have empty names.');
+        new ButtonBuilder($name);
+    }
+
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

**Bug:**

For any scalar of name, expression `empty($name) && 0 != $name` is never true,
and as result - empty string ('') is allowed.

**Examples:**

``` php
$name = ''; var_dump(empty($name) && 0 != $name); // false
$name = '0'; var_dump(empty($name) && 0 != $name); // false
$name = null; var_dump(empty($name) && 0 != $name); // false
$name = false; var_dump(empty($name) && 0 != $name); // false
$name = 0; var_dump(empty($name) && 0 != $name); // false
```
