### PR TITLE
[Form] fixed bug - name in ButtonBuilder

### DIFF
--- a/src/Symfony/Component/Form/ButtonBuilder.php
+++ b/src/Symfony/Component/Form/ButtonBuilder.php
@@ -62,11 +62,12 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      */
     public function __construct($name, array $options = array())
     {
-        if (empty($name) && 0 != $name) {
+        $name = (string) $name;
+        if ('' === $name) {
             throw new InvalidArgumentException('Buttons cannot have empty names.');
         }
 
-        $this->name = (string) $name;
+        $this->name = $name;
         $this->options = $options;
     }
 

--- a/src/Symfony/Component/Form/Tests/ButtonBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/ButtonBuilderTest.php
@@ -18,9 +18,6 @@ use Symfony\Component\Form\ButtonBuilder;
  */
 class ButtonBuilderTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @return array
-     */
     public function getValidNames()
     {
         return array(
@@ -35,17 +32,12 @@ class ButtonBuilderTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider getValidNames
-     *
-     * @param string $name
      */
     public function testValidNames($name)
     {
         $this->assertInstanceOf('\Symfony\Component\Form\ButtonBuilder', new ButtonBuilder($name));
     }
 
-    /**
-     * @return array
-     */
     public function getInvalidNames()
     {
         return array(
@@ -57,8 +49,6 @@ class ButtonBuilderTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider getInvalidNames
-     *
-     * @param string $name
      */
     public function testInvalidNames($name)
     {

--- a/src/Symfony/Component/Form/Tests/ButtonBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/ButtonBuilderTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests;
+
+use Symfony\Component\Form\ButtonBuilder;
+
+/**
+ * @author Alexander Cheprasov <cheprasov.84@ya.ru>
+ */
+class ButtonBuilderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @return array
+     */
+    public function getValidNames()
+    {
+        return array(
+            array('reset'),
+            array('submit'),
+            array('foo'),
+            array('0'),
+            array(0),
+            array('button[]'),
+        );
+    }
+
+    /**
+     * @dataProvider getValidNames
+     *
+     * @param string $name
+     */
+    public function testValidNames($name)
+    {
+        $this->assertInstanceOf('\Symfony\Component\Form\ButtonBuilder', new ButtonBuilder($name));
+    }
+
+    /**
+     * @return array
+     */
+    public function getInvalidNames()
+    {
+        return array(
+            array(''),
+            array(false),
+            array(null),
+        );
+    }
+
+    /**
+     * @dataProvider getInvalidNames
+     *
+     * @param string $name
+     */
+    public function testInvalidNames($name)
+    {
+        $this->setExpectedException(
+            '\Symfony\Component\Form\Exception\InvalidArgumentException',
+            'Buttons cannot have empty names.'
+        );
+        new ButtonBuilder($name);
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

**Bug:**

For any scalar of name, expression `empty($name) && 0 != $name` is never true,
and as result - empty string ('') is allowed.

**Examples:**

``` php
$name = ''; var_dump(empty($name) && 0 != $name); // false
$name = '0'; var_dump(empty($name) && 0 != $name); // false
$name = null; var_dump(empty($name) && 0 != $name); // false
$name = false; var_dump(empty($name) && 0 != $name); // false
$name = 0; var_dump(empty($name) && 0 != $name); // false
```
