### PR TITLE
[FrameworkBundle] Allow to specify a domain when updating translations

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
@@ -25,16 +25,31 @@ class TranslationUpdateCommandTest extends \PHPUnit_Framework_TestCase
 
     public function testDumpMessagesAndClean()
     {
-        $tester = $this->createCommandTester($this->getContainer(array('foo' => 'foo')));
+        $tester = $this->createCommandTester($this->getContainer(array('messages' => array('foo' => 'foo'))));
         $tester->execute(array('command' => 'translation:update', 'locale' => 'en', 'bundle' => 'foo', '--dump-messages' => true, '--clean' => true));
         $this->assertRegExp('/foo/', $tester->getDisplay());
         $this->assertRegExp('/2 messages were successfully extracted/', $tester->getDisplay());
     }
 
+    public function testDumpMessagesForSpecificDomain()
+    {
+        $tester = $this->createCommandTester($this->getContainer(array('messages' => array('foo' => 'foo'), 'mydomain' => array('bar' => 'bar'))));
+        $tester->execute(array('command' => 'translation:update', 'locale' => 'en', 'bundle' => 'foo', '--dump-messages' => true, '--clean' => true, '--domain' => 'mydomain'));
+        $this->assertRegExp('/bar/', $tester->getDisplay());
+        $this->assertRegExp('/2 messages were successfully extracted/', $tester->getDisplay());
+    }
+
     public function testWriteMessages()
     {
-        $tester = $this->createCommandTester($this->getContainer(array('foo' => 'foo')));
+        $tester = $this->createCommandTester($this->getContainer(array('messages' => array('foo' => 'foo'))));
         $tester->execute(array('command' => 'translation:update', 'locale' => 'en', 'bundle' => 'foo', '--force' => true));
+        $this->assertRegExp('/Translation files were successfully updated./', $tester->getDisplay());
+    }
+
+    public function testWriteMessagesForSpecificDomain()
+    {
+        $tester = $this->createCommandTester($this->getContainer(array('messages' => array('foo' => 'foo'), 'mydomain' => array('bar' => 'bar'))));
+        $tester->execute(array('command' => 'translation:update', 'locale' => 'en', 'bundle' => 'foo', '--force' => true, '--domain' => 'mydomain'));
         $this->assertRegExp('/Translation files were successfully updated./', $tester->getDisplay());
     }
 
@@ -82,7 +97,9 @@ class TranslationUpdateCommandTest extends \PHPUnit_Framework_TestCase
             ->method('extract')
             ->will(
                 $this->returnCallback(function ($path, $catalogue) use ($extractedMessages) {
-                  $catalogue->add($extractedMessages);
+                    foreach ($extractedMessages as $domain => $messages) {
+                        $catalogue->add($messages, $domain);
+                    }
                 })
             );
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes/ |
| Fixed tickets |  |
| License | MIT |
| Doc PR | no |

The MR add the `--domain` option to the `translation:update` console command
When working with large number of domains, this helps to reduce the noise in the diff when updating only a translation file.
