### PR TITLE
[HttpFoundation] Add OPTIONS and TRACE to the list of safe methods

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1470,7 +1470,7 @@ class Request
      */
     public function isMethodSafe()
     {
-        return in_array($this->getMethod(), array('GET', 'HEAD'));
+        return in_array($this->getMethod(), array('GET', 'HEAD', 'OPTIONS', 'TRACE'));
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1914,7 +1914,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider methodProvider
+     * @dataProvider methodSafeProvider
      */
     public function testMethodSafe($method, $safe)
     {
@@ -1923,19 +1923,19 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($safe, $request->isMethodSafe());
     }
 
-    public function methodProvider()
+    public function methodSafeProvider()
     {
         return array(
-            array(Request::METHOD_HEAD, true),
-            array(Request::METHOD_GET, true),
-            array(Request::METHOD_POST, false),
-            array(Request::METHOD_PUT, false),
-            array(Request::METHOD_PATCH, false),
-            array(Request::METHOD_DELETE, false),
-            array(Request::METHOD_PURGE, false),
-            array(Request::METHOD_OPTIONS, true),
-            array(Request::METHOD_TRACE, true),
-            array(Request::METHOD_CONNECT, false),
+            array('HEAD', true),
+            array('GET', true),
+            array('POST', false),
+            array('PUT', false),
+            array('PATCH', false),
+            array('DELETE', false),
+            array('PURGE', false),
+            array('OPTIONS', true),
+            array('TRACE', true),
+            array('CONNECT', false),
         );
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1912,6 +1912,32 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             array(str_repeat(':', 101)),
         );
     }
+
+    /**
+     * @dataProvider methodProvider
+     */
+    public function testMethodSafe($method, $safe)
+    {
+        $request = new Request();
+        $request->setMethod($method);
+        $this->assertEquals($safe, $request->isMethodSafe());
+    }
+
+    public function methodProvider()
+    {
+        return array(
+            array(Request::METHOD_HEAD, true),
+            array(Request::METHOD_GET, true),
+            array(Request::METHOD_POST, false),
+            array(Request::METHOD_PUT, false),
+            array(Request::METHOD_PATCH, false),
+            array(Request::METHOD_DELETE, false),
+            array(Request::METHOD_PURGE, false),
+            array(Request::METHOD_OPTIONS, true),
+            array(Request::METHOD_TRACE, true),
+            array(Request::METHOD_CONNECT, false),
+        );
+    }
 }
 
 class RequestContentProxy extends Request


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

According to [RFC 7231](https://tools.ietf.org/html/rfc7231#section-8.1.3) `OPTIONS` and `TRACE` are safe methods.
