### PR TITLE
[Yaml] Fix PHPDoc of the Yaml class

### DIFF
--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -73,7 +73,7 @@ class Yaml
     }
 
     /**
-     * Dumps a PHP array to a YAML string.
+     * Dumps a PHP value to a YAML string.
      *
      * The dump method, when supplied with an array, will do its best
      * to convert the array into friendly YAML.
@@ -84,7 +84,7 @@ class Yaml
      * @param bool  $exceptionOnInvalidType true if an exception must be thrown on invalid types (a PHP resource or object), false otherwise
      * @param bool  $objectSupport          true if object support is enabled, false otherwise
      *
-     * @return string A YAML string representing the original PHP array
+     * @return string A YAML string representing the original PHP value
      */
     public static function dump($input, $inline = 2, $indent = 4, $exceptionOnInvalidType = false, $objectSupport = false)
     {

--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -78,7 +78,7 @@ class Yaml
      * The dump method, when supplied with an array, will do its best
      * to convert the array into friendly YAML.
      *
-     * @param array $array                  PHP array
+     * @param mixed $input                  The PHP value
      * @param int   $inline                 The level where you switch to inline YAML
      * @param int   $indent                 The amount of spaces to use for indentation of nested nodes
      * @param bool  $exceptionOnInvalidType true if an exception must be thrown on invalid types (a PHP resource or object), false otherwise
@@ -86,7 +86,7 @@ class Yaml
      *
      * @return string A YAML string representing the original PHP array
      */
-    public static function dump($array, $inline = 2, $indent = 4, $exceptionOnInvalidType = false, $objectSupport = false)
+    public static function dump($input, $inline = 2, $indent = 4, $exceptionOnInvalidType = false, $objectSupport = false)
     {
         if ($indent < 1) {
             throw new \InvalidArgumentException('The indentation must be greater than zero.');
@@ -95,6 +95,6 @@ class Yaml
         $yaml = new Dumper();
         $yaml->setIndentation($indent);
 
-        return $yaml->dump($array, $inline, 0, $exceptionOnInvalidType, $objectSupport);
+        return $yaml->dump($input, $inline, 0, $exceptionOnInvalidType, $objectSupport);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

The YAML dumper is able to serialize any PHP type, not just arrays.
