### PR TITLE
Use LockHandler to manage HttpCache's lock files

### DIFF
--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -20,6 +20,7 @@
         "symfony/event-dispatcher": "~2.6,>=2.6.7",
         "symfony/http-foundation": "~2.7.15|~2.8.8",
         "symfony/debug": "~2.6,>=2.6.2",
+        "symfony/filesystem": "~2.6",
         "psr/log": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | #16777, #15813 and #16312 are also related |
| License | MIT |
| Doc PR |  |

I wrote this as bugfix against 2.7 because every once in a while encounter situations (not always reproducible) where `.lock` files are left over and keep the cache locked.
