### PR TITLE
PassConfig::getMergePass is not an array

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -154,7 +154,7 @@ class PassConfig
     /**
      * Gets all passes for the Merge pass.
      *
-     * @return array An array of passes
+     * @return CompilerPassInterface An array of passes
      */
     public function getMergePass()
     {

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -154,7 +154,7 @@ class PassConfig
     /**
      * Gets all passes for the Merge pass.
      *
-     * @return CompilerPassInterface An array of passes
+     * @return CompilerPassInterface The merge pass
      */
     public function getMergePass()
     {

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -152,7 +152,7 @@ class PassConfig
     }
 
     /**
-     * Gets all passes for the Merge pass.
+     * Gets the Merge pass.
      *
      * @return CompilerPassInterface The merge pass
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Just a minor glitch my IDE noticed :-)
