### PR TITLE
[Serializer] Include the format in the cache key

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -56,7 +56,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
     public function normalize($object, $format = null, array $context = array())
     {
         if (!isset($context['cache_key'])) {
-            $context['cache_key'] = $this->getCacheKey($context);
+            $context['cache_key'] = $this->getCacheKey($format, $context);
         }
 
         if ($this->isCircularReference($object, $context)) {
@@ -169,7 +169,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!isset($context['cache_key'])) {
-            $context['cache_key'] = $this->getCacheKey($context);
+            $context['cache_key'] = $this->getCacheKey($format, $context);
         }
         $allowedAttributes = $this->getAllowedAttributes($class, $context, true);
         $normalizedData = $this->prepareForDenormalization($data);
@@ -336,14 +336,15 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
     /**
      * Gets the cache key to use.
      *
-     * @param array $context
+     * @param string|null $format
+     * @param array       $context
      *
      * @return bool|string
      */
-    private function getCacheKey(array $context)
+    private function getCacheKey($format, array $context)
     {
         try {
-            return md5(serialize($context));
+            return $format.'-'.md5(serialize($context));
         } catch (\Exception $exception) {
             // The context cannot be serialized, skip the cache
             return false;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Attributes to normalize can vary by format. For instance in API Platform normalized attributes aren't the same in JSON-LD (all attributes) and HAL (relations are not serialized in the document body).
This PR fixes that. 
