### PR TITLE
[HttpFoundation] adds getDate method to the ParameterBag class

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -188,6 +188,54 @@ class ParameterBag implements \IteratorAggregate, \Countable
     }
 
     /**
+     * Returns the parameter value converted to a DateTime object.
+     *
+     * @param string             $key      The parameter key
+     * @param string             $format   The expected date format
+     * @param \DateTime|null     $default  The default value if the parameter key does not exist
+     * @param \DateTimeZone|null $timeZone
+     *
+     * @return \DateTime|null
+     */
+    public function getDate($key, $format = 'Y-m-d', $default = null, $timeZone = null)
+    {
+        if (!$this->has($key)) {
+            return $default;
+        }
+
+        $time = $this->get($key);
+
+        // if the user has specified a timezone then pass that
+        // otherwise do not even attempt to put a value but rather let the runtime decide
+        // the default value by itself
+        // this is in order to ensure compatibility with all php versions since
+        // some accept null as a TimeZone parameter and others do not
+        if ($timeZone !== null) {
+            $result = \DateTime::createFromFormat($format, $time, $timeZone);
+        } else {
+            $result = \DateTime::createFromFormat($format, $time);
+        }
+
+        // Failure to parse the date according to the specified format will return null
+        return false === $result ? null : $result;
+    }
+
+    /**
+     * Returns the parameter value converted to a DateTime object while also parsing the time.
+     *
+     * @param string             $key      The parameter key
+     * @param string             $format   The expected date format
+     * @param \DateTime|null     $default  The default value if the parameter key does not exist
+     * @param \DateTimeZone|null $timeZone
+     *
+     * @return \DateTime|null
+     */
+    public function getDateTime($key, $format = 'Y-m-d H:i:s', $default = null, \DateTimeZone $timeZone = null)
+    {
+        return $this->getDate($key, $format, $default, $timeZone);
+    }
+
+    /**
      * Filter key.
      *
      * @param string $key     Key

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -190,10 +190,10 @@ class ParameterBag implements \IteratorAggregate, \Countable
     /**
      * Returns the parameter value converted to a DateTime object.
      *
-     * @param string                    $key      The parameter key
-     * @param string                    $format   The expected date format
-     * @param \DateTimeInterface|string $default  The default value to be converted to a DateTime object if the parameter key does not exist
-     * @param \DateTimeZone|null        $timeZone A DateTimeZone object representing the desired time zone
+     * @param string                          $key      The parameter key
+     * @param string                          $format   The expected date format
+     * @param \DateTimeInterface|string|null  $default  The default value to be converted to a DateTime object if the parameter key does not exist
+     * @param \DateTimeZone|null              $timeZone A DateTimeZone object representing the desired time zone
      *
      * @return \DateTimeInterface|null
      */
@@ -201,8 +201,8 @@ class ParameterBag implements \IteratorAggregate, \Countable
     {
         $time = $this->get($key, $default);
 
-        if ($time instanceof \DateTimeInterface) {
-            return $default;
+        if ((null === $time) || $time instanceof \DateTimeInterface) {
+            return $time;
         }
 
         // if the user has specified a timezone then pass that

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -192,25 +192,21 @@ class ParameterBag implements \IteratorAggregate, \Countable
      *
      * @param string             $key      The parameter key
      * @param string             $format   The expected date format
-     * @param \DateTime|null     $default  The default value if the parameter key does not exist
-     * @param \DateTimeZone|null $timeZone
+     * @param string             $default  The default value to be converted to a DateTime object if the parameter key does not exist
+     * @param \DateTimeZone|null $timeZone A DateTimeZone object representing the desired time zone
      *
      * @return \DateTime|null
      */
-    public function getDate($key, $format = 'Y-m-d', $default = null, $timeZone = null)
+    public function getDate($key, $format, $default = null, $timeZone = null)
     {
-        if (!$this->has($key)) {
-            return $default;
-        }
-
-        $time = $this->get($key);
+        $time = $this->get($key, (string) $default);
 
         // if the user has specified a timezone then pass that
         // otherwise do not even attempt to put a value but rather let the runtime decide
         // the default value by itself
         // this is in order to ensure compatibility with all php versions since
         // some accept null as a TimeZone parameter and others do not
-        if ($timeZone !== null) {
+        if (null !== $timeZone) {
             $result = \DateTime::createFromFormat($format, $time, $timeZone);
         } else {
             $result = \DateTime::createFromFormat($format, $time);
@@ -218,21 +214,6 @@ class ParameterBag implements \IteratorAggregate, \Countable
 
         // Failure to parse the date according to the specified format will return null
         return false === $result ? null : $result;
-    }
-
-    /**
-     * Returns the parameter value converted to a DateTime object while also parsing the time.
-     *
-     * @param string             $key      The parameter key
-     * @param string             $format   The expected date format
-     * @param \DateTime|null     $default  The default value if the parameter key does not exist
-     * @param \DateTimeZone|null $timeZone
-     *
-     * @return \DateTime|null
-     */
-    public function getDateTime($key, $format = 'Y-m-d H:i:s', $default = null, \DateTimeZone $timeZone = null)
-    {
-        return $this->getDate($key, $format, $default, $timeZone);
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -197,9 +197,9 @@ class ParameterBag implements \IteratorAggregate, \Countable
      *
      * @return \DateTime|null
      */
-    public function getDate($key, $format, $default = null, $timeZone = null)
+    public function getDate($key, $format, $default = null, \DateTimeZone $timeZone = null)
     {
-        $time = $this->get($key, (string) $default);
+        $time = $this->get($key, $default);
 
         // if the user has specified a timezone then pass that
         // otherwise do not even attempt to put a value but rather let the runtime decide

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -190,16 +190,20 @@ class ParameterBag implements \IteratorAggregate, \Countable
     /**
      * Returns the parameter value converted to a DateTime object.
      *
-     * @param string             $key      The parameter key
-     * @param string             $format   The expected date format
-     * @param string             $default  The default value to be converted to a DateTime object if the parameter key does not exist
-     * @param \DateTimeZone|null $timeZone A DateTimeZone object representing the desired time zone
+     * @param string                    $key      The parameter key
+     * @param string                    $format   The expected date format
+     * @param \DateTimeInterface|string $default  The default value to be converted to a DateTime object if the parameter key does not exist
+     * @param \DateTimeZone|null        $timeZone A DateTimeZone object representing the desired time zone
      *
-     * @return \DateTime|null
+     * @return \DateTimeInterface|null
      */
     public function getDate($key, $format, $default = null, \DateTimeZone $timeZone = null)
     {
         $time = $this->get($key, $default);
+
+        if ($time instanceof \DateTimeInterface) {
+            return $default;
+        }
 
         // if the user has specified a timezone then pass that
         // otherwise do not even attempt to put a value but rather let the runtime decide

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -138,7 +138,7 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, $diff->days, '->getDate() returns a date via the format specified');
         $this->assertNull($bag->getDate('d1', 'd/m/Y'), '->getDate() returns null if the format is not valid');
         $this->assertNull($bag->getDate('d2', 'd/m/Y'), '->getDate() returns null if the parameter is not found');
-        $this->assertEquals($date, $bag->getDate('d1', 'Y-m-d', new \DateTime('2016-12-01')), '->getDate() parses the value if the key is present');
+        $this->assertEquals($date->format('Ymd'), $bag->getDate('d1', 'Y-m-d', new \DateTime('2016-12-01'))->format('Ymd'), '->getDate() parses the value if the key is present');
 
         $date = $bag->getDate('iso', \DateTime::ISO8601);
         $this->assertEquals(new \DateTime($isoDate), $date);

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -124,6 +124,37 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, $bag->getInt('unknown'), '->getInt() returns zero if a parameter is not defined');
     }
 
+    public function testGetDateTime()
+    {
+        $format = 'Y-m-d H:i:s';
+        $bag = new ParameterBag(array('d1' => '2016-01-01 00:00:00'));
+        $date = \DateTime::createFromFormat($format, '2016-01-01 00:00:00');
+
+        $this->assertEquals($date, $bag->getDateTime('d1', $format), '->getDateTime() returns a date from the specified format');
+    }
+
+    public function testGetDate()
+    {
+        $isoDate = '2016-07-05T15:30:00UTC';
+        $bag = new ParameterBag(array(
+            'd1' => '2016-01-01',
+            'iso' => $isoDate,
+        ));
+
+        $date = \DateTime::createFromFormat('Y-m-d', '2016-01-01');
+        $diff = $date->diff($bag->getDate('d1'));
+
+        $this->assertEquals(0, $diff->days, '->getDate() returns a date via the format specified');
+        $this->assertNull($bag->getDate('d1', 'd/m/Y'), '->getDate() returns false if the format is not valid');
+        $this->assertNull($bag->getDate('d2', 'd/m/Y'), '->getDate() returns null if the parameter is not found');
+
+        $date = $bag->getDate('iso', \DateTime::ISO8601);
+        $this->assertEquals(new \DateTime($isoDate), $date);
+        $this->assertEquals('UTC', $date->getTimezone()->getName());
+
+        $this->assertEquals($date, $bag->getDate('nokey', 'Y-m-d', $date));
+    }
+
     public function testFilter()
     {
         $bag = new ParameterBag(array(
@@ -133,7 +164,7 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
             'dec' => '256',
             'hex' => '0x100',
             'array' => array('bang'),
-            ));
+        ));
 
         $this->assertEmpty($bag->filter('nokey'), '->filter() should return empty by default if no key is found');
 

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -124,15 +124,6 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, $bag->getInt('unknown'), '->getInt() returns zero if a parameter is not defined');
     }
 
-    public function testGetDateTime()
-    {
-        $format = 'Y-m-d H:i:s';
-        $bag = new ParameterBag(array('d1' => '2016-01-01 00:00:00'));
-        $date = \DateTime::createFromFormat($format, '2016-01-01 00:00:00');
-
-        $this->assertEquals($date, $bag->getDateTime('d1', $format), '->getDateTime() returns a date from the specified format');
-    }
-
     public function testGetDate()
     {
         $isoDate = '2016-07-05T15:30:00UTC';
@@ -142,17 +133,21 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         ));
 
         $date = \DateTime::createFromFormat('Y-m-d', '2016-01-01');
-        $diff = $date->diff($bag->getDate('d1'));
+        $diff = $date->diff($bag->getDate('d1', 'Y-m-d'));
 
         $this->assertEquals(0, $diff->days, '->getDate() returns a date via the format specified');
-        $this->assertNull($bag->getDate('d1', 'd/m/Y'), '->getDate() returns false if the format is not valid');
+        $this->assertNull($bag->getDate('d1', 'd/m/Y'), '->getDate() returns null if the format is not valid');
         $this->assertNull($bag->getDate('d2', 'd/m/Y'), '->getDate() returns null if the parameter is not found');
 
         $date = $bag->getDate('iso', \DateTime::ISO8601);
         $this->assertEquals(new \DateTime($isoDate), $date);
         $this->assertEquals('UTC', $date->getTimezone()->getName());
 
-        $this->assertEquals($date, $bag->getDate('nokey', 'Y-m-d', $date));
+        $this->assertEquals($date, $bag->getDate('nokey', \DateTime::ISO8601, $isoDate));
+        $this->assertNull($bag->getDate('nokey', 'd/m/Y', $isoDate), '->getDate() returns null when the default value is not in the specified format');
+
+        $tz = $bag->getDate('d1', 'Y-m-d', null, new \DateTimeZone('Europe/Tirane'))->getTimezone()->getName();
+        $this->assertEquals('Europe/Tirane', $tz, '->getDate() accepts a DateTimeZone object which specifies the preferred timezone');
     }
 
     public function testFilter()

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -138,12 +138,14 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, $diff->days, '->getDate() returns a date via the format specified');
         $this->assertNull($bag->getDate('d1', 'd/m/Y'), '->getDate() returns null if the format is not valid');
         $this->assertNull($bag->getDate('d2', 'd/m/Y'), '->getDate() returns null if the parameter is not found');
+        $this->assertEquals($date, $bag->getDate('d1', 'Y-m-d', new \DateTime('2016-12-01')), '->getDate() parses the value if the key is present');
 
         $date = $bag->getDate('iso', \DateTime::ISO8601);
         $this->assertEquals(new \DateTime($isoDate), $date);
         $this->assertEquals('UTC', $date->getTimezone()->getName());
 
         $this->assertEquals($date, $bag->getDate('nokey', \DateTime::ISO8601, $isoDate));
+        $this->assertInstanceOf(\DateTimeInterface::class, $bag->getDate('nokey', \DateTime::ISO8601, $date));
         $this->assertNull($bag->getDate('nokey', 'd/m/Y', $isoDate), '->getDate() returns null when the default value is not in the specified format');
 
         $tz = $bag->getDate('d1', 'Y-m-d', null, new \DateTimeZone('Europe/Tirane'))->getTimezone()->getName();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | [#6718](https://github.com/symfony/symfony-docs/pull/6718) |

This adds a `getDate` method to the `ParameterBag` class which convert the specified key to a `DateTime` object

**Edit**: The main motivation behind this PR (from my PoV at least) is to avoid repetitive tasks with handling date parameters on GET requests.

---

This is a continuation of #19295. Moved here in order to have a cleaner git history.
