### PR TITLE
Make the exception message more clear.

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/PropertyMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/PropertyMetadata.php
@@ -39,7 +39,7 @@ class PropertyMetadata extends MemberMetadata
     public function __construct($class, $name)
     {
         if (!property_exists($class, $name)) {
-            throw new ValidatorException(sprintf('Property %s does not exist in class %s', $name, $class));
+            throw new ValidatorException(sprintf('Property "%s" does not exist in class %s', $name, $class));
         }
 
         parent::__construct($class, $name, $name);

--- a/src/Symfony/Component/Validator/Mapping/PropertyMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/PropertyMetadata.php
@@ -39,7 +39,7 @@ class PropertyMetadata extends MemberMetadata
     public function __construct($class, $name)
     {
         if (!property_exists($class, $name)) {
-            throw new ValidatorException(sprintf('Property "%s" does not exist in class %s', $name, $class));
+            throw new ValidatorException(sprintf('Property "%s" does not exist in class "%s"', $name, $class));
         }
 
         parent::__construct($class, $name, $name);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

A small change that makes the error message more clear. If your property is named "type", "value" or something similar it is not obvious that we refer to the property name. 

See example: https://github.com/schmittjoh/JMSTranslationBundle/issues/373
