### PR TITLE
[Routing][FrameworkBundle] Add route collection caching

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -13,6 +13,7 @@
         <parameter key="router.options.matcher_dumper_class">Symfony\Component\Routing\Matcher\Dumper\PhpMatcherDumper</parameter>
         <parameter key="router.options.matcher.cache_class">%router.cache_class_prefix%UrlMatcher</parameter>
         <parameter key="router.options.generator.cache_class">%router.cache_class_prefix%UrlGenerator</parameter>
+        <parameter key="router.options.route_collection.cache_file">%router.cache_class_prefix%RouteCollection</parameter>
         <parameter key="router.request_context.host">localhost</parameter>
         <parameter key="router.request_context.scheme">http</parameter>
         <parameter key="router.request_context.base_url"></parameter>
@@ -73,6 +74,7 @@
                 <argument key="matcher_base_class">%router.options.matcher_base_class%</argument>
                 <argument key="matcher_dumper_class">%router.options.matcher_dumper_class%</argument>
                 <argument key="matcher_cache_class">%router.options.matcher.cache_class%</argument>
+                <argument key="route_collection_cache_file">%router.options.route_collection.cache_file%</argument>
             </argument>
             <argument type="service" id="router.request_context" on-invalid="ignore" />
             <argument type="service" id="logger" on-invalid="ignore" />

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -64,12 +64,6 @@ class Router extends BaseRouter implements WarmableInterface, ServiceSubscriberI
             }
         }
 
-        if ($this->container->has('service_container.resources')) {
-            foreach ($this->container->get('service_container.resources') as $resource) {
-                $collection->addResource($resource);
-            }
-        }
-
         return $collection;
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -52,15 +52,19 @@ class Router extends BaseRouter implements WarmableInterface, ServiceSubscriberI
     /**
      * {@inheritdoc}
      */
-    public function getRouteCollection()
+    protected function loadRouteCollection()
     {
-        if (null === $this->collection) {
-            $this->collection = $this->container->get('routing.loader')->load($this->resource, $this->options['resource_type']);
-            $this->resolveParameters($this->collection);
-            $this->collection->addResource(new ContainerParametersResource($this->collectedParameters));
+        $this->collection = $this->container->get('routing.loader')->load($this->resource, $this->options['resource_type']);
+        $this->resolveParameters($this->collection);
+        $this->collection->addResource(new ContainerParametersResource($this->collectedParameters));
+
+        if ($this->container->has('service_container.resources')) {
+            foreach ($this->container->get('service_container.resources') as $resource) {
+                $collection->addResource($resource);
+            }
         }
 
-        return $this->collection;
+        return $collection;
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -82,6 +82,7 @@ class Router extends BaseRouter implements WarmableInterface, ServiceSubscriberI
 
         // force cache generation
         $this->setOption('cache_dir', $cacheDir);
+        $this->getRouteCollection();
         $this->getMatcher();
         $this->getGenerator();
 

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -64,6 +64,12 @@ class Router extends BaseRouter implements WarmableInterface, ServiceSubscriberI
             }
         }
 
+        if ($this->container->has('service_container.resources')) {
+            foreach ($this->container->get('service_container.resources') as $resource) {
+                $collection->addResource($resource);
+            }
+        }
+
         return $collection;
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -54,9 +54,9 @@ class Router extends BaseRouter implements WarmableInterface, ServiceSubscriberI
      */
     protected function loadRouteCollection()
     {
-        $this->collection = $this->container->get('routing.loader')->load($this->resource, $this->options['resource_type']);
-        $this->resolveParameters($this->collection);
-        $this->collection->addResource(new ContainerParametersResource($this->collectedParameters));
+        $collection = $this->container->get('routing.loader')->load($this->resource, $this->options['resource_type']);
+        $this->resolveParameters($collection);
+        $collection->addResource(new ContainerParametersResource($this->collectedParameters));
 
         if ($this->container->has('service_container.resources')) {
             foreach ($this->container->get('service_container.resources') as $resource) {

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -583,6 +583,8 @@ abstract class Kernel implements KernelInterface, TerminableInterface
                     file_put_contents($this->getCacheDir().'/'.$class.'Compiler.log', null !== $container ? implode("\n", $container->getCompiler()->getLog()) : '');
                 }
             }
+
+            $resources = $container->getResources();
             $this->dumpContainer($cache, $container, $class, $this->getContainerBaseClass());
 
             $fresh = false;
@@ -592,6 +594,10 @@ abstract class Kernel implements KernelInterface, TerminableInterface
 
         $this->container = new $class();
         $this->container->set('kernel', $this);
+
+        if (!$fresh) {
+            $this->container->set('service_container.resources', $resources);
+        }
 
         if (!$fresh && $this->container->has('cache_warmer')) {
             $this->container->get('cache_warmer')->warmUp($this->container->getParameter('kernel.cache_dir'));

--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -277,11 +277,15 @@ class RouteCollection implements \IteratorAggregate, \Countable, \Serializable
 
     public function serialize()
     {
-        return serialize($this->routes);
+        $serializableResources = array_filter($this->resources, function($resource) {
+            return $resource instanceof \Serializable;
+        });
+
+        return serialize(array($this->routes, $serializableResources));
     }
 
     public function unserialize($serialized)
     {
-        $this->routes = unserialize($serialized);
+        list($this->routes, $this->resources) = unserialize($serialized);
     }
 }

--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -277,7 +277,7 @@ class RouteCollection implements \IteratorAggregate, \Countable, \Serializable
 
     public function serialize()
     {
-        $serializableResources = array_filter($this->resources, function($resource) {
+        $serializableResources = array_filter($this->resources, function ($resource) {
             return $resource instanceof \Serializable;
         });
 

--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -23,7 +23,7 @@ use Symfony\Component\Config\Resource\ResourceInterface;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Tobias Schultze <http://tobion.de>
  */
-class RouteCollection implements \IteratorAggregate, \Countable
+class RouteCollection implements \IteratorAggregate, \Countable, \Serializable
 {
     /**
      * @var Route[]
@@ -273,5 +273,15 @@ class RouteCollection implements \IteratorAggregate, \Countable
     public function addResource(ResourceInterface $resource)
     {
         $this->resources[] = $resource;
+    }
+
+    public function serialize()
+    {
+        return serialize($this->routes);
+    }
+
+    public function unserialize($serialized)
+    {
+        $this->routes = unserialize($serialized);
     }
 }

--- a/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
@@ -302,4 +302,17 @@ class RouteCollectionTest extends TestCase
         $this->assertEquals(array('PUT'), $routea->getMethods());
         $this->assertEquals(array('PUT'), $routeb->getMethods());
     }
+    public function testSerialize()
+    {
+        $collection = new RouteCollection();
+
+        $collection->add('route1', new Route('/homepage'));
+        $collection->add('route2', new Route('/prefix/{foo}', array('foo' => 'default'), array('foo' => '\d+')));
+
+        $serialized = serialize($collection);
+        $unserialized = unserialize($serialized);
+
+        $this->assertEquals($collection, $unserialized);
+        $this->assertNotSame($collection, $unserialized);
+    }
 }

--- a/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
@@ -302,6 +302,7 @@ class RouteCollectionTest extends TestCase
         $this->assertEquals(array('PUT'), $routea->getMethods());
         $this->assertEquals(array('PUT'), $routeb->getMethods());
     }
+
     public function testSerialize()
     {
         $collection = new RouteCollection();

--- a/src/Symfony/Component/Routing/Tests/RouterTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouterTest.php
@@ -93,6 +93,30 @@ class RouterTest extends TestCase
     }
 
     /**
+     * @dataProvider provideRouteCollectionOptionsPreventingCaching
+     */
+    public function testThatRouteCollectionIsLoadedIfCacheIsNotConfigured($option)
+    {
+        $this->router->setOption($option, null);
+
+        $routeCollection = $this->getMock('Symfony\Component\Routing\RouteCollection');
+
+        $this->loader->expects($this->once())
+            ->method('load')->with('routing.yml', null)
+            ->will($this->returnValue($routeCollection));
+
+        $this->assertSame($routeCollection, $this->router->getRouteCollection());
+    }
+
+    public function provideRouteCollectionOptionsPreventingCaching()
+    {
+        return array(
+            array('cache_dir'),
+            array('route_collection_cache_file'),
+        );
+    }
+
+    /**
      * @dataProvider provideMatcherOptionsPreventingCaching
      */
     public function testMatcherIsCreatedIfCacheIsNotConfigured($option)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.4 |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #11211 |
| License | MIT |
| Doc PR | - |

This PR adds a routes collection caching. It allows us to use `Router::getRouteCollection` at runtime.
See https://github.com/symfony/symfony/pull/19274, https://github.com/symfony/symfony/pull/19273
