### PR TITLE
[HttpFoundation] Add Request::isMethodIdempotent method

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1473,7 +1473,7 @@ class Request
     }
 
     /**
-     * Checks whether the method is safe or not.
+     * Checks whether or not the method is safe.
      *
      * @return bool
      */
@@ -1483,21 +1483,13 @@ class Request
     }
 
     /**
-     * Checks whether the method is idempotent or not.
+     * Checks whether or not the method is idempotent.
      *
      * @return bool
      */
     public function isMethodIdempotent()
     {
-        return in_array($this->getMethod(), array(
-            self::METHOD_HEAD,
-            self::METHOD_GET,
-            self::METHOD_PUT,
-            self::METHOD_DELETE,
-            self::METHOD_TRACE,
-            self::METHOD_OPTIONS,
-            self::METHOD_PURGE,
-        ));
+        return in_array($this->getMethod(), array('HEAD', 'GET', 'PUT', 'DELETE', 'TRACE', 'OPTIONS', 'PURGE'));
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1483,6 +1483,24 @@ class Request
     }
 
     /**
+     * Checks whether the method is idempotent or not.
+     *
+     * @return bool
+     */
+    public function isMethodIdempotent()
+    {
+        return in_array($this->getMethod(), array(
+            self::METHOD_HEAD,
+            self::METHOD_GET,
+            self::METHOD_PUT,
+            self::METHOD_DELETE,
+            self::METHOD_TRACE,
+            self::METHOD_OPTIONS,
+            self::METHOD_PURGE,
+        ));
+    }
+
+    /**
      * Returns the request body content.
      *
      * @param bool $asResource If true, a resource will be returned

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1951,6 +1951,32 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             array(str_repeat(':', 101)),
         );
     }
+
+    /**
+     * @dataProvider methodProvider
+     */
+    public function testMethodIdempotent($method, $idempotent)
+    {
+        $request = new Request();
+        $request->setMethod($method);
+        $this->assertEquals($idempotent, $request->isMethodIdempotent());
+    }
+
+    public function methodProvider()
+    {
+        return array(
+            array(Request::METHOD_HEAD, true),
+            array(Request::METHOD_GET, true),
+            array(Request::METHOD_POST, false),
+            array(Request::METHOD_PUT, true),
+            array(Request::METHOD_PATCH, false),
+            array(Request::METHOD_DELETE, true),
+            array(Request::METHOD_PURGE, true),
+            array(Request::METHOD_OPTIONS, true),
+            array(Request::METHOD_TRACE, true),
+            array(Request::METHOD_CONNECT, false),
+        );
+    }
 }
 
 class RequestContentProxy extends Request

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1953,7 +1953,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider methodProvider
+     * @dataProvider methodIdempotentProvider
      */
     public function testMethodIdempotent($method, $idempotent)
     {
@@ -1962,19 +1962,19 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($idempotent, $request->isMethodIdempotent());
     }
 
-    public function methodProvider()
+    public function methodIdempotentProvider()
     {
         return array(
-            array(Request::METHOD_HEAD, true),
-            array(Request::METHOD_GET, true),
-            array(Request::METHOD_POST, false),
-            array(Request::METHOD_PUT, true),
-            array(Request::METHOD_PATCH, false),
-            array(Request::METHOD_DELETE, true),
-            array(Request::METHOD_PURGE, true),
-            array(Request::METHOD_OPTIONS, true),
-            array(Request::METHOD_TRACE, true),
-            array(Request::METHOD_CONNECT, false),
+            array('HEAD', true),
+            array('GET', true),
+            array('POST', false),
+            array('PUT', true),
+            array('PATCH', false),
+            array('DELETE', true),
+            array('PURGE', true),
+            array('OPTIONS', true),
+            array('TRACE', true),
+            array('CONNECT', false),
         );
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Addd a new method in the spirit of `isMethodSafe` to know if the current method is idempotent according to RFCs.
