### PR TITLE
[FrameworkBundle] Multiple services on one Command class

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddConsoleCommandPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddConsoleCommandPass.php
@@ -37,7 +37,11 @@ class AddConsoleCommandPass implements CompilerPassInterface
             if (!is_subclass_of($class, 'Symfony\\Component\\Console\\Command\\Command')) {
                 throw new \InvalidArgumentException(sprintf('The service "%s" tagged "console.command" must be a subclass of "Symfony\\Component\\Console\\Command\\Command".', $id));
             }
-            $container->setAlias($serviceId = 'console.command.'.strtolower(str_replace('\\', '_', $class)), $id);
+            $serviceId = 'console.command.'.strtolower(str_replace('\\', '_', $class));
+            if ($container->hasAlias($serviceId)) {
+                $serviceId = $serviceId . '_' . $id;
+            }
+            $container->setAlias($serviceId, $id);
             $serviceIds[] = $definition->isPublic() ? $id : $serviceId;
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddConsoleCommandPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddConsoleCommandPass.php
@@ -39,7 +39,7 @@ class AddConsoleCommandPass implements CompilerPassInterface
             }
             $serviceId = 'console.command.'.strtolower(str_replace('\\', '_', $class));
             if ($container->hasAlias($serviceId)) {
-                $serviceId = $serviceId . '_' . $id;
+                $serviceId = $serviceId.'_'.$id;
             }
             $container->setAlias($serviceId, $id);
             $serviceIds[] = $definition->isPublic() ? $id : $serviceId;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddConsoleCommandPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddConsoleCommandPassTest.php
@@ -110,6 +110,29 @@ class AddConsoleCommandPassTest extends \PHPUnit_Framework_TestCase
         $bundle->setContainer($container);
         $bundle->registerCommands($application);
     }
+
+    public function testProcessServicesWithSameCommand()
+    {
+        $container = new ContainerBuilder();
+        $container->addCompilerPass(new AddConsoleCommandPass());
+        $container->setParameter('my-command.class', 'Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler\MyCommand');
+
+        $definition1 = new Definition('%my-command.class%');
+        $definition1->addTag('console.command');
+
+        $definition2 = new Definition('%my-command.class%');
+        $definition2->addTag('console.command');
+        
+        $container->setDefinition('my-command1', $definition1);
+        $container->setDefinition('my-command2', $definition2);
+
+        $container->compile();
+
+        $alias1 = 'console.command.symfony_bundle_frameworkbundle_tests_dependencyinjection_compiler_mycommand';
+        $alias2 = $alias1 . '_my-command2';
+        $this->assertTrue($container->hasAlias($alias1));
+        $this->assertTrue($container->hasAlias($alias2));
+    }
 }
 
 class MyCommand extends Command

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddConsoleCommandPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddConsoleCommandPassTest.php
@@ -115,12 +115,12 @@ class AddConsoleCommandPassTest extends \PHPUnit_Framework_TestCase
     {
         $container = new ContainerBuilder();
         $container->addCompilerPass(new AddConsoleCommandPass());
-        $container->setParameter('my-command.class', 'Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler\MyCommand');
+        $className = 'Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler\MyCommand';
 
-        $definition1 = new Definition('%my-command.class%');
+        $definition1 = new Definition($className);
         $definition1->addTag('console.command');
 
-        $definition2 = new Definition('%my-command.class%');
+        $definition2 = new Definition($className);
         $definition2->addTag('console.command');
 
         $container->setDefinition('my-command1', $definition1);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddConsoleCommandPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddConsoleCommandPassTest.php
@@ -122,14 +122,14 @@ class AddConsoleCommandPassTest extends \PHPUnit_Framework_TestCase
 
         $definition2 = new Definition('%my-command.class%');
         $definition2->addTag('console.command');
-        
+
         $container->setDefinition('my-command1', $definition1);
         $container->setDefinition('my-command2', $definition2);
 
         $container->compile();
 
         $alias1 = 'console.command.symfony_bundle_frameworkbundle_tests_dependencyinjection_compiler_mycommand';
-        $alias2 = $alias1 . '_my-command2';
+        $alias2 = $alias1.'_my-command2';
         $this->assertTrue($container->hasAlias($alias1));
         $this->assertTrue($container->hasAlias($alias2));
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #19001 |
| License | MIT |
| Doc PR |  |

Based on my opened issue #19001, I created this PR to introduce the possibility of using multiple command-services with one command class. This should make Commands much more equal to other services in Symfony. 
