### PR TITLE
[HttpKernel] Use flock() for HttpCache's lock files

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTestCase.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTestCase.php
@@ -50,6 +50,9 @@ class HttpCacheTestCase extends \PHPUnit_Framework_TestCase
 
     protected function tearDown()
     {
+        if ($this->cache) {
+            $this->cache->getStore()->cleanup();
+        }
         $this->kernel = null;
         $this->cache = null;
         $this->caches = null;

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/StoreTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/StoreTest.php
@@ -19,6 +19,10 @@ class StoreTest extends \PHPUnit_Framework_TestCase
 {
     protected $request;
     protected $response;
+
+    /**
+     * @var Store
+     */
     protected $store;
 
     protected function setUp()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | #16777, #15813 and #16312 are also related |
| License | MIT |
| Doc PR |  |

When a PHP process crashes or terminates (maybe the OOM killer kicks in or other bad things :tm: happen) while the `HttpCache` holds a `.lck` file, that lock file may not get `unlink()`ed.

The result is that other requests trying to access this cache entry will see a few seconds delay while waiting for the lock; they will eventually continue but send 503 status codes along with the response. The sudden buildup of PHP processes caused by the additional delay may cause further problems (sudden load increase).

As `LockHandler` is using `flock()`-based locking, locks should be released by the OS when the PHP process terminates. 

I wrote this as bugfix against 2.7 because every once in a while I encounter situations (not always reproducible) where `.lock` files are left over and keep the cache locked.
