### PR TITLE
[Serializer]  $serializer property private to protected in ArrayDenormalizer

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
@@ -26,7 +26,7 @@ class ArrayDenormalizer implements DenormalizerInterface, SerializerAwareInterfa
     /**
      * @var SerializerInterface|DenormalizerInterface
      */
-    private $serializer;
+    protected $serializer;
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

As the ArrayDenormalizer is not a final class, I think the $serializer property should be protected. We could extend the ArrayDenormalizer and use the $serializer as well.
