### PR TITLE
[Console] allow comma separator for array input options

### DIFF
--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -246,7 +246,16 @@ class ArgvInput extends Input
         }
 
         if ($option->isArray()) {
-            $this->options[$name][] = $value;
+            if (strpos($value, ',') !== false) {
+                if (!isset($this->options[$name])) {
+                    $this->options[$name] = array();
+                }
+
+                $values = explode(',', $value);
+                $this->options[$name] = array_merge($this->options[$name], $values);
+            } else {
+                $this->options[$name][] = $value;
+            }
         } else {
             $this->options[$name] = $value;
         }

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -246,7 +246,7 @@ class ArgvInput extends Input
         }
 
         if ($option->isArray()) {
-            if (strpos($value, ',') !== false) {
+            if ($option->isValueCommaSeparated()) {
                 if (!isset($this->options[$name])) {
                     $this->options[$name] = array();
                 }

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -25,6 +25,7 @@ class InputOption
     const VALUE_REQUIRED = 2;
     const VALUE_OPTIONAL = 4;
     const VALUE_IS_ARRAY = 8;
+    const VALUE_IS_COMMA_SEPARATED = 16;
 
     private $name;
     private $shortcut;
@@ -72,7 +73,7 @@ class InputOption
 
         if (null === $mode) {
             $mode = self::VALUE_NONE;
-        } elseif (!is_int($mode) || $mode > 15 || $mode < 1) {
+        } elseif (!is_int($mode) || $mode > 31 || $mode < 1) {
             throw new InvalidArgumentException(sprintf('Option mode "%s" is not valid.', $mode));
         }
 
@@ -83,6 +84,10 @@ class InputOption
 
         if ($this->isArray() && !$this->acceptValue()) {
             throw new InvalidArgumentException('Impossible to have an option mode VALUE_IS_ARRAY if the option does not accept a value.');
+        }
+
+        if ($this->isValueCommaSeparated() && !$this->isArray()) {
+            throw new InvalidArgumentException('Impossible to have an option mode VALUE_IS_COMMA_SEPARATED without VALUE_IS_ARRAY.');
         }
 
         $this->setDefault($default);
@@ -146,6 +151,16 @@ class InputOption
     public function isArray()
     {
         return self::VALUE_IS_ARRAY === (self::VALUE_IS_ARRAY & $this->mode);
+    }
+
+    /**
+     * Returns true if the value is comma separated.
+     *
+     * @return bool true if mode is self::VALUE_IS_COMMA_SEPARATED, false otherwise
+     */
+    public function isValueCommaSeparated()
+    {
+        return self::VALUE_IS_COMMA_SEPARATED === (self::VALUE_IS_COMMA_SEPARATED & $this->mode);
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
@@ -226,6 +226,10 @@ class ArgvInputTest extends \PHPUnit_Framework_TestCase
         $input->bind(new InputDefinition(array(new InputOption('name', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY))));
         $this->assertSame(array('name' => array('foo', 'bar', null)), $input->getOptions(), '->parse() parses empty array options as null ("--option=value" syntax)');
 
+        $input = new ArgvInput(array('cli.php', '--name=foo,bar'));
+        $input->bind(new InputDefinition(array(new InputOption('name', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY))));
+        $this->assertSame(array('name' => array('foo', 'bar')), $input->getOptions(), '->parse() parses empty array options as null ("--option=value" syntax)');
+
         $input = new ArgvInput(array('cli.php', '--name', 'foo', '--name', 'bar', '--name', '--anotherOption'));
         $input->bind(new InputDefinition(array(
             new InputOption('name', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY),

--- a/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
@@ -215,7 +215,6 @@ class ArgvInputTest extends \PHPUnit_Framework_TestCase
     {
         $input = new ArgvInput(array('cli.php', '--name=foo', '--name=bar', '--name=baz'));
         $input->bind(new InputDefinition(array(new InputOption('name', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY))));
-
         $this->assertEquals(array('name' => array('foo', 'bar', 'baz')), $input->getOptions(), '->parse() parses array options ("--option=value" syntax)');
 
         $input = new ArgvInput(array('cli.php', '--name', 'foo', '--name', 'bar', '--name', 'baz'));
@@ -228,7 +227,7 @@ class ArgvInputTest extends \PHPUnit_Framework_TestCase
 
         $input = new ArgvInput(array('cli.php', '--name=foo,bar'));
         $input->bind(new InputDefinition(array(new InputOption('name', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY))));
-        $this->assertSame(array('name' => array('foo', 'bar')), $input->getOptions(), '->parse() parses empty array options as null ("--option=value" syntax)');
+        $this->assertSame(array('name' => array('foo,bar')), $input->getOptions(), '->parse() parses empty array options as null ("--option=value" syntax)');
 
         $input = new ArgvInput(array('cli.php', '--name', 'foo', '--name', 'bar', '--name', '--anotherOption'));
         $input->bind(new InputDefinition(array(
@@ -236,6 +235,13 @@ class ArgvInputTest extends \PHPUnit_Framework_TestCase
             new InputOption('anotherOption', null, InputOption::VALUE_NONE),
         )));
         $this->assertSame(array('name' => array('foo', 'bar', null), 'anotherOption' => true), $input->getOptions(), '->parse() parses empty array options as null ("--option value" syntax)');
+    }
+
+    public function testParseArrayValueIsCommaSeparatedOption()
+    {
+        $input = new ArgvInput(array('cli.php', '--name=foo,bar'));
+        $input->bind(new InputDefinition(array(new InputOption('name', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY | InputOption::VALUE_IS_COMMA_SEPARATED))));
+        $this->assertSame(array('name' => array('foo', 'bar')), $input->getOptions(), '->parse() parses empty array options as null ("--option=value" syntax)');
     }
 
     public function testParseNegativeNumberAfterDoubleDash()

--- a/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Console\Tests\Input;
 
+use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputOption;
 
 class InputOptionTest extends \PHPUnit_Framework_TestCase
@@ -177,6 +178,15 @@ class InputOptionTest extends \PHPUnit_Framework_TestCase
     {
         $option = new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY);
         $option->setDefault('default');
+    }
+
+    /**
+     * @expectedException        InvalidArgumentException
+     * @expectedExceptionMessage Impossible to have an option mode VALUE_IS_COMMA_SEPARATED without VALUE_IS_ARRAY.
+     */
+    public function testValueIsCommaSeparatedWithoutArrayMode()
+    {
+        new InputOption('name', null, InputOption::VALUE_IS_COMMA_SEPARATED);
     }
 
     public function testEquals()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
# The Issue

To add multiple options, now you have to name both key and value. 

```
bin/console-app --source=dir --source=dir2
```

Take well known php-cs-fixer for example allows comma separated values.

```
php-cs-fixer fix dir --fixers=foo,bar
phpcs dir --sniffs=foo,bar
apigen --source=src,tests
```

It has better usability and is easier to understand to end user.

But to make this work, you have to use custom solution: [options resolver](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/2afe85e1813820e4b1e059a5a44364d3a9c59171/Symfony/CS/ConfigurationResolver.php#L194-L205) or [modified ArgInput](https://github.com/ApiGen/ApiGen/blob/master/src/Console/Input/LiberalFormatArgvInput.php).
# Solution

A option `InputOption::VALUE_IS_COMMA_SEPARATED` is added. This will split value by comma to an array.

``` php
$this->addInput('name', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY | InputOption::VALUE_IS_COMMA_SEPARATED);

dump($input->getOption('name'));
```

``` bash
bin/console-app --name=foo,bar # array('foo', 'bar');
```
## BC for values that includes comma

In some case, you might want to add value with a comma.

As the option `InputOption::VALUE_IS_COMMA_SEPARATED` is optional, you can leave it.

``` php
$this->addInput('name', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY);

dump($input->getOption('price'));
```

``` bash
bin/console-app --price=20,05 --price=10,25 # array('20,05', '10,25');
```

**What do you think?**
