### PR TITLE
[Validator] Added additional MasterCard range to the CardSchemeValidator

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/CardSchemeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CardSchemeValidator.php
@@ -74,8 +74,10 @@ class CardSchemeValidator extends ConstraintValidator
             '/^6[0-9]{11,18}$/',
         ),
         // All MasterCard numbers start with the numbers 51 through 55. All have 16 digits.
+        // October 2016 MasterCard numbers can also start with 222100 through 272099.
         'MASTERCARD' => array(
             '/^5[1-5][0-9]{14}$/',
+            '/^2(22[1-9][0-9]{12}|2[3-9][0-9]{13}|[3-6][0-9]{14}|7[0-1][0-9]{13}|720[0-9]{12})$/',
         ),
         // All Visa card numbers start with a 4. New cards have 16 digits. Old cards have 13.
         'VISA' => array(

--- a/src/Symfony/Component/Validator/Tests/Constraints/CardSchemeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CardSchemeValidatorTest.php
@@ -102,6 +102,12 @@ class CardSchemeValidatorTest extends AbstractConstraintValidatorTest
             array('MAESTRO', '6594371785970435599'),
             array('MASTERCARD', '5555555555554444'),
             array('MASTERCARD', '5105105105105100'),
+            array('MASTERCARD', '2221005555554444'),
+            array('MASTERCARD', '2230000000000000'),
+            array('MASTERCARD', '2300000000000000'),
+            array('MASTERCARD', '2699999999999999'),
+            array('MASTERCARD', '2709999999999999'),
+            array('MASTERCARD', '2720995105105100'),
             array('VISA', '4111111111111111'),
             array('VISA', '4012888888881881'),
             array('VISA', '4222222222222'),
@@ -129,6 +135,8 @@ class CardSchemeValidatorTest extends AbstractConstraintValidatorTest
             array('AMEX', '000000000000', CardScheme::INVALID_FORMAT_ERROR), // a lone number
             array('DINERS', '3056930', CardScheme::INVALID_FORMAT_ERROR), // only first part of the number
             array('DISCOVER', '1117', CardScheme::INVALID_FORMAT_ERROR), // only last 4 digits
+            array('MASTERCARD', '2721001234567890', CardScheme::INVALID_FORMAT_ERROR), // Not assigned yet
+            array('MASTERCARD', '2220991234567890', CardScheme::INVALID_FORMAT_ERROR), // Not assigned yet
         );
     }
 }


### PR DESCRIPTION
From October 2016 MasterCard will introduce a new card range, 222100 through 272099.
See: https://www.mctestcards.com/ (click the help in top right)
This implements the additional regex for validation to succeed, and some additional unit tests for this new range.

| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
