### PR TITLE
[Security] Fix deprecated usage of DigestAuthenticationEntryPoint::getKey() in DigestAuthenticationListener

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/DigestAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/DigestAuthenticationListener.php
@@ -78,7 +78,7 @@ class DigestAuthenticationListener implements ListenerInterface
         }
 
         try {
-            $digestAuth->validateAndDecode($this->authenticationEntryPoint->getKey(), $this->authenticationEntryPoint->getRealmName());
+            $digestAuth->validateAndDecode($this->authenticationEntryPoint->getSecret(), $this->authenticationEntryPoint->getRealmName());
         } catch (BadCredentialsException $e) {
             $this->fail($event, $request, $e);
 

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/DigestAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/DigestAuthenticationListenerTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Symfony\Component\Security\Http\Tests\Firewall;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Http\EntryPoint\DigestAuthenticationEntryPoint;
+use Symfony\Component\Security\Http\Firewall\DigestAuthenticationListener;
+
+class DigestAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testHandleWithValidDigest()
+    {
+        $time = microtime(true) + 1000;
+        $secret = 'ThisIsASecret';
+        $nonce = base64_encode($time.':'.md5($time.':'.$secret));
+        $username = 'user';
+        $password = 'password';
+        $realm = 'Welcome, robot!';
+        $cnonce = 'MDIwODkz';
+        $nc = '00000001';
+        $qop = 'auth';
+        $uri = '/path/info?p1=5&p2=5';
+
+        $serverDigest = $this->calculateServerDigest($username, $realm, $password, $nc, $nonce, $cnonce, $qop, 'GET', $uri);
+
+        $digestData =
+            'username="'.$username.'", realm="'.$realm.'", nonce="'.$nonce.'", '.
+            'uri="'.$uri.'", cnonce="'.$cnonce.'", nc='.$nc.', qop="'.$qop.'", '.
+            'response="'.$serverDigest.'"'
+        ;
+
+        $request = new Request(array(), array(), array(), array(), array(), array('PHP_AUTH_DIGEST' => $digestData));
+
+        $entryPoint = new DigestAuthenticationEntryPoint($realm, $secret);
+
+        $user = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
+        $user->method('getPassword')->willReturn($password);
+
+        $providerKey = 'TheProviderKey';
+
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $tokenStorage
+            ->expects($this->once())
+            ->method('getToken')
+            ->will($this->returnValue(null))
+        ;
+        $tokenStorage
+            ->expects($this->once())
+            ->method('setToken')
+            ->with($this->equalTo(new UsernamePasswordToken($user, $password, $providerKey)))
+        ;
+
+        $userProvider = $this->getMock('Symfony\Component\Security\Core\User\UserProviderInterface');
+        $userProvider->method('loadUserByUsername')->willReturn($user);
+
+        $listener = new DigestAuthenticationListener($tokenStorage, $userProvider, $providerKey, $entryPoint);
+
+        $event = $this->getMock('Symfony\Component\HttpKernel\Event\GetResponseEvent', array(), array(), '', false);
+        $event
+            ->expects($this->any())
+            ->method('getRequest')
+            ->will($this->returnValue($request))
+        ;
+
+        $listener->handle($event);
+    }
+
+    private function calculateServerDigest($username, $realm, $password, $nc, $nonce, $cnonce, $qop, $method, $uri)
+    {
+        $response = md5(
+            md5($username.':'.$realm.':'.$password).':'.$nonce.':'.$nc.':'.$cnonce.':'.$qop.':'.md5($method.':'.$uri)
+        );
+
+        return sprintf('username="%s", realm="%s", nonce="%s", uri="%s", cnonce="%s", nc=%s, qop="%s", response="%s"',
+            $username, $realm, $nonce, $uri, $cnonce, $nc, $qop, $response
+        );
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Fix the following deprecation triggered by Symfony when using the `http_digest` authentication:

<details>
 <summary>

Symfony\Component\Security\Http\EntryPoint\DigestAuthenticationEntryPoint::getKey() is deprecated since version 2.8 and will be removed in 3.0. Use getSecret() instead. </summary>



> DigestAuthenticationEntryPoint::getKey() (called from DigestAuthenticationListener.php at line 81)
> DigestAuthenticationListener::handle() (called from classes.php at line 2622)
> Firewall::onKernelRequest()
> call_user_func() (called from WrappedListener.php at line 61)
> WrappedListener::__invoke()
> call_user_func() (called from classes.php at line 1858)
> EventDispatcher::doDispatch() (called from classes.php at line 1773)
> EventDispatcher::dispatch() (called from TraceableEventDispatcher.php at line 140)
> TraceableEventDispatcher::dispatch() (called from HttpKernel.php at line 125)
> HttpKernel::handleRaw() (called from HttpKernel.php at line 64)
> HttpKernel::handle() (called from ContainerAwareHttpKernel.php at line 69)
> ContainerAwareHttpKernel::handle() (called from Kernel.php at line 193)
> Kernel::handle() (called from app_dev.php at line 36)
> </details>

Refs: #16493
