### PR TITLE
[ParameterBag] Added getDate/getDateTime methods to simplify handling of date keys

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -196,7 +196,11 @@ class ParameterBag implements \IteratorAggregate, \Countable
      */
     public function getDate($key, $format = 'Y-m-d', $default = null, \DateTimeZone $timeZone = null)
     {
-        return \DateTime::createFromFormat($format, $this->get($key, $default), $timeZone);
+        if ($this->has($key)) {
+            return \DateTime::createFromFormat($format, $this->get($key), $timeZone);
+        }
+
+        return $default;
     }
 
     /***

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -80,7 +80,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
      *
      * @param string $key     The key
      * @param mixed  $default The default value if the parameter key does not exist
-     *g
+     *
      * @return mixed
      */
     public function get($key, $default = null)

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -190,10 +190,10 @@ class ParameterBag implements \IteratorAggregate, \Countable
     /**
      * Returns the parameter value converted to a DateTime object.
      *
-     * @param string              $key      The parameter key
-     * @param string              $format   The expected date format
-     * @param \DateTime|null      $default  The default value if the parameter key does not exist
-     * @param \DateTimeZone|null  $timeZone
+     * @param string             $key      The parameter key
+     * @param string             $format   The expected date format
+     * @param \DateTime|null     $default  The default value if the parameter key does not exist
+     * @param \DateTimeZone|null $timeZone
      *
      * @return \DateTime|null
      */
@@ -215,7 +215,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
 
             // Failure to parse the date according to the specified format will return null
             if ($result === false) {
-                return null;
+                return;
             }
 
             return $result;
@@ -227,10 +227,10 @@ class ParameterBag implements \IteratorAggregate, \Countable
     /**
      * Returns the parameter value converted to a DateTime object while also parsing the time.
      *
-     * @param string              $key      The parameter key
-     * @param string              $format   The expected date format
-     * @param \DateTime|null      $default  The default value if the parameter key does not exist
-     * @param \DateTimeZone|null  $timeZone
+     * @param string             $key      The parameter key
+     * @param string             $format   The expected date format
+     * @param \DateTime|null     $default  The default value if the parameter key does not exist
+     * @param \DateTimeZone|null $timeZone
      *
      * @return \DateTime|null
      */

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -187,27 +187,44 @@ class ParameterBag implements \IteratorAggregate, \Countable
         return $this->filter($key, $default, FILTER_VALIDATE_BOOLEAN);
     }
 
-    /***
-     * @param string             $key     The parameter key
-     * @param string             $format  The expected date format
-     * @param mixed              $default The default value if the parameter key does not exist
-     * @param \DateTimeZone|null $timeZone
+    /**
+     * Returns the parameter value converted to a DateTime object
+     *
+     * @param string $key      The parameter key
+     * @param string $format   The expected date format
+     * @param mixed  $default  The default value if the parameter key does not exist
+     * @param mixed  $timeZone
+     *
      * @return \DateTime|false
      */
-    public function getDate($key, $format = 'Y-m-d', $default = null, \DateTimeZone $timeZone = null)
+    public function getDate($key, $format = 'Y-m-d', $default = null, $timeZone = null)
     {
         if ($this->has($key)) {
-            return \DateTime::createFromFormat($format, $this->get($key), $timeZone);
+            $time = $this->get($key);
+
+            // if the user has specified a timezone then pass that
+            // otherwise do not even attempt to put a value but rather let the runtime decide
+            // the default value by itself
+            // this is in order to ensure compatibility with all php versions since
+            // some accept null as a TimeZone parameter and others do not
+            if ($timeZone !== null) {
+                return \DateTime::createFromFormat($format, $time, $timeZone);
+            }
+
+            return \DateTime::createFromFormat($format, $time);
         }
 
         return $default;
     }
 
-    /***
-     * @param string             $key     The parameter key
-     * @param string             $format  The expected date time format
-     * @param mixed              $default The default value if the parameter key does not exist
-     * @param \DateTimeZone|null $timeZone
+    /**
+     * Returns the parameter value converted to a DateTime object while also paring the time portion
+     *
+     * @param string $key      The parameter key
+     * @param string $format   The expected date format
+     * @param mixed  $default  The default value if the parameter key does not exist
+     * @param mixed  $timeZone
+     *
      * @return \DateTime|false
      */
     public function getDateTime($key, $format = 'Y-m-d H:i:s', $default = null, \DateTimeZone $timeZone = null)

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -187,6 +187,30 @@ class ParameterBag implements \IteratorAggregate, \Countable
         return $this->filter($key, $default, FILTER_VALIDATE_BOOLEAN);
     }
 
+    /***
+     * @param string             $key     The parameter key
+     * @param string             $format  The expected date format
+     * @param mixed              $default The default value if the parameter key does not exist
+     * @param \DateTimeZone|null $timeZone
+     * @return \DateTime|false
+     */
+    public function getDate($key, $format = 'Y-m-d', $default = null, \DateTimeZone $timeZone = null)
+    {
+        return \DateTime::createFromFormat($format, $this->get($key, $default), $timeZone);
+    }
+
+    /***
+     * @param string             $key     The parameter key
+     * @param string             $format  The expected date time format
+     * @param mixed              $default The default value if the parameter key does not exist
+     * @param \DateTimeZone|null $timeZone
+     * @return \DateTime|false
+     */
+    public function getDateTime($key, $format = 'Y-m-d H:i:s', $default = null, \DateTimeZone $timeZone = null)
+    {
+        return $this->getDate($key, $format, $default, $timeZone);
+    }
+
     /**
      * Filter key.
      *

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -202,7 +202,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
         if (!$this->has($key)) {
             return $default;
         }
-        
+
         $time = $this->get($key);
 
         // if the user has specified a timezone then pass that

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -195,7 +195,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
      * @param mixed  $default  The default value if the parameter key does not exist
      * @param mixed  $timeZone
      *
-     * @return \DateTime|false
+     * @return mixed
      */
     public function getDate($key, $format = 'Y-m-d', $default = null, $timeZone = null)
     {
@@ -225,7 +225,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
      * @param mixed  $default  The default value if the parameter key does not exist
      * @param mixed  $timeZone
      *
-     * @return \DateTime|false
+     * @return mixed
      */
     public function getDateTime($key, $format = 'Y-m-d H:i:s', $default = null, \DateTimeZone $timeZone = null)
     {

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -80,7 +80,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
      *
      * @param string $key     The key
      * @param mixed  $default The default value if the parameter key does not exist
-     *
+     *g
      * @return mixed
      */
     public function get($key, $default = null)
@@ -199,29 +199,25 @@ class ParameterBag implements \IteratorAggregate, \Countable
      */
     public function getDate($key, $format = 'Y-m-d', $default = null, $timeZone = null)
     {
-        if ($this->has($key)) {
-            $time = $this->get($key);
+        if (!$this->has($key)) {
+            return $default;
+        }
+        
+        $time = $this->get($key);
 
-            // if the user has specified a timezone then pass that
-            // otherwise do not even attempt to put a value but rather let the runtime decide
-            // the default value by itself
-            // this is in order to ensure compatibility with all php versions since
-            // some accept null as a TimeZone parameter and others do not
-            if ($timeZone !== null) {
-                $result = \DateTime::createFromFormat($format, $time, $timeZone);
-            } else {
-                $result = \DateTime::createFromFormat($format, $time);
-            }
-
-            // Failure to parse the date according to the specified format will return null
-            if ($result === false) {
-                return;
-            }
-
-            return $result;
+        // if the user has specified a timezone then pass that
+        // otherwise do not even attempt to put a value but rather let the runtime decide
+        // the default value by itself
+        // this is in order to ensure compatibility with all php versions since
+        // some accept null as a TimeZone parameter and others do not
+        if ($timeZone !== null) {
+            $result = \DateTime::createFromFormat($format, $time, $timeZone);
+        } else {
+            $result = \DateTime::createFromFormat($format, $time);
         }
 
-        return $default;
+        // Failure to parse the date according to the specified format will return null
+        return false === $result ? null : $result;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -188,7 +188,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
     }
 
     /**
-     * Returns the parameter value converted to a DateTime object
+     * Returns the parameter value converted to a DateTime object.
      *
      * @param string $key      The parameter key
      * @param string $format   The expected date format
@@ -218,7 +218,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
     }
 
     /**
-     * Returns the parameter value converted to a DateTime object while also paring the time portion
+     * Returns the parameter value converted to a DateTime object while also paring the time portion.
      *
      * @param string $key      The parameter key
      * @param string $format   The expected date format

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -190,12 +190,12 @@ class ParameterBag implements \IteratorAggregate, \Countable
     /**
      * Returns the parameter value converted to a DateTime object.
      *
-     * @param string $key      The parameter key
-     * @param string $format   The expected date format
-     * @param mixed  $default  The default value if the parameter key does not exist
-     * @param mixed  $timeZone
+     * @param string              $key      The parameter key
+     * @param string              $format   The expected date format
+     * @param \DateTime|null      $default  The default value if the parameter key does not exist
+     * @param \DateTimeZone|null  $timeZone
      *
-     * @return mixed
+     * @return \DateTime|null
      */
     public function getDate($key, $format = 'Y-m-d', $default = null, $timeZone = null)
     {
@@ -208,24 +208,31 @@ class ParameterBag implements \IteratorAggregate, \Countable
             // this is in order to ensure compatibility with all php versions since
             // some accept null as a TimeZone parameter and others do not
             if ($timeZone !== null) {
-                return \DateTime::createFromFormat($format, $time, $timeZone);
+                $result = \DateTime::createFromFormat($format, $time, $timeZone);
+            } else {
+                $result = \DateTime::createFromFormat($format, $time);
             }
 
-            return \DateTime::createFromFormat($format, $time);
+            // Failure to parse the date according to the specified format will return null
+            if ($result === false) {
+                return null;
+            }
+
+            return $result;
         }
 
         return $default;
     }
 
     /**
-     * Returns the parameter value converted to a DateTime object while also paring the time portion.
+     * Returns the parameter value converted to a DateTime object while also parsing the time.
      *
-     * @param string $key      The parameter key
-     * @param string $format   The expected date format
-     * @param mixed  $default  The default value if the parameter key does not exist
-     * @param mixed  $timeZone
+     * @param string              $key      The parameter key
+     * @param string              $format   The expected date format
+     * @param \DateTime|null      $default  The default value if the parameter key does not exist
+     * @param \DateTimeZone|null  $timeZone
      *
-     * @return mixed
+     * @return \DateTime|null
      */
     public function getDateTime($key, $format = 'Y-m-d H:i:s', $default = null, \DateTimeZone $timeZone = null)
     {

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -135,7 +135,7 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
 
     public function testGetDate()
     {
-        $isoDate = '2016-07-05T15:30:00+00:00';
+        $isoDate = '2016-07-05T15:30:00UTC';
         $bag = new ParameterBag(array(
             'd1' => '2016-01-01',
             'iso' => $isoDate,
@@ -150,7 +150,7 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
 
         $date = $bag->getDate('iso', \DateTime::ISO8601);
         $this->assertEquals(new \DateTime($isoDate), $date);
-        $this->assertEquals('+00:00', $date->getTimezone()->getName());
+        $this->assertEquals('UTC', $date->getTimezone()->getName());
     }
 
     public function testFilter()

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -140,9 +140,12 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         
         $diff = $date->diff($bag->getDate('d1'));
 
+        var_dump($bag->getDate('d1', 'd/m/Y'));
+        var_dump($bag->getDate('d1', 'd/m/Y'));
+
         $this->assertEquals(0, $diff->days, '->getDate() returns a date via the format specified');
-        $this->assertEquals(false, $bag->getDate('d1', 'd/m/Y'), '->getDate() returns a date from the specified format');
-        $this->assertEquals(null, $bag->getDate('d1', 'd/m/Y'), '->getDate() returns null if the parameter is not found');
+        $this->assertFalse($bag->getDate('d1', 'd/m/Y'), '->getDate() returns false if the format is not valid');
+        $this->assertNull($bag->getDate('d2', 'd/m/Y'), '->getDate() returns null if the parameter is not found');
     }
 
     public function testFilter()

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -137,7 +137,6 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
     {
         $bag = new ParameterBag(array('d1' => '2016-01-01'));
         $date = \DateTime::createFromFormat('Y-m-d', '2016-01-01');
-        
         $diff = $date->diff($bag->getDate('d1'));
 
         $this->assertEquals(0, $diff->days, '->getDate() returns a date via the format specified');

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -135,7 +135,7 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
 
     public function testGetDate()
     {
-        $isoDate = '2016-07-05T15:30:00CET';
+        $isoDate = '2016-07-05T15:30:00+00:00';
         $bag = new ParameterBag(array(
             'd1' => '2016-01-01',
             'iso' => $isoDate,
@@ -150,7 +150,7 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
 
         $date = $bag->getDate('iso', \DateTime::ISO8601);
         $this->assertEquals(new \DateTime($isoDate), $date);
-        $this->assertEquals('CET', $date->getTimezone()->getName());
+        $this->assertEquals('+00:00', $date->getTimezone()->getName());
     }
 
     public function testFilter()

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -124,6 +124,27 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, $bag->getInt('unknown'), '->getInt() returns zero if a parameter is not defined');
     }
 
+    public function testGetDateTime()
+    {
+        $format = 'Y-m-d H:i:s';
+        $bag = new ParameterBag(array('d1' => '2016-01-01 00:00:00'));
+        $date = \DateTime::createFromFormat($format, '2016-01-01 00:00:00');
+
+        $this->assertEquals($date, $bag->getDateTime('d1', $format), '->getDateTime() returns a date from the specified format');
+    }
+
+    public function testGetDate()
+    {
+        $bag = new ParameterBag(array('d1' => '2016-01-01'));
+        $date = \DateTime::createFromFormat('Y-m-d', '2016-01-01');
+        
+        $diff = $date->diff($bag->getDate('d1'));
+
+        $this->assertEquals(0, $diff->days, '->getDate() returns a date via the format specified');
+        $this->assertEquals(false, $bag->getDate('d1', 'd/m/Y'), '->getDate() returns a date from the specified format');
+        $this->assertEquals(null, $bag->getDate('d1', 'd/m/Y'), '->getDate() returns null if the parameter is not found');
+    }
+
     public function testFilter()
     {
         $bag = new ParameterBag(array(

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -145,7 +145,7 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $diff = $date->diff($bag->getDate('d1'));
 
         $this->assertEquals(0, $diff->days, '->getDate() returns a date via the format specified');
-        $this->assertFalse($bag->getDate('d1', 'd/m/Y'), '->getDate() returns false if the format is not valid');
+        $this->assertNull($bag->getDate('d1', 'd/m/Y'), '->getDate() returns false if the format is not valid');
         $this->assertNull($bag->getDate('d2', 'd/m/Y'), '->getDate() returns null if the parameter is not found');
 
         $date = $bag->getDate('iso', \DateTime::ISO8601);

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\HttpFoundation\Tests;
 
 use Symfony\Component\HttpFoundation\ParameterBag;
-use Symfony\Component\Validator\Constraints\DateTime;
 
 class ParameterBagTest extends \PHPUnit_Framework_TestCase
 {
@@ -139,7 +138,7 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $isoDate = '2016-07-05T15:30:00CET';
         $bag = new ParameterBag(array(
             'd1' => '2016-01-01',
-            'iso' => $isoDate
+            'iso' => $isoDate,
         ));
 
         $date = \DateTime::createFromFormat('Y-m-d', '2016-01-01');
@@ -151,7 +150,7 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
 
         $date = $bag->getDate('iso', \DateTime::ISO8601);
         $this->assertEquals(new \DateTime($isoDate), $date);
-        $this->assertEquals("CET", $date->getTimezone()->getName());
+        $this->assertEquals('CET', $date->getTimezone()->getName());
     }
 
     public function testFilter()

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -151,6 +151,8 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $date = $bag->getDate('iso', \DateTime::ISO8601);
         $this->assertEquals(new \DateTime($isoDate), $date);
         $this->assertEquals('UTC', $date->getTimezone()->getName());
+
+        $this->assertEquals($date, $bag->getDate('nokey', 'Y-m-d', $date));
     }
 
     public function testFilter()

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -140,9 +140,6 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         
         $diff = $date->diff($bag->getDate('d1'));
 
-        var_dump($bag->getDate('d1', 'd/m/Y'));
-        var_dump($bag->getDate('d1', 'd/m/Y'));
-
         $this->assertEquals(0, $diff->days, '->getDate() returns a date via the format specified');
         $this->assertFalse($bag->getDate('d1', 'd/m/Y'), '->getDate() returns false if the format is not valid');
         $this->assertNull($bag->getDate('d2', 'd/m/Y'), '->getDate() returns null if the parameter is not found');

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Tests;
 
 use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\Validator\Constraints\DateTime;
 
 class ParameterBagTest extends \PHPUnit_Framework_TestCase
 {
@@ -135,13 +136,22 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
 
     public function testGetDate()
     {
-        $bag = new ParameterBag(array('d1' => '2016-01-01'));
+        $isoDate = '2016-07-05T15:30:00CET';
+        $bag = new ParameterBag(array(
+            'd1' => '2016-01-01',
+            'iso' => $isoDate
+        ));
+
         $date = \DateTime::createFromFormat('Y-m-d', '2016-01-01');
         $diff = $date->diff($bag->getDate('d1'));
 
         $this->assertEquals(0, $diff->days, '->getDate() returns a date via the format specified');
         $this->assertFalse($bag->getDate('d1', 'd/m/Y'), '->getDate() returns false if the format is not valid');
         $this->assertNull($bag->getDate('d2', 'd/m/Y'), '->getDate() returns null if the parameter is not found');
+
+        $date = $bag->getDate('iso', \DateTime::ISO8601);
+        $this->assertEquals(new \DateTime($isoDate), $date);
+        $this->assertEquals("CET", $date->getTimezone()->getName());
     }
 
     public function testFilter()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | [#6718](https://github.com/symfony/symfony-docs/pull/6718) |

This adds two methods to the `ParameterBag` class: `getDate` and `getDateTime`, which convert the specified key to a `DateTime` object
