### PR TITLE
[Form] Ease immutable/value objects mapping

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataMapper/CallbackFormDataToObjectConverter.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataMapper/CallbackFormDataToObjectConverter.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Core\DataMapper;
+
+/**
+ * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
+ */
+class CallbackFormDataToObjectConverter implements FormDataToObjectConverterInterface
+{
+    /**
+     * The callable used to map form data to an object.
+     *
+     * @var callable
+     */
+    private $converter;
+
+    /**
+     * @param callable $converter
+     */
+    public function __construct(callable $converter)
+    {
+        $this->converter = $converter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertFormDataToObject(array $data, $originalData)
+    {
+        return call_user_func($this->converter, $data, $originalData);
+    }
+}

--- a/src/Symfony/Component/Form/Extension/Core/DataMapper/FormDataToObjectConverterInterface.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataMapper/FormDataToObjectConverterInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Core\DataMapper;
+
+/**
+ * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
+ */
+interface FormDataToObjectConverterInterface
+{
+    /**
+     * Convert the form data into an object.
+     *
+     * @param array       $data         Array of form data indexed by fields names.
+     * @param object|null $originalData Original data set in the form (after FormEvents::PRE_SET_DATA).
+     *
+     * @return object|null
+     */
+    public function convertFormDataToObject(array $data, $originalData);
+}

--- a/src/Symfony/Component/Form/Extension/Core/DataMapper/ObjectToFormDataConverterInterface.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataMapper/ObjectToFormDataConverterInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Core\DataMapper;
+
+/**
+ * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
+ */
+interface ObjectToFormDataConverterInterface
+{
+    /**
+     * Convert given object to form data.
+     *
+     * @param object|null $object The object to map to the form.
+     *
+     * @return array The array of form data indexed by fields names.
+     */
+    public function convertObjectToFormData($object);
+}

--- a/src/Symfony/Component/Form/Extension/Core/DataMapper/SimpleObjectMapper.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataMapper/SimpleObjectMapper.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Core\DataMapper;
+
+use Symfony\Component\Form\DataMapperInterface;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
+
+/**
+ * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
+ */
+class SimpleObjectMapper implements DataMapperInterface
+{
+    /**
+     * @var FormDataToObjectConverterInterface
+     */
+    private $converter;
+
+    /**
+     * @var DataMapperInterface|null
+     */
+    private $originalMapper;
+
+    /**
+     * @param FormDataToObjectConverterInterface $converter
+     * @param DataMapperInterface|null           $originalMapper
+     */
+    public function __construct(FormDataToObjectConverterInterface $converter, DataMapperInterface $originalMapper = null)
+    {
+        $this->converter = $converter;
+        $this->originalMapper = $originalMapper;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function mapDataToForms($data, $forms)
+    {
+        // Fallback to original mapper instance or default to "PropertyPathMapper"
+        // mapper implementation if not an "ObjectToFormDataConverterInterface" instance:
+        if (!$this->converter instanceof ObjectToFormDataConverterInterface) {
+            $propertyPathMapper = $this->originalMapper ?: new PropertyPathMapper();
+            $propertyPathMapper->mapDataToForms($data, $forms);
+
+            return;
+        }
+
+        if (!is_object($data) && null !== $data) {
+            throw new UnexpectedTypeException($data, 'object or null');
+        }
+
+        $data = $this->converter->convertObjectToFormData($data);
+
+        if (!is_array($data)) {
+            throw new UnexpectedTypeException($data, 'array');
+        }
+
+        foreach ($forms as $form) {
+            $config = $form->getConfig();
+
+            if ($config->getMapped() && isset($data[$form->getName()])) {
+                $form->setData($data[$form->getName()]);
+
+                continue;
+            }
+
+            $form->setData($config->getData());
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function mapFormsToData($forms, &$data)
+    {
+        $fieldsData = array();
+        foreach ($forms as $form) {
+            $fieldsData[$form->getName()] = $form->getData();
+        }
+
+        $data = $this->converter->convertFormDataToObject($fieldsData, $data);
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/CallbackFormDataToObjectConverterTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/CallbackFormDataToObjectConverterTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Core\DataMapper;
+
+use Symfony\Component\Form\Extension\Core\DataMapper\CallbackFormDataToObjectConverter;
+
+class CallbackFormDataToObjectConverterTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConvertFormDataToObject()
+    {
+        $data = array('amount' => 15.0, 'currency' => 'EUR');
+        $originalData = (object) $data;
+
+        $converter = new CallbackFormDataToObjectConverter(function ($arg1, $arg2) use ($data, $originalData) {
+            $this->assertSame($data, $arg1);
+            $this->assertSame($originalData, $arg2);
+
+            return 'converted';
+        });
+
+        $this->assertSame('converted', $converter->convertFormDataToObject($data, $originalData));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/SimpleObjectMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/SimpleObjectMapperTest.php
@@ -1,0 +1,253 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Core\DataMapper;
+
+use Symfony\Component\Form\DataMapperInterface;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+use Symfony\Component\Form\Extension\Core\DataMapper\FormDataToObjectConverterInterface;
+use Symfony\Component\Form\Extension\Core\DataMapper\ObjectToFormDataConverterInterface;
+use Symfony\Component\Form\Extension\Core\DataMapper\SimpleObjectMapper;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\Forms;
+use Symfony\Component\Form\Tests\Fixtures\Money;
+use Symfony\Component\Form\Tests\Fixtures\MoneyTypeConverter;
+
+class SimpleObjectMapperTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var FormFactoryInterface
+     */
+    protected $factory;
+
+    protected function setUp()
+    {
+        $this->factory = Forms::createFormFactoryBuilder()->getFormFactory();
+    }
+
+    public function testMapDataToFormsUsesOriginalMapper()
+    {
+        $converter = $this->getMockBuilder(FormDataToObjectConverterInterface::class)->getMock();
+
+        $originalMapper = $this->getMockBuilder(DataMapperInterface::class)->getMock();
+        $originalMapper->expects($this->once())->method('mapDataToForms');
+
+        $simpleObjectMapper = new SimpleObjectMapper($converter, $originalMapper);
+        $simpleObjectMapper->mapDataToForms(new \stdClass(), array());
+    }
+
+    public function testMapDataToFormsUsesConverterOnObjectToFormDataConverterInterfaceInstance()
+    {
+        $converter = $this->getMockBuilder(ConverterStub::class)->getMock();
+        $converter->expects($this->once())->method('convertObjectToFormData')->willReturn(array());
+
+        $originalMapper = $this->getMockBuilder(DataMapperInterface::class)->getMock();
+        $originalMapper->expects($this->never())->method('mapDataToForms');
+
+        $simpleObjectMapper = new SimpleObjectMapper($converter, $originalMapper);
+        $simpleObjectMapper->mapDataToForms(new \stdClass(), array());
+    }
+
+    public function testItProperlyMapsObject()
+    {
+        $money = new Money(20.5, 'EUR');
+
+        $simpleObjectMapper = new SimpleObjectMapper(new FormDataToMoneyConverter($money));
+
+        /** @var FormInterface[] $forms */
+        $forms = array(
+            'amount' => $this->factory->createNamed('amount', NumberType::class),
+            'currency' => $this->factory->createNamed('currency'),
+        );
+
+        $simpleObjectMapper->mapDataToForms($money, $forms);
+
+        $this->assertSame(20.5, $forms['amount']->getData());
+        $this->assertSame('EUR', $forms['currency']->getData());
+
+        $newMoney = $money;
+        $forms['amount']->setData(15.0);
+        $forms['currency']->setData('USD');
+        $simpleObjectMapper->mapFormsToData($forms, $newMoney);
+
+        $this->assertNotSame($money, $newMoney);
+        $this->assertInstanceOf(Money::class, $newMoney);
+        $this->assertSame(15.0, $newMoney->getAmount());
+        $this->assertSame('USD', $newMoney->getCurrency());
+    }
+
+    public function testSettingSimpleObjectMapperOnForm()
+    {
+        $money = new Money(20.5, 'EUR');
+
+        $simpleObjectMapper = new SimpleObjectMapper(new FormDataToMoneyConverter($money));
+
+        $form = $this->factory->createBuilder(FormType::class, $money, array('data_class' => Money::class))
+            ->add('amount', NumberType::class)
+            ->add('currency')
+            ->setDataMapper($simpleObjectMapper)
+            ->getForm()
+        ;
+
+        $form->submit(array('amount' => 15.0, 'currency' => 'USD'));
+
+        $newMoney = $form->getData();
+
+        $this->assertNotSame($money, $newMoney);
+        $this->assertInstanceOf(Money::class, $newMoney);
+        $this->assertSame(15.0, $newMoney->getAmount());
+        $this->assertSame('USD', $newMoney->getCurrency());
+    }
+
+    public function testItProperlyMapsObjectWithObjectToFormDataConverter()
+    {
+        $media = new Book('foo');
+
+        $simpleObjectMapper = new SimpleObjectMapper(new MediaConverter());
+
+        /** @var FormInterface[] $forms */
+        $forms = array(
+            'author' => $this->factory->createNamed('author'),
+            'mediaType' => $this->factory->createNamed('mediaType'),
+        );
+
+        $simpleObjectMapper->mapDataToForms($media, $forms);
+
+        $this->assertSame('foo', $forms['author']->getData());
+        $this->assertSame('book', $forms['mediaType']->getData());
+
+        $newMedia = $media;
+        $forms['author']->setData('bar');
+        $forms['mediaType']->setData('movie');
+        $simpleObjectMapper->mapFormsToData($forms, $newMedia);
+
+        $this->assertNotSame($media, $newMedia);
+        $this->assertInstanceOf(Movie::class, $newMedia);
+        $this->assertSame('bar', $newMedia->getAuthor());
+    }
+
+    public function testSettingSimpleObjectOnFormWithObjectToFormDataConverter()
+    {
+        $media = new Book('foo');
+
+        $simpleObjectMapper = new SimpleObjectMapper(new MediaConverter());
+
+        $form = $this->factory->createBuilder(FormType::class, $media, array('data_class' => Media::class))
+            ->add('author')
+            ->add('mediaType')
+            ->setDataMapper($simpleObjectMapper)
+            ->getForm()
+        ;
+
+        $this->assertSame('foo', $form->get('author')->getData());
+        $this->assertSame('book', $form->get('mediaType')->getData());
+
+        $form->submit(array('author' => 'bar', 'mediaType' => 'movie'));
+
+        $newMedia = $form->getData();
+
+        $this->assertNotSame($media, $newMedia);
+        $this->assertInstanceOf(Movie::class, $newMedia);
+        $this->assertSame('bar', $newMedia->getAuthor());
+    }
+}
+
+class FormDataToMoneyConverter extends \PHPUnit_Framework_TestCase implements FormDataToObjectConverterInterface
+{
+    private $originalData;
+
+    public function __construct($originalData)
+    {
+        $this->originalData = $originalData;
+    }
+
+    public function convertFormDataToObject(array $data, $originalData)
+    {
+        $this->assertSame($this->originalData, $originalData);
+
+        $converter = new MoneyTypeConverter();
+
+        return $converter->convertFormDataToObject($data, $originalData);
+    }
+}
+
+interface ConverterStub extends FormDataToObjectConverterInterface, ObjectToFormDataConverterInterface
+{
+}
+
+class MediaConverter implements FormDataToObjectConverterInterface, ObjectToFormDataConverterInterface
+{
+    public function convertFormDataToObject(array $data, $originalData = null)
+    {
+        $author = $data['author'];
+
+        switch ($data['mediaType']) {
+            case 'movie':
+                return new Movie($author);
+            case 'book':
+                return new Book($author);
+            default:
+                throw new TransformationFailedException();
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param Media|null $object
+     */
+    public function convertObjectToFormData($object)
+    {
+        if (null === $object) {
+            return array();
+        }
+
+        $mediaTypeByClass = array(
+            Movie::class => 'movie',
+            Book::class => 'book',
+        );
+
+        if (!isset($mediaTypeByClass[get_class($object)])) {
+            throw new TransformationFailedException();
+        }
+
+        return array(
+            'mediaType' => $mediaTypeByClass[get_class($object)],
+            'author' => $object->getAuthor(),
+        );
+    }
+}
+
+abstract class Media
+{
+    private $author;
+
+    public function __construct($author)
+    {
+        $this->author = $author;
+    }
+
+    public function getAuthor()
+    {
+        return $this->author;
+    }
+}
+
+class Movie extends Media
+{
+}
+
+class Book extends Media
+{
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/Money.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Money.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+class Money
+{
+    /** @var float */
+    private $amount;
+
+    /** @var string */
+    private $currency;
+
+    public function __construct($amount, $currency)
+    {
+        $this->amount = $amount;
+        $this->currency = $currency;
+    }
+
+    public function getAmount()
+    {
+        return $this->amount;
+    }
+
+    public function getCurrency()
+    {
+        return $this->currency;
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/MoneyType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/MoneyType.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class MoneyType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('amount', NumberType::class)
+            ->add('currency')
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => Money::class,
+            'simple_object_mapper' => new MoneyTypeConverter(),
+        ));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/MoneyTypeConverter.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/MoneyTypeConverter.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+use Symfony\Component\Form\Extension\Core\DataMapper\FormDataToObjectConverterInterface;
+
+class MoneyTypeConverter implements FormDataToObjectConverterInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @param Money|null $originalData
+     */
+    public function convertFormDataToObject(array $data, $originalData)
+    {
+        // Logic to determine if the result should be considered null according to form fields data.
+        if (null === $data['amount'] && null === $data['currency']) {
+            return;
+        }
+
+        return new Money($data['amount'], $data['currency']);
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.4 |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

by adding a new `SimpleObjectMapper`data mapper and `simple_object_mapper` FormType option.

This new feature is based on the great @webmozart 's blog post about ["Value Objects in Symfony Forms"](https://webmozart.io/blog/2015/09/09/value-objects-in-symfony-forms/), but tries to expose a simpler API to ease value objects & immutable objects manipulations with Symfony forms.

<details>
 <summary>Show code</summary>

Considering the following value object:

``` php
class Money
{
    private $amount;
    private $currency;

    public function __construct($amount, $currency)
    {
        $this->amount = $amount;
        $this->currency = $currency;
    }

    public function getAmount() // ...
    public function getCurrency() // ...
}
```
#### Before

``` php
class MoneyType extends AbstractType implements DataMapperInterface 
{
    public function buildForm(FormBuilderInterface $builder, array $options)
    {
        $builder
            ->add('amount', NumberType::class)
            ->add('currency')
            ->setDataMapper($this)
        ;
    }

    public function configureOptions(OptionsResolver $resolver)
    {
        $resolver->setDefaults([
            'data_class' => Money::class,
            'empty_data' => null,
        ]);
    }

    public function mapDataToForms($data, $forms)
    {
        if (null === $data) {
            return;
        }

        $forms = iterator_to_array($forms);
        $forms['amount']->setData($data->getAmount());
        $forms['currency']->setData($data->getCurrency());
    }

    public function mapFormsToData($forms, &$data)
    {
        $forms = iterator_to_array($forms);

        // Logic to determine if the result should be considered null according to form fields data.
        if (null === $forms['amount']->getData() && null === $forms['currency']->getData()) {
            $data = null;

            return;
        }

        $data = new Money(
            $forms['amount']->getData(),
            $forms['currency']->getData()
        );
    }
}
```
#### After

``` php
class MoneyType extends AbstractType implements FormDataToObjectConverterInterface 
{
    public function buildForm(FormBuilderInterface $builder, array $options)
    {
        $builder
            ->add('amount', NumberType::class)
            ->add('currency')
        ;
    }

    public function configureOptions(OptionsResolver $resolver)
    {
        $resolver->setDefaults([
            'data_class' => Money::class,
            'simple_object_mapper' => $this,
        ]);
    }

    /**
     * {@inheritdoc}
     *
     * @param Money|null $originalData
     */
    public function convertFormDataToObject(array $data, $originalData)
    {
        // Logic to determine if the result should be considered null according to form fields data.
        if (null === $data['amount'] && null === $data['currency']) {
            return null;
        }

        return new Money($data['amount'], $data['currency']);
    }
}
```
#### After (with shortcut)

_with `simple_object_mapper` option as a callable_

``` php
class MoneyType extends AbstractType 
{
    public function buildForm(FormBuilderInterface $builder, array $options)
    {
        $builder
            ->add('amount', NumberType::class)
            ->add('currency')
        ;
    }

    public function configureOptions(OptionsResolver $resolver)
    {
        $resolver->setDefaults([
            'data_class' => Money::class,
            'simple_object_mapper' => function (array $data) {
                // Logic to determine if the result should be considered null according to form fields data.
                if (null === $data['amount'] && null === $data['currency']) {
                    return null;
                }

                return new Money($data['amount'], $data['currency']);
            },
        ]);
    }
}
```

<details>
<summary>Show basic API (without using the form option)</summary>


##### Setting the data mapper yourself:

``` php
class MoneyType extends AbstractType implements FormDataToObjectConverterInterface
{
    public function buildForm(FormBuilderInterface $builder, array $options)
    {
        $builder
            ->add('amount', NumberType::class)
            ->add('currency')
            ->setDataMapper(new SimpleObjectMapper($this, $builder->getDataMapper()))
        ;
    }

    public function configureOptions(OptionsResolver $resolver)
    {
        $resolver->setDefault('data_class', Money::class);
    }

    /**
     * {@inheritdoc}
     *
     * @param Money|null $originalData
     */
    public function convertFormDataToObject(array $data, $originalData)
    {
        // Logic to determine if the result should be considered null according to form fields data.
        if (null === $data['amount'] && null === $data['currency']) {
            return null;
        }

        return new Money($data['amount'], $data['currency']);
    }
}
```
##### Using the `CallbackFormDataToObjectConverter`:

``` php
class MoneyType extends AbstractType
{
    public function buildForm(FormBuilderInterface $builder, array $options)
    {
        $builder
            ->add('amount', NumberType::class)
            ->add('currency')
            ->setDataMapper(new SimpleObjectMapper(new CallbackFormDataToObjectConverter(function (array $data, Money $originalData ) {
                // Logic to determine if the result should be considered null according to form fields data.
                if (null === $data['amount'] && null === $data['currency']) {
                    return null;
                }

                return new Money($data['amount'], $data['currency']);
            }), $builder->getDataMapper()))
        ;
    }

    public function configureOptions(OptionsResolver $resolver)
    {
        $resolver->setDefault('data_class', Money::class);
    }
}
```

</details>

</details>

I make this suggestion in order to ease value objects & immutable objects manipulations in forms, considering the fact most of the time, we don't need to bother about implementing the `DataMapperInterface::mapDataToForms()` method. We can simply reuse the `PropertyPathMapper` implementation.

Then, only the `DataMapperInterface::mapFormsToData()` method is useful. But once again, we don't really need to deal with `Form` instances, only with form's data, in order to describe to our form type how to create a new value object instance.

For most advanced usages, an `ObjectToFormDataConverterInterface` interface can also be implemented, allowing to skip the original mapper (in most cases the `PropertyPathMapper`) implementation, to simply map the data to the form ourself, by converting to value object to an array of form data indexed by field name.

<details>
    <summary>Show `ObjectToFormDataConverterInterface` implementation sample</summary>

``` php
class MediaConverter implements FormDataToObjectConverterInterface, ObjectToFormDataConverterInterface 
{
    // ...

    /**
     * {@inheritdoc}
     *
     * @param Media|null $object
     */
    public function convertObjectToFormData($object)
    {
        if (null === $object) {
            return array();
        }

        $mediaTypeByClass = array(
            Movie::class => 'movie',
            Book::class => 'book',
        );

        if (!isset($mediaTypeByClass[get_class($object)])) {
            throw new TransformationFailedException();
        }

        return array(
            'mediaType' => $mediaTypeByClass[get_class($object)],
            'author' => $object->getAuthor(),
        );
    }
}
```
</details>

---

Now, given the following two facts:
1. There are only two hard things in Computer Science: cache invalidation and naming things.
2. This PR does not deal with cache invalidation at all.

I suck at naming things, and I'll gladly consider any better name for the followings:
- The 2 `FormDataToObjectConverterInterface` and `ObjectToFormDataConverterInterface` interfaces and methods.
- The `SimpleObjectMapper` data mapper name and `simple_object_mapper` option.

**Note:** I originally made this available as a `FormType` extension for one of our projects. But considering the DDD and clear DTOs, Model & Entity separation vibes, I think it makes sense to have this new mapper in the `Symfony\Form\Extension\Core` namespace.

---

As a solution until a decision is made here, the code is available in a dedicated repository: https://github.com/Elao/FormSimpleObjectMapper