### PR TITLE
[Form] Skip CSRF validation on form when POST max size is exceeded

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_csrf.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_csrf.xml
@@ -16,6 +16,7 @@
             <argument>%form.type_extension.csrf.field_name%</argument>
             <argument type="service" id="translator.default" />
             <argument>%validator.translation_domain%</argument>
+            <argument type="service" id="form.server_params" />
         </service>
     </services>
 </container>

--- a/src/Symfony/Component/Form/Extension/Csrf/EventListener/CsrfValidationListener.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/EventListener/CsrfValidationListener.php
@@ -101,8 +101,7 @@ class CsrfValidationListener implements EventSubscriberInterface
     public function preSubmit(FormEvent $event)
     {
         $form = $event->getForm();
-        $method = $form->getConfig()->getMethod();
-        $postRequestSizeExceeded = $method === 'POST' && $this->serverParams->hasPostMaxSizeBeenExceeded();
+        $postRequestSizeExceeded = $form->getConfig()->getMethod() === 'POST' && $this->serverParams->hasPostMaxSizeBeenExceeded();
 
         if ($form->isRoot() && $form->getConfig()->getOption('compound') && !$postRequestSizeExceeded) {
             $data = $event->getData();

--- a/src/Symfony/Component/Form/Extension/Csrf/EventListener/CsrfValidationListener.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/EventListener/CsrfValidationListener.php
@@ -101,8 +101,10 @@ class CsrfValidationListener implements EventSubscriberInterface
     public function preSubmit(FormEvent $event)
     {
         $form = $event->getForm();
+        $method = $form->getConfig()->getMethod();
+        $postRequestSizeExceeded = $method === 'POST' && $this->serverParams->hasPostMaxSizeBeenExceeded();
 
-        if ($form->isRoot() && $form->getConfig()->getOption('compound') && !$this->serverParams->hasPostMaxSizeBeenExceeded()) {
+        if ($form->isRoot() && $form->getConfig()->getOption('compound') && !$postRequestSizeExceeded) {
             $data = $event->getData();
 
             if (!isset($data[$this->fieldName]) || !$this->tokenManager->isTokenValid(new CsrfToken($this->tokenId, $data[$this->fieldName]))) {

--- a/src/Symfony/Component/Form/Extension/Csrf/EventListener/CsrfValidationListener.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/EventListener/CsrfValidationListener.php
@@ -18,6 +18,7 @@ use Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\Util\ServerParams;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -68,6 +69,11 @@ class CsrfValidationListener implements EventSubscriberInterface
      */
     private $translationDomain;
 
+    /**
+     * @var ServerParams
+     */
+    private $serverParams;
+
     public static function getSubscribedEvents()
     {
         return array(
@@ -75,7 +81,7 @@ class CsrfValidationListener implements EventSubscriberInterface
         );
     }
 
-    public function __construct($fieldName, $tokenManager, $tokenId, $errorMessage, TranslatorInterface $translator = null, $translationDomain = null)
+    public function __construct($fieldName, $tokenManager, $tokenId, $errorMessage, TranslatorInterface $translator = null, $translationDomain = null, ServerParams $serverParams = null)
     {
         if ($tokenManager instanceof CsrfProviderInterface) {
             $tokenManager = new CsrfProviderAdapter($tokenManager);
@@ -89,13 +95,14 @@ class CsrfValidationListener implements EventSubscriberInterface
         $this->errorMessage = $errorMessage;
         $this->translator = $translator;
         $this->translationDomain = $translationDomain;
+        $this->serverParams = $serverParams ?: new ServerParams();
     }
 
     public function preSubmit(FormEvent $event)
     {
         $form = $event->getForm();
 
-        if ($form->isRoot() && $form->getConfig()->getOption('compound')) {
+        if ($form->isRoot() && $form->getConfig()->getOption('compound') && !$this->serverParams->hasPostMaxSizeBeenExceeded()) {
             $data = $event->getData();
 
             if (!isset($data[$this->fieldName]) || !$this->tokenManager->isTokenValid(new CsrfToken($this->tokenId, $data[$this->fieldName]))) {

--- a/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
@@ -20,6 +20,7 @@ use Symfony\Component\Form\Extension\Csrf\EventListener\CsrfValidationListener;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\Util\ServerParams;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
@@ -55,7 +56,12 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
      */
     private $translationDomain;
 
-    public function __construct($defaultTokenManager, $defaultEnabled = true, $defaultFieldName = '_token', TranslatorInterface $translator = null, $translationDomain = null)
+    /**
+     * @var ServerParams
+     */
+    private $serverParams;
+
+    public function __construct($defaultTokenManager, $defaultEnabled = true, $defaultFieldName = '_token', TranslatorInterface $translator = null, $translationDomain = null, ServerParams $serverParams = null)
     {
         if ($defaultTokenManager instanceof CsrfProviderInterface) {
             $defaultTokenManager = new CsrfProviderAdapter($defaultTokenManager);
@@ -68,6 +74,7 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
         $this->defaultFieldName = $defaultFieldName;
         $this->translator = $translator;
         $this->translationDomain = $translationDomain;
+        $this->serverParams = $serverParams;
     }
 
     /**
@@ -89,7 +96,8 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
                 $options['csrf_token_id'] ?: ($builder->getName() ?: get_class($builder->getType()->getInnerType())),
                 $options['csrf_message'],
                 $this->translator,
-                $this->translationDomain
+                $this->translationDomain,
+                $this->serverParams
             ))
         ;
     }

--- a/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
+++ b/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
@@ -73,10 +73,7 @@ class HttpFoundationRequestHandler implements RequestHandlerInterface
             // Mark the form with an error if the uploaded size was too large
             // This is done here and not in FormValidator because $_POST is
             // empty when that error occurs. Hence the form is never submitted.
-            $contentLength = $this->serverParams->getContentLength();
-            $maxContentLength = $this->serverParams->getPostMaxSize();
-
-            if (!empty($maxContentLength) && $contentLength > $maxContentLength) {
+            if ($this->serverParams->hasPostMaxSizeBeenExceeded()) {
                 // Submit the form, but don't clear the default values
                 $form->submit(null, false);
 

--- a/src/Symfony/Component/Form/NativeRequestHandler.php
+++ b/src/Symfony/Component/Form/NativeRequestHandler.php
@@ -81,10 +81,7 @@ class NativeRequestHandler implements RequestHandlerInterface
             // Mark the form with an error if the uploaded size was too large
             // This is done here and not in FormValidator because $_POST is
             // empty when that error occurs. Hence the form is never submitted.
-            $contentLength = $this->serverParams->getContentLength();
-            $maxContentLength = $this->serverParams->getPostMaxSize();
-
-            if (!empty($maxContentLength) && $contentLength > $maxContentLength) {
+            if ($this->serverParams->hasPostMaxSizeBeenExceeded()) {
                 // Submit the form, but don't clear the default values
                 $form->submit(null, false);
 

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/EventListener/CsrfValidationListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/EventListener/CsrfValidationListenerTest.php
@@ -72,4 +72,25 @@ class CsrfValidationListenerTest extends \PHPUnit_Framework_TestCase
         // Validate accordingly
         $this->assertSame($data, $event->getData());
     }
+
+    public function testMaxPostSizeExceeded()
+    {
+        $serverParams = $this
+            ->getMockBuilder('\Symfony\Component\Form\Util\ServerParams')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $serverParams
+            ->expects($this->once())
+            ->method('hasPostMaxSizeBeenExceeded')
+            ->willReturn(true)
+        ;
+
+        $event = new FormEvent($this->form, ['csrf' => 'token']);
+        $validation = new CsrfValidationListener('csrf', $this->tokenManager, 'unknown', 'Error message', null, null, $serverParams);
+
+        $validation->preSubmit($event);
+        $this->assertEmpty($this->form->getErrors());
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/EventListener/CsrfValidationListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/EventListener/CsrfValidationListenerTest.php
@@ -88,7 +88,7 @@ class CsrfValidationListenerTest extends \PHPUnit_Framework_TestCase
             ->willReturn(true)
         ;
 
-        $event = new FormEvent($this->form, ['csrf' => 'token']);
+        $event = new FormEvent($this->form, array('csrf' => 'token'));
         $validation = new CsrfValidationListener('csrf', $this->tokenManager, 'unknown', 'Error message', null, null, $serverParams);
 
         $validation->preSubmit($event);

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/EventListener/CsrfValidationListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/EventListener/CsrfValidationListenerTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Csrf\EventListener;
 
+use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\Extension\Csrf\EventListener\CsrfValidationListener;

--- a/src/Symfony/Component/Form/Util/ServerParams.php
+++ b/src/Symfony/Component/Form/Util/ServerParams.php
@@ -26,6 +26,19 @@ class ServerParams
     }
 
     /**
+     * Returns true if the POST max size has been exceeded in the request
+     *
+     * @return bool
+     */
+    public function hasPostMaxSizeBeenExceeded()
+    {
+        $contentLength = $this->getContentLength();
+        $maxContentLength = $this->getPostMaxSize();
+
+        return !empty($maxContentLength) && $contentLength > $maxContentLength;
+    }
+
+    /**
      * Returns maximum post size in bytes.
      *
      * @return null|int The maximum post size in bytes

--- a/src/Symfony/Component/Form/Util/ServerParams.php
+++ b/src/Symfony/Component/Form/Util/ServerParams.php
@@ -26,7 +26,7 @@ class ServerParams
     }
 
     /**
-     * Returns true if the POST max size has been exceeded in the request
+     * Returns true if the POST max size has been exceeded in the request.
      *
      * @return bool
      */

--- a/src/Symfony/Component/Form/Util/ServerParams.php
+++ b/src/Symfony/Component/Form/Util/ServerParams.php
@@ -35,7 +35,7 @@ class ServerParams
         $contentLength = $this->getContentLength();
         $maxContentLength = $this->getPostMaxSize();
 
-        return !empty($maxContentLength) && $contentLength > $maxContentLength;
+        return $maxContentLength && $contentLength > $maxContentLength;
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #19140 |
| License | MIT |
| Doc PR | N/A |

In #19140 the CSRF validation listener was not aware that the POST max size had exceeded, and was adding a form error message that wasn't relevant to the actual error. 

This introduces the `ServerParams` utility class into the `CsrfValidationListener` and checks that the POST max size has not been exceeded. If it has then it won't bother trying to validate the CSRF token.

My main concern with this change is that it opens up an attack vector around tokens, but I've encapsulated the request size validation in a single method in `ServerParams` now so that the request handlers are using the same logic.
