### PR TITLE
[WiP] Using a cache for Controller Argument and Configuration

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ControllerMetadataCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ControllerMetadataCacheWarmer.php
@@ -100,7 +100,6 @@ final class ControllerMetadataCacheWarmer implements CacheWarmerInterface
                     continue;
                 }
 
-                // avoid duplicates
                 $controllers[$className][$method->getName()] = true;
             }
         }
@@ -114,7 +113,6 @@ final class ControllerMetadataCacheWarmer implements CacheWarmerInterface
                 $metadatas[$controller.':'.$method] = serialize($metadata);
                 foreach ($metadata->getTrackedFiles() as $file) {
                     if (isset($trackedFiles[$file])) {
-                        // already tracked
                         continue;
                     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ControllerMetadataCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ControllerMetadataCacheWarmer.php
@@ -11,17 +11,9 @@
 
 namespace Symfony\Bundle\FrameworkBundle\CacheWarmer;
 
-use Symfony\Component\Config\ConfigCacheFactoryInterface;
-use Symfony\Component\Config\ConfigCacheInterface;
-use Symfony\Component\Config\Resource\FileResource;
-use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
-use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
+use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ControllerMetadataFactoryInterface;
-use Symfony\Component\HttpKernel\ControllerMetadata\ControllerMetadataUtil;
-use Symfony\Component\Routing\Route;
-use Symfony\Component\Routing\RouterInterface;
 
 /**
  * Generates the cache for controller metadata.
@@ -30,19 +22,11 @@ use Symfony\Component\Routing\RouterInterface;
  */
 final class ControllerMetadataCacheWarmer implements CacheWarmerInterface
 {
-    private $router;
-    private $controllerResolver;
     private $controllerMetadataFactory;
-    private $configCacheFactory;
-    private $cacheFile;
 
-    public function __construct(RouterInterface $router, ControllerResolverInterface $controllerResolver, ConfigCacheFactoryInterface $configCacheFactory, ControllerMetadataFactoryInterface $controllerMetadataFactory, $cacheFile)
+    public function __construct(ControllerMetadataFactoryInterface $controllerMetadataFactory)
     {
-        $this->router = $router;
-        $this->controllerResolver = $controllerResolver;
-        $this->configCacheFactory = $configCacheFactory;
         $this->controllerMetadataFactory = $controllerMetadataFactory;
-        $this->cacheFile = $cacheFile;
     }
 
     /**
@@ -50,9 +34,9 @@ final class ControllerMetadataCacheWarmer implements CacheWarmerInterface
      */
     public function warmUp($cacheDir)
     {
-        $this->configCacheFactory->cache($this->cacheFile, function (ConfigCacheInterface $cache) {
-            $this->refreshCache($cache);
-        });
+        if ($this->controllerMetadataFactory instanceof WarmableInterface) {
+            $this->controllerMetadataFactory->warmUp($cacheDir);
+        }
     }
 
     /**
@@ -61,75 +45,5 @@ final class ControllerMetadataCacheWarmer implements CacheWarmerInterface
     public function isOptional()
     {
         return true;
-    }
-
-    private function refreshCache(ConfigCacheInterface $cache)
-    {
-        // make sure the cache is not used when executing createControllerMetadata
-        (new Filesystem())->remove($cache->getPath());
-
-        $controllers = array();
-
-        foreach ($this->router->getRouteCollection()->all() as $route) {
-            /* @var $route Route */
-            if (!$route->hasDefault('_controller')) {
-                continue;
-            }
-
-            $controller = $this->controllerResolver->getController(new Request(array(), array(), array('_controller' => $route->getDefault('_controller'))));
-
-            if (null === ($logicalName = ControllerMetadataUtil::getControllerLogicalName($controller))) {
-                continue;
-            }
-
-            list($className, $methodName) = $logicalName;
-
-            if (null === $className || isset($controllers[$className])) {
-                // either a closure or controller is already processed
-                continue;
-            }
-
-            $controllers[$className][$methodName] = true;
-
-            // Not all actions are mapped by routes, such as sub-requests. Just add everything public as possibility
-            $reflection = new \ReflectionClass($className);
-
-            foreach ($reflection->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
-                // avoid magic methods
-                if (0 === strpos($method->getName(), '__')) {
-                    continue;
-                }
-
-                $controllers[$className][$method->getName()] = true;
-            }
-        }
-
-        $metadatas = array();
-        $trackedFiles = array();
-
-        foreach ($controllers as $controller => $methods) {
-            foreach ($methods as $method => $unused) {
-                $metadata = $this->controllerMetadataFactory->createControllerMetadata(array($controller, $method));
-                $metadatas[$controller.':'.$method] = serialize($metadata);
-                foreach ($metadata->getTrackedFiles() as $file) {
-                    if (isset($trackedFiles[$file])) {
-                        continue;
-                    }
-
-                    $trackedFiles[$file] = new FileResource($file);
-                }
-            }
-        }
-
-        $content = sprintf(<<<EOF
-<?php
-
-return %s;
-
-EOF
-            ,
-            var_export($metadatas, true)
-        );
-        $cache->write($content, $trackedFiles);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ControllerMetadataCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ControllerMetadataCacheWarmer.php
@@ -1,0 +1,137 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\CacheWarmer;
+
+use Symfony\Component\Config\ConfigCacheFactoryInterface;
+use Symfony\Component\Config\ConfigCacheInterface;
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ControllerMetadataFactoryInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ControllerMetadataUtil;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * Generates the cache for controller metadata.
+ *
+ * @author Iltar van der Berg <kjarli@gmail.com>
+ */
+final class ControllerMetadataCacheWarmer implements CacheWarmerInterface
+{
+    private $router;
+    private $controllerResolver;
+    private $controllerMetadataFactory;
+    private $configCacheFactory;
+    private $cacheFile;
+
+    public function __construct(RouterInterface $router, ControllerResolverInterface $controllerResolver, ConfigCacheFactoryInterface $configCacheFactory, ControllerMetadataFactoryInterface $controllerMetadataFactory, $cacheFile)
+    {
+        $this->router = $router;
+        $this->controllerResolver = $controllerResolver;
+        $this->configCacheFactory = $configCacheFactory;
+        $this->controllerMetadataFactory = $controllerMetadataFactory;
+        $this->cacheFile = $cacheFile;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function warmUp($cacheDir)
+    {
+        $this->configCacheFactory->cache($this->cacheFile, function (ConfigCacheInterface $cache) {
+            $this->refreshCache($cache);
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isOptional()
+    {
+        return true;
+    }
+
+    private function refreshCache(ConfigCacheInterface $cache)
+    {
+        // make sure the cache is not used when executing createControllerMetadata
+        (new Filesystem())->remove($cache->getPath());
+
+        $controllers = array();
+
+        foreach ($this->router->getRouteCollection()->all() as $route) {
+            /* @var $route Route */
+            if (!$route->hasDefault('_controller')) {
+                continue;
+            }
+
+            $controller = $this->controllerResolver->getController(new Request(array(), array(), array('_controller' => $route->getDefault('_controller'))));
+
+            if (null === ($logicalName = ControllerMetadataUtil::getControllerLogicalName($controller))) {
+                continue;
+            }
+
+            list($className, $methodName) = $logicalName;
+
+            if (null === $className || isset($controllers[$className])) {
+                // either a closure or controller is already processed
+                continue;
+            }
+
+            $controllers[$className][$methodName] = true;
+
+            // Not all actions are mapped by routes, such as sub-requests. Just add everything public as possibility
+            $reflection = new \ReflectionClass($className);
+
+            foreach ($reflection->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+                // avoid magic methods
+                if (0 === strpos($method->getName(), '__')) {
+                    continue;
+                }
+
+                // avoid duplicates
+                $controllers[$className][$method->getName()] = true;
+            }
+        }
+
+        $metadatas = array();
+        $trackedFiles = array();
+
+        foreach ($controllers as $controller => $methods) {
+            foreach ($methods as $method => $unused) {
+                $metadata = $this->controllerMetadataFactory->createControllerMetadata(array($controller, $method));
+                $metadatas[$controller.':'.$method] = serialize($metadata);
+                foreach ($metadata->getTrackedFiles() as $file) {
+                    if (isset($trackedFiles[$file])) {
+                        // already tracked
+                        continue;
+                    }
+
+                    $trackedFiles[$file] = new FileResource($file);
+                }
+            }
+        }
+
+        $content = sprintf(<<<EOF
+<?php
+
+return %s;
+
+EOF
+            ,
+            var_export($metadatas, true)
+        );
+        $cache->write($content, $trackedFiles);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerResolverAdapter.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerResolverAdapter.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Controller;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ControllerFactoryInterface;
+
+/**
+ * @author Iltar van der Berg <kjarli@gmail.com>
+ *
+ * @internal only used to work around a circular dependency in a BC layer.
+ */
+final class ControllerResolverAdapter implements ControllerFactoryInterface
+{
+    private $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createFromString($controller)
+    {
+        return $this->container->get('obfuscated_controller_resolver')->getController(new Request(array(), array(), array('_controller' => $controller)));
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/CachedArgumentMetadataFactory.php
+++ b/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/CachedArgumentMetadataFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\ControllerMetadata;
+
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadataFactoryInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ControllerMetadataFactoryInterface;
+
+/**
+ * @author Iltar van der Berg <kjarli@gmail.com>
+ */
+final class CachedArgumentMetadataFactory implements ArgumentMetadataFactoryInterface
+{
+    private $baseFactory;
+    private $controllerMetadata;
+
+    public function __construct(ArgumentMetadataFactoryInterface $baseFactory, ControllerMetadataFactoryInterface $controllerMetadata)
+    {
+        $this->baseFactory = $baseFactory;
+        $this->controllerMetadata = $controllerMetadata;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createArgumentMetadata($controller)
+    {
+        if (null !== ($metadata = $this->controllerMetadata->createControllerMetadata($controller))) {
+            return $metadata->getArguments();
+        }
+
+        return $this->baseFactory->createArgumentMetadata($controller);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/CachedControllerMetadataFactory.php
+++ b/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/CachedControllerMetadataFactory.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\ControllerMetadata;
+
+use Symfony\Component\HttpKernel\ControllerMetadata\ControllerMetadata;
+use Symfony\Component\HttpKernel\ControllerMetadata\ControllerMetadataFactoryInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ControllerMetadataUtil;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * @author Iltar van der Berg <kjarli@gmail.com>
+ */
+final class CachedControllerMetadataFactory implements ControllerMetadataFactoryInterface
+{
+    private $baseFactory;
+    private $router;
+
+    /**
+     * Contains all previously requested metadata.
+     *
+     * @var ControllerMetadata[]
+     */
+    private $requested = [];
+    private $cacheFile;
+
+    /**
+     * Contains serialized controller metedata for each pre-defined controller.
+     *
+     * @var string[]
+     */
+    private $warmed = [];
+
+    public function __construct(ControllerMetadataFactoryInterface $baseFactory, RouterInterface $router, $cacheFile)
+    {
+        $this->baseFactory = $baseFactory;
+        $this->router = $router;
+        $this->cacheFile = $cacheFile;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createControllerMetadata(callable $controller)
+    {
+        if (empty($this->warmed) && file_exists($this->cacheFile)) {
+            $this->warmed = include $this->cacheFile;
+        }
+
+        if (null === ($logicalName = ControllerMetadataUtil::getControllerLogicalName($controller))) {
+            return null;
+        }
+
+        $index = implode(':', $logicalName);
+
+        // if already requested
+        if (isset($this->requested[$index])) {
+            return $this->requested[$index];
+        }
+
+        // if not requested but in cache
+        if (isset($this->warmed[$index])) {
+            return $this->requested[$index] = unserialize($this->warmed[$index]);
+        }
+
+        // not in cache but lets cache it for at least this request
+        return $this->requested[$index] = $this->baseFactory->createControllerMetadata($controller);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/CachedControllerMetadataFactory.php
+++ b/src/Symfony/Bundle/FrameworkBundle/ControllerMetadata/CachedControllerMetadataFactory.php
@@ -11,6 +11,11 @@
 
 namespace Symfony\Bundle\FrameworkBundle\ControllerMetadata;
 
+use Symfony\Component\Config\ConfigCacheFactoryInterface;
+use Symfony\Component\Config\ConfigCacheInterface;
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
+use Symfony\Component\HttpKernel\Controller\ControllerFactoryInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ControllerMetadata;
 use Symfony\Component\HttpKernel\ControllerMetadata\ControllerMetadataFactoryInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ControllerMetadataUtil;
@@ -19,8 +24,10 @@ use Symfony\Component\Routing\RouterInterface;
 /**
  * @author Iltar van der Berg <kjarli@gmail.com>
  */
-final class CachedControllerMetadataFactory implements ControllerMetadataFactoryInterface
+final class CachedControllerMetadataFactory implements ControllerMetadataFactoryInterface, WarmableInterface
 {
+    private $controllerFactory;
+    private $configCacheFactory;
     private $baseFactory;
     private $router;
 
@@ -29,20 +36,22 @@ final class CachedControllerMetadataFactory implements ControllerMetadataFactory
      *
      * @var ControllerMetadata[]
      */
-    private $requested = [];
-    private $cacheFile;
+    private $requested = array();
 
+    private $cacheFile;
     /**
      * Contains serialized controller metedata for each pre-defined controller.
      *
      * @var string[]
      */
-    private $warmed = [];
+    private $warmed = array();
 
-    public function __construct(ControllerMetadataFactoryInterface $baseFactory, RouterInterface $router, $cacheFile)
+    public function __construct(ControllerFactoryInterface $controllerFactory, ControllerMetadataFactoryInterface $baseFactory, RouterInterface $router, ConfigCacheFactoryInterface $configCacheFactory, $cacheFile)
     {
+        $this->controllerFactory = $controllerFactory;
         $this->baseFactory = $baseFactory;
         $this->router = $router;
+        $this->configCacheFactory = $configCacheFactory;
         $this->cacheFile = $cacheFile;
     }
 
@@ -51,12 +60,16 @@ final class CachedControllerMetadataFactory implements ControllerMetadataFactory
      */
     public function createControllerMetadata(callable $controller)
     {
-        if (empty($this->warmed) && file_exists($this->cacheFile)) {
-            $this->warmed = include $this->cacheFile;
+        if (null === ($logicalName = ControllerMetadataUtil::getControllerLogicalName($controller))) {
+            return;
         }
 
-        if (null === ($logicalName = ControllerMetadataUtil::getControllerLogicalName($controller))) {
-            return null;
+        $cache = $this->configCacheFactory->cache($this->cacheFile, function (ConfigCacheInterface $cache) {
+            $this->refreshCache($cache);
+        });
+
+        if (empty($this->warmed)) {
+            $this->warmed = include $cache->getPath();
         }
 
         $index = implode(':', $logicalName);
@@ -73,5 +86,87 @@ final class CachedControllerMetadataFactory implements ControllerMetadataFactory
 
         // not in cache but lets cache it for at least this request
         return $this->requested[$index] = $this->baseFactory->createControllerMetadata($controller);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function warmUp($cacheDir)
+    {
+        $this->configCacheFactory->cache($this->cacheFile, function (ConfigCacheInterface $cache) {
+            $this->refreshCache($cache);
+        });
+    }
+
+    /**
+     * Builds the actual cache.
+     *
+     * @param ConfigCacheInterface $cache
+     */
+    private function refreshCache(ConfigCacheInterface $cache)
+    {
+        $controllers = array();
+
+        foreach ($this->router->getRouteCollection()->all() as $route) {
+            if (!$route->hasDefault('_controller')) {
+                continue;
+            }
+
+            $controller = $this->controllerFactory->createFromString($route->getDefault('_controller'));
+
+            if (null === ($logicalName = ControllerMetadataUtil::getControllerLogicalName($controller))) {
+                continue;
+            }
+
+            list($className) = $logicalName;
+
+            if (null === $className || isset($controllers[$className])) {
+                // either a closure or controller is already processed
+                continue;
+            }
+
+            // Not all actions are mapped by routes, such as sub-requests. Just add everything public as possibility
+            $reflection = new \ReflectionClass($className);
+
+            foreach ($reflection->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+                // avoid magic methods
+                if ($method->isConstructor() || $method->isDestructor()) {
+                    continue;
+                }
+
+                $controllers[$className][] = $method->getName();
+            }
+        }
+
+        $metadatas = array();
+        $trackedFiles = array();
+
+        foreach ($controllers as $controller => $methods) {
+            foreach ($methods as $method) {
+                $metadata = $this->baseFactory->createControllerMetadata(array($controller, $method));
+                $metadatas[$controller.':'.$method] = serialize($metadata);
+                foreach ($metadata->getTrackedFiles() as $file) {
+                    if (isset($trackedFiles[$file])) {
+                        continue;
+                    }
+
+                    $trackedFiles[$file] = new FileResource($file);
+                }
+            }
+        }
+
+        $content = sprintf(<<<EOF
+<?php
+
+return %s;
+
+EOF
+            ,
+            var_export($metadatas, true)
+        );
+
+        $cache->write($content, array_values($trackedFiles));
+
+        $this->warmed = $metadatas;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
@@ -20,7 +20,7 @@
         <service id="argument_metadata_factory" class="Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadataFactory" public="false" />
 
         <service id="argument_resolver" class="Symfony\Component\HttpKernel\Controller\ArgumentResolver" public="false">
-            <argument type="service" id="argument_metadata_factory" />
+            <argument type="service" id="argument_metadata_factory.cached" />
             <argument type="collection" />
         </service>
 
@@ -38,6 +38,31 @@
 
         <service id="argument_resolver.variadic" class="Symfony\Component\HttpKernel\Controller\ArgumentResolver\VariadicValueResolver" public="false">
             <tag name="controller.argument_value_resolver" priority="-150" />
+        </service>
+
+        <service id="argument_metadata_factory.cached" class="Symfony\Bundle\FrameworkBundle\ControllerMetadata\CachedArgumentMetadataFactory" public="false">
+            <argument type="service" id="argument_metadata_factory"/>
+            <argument type="service" id="controller_metadata_factory"/>
+        </service>
+
+        <service id="controller_metadata_factory" class="Symfony\Component\HttpKernel\ControllerMetadata\ControllerMetadataFactory">
+            <argument type="service" id="argument_metadata_factory"/>
+            <!-- config factory -->
+        </service>
+
+        <service id="controller_metadata_factory.cached" public="false" class="Symfony\Bundle\FrameworkBundle\ControllerMetadata\CachedControllerMetadataFactory" decorates="controller_metadata_factory">
+            <argument type="service" id="controller_metadata_factory.cached.inner"/>
+            <argument type="service" id="router"/>
+            <argument>%kernel.cache_dir%/controller_metadata.php</argument>
+        </service>
+
+        <service id="controller_metadata_factory.cache_warmer" class="Symfony\Bundle\FrameworkBundle\CacheWarmer\ControllerMetadataCacheWarmer">
+            <tag name="kernel.cache_warmer" />
+            <argument type="service" id="router"/>
+            <argument type="service" id="controller_resolver"/>
+            <argument type="service" id="config_cache_factory"/>
+            <argument type="service" id="controller_metadata_factory.cached"/>
+            <argument>%kernel.cache_dir%/controller_metadata.php</argument>
         </service>
 
         <service id="response_listener" class="Symfony\Component\HttpKernel\EventListener\ResponseListener">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
@@ -17,6 +17,8 @@
             <argument type="service" id="logger" on-invalid="ignore" />
         </service>
 
+        <service id="obfuscated_controller_resolver" alias="controller_resolver" />
+
         <service id="argument_metadata_factory" class="Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadataFactory" public="false" />
 
         <service id="argument_resolver" class="Symfony\Component\HttpKernel\Controller\ArgumentResolver" public="false">
@@ -45,24 +47,26 @@
             <argument type="service" id="controller_metadata_factory"/>
         </service>
 
+        <service id="controller_factory.controller_resolver" class="Symfony\Bundle\FrameworkBundle\Controller\ControllerResolverAdapter">
+            <argument type="service" id="service_container"/>
+        </service>
+
         <service id="controller_metadata_factory" class="Symfony\Component\HttpKernel\ControllerMetadata\ControllerMetadataFactory">
             <argument type="service" id="argument_metadata_factory"/>
             <!-- config factory -->
         </service>
 
         <service id="controller_metadata_factory.cached" public="false" class="Symfony\Bundle\FrameworkBundle\ControllerMetadata\CachedControllerMetadataFactory" decorates="controller_metadata_factory">
+            <argument type="service" id="controller_factory.controller_resolver"/>
             <argument type="service" id="controller_metadata_factory.cached.inner"/>
             <argument type="service" id="router"/>
+            <argument type="service" id="config_cache_factory"/>
             <argument>%kernel.cache_dir%/controller_metadata.php</argument>
         </service>
 
         <service id="controller_metadata_factory.cache_warmer" class="Symfony\Bundle\FrameworkBundle\CacheWarmer\ControllerMetadataCacheWarmer">
-            <tag name="kernel.cache_warmer" />
-            <argument type="service" id="router"/>
-            <argument type="service" id="controller_resolver"/>
-            <argument type="service" id="config_cache_factory"/>
             <argument type="service" id="controller_metadata_factory.cached"/>
-            <argument>%kernel.cache_dir%/controller_metadata.php</argument>
+            <tag name="kernel.cache_warmer" />
         </service>
 
         <service id="response_listener" class="Symfony\Component\HttpKernel\EventListener\ResponseListener">

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerFactoryInterface.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerFactoryInterface.php
@@ -9,19 +9,19 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\HttpKernel\ControllerMetadata;
+namespace Symfony\Component\HttpKernel\Controller;
 
 /**
- * Builds controller data.
- *
  * @author Iltar van der Berg <kjarli@gmail.com>
  */
-interface ControllerMetadataFactoryInterface
+interface ControllerFactoryInterface
 {
     /**
-     * @param callable $controller The controller to resolve the arguments for
+     * Create a controller callable based on a string.
      *
-     * @return ControllerMetadata|null
+     * @param string $controller
+     *
+     * @return callable
      */
-    public function createControllerMetadata(callable $controller);
+    public function createFromString($controller);
 }

--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadata.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadata.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\HttpKernel\ControllerMetadata;
  *
  * @author Iltar van der Berg <kjarli@gmail.com>
  */
-class ArgumentMetadata
+class ArgumentMetadata implements \Serializable
 {
     private $name;
     private $type;
@@ -98,5 +98,21 @@ class ArgumentMetadata
         }
 
         return $this->defaultValue;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize()
+    {
+        return serialize([$this->name, $this->type, $this->isVariadic, $this->hasDefaultValue, $this->defaultValue]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize($serialized)
+    {
+        list($this->name, $this->type, $this->isVariadic, $this->hasDefaultValue, $this->defaultValue) = unserialize($serialized);
     }
 }

--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadata.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadata.php
@@ -105,7 +105,7 @@ class ArgumentMetadata implements \Serializable
      */
     public function serialize()
     {
-        return serialize([$this->name, $this->type, $this->isVariadic, $this->hasDefaultValue, $this->defaultValue]);
+        return serialize(array($this->name, $this->type, $this->isVariadic, $this->hasDefaultValue, $this->defaultValue));
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/Configuration/ConfigurationFactoryInterface.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/Configuration/ConfigurationFactoryInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\ControllerMetadata\Configuration;
+
+/**
+ * Responsible for the creation of controller action configuration.
+ *
+ * @author Iltar van der Berg <kjarli@gmail.com>
+ */
+interface ConfigurationFactoryInterface
+{
+    /**
+     * @param string $className
+     * @param string $method
+     *
+     * @return ConfigurationInterface[]
+     */
+    public function createConfiguration($className, $method);
+}

--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/Configuration/ConfigurationInterface.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/Configuration/ConfigurationInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\ControllerMetadata\Configuration;
+
+/**
+ * Shared interface between configurations on a controller action.
+ *
+ * @author Iltar van der Berg <kjarli@gmail.com>
+ */
+interface ConfigurationInterface
+{
+    /**
+     * True if this configuration option is allowed to be added multiple times
+     * on the single controller action.
+     *
+     * @return bool
+     */
+    public function allowMultiple();
+
+    /**
+     * Returns the files that should be tracked for modification.
+     *
+     * @return string[]
+     */
+    public function getTrackedFiles();
+}

--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/Configuration/ConfigurationInterface.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/Configuration/ConfigurationInterface.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\HttpKernel\ControllerMetadata\Configuration;
  * Shared interface between configurations on a controller action.
  *
  * @author Iltar van der Berg <kjarli@gmail.com>
+ * @internal 
  */
 interface ConfigurationInterface
 {

--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/Configuration/ConfigurationInterface.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/Configuration/ConfigurationInterface.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\HttpKernel\ControllerMetadata\Configuration;
  * Shared interface between configurations on a controller action.
  *
  * @author Iltar van der Berg <kjarli@gmail.com>
+ *
  * @internal 
  */
 interface ConfigurationInterface

--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/Configuration/DefaultConfiguration.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/Configuration/DefaultConfiguration.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\HttpKernel\ControllerMetadata\Configuration;
  * A default implemention of a configuration option on a controller action.
  *
  * @author Iltar van der Berg <kjarli@gmail.com>
+ *
  * @internal
  */
 abstract class DefaultConfiguration implements ConfigurationInterface

--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/Configuration/DefaultConfiguration.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/Configuration/DefaultConfiguration.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\HttpKernel\ControllerMetadata\Configuration;
  * A default implemention of a configuration option on a controller action.
  *
  * @author Iltar van der Berg <kjarli@gmail.com>
+ * @internal
  */
 abstract class DefaultConfiguration implements ConfigurationInterface
 {

--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/Configuration/DefaultConfiguration.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/Configuration/DefaultConfiguration.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\ControllerMetadata\Configuration;
+
+/**
+ * A default implemention of a configuration option on a controller action.
+ *
+ * @author Iltar van der Berg <kjarli@gmail.com>
+ */
+abstract class DefaultConfiguration implements ConfigurationInterface
+{
+    public function __construct(array $values)
+    {
+        foreach ($values as $k => $v) {
+            if (!method_exists($this, $name = 'set'.$k)) {
+                throw new \RuntimeException(sprintf('Unknown key "%s" for annotation "@%s".', $k, get_class($this)));
+            }
+
+            $this->$name($v);
+        }
+    }
+}

--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/ControllerMetadata.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/ControllerMetadata.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\ControllerMetadata;
+
+use Symfony\Component\HttpKernel\ControllerMetadata\Configuration\ConfigurationInterface;
+
+/**
+ * Responsible for storing metadata of a controller action.
+ *
+ * @author Iltar van der Berg <kjarli@gmail.com>
+ */
+class ControllerMetadata implements \Serializable
+{
+    private $className;
+    private $method;
+    private $arguments;
+    private $configurations;
+
+    /**
+     * @param string                   $className
+     * @param string                   $method
+     * @param ArgumentMetadata[]       $arguments
+     * @param ConfigurationInterface[] $configurations
+     */
+    public function __construct($className, $method, array $arguments, array $configurations)
+    {
+        $this->className = $className;
+        $this->method = $method;
+        $this->arguments = $arguments;
+        $this->configurations = $configurations;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClassName()
+    {
+        return $this->className;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMethod()
+    {
+        return $this->method;
+    }
+
+    /**
+     * @return ArgumentMetadata[]
+     */
+    public function getArguments()
+    {
+        return $this->arguments;
+    }
+
+    /**
+     * @return ConfigurationInterface[]
+     */
+    public function getConfigurations()
+    {
+        return $this->configurations;
+    }
+
+    /**
+     * Returns all files related to this controller.
+     *
+     * @return string[]
+     */
+    public function getTrackedFiles()
+    {
+        $tracked = array();
+
+        foreach ($this->configurations as $configuration) {
+            $tracked[] = $configuration->getTrackedFiles();
+        }
+
+        return array_merge([(new \ReflectionClass($this->className))->getFileName()], ...$tracked);
+    }
+
+    /**
+     * @param string $className
+     *
+     * @return ConfigurationInterface[]
+     */
+    public function getConfigurationsByClass($className)
+    {
+        $found = [];
+
+        foreach ($this->configurations as $configuration) {
+            if (get_class($configuration) === $className || is_subclass_of($className, $configuration)) {
+                $found[] = $configuration;
+            }
+        }
+
+        return $found;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize()
+    {
+        return serialize([$this->className, $this->method, $this->arguments, $this->configurations]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize($serialized)
+    {
+        list($this->className, $this->method, $this->arguments, $this->configurations) = unserialize($serialized);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/ControllerMetadata.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/ControllerMetadata.php
@@ -87,7 +87,7 @@ class ControllerMetadata implements \Serializable
      */
     public function getConfigurationsByClass($className)
     {
-        $found = [];
+        $found = array();
 
         foreach ($this->configurations as $configuration) {
             if (get_class($configuration) === $className || is_subclass_of($className, $configuration)) {

--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/ControllerMetadata.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/ControllerMetadata.php
@@ -69,13 +69,15 @@ class ControllerMetadata implements \Serializable
      */
     public function getTrackedFiles()
     {
-        $tracked = array();
+        $tracked = array((new \ReflectionClass($this->className))->getFileName());
 
         foreach ($this->configurations as $configuration) {
-            $tracked[] = $configuration->getTrackedFiles();
+            foreach ($configuration->getTrackedFiles() as $trackedFile) {
+                $tracked[] = $trackedFile;
+            }
         }
 
-        return array_merge([(new \ReflectionClass($this->className))->getFileName()], ...$tracked);
+        return $tracked;
     }
 
     /**
@@ -101,7 +103,7 @@ class ControllerMetadata implements \Serializable
      */
     public function serialize()
     {
-        return serialize([$this->className, $this->method, $this->arguments, $this->configurations]);
+        return serialize(array($this->className, $this->method, $this->arguments, $this->configurations));
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/ControllerMetadataFactory.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/ControllerMetadataFactory.php
@@ -35,7 +35,7 @@ final class ControllerMetadataFactory implements ControllerMetadataFactoryInterf
     public function createControllerMetadata(callable $controller)
     {
         if (null === ($logicalName = ControllerMetadataUtil::getControllerLogicalName($controller))) {
-            return null;
+            return;
         }
 
         list($className, $method) = $logicalName;

--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/ControllerMetadataFactory.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/ControllerMetadataFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\ControllerMetadata;
+
+use Symfony\Component\HttpKernel\ControllerMetadata\Configuration\ConfigurationFactoryInterface;
+
+/**
+ * Builds {@see ControllerMetadata} objects based on the given Controller.
+ *
+ * @author Iltar van der Berg <kjarli@gmail.com>
+ */
+final class ControllerMetadataFactory implements ControllerMetadataFactoryInterface
+{
+    private $argumentMetadataFactory;
+    private $configurationFactory;
+
+    public function __construct(ArgumentMetadataFactoryInterface $argumentMetadataFactory, ConfigurationFactoryInterface $configurationFactory = null)
+    {
+        $this->argumentMetadataFactory = $argumentMetadataFactory;
+        $this->configurationFactory = $configurationFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createControllerMetadata(callable $controller)
+    {
+        if (null === ($logicalName = ControllerMetadataUtil::getControllerLogicalName($controller))) {
+            return null;
+        }
+
+        list($className, $method) = $logicalName;
+
+        $arguments = $this->argumentMetadataFactory->createArgumentMetadata($controller);
+        $configurations = null !== $this->configurationFactory ? $this->configurationFactory->createConfiguration($className, $method) : array();
+
+        return new ControllerMetadata($className, $method, $arguments, $configurations);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/ControllerMetadataFactoryInterface.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/ControllerMetadataFactoryInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\ControllerMetadata;
+
+/**
+ * Builds controller data.
+ *
+ * @author Iltar van der Berg <kjarli@gmail.com>
+ */
+interface ControllerMetadataFactoryInterface
+{
+    /**
+     * @param callable $controller The controller to resolve the arguments for
+     * @return ControllerMetadata|null
+     */
+    public function createControllerMetadata(callable $controller);
+}

--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/ControllerMetadataUtil.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/ControllerMetadataUtil.php
@@ -26,7 +26,7 @@ abstract class ControllerMetadataUtil
     {
         if ($controller instanceof \Closure) {
             // cannot store any metadata of anonymous functions
-            return null;
+            return;
         }
 
         if (is_object($controller)) {
@@ -42,7 +42,7 @@ abstract class ControllerMetadataUtil
 
         if (null !== $controller[0]) {
             if (!is_string($controller[0])) {
-                $className = class_exists('Doctrine\Common\Util\ClassUtils') ? ClassUtils::getClass($controller[0]) : get_class($controller[0]);
+                $className = class_exists(ClassUtils::class) ? ClassUtils::getClass($controller[0]) : get_class($controller[0]);
             } else {
                 $className = $controller[0];
             }

--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/ControllerMetadataUtil.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/ControllerMetadataUtil.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\ControllerMetadata;
+
+use Doctrine\Common\Util\ClassUtils;
+
+abstract class ControllerMetadataUtil
+{
+    /**
+     * Gets a class name (if available) and method/function name from a callable.
+     *
+     * @param callable $controller
+     *
+     * @return string[]|null the class name and method name (where applicable)
+     */
+    public static function getControllerLogicalName(callable $controller)
+    {
+        if ($controller instanceof \Closure) {
+            // cannot store any metadata of anonymous functions
+            return null;
+        }
+
+        if (is_object($controller)) {
+            // callable class
+            $controller = array($controller, '__invoke');
+        } elseif (is_string($controller)) {
+            // normal function
+            $controller = array(null, $controller);
+        }
+
+        $className = null;
+        $method = $controller[1];
+
+        if (null !== $controller[0]) {
+            if (!is_string($controller[0])) {
+                $className = class_exists('Doctrine\Common\Util\ClassUtils') ? ClassUtils::getClass($controller[0]) : get_class($controller[0]);
+            } else {
+                $className = $controller[0];
+            }
+        }
+
+        return array($className, $method);
+    }
+
+    private function __construct()
+    {
+        // private by design
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Some time ago I was working on the `ArgumentResolver`. This PR adds the following:
- A cache to store the resolved arguments
- A cache to store controller configuration

What I'm aiming for is something like this:

``` php
public function onKernelController(FilterControllerEvent $event)
{
    $method = $this->controllerConfig->get(Method::class);
}
```

I'm not 100% satisfied with this yet so I'm all up for discussion (see the added configuration interface). I want this eventually to replace the annotation/reflection variant: https://github.com/sensiolabs/SensioFrameworkExtraBundle/tree/master/EventListener
## Cache to store Resolved Arguments

The first part is done. During cache warm-up it instantiates all controllers (sadly no other way atm) and indexes all available actions from those controllers. The second part has an extension point already but has yet to be implemented. The idea is to cache away the entire configuration; Like the SensioFrameworkExtraBundle does, except it doesn't need run-time reflection anymore as it's cached. 

I've tested this in my own application:
- 55 controllers
- 430 actions on those controllers
- 9 subrequests on average 
- 5 of those are from controllers which are completely excluded from the routing (subrequests only)
- argument resolving was done 500 times in a for loop during 1 request
- php 7
- xdebug enabled (thus reflection will most likely be a bit faster)

**Cached**
"20 ms with 3 arguments"
"8 ms with 0 arguments"
"8 ms with 0 arguments"
"10 ms with 1 arguments"
"11 ms with 1 arguments"
"18 ms with 2 arguments"
"11 ms with 1 arguments"
"8 ms with 0 arguments"
"11 ms with 1 arguments"

**Fresh** 
"25 ms with 3 arguments"
"6 ms with 0 arguments"
"5 ms with 0 arguments"
"12 ms with 1 arguments"
"14 ms with 1 arguments"
"23 ms with 2 arguments"
"12 ms with 1 arguments"
"5 ms with 0 arguments"
"12 ms with 1 arguments"

The ones with 0 arguments have a bit more overhead because an unserialize is triggered while it has no arguments. In total, the cache warm-up for this application takes ~230ms longer. I've used the `\Serializable` interface to reduce the cache size and speed up unserialize. The file went from 360K to 105K by adding the interface to the `ControllerMetadata` and `ArgumentMetadata`. Executing the `include` 500 times in a row went from 1450ms before to 135ms after adding the interface.
## controller configuration

The biggest power lies in the added possibility to store configurations for controllers. The Extra Bundle already allows you to add Annotations on the controller and actions, but this requires run-time reflection (only annotations are cached via the reader). Because the controller config doesn't change, this can easily be cached away. 

By implementing an interface, I've also made it possible to implement an XML, Yaml or even a raw PHP variant if desired. This will reduce overhead at run-time.

The only thing I'm not sure of yet, is the caching method. At the moment it generates one big array of serialized strings and I'm afraid this might have a performance impact once the configurations are loaded. If you have any caching suggestions, they are more than welcome.

_Before I continue to put more time and effort in here, do you think this feature is nice to have? Personally I'd like to move this functionality to the core instead of the extra bundle, but in a well-designed way._
