### PR TITLE
[EventDispatcher] small optimization

### DIFF
--- a/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
@@ -105,7 +105,7 @@ class ContainerAwareEventDispatcher extends EventDispatcher
     public function hasListeners($eventName = null)
     {
         if (null === $eventName) {
-            return count($this->listenerIds) || count($this->listeners);
+            return $this->listenerIds || $this->listeners;
         }
 
         if (isset($this->listenerIds[$eventName])) {

--- a/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
@@ -105,7 +105,7 @@ class ContainerAwareEventDispatcher extends EventDispatcher
     public function hasListeners($eventName = null)
     {
         if (null === $eventName) {
-            return (bool) count($this->listenerIds) || (bool) count($this->listeners);
+            return count($this->listenerIds) || count($this->listeners);
         }
 
         if (isset($this->listenerIds[$eventName])) {

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -132,7 +132,7 @@ class EventDispatcher implements EventDispatcherInterface
     public function removeSubscriber(EventSubscriberInterface $subscriber)
     {
         foreach ($subscriber->getSubscribedEvents() as $eventName => $params) {
-            if (is_array($params) && is_array($params[0])) {
+            if (isset($params[0]) && is_array($params[0])) {
                 foreach ($params as $listener) {
                     $this->removeListener($eventName, array($subscriber, $listener[0]));
                 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
1. `$this->listenerIds || $this->listeners` returns `bool`
2. `isset($params[0])` is faster and safer than `is_array($params)`
