### PR TITLE
[Security] Fix the retrieval of the last username when using forwarding

### DIFF
--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticationUtils.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticationUtils.php
@@ -65,7 +65,13 @@ class AuthenticationUtils
      */
     public function getLastUsername()
     {
-        $session = $this->getRequest()->getSession();
+        $request = $this->getRequest();
+
+        if ($request->attributes->has(Security::LAST_USERNAME)) {
+            return $request->attributes->get(Security::LAST_USERNAME);
+        }
+
+        $session = $request->getSession();
 
         return null === $session ? '' : $session->get(Security::LAST_USERNAME);
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

When using forwarding to render the login page (which is not the default), the info are stored in the subrequest attributes rather than the session. `getLastAuthenticationError` was handling this properly but `getLastUsername` was not checking the attributes.
This fixes it by checking the attributes (I'm checking them before the session, to be consistent with `getLastAuthenticationError`)
