### PR TITLE
[VarDumper] Fix indentation trimming in ExceptionCaster

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
@@ -253,19 +253,24 @@ class ExceptionCaster
         }
 
         $ltrim = 0;
-        while (' ' === $src[0][$ltrim] || "\t" === $src[0][$ltrim]) {
-            $i = $srcContext << 1;
-            while ($i > 0 && $src[0][$ltrim] === $src[$i][$ltrim]) {
-                --$i;
-            }
-            if ($i) {
-                break;
+        do {
+            $pad = null;
+            for ($i = $srcContext << 1; $i >= 0; --$i) {
+                if (isset($src[$i][$ltrim]) && "\r" !== ($c = $src[$i][$ltrim]) && "\n" !== $c) {
+                    if (null === $pad) {
+                        $pad = $c;
+                    }
+                    if ((' ' !== $c && "\t" !== $c) || $pad !== $c) {
+                        break;
+                    }
+                }
             }
             ++$ltrim;
-        }
-        if ($ltrim) {
+        } while (0 > $i && null !== $pad);
+
+        if (--$ltrim) {
             foreach ($src as $i => $line) {
-                $src[$i] = substr($line, $ltrim);
+                $src[$i] = isset($line[$ltrim]) && "\r" !== $line[$ltrim] ? substr($line, $ltrim) : ltrim($line, " \t");
             }
         }
 

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
@@ -208,8 +208,8 @@ array:2 [
     executing: {
       Symfony\Component\VarDumper\Tests\Fixtures\GeneratorDemo::foo(): {
         %sGeneratorDemo.php:10: """
-                  yield 1;\n
-              }\n
+              yield 1;\n
+          }\n
           \n
           """
       }

--- a/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
@@ -200,7 +200,7 @@ EOTXT
             $twig = <<<EOTXT
           foo.twig:2: """
             foo bar\\n
-                twig source\\n
+              twig source\\n
             \\n
             """
 

--- a/src/Symfony/Component/VarDumper/Tests/Fixtures/Twig.php
+++ b/src/Symfony/Component/VarDumper/Tests/Fixtures/Twig.php
@@ -29,6 +29,6 @@ class __TwigTemplate_VarDumperFixture_u75a09 extends Twig_Template
         return array (19 => 2);
     }
 }
-/* foo bar*/
+/*   foo bar*/
 /*     twig source*/
 /* */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Blank lines prevent left-trimming of source code excerpts currently.
