### PR TITLE
[WIP] [Console] Add basic support for automatic console exception logging

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -66,6 +66,7 @@ class FrameworkExtension extends Extension
         $loader->load('web.xml');
         $loader->load('services.xml');
         $loader->load('fragment_renderer.xml');
+        $loader->load('console.xml');
 
         // A translator must always be registered (as support is included by
         // default in the Form component). If disabled, an identity translator

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="console.exception_listener" class="Symfony\Component\Console\EventListener\ExceptionListener">
+            <tag name="kernel.event_subscriber" />
+            <argument type="service" id="logger" on-invalid="null" />
+        </service>
+    </services>
+</container>

--- a/src/Symfony/Component/Console/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/Console/EventListener/ExceptionListener.php
@@ -68,9 +68,7 @@ class ExceptionListener implements EventSubscriberInterface
             $exitCode
         );
 
-        $this->logger->error(
-            $message
-        );
+        $this->logger->error($message);
     }
 
     public static function getSubscribedEvents()

--- a/src/Symfony/Component/Console/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/Console/EventListener/ExceptionListener.php
@@ -64,7 +64,7 @@ class ExceptionListener implements EventSubscriberInterface
 
         $message = sprintf(
             'Command `%s` exited with status code %d',
-            join(' ', $_SERVER['argv']),
+            implode(' ', $_SERVER['argv']),
             $exitCode
         );
 

--- a/src/Symfony/Component/Console/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/Console/EventListener/ExceptionListener.php
@@ -75,9 +75,9 @@ class ExceptionListener implements EventSubscriberInterface
             return;
         }
 
-        $input = new ArgvInput(null, $event->getCommand()->getDefinition());
+        $input = (string) $event->getInput();
 
-        $this->logger->error('Command {command} exited with status code {code}', array('command' => (string) $input, 'code' => $exitCode));
+        $this->logger->error('Command "{command}" exited with status code "{code}"', array('command' => (string) $input, 'code' => $exitCode));
     }
 
     public static function getSubscribedEvents()

--- a/src/Symfony/Component/Console/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/Console/EventListener/ExceptionListener.php
@@ -1,12 +1,20 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Console\EventListener;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleExceptionEvent;
 use Symfony\Component\Console\Event\ConsoleTerminateEvent;
-use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -45,8 +53,9 @@ class ExceptionListener implements EventSubscriberInterface
         }
 
         $exception = $event->getException();
+        $input = (string) $event->getInput();
 
-        $this->logger->error($exception->getMessage(), array('exception' => $exception));
+        $this->logger->error('Exception thrown while running command: "{command}". Message: "{message}"', array('exception' => $exception, 'command' => $input, 'message' => $exception->getMessage()));
     }
 
     /**

--- a/src/Symfony/Component/Console/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/Console/EventListener/ExceptionListener.php
@@ -62,9 +62,15 @@ class ExceptionListener implements EventSubscriberInterface
             return;
         }
 
-        $message = sprintf('Command `%s` exited with status code %d');
+        $message = sprintf(
+            'Command `%s` exited with status code %d',
+            join(' ', $_SERVER['argv']),
+            $exitCode
+        );
 
-        $this->logger->warning($message);
+        $this->logger->error(
+            $message
+        );
     }
 
     public static function getSubscribedEvents()

--- a/src/Symfony/Component/Console/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/Console/EventListener/ExceptionListener.php
@@ -42,16 +42,7 @@ class ExceptionListener implements EventSubscriberInterface
 
         $exception = $event->getException();
 
-        $message = sprintf(
-            '%s: %s (uncaught exception) at %s line %s while running console command `%s`',
-            get_class($exception),
-            $exception->getMessage(),
-            $exception->getFile(),
-            $exception->getLine(),
-            $event->getCommand()->getName()
-        );
-
-        $this->logger->error($message, array('exception' => $exception));
+        $this->logger->error($exception->getMessage(), array('exception' => $exception));
     }
 
     /**

--- a/src/Symfony/Component/Console/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/Console/EventListener/ExceptionListener.php
@@ -62,11 +62,8 @@ class ExceptionListener implements EventSubscriberInterface
             return;
         }
 
-        $message = sprintf(
-            'Command `%s` exited with status code %d',
-            implode(' ', $_SERVER['argv']),
-            $exitCode
-        );
+        // TODO: replace $_SERVER global usage with data from Input
+        $message = sprintf('Command `%s` exited with status code %d', implode(' ', $_SERVER['argv']), $exitCode);
 
         $this->logger->error($message);
     }

--- a/src/Symfony/Component/Console/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/Console/EventListener/ExceptionListener.php
@@ -6,6 +6,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleExceptionEvent;
 use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -62,7 +63,9 @@ class ExceptionListener implements EventSubscriberInterface
             return;
         }
 
-        $this->logger->error('Command `{command}` exited with status code {code}', array('command' => implode(' ', $_SERVER['argv']), 'code' => $exitCode));
+        $input = new ArgvInput(null, $event->getCommand()->getDefinition());
+
+        $this->logger->error('Command `{command}` exited with status code {code}', array('command' => (string) $input, 'code' => $exitCode));
     }
 
     public static function getSubscribedEvents()

--- a/src/Symfony/Component/Console/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/Console/EventListener/ExceptionListener.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Symfony\Component\Console\EventListener;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleExceptionEvent;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Console exception listener.
+ *
+ * Attempts to log exceptions or abnormal terminations of console commands.
+ *
+ * @package Symfony\Component\Console\EventListener;
+ * @author  James Halsall <james.t.halsall@googlemail.com>
+ */
+class ExceptionListener implements EventSubscriberInterface
+{
+    protected $logger;
+
+    /**
+     * Constructor.
+     *
+     * @param LoggerInterface $logger A logger
+     */
+    public function __construct(LoggerInterface $logger = null)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * Handles console command exception.
+     *
+     * @param ConsoleExceptionEvent $event Console event
+     */
+    public function onKernelException(ConsoleExceptionEvent $event)
+    {
+        if (null === $this->logger) {
+            return;
+        }
+
+        $exception = $event->getException();
+
+        $message = sprintf(
+            '%s: %s (uncaught exception) at %s line %s while running console command `%s`',
+            get_class($exception),
+            $exception->getMessage(),
+            $exception->getFile(),
+            $exception->getLine(),
+            $event->getCommand()->getName()
+        );
+
+        $this->logger->error($message, array('exception' => $exception));
+    }
+
+    /**
+     * Handles termination of console command.
+     *
+     * @param ConsoleTerminateEvent $event Console event
+     */
+    public function onKernelTerminate(ConsoleTerminateEvent $event)
+    {
+        if (null === $this->logger) {
+            return;
+        }
+
+        $exitCode = $event->getExitCode();
+
+        if ($exitCode === 0) {
+            return;
+        }
+
+        if ($exitCode > 255) {
+            $event->setExitCode(255);
+        }
+
+        $message = sprintf('Command `%s` exited with status code %d');
+
+        $this->logger->warning($message);
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            ConsoleEvents::EXCEPTION => array('onKernelException', -128),
+            ConsoleEvents::TERMINATE => array('onKernelTerminate', -128)
+        );
+    }
+}

--- a/src/Symfony/Component/Console/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/Console/EventListener/ExceptionListener.php
@@ -13,7 +13,6 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  *
  * Attempts to log exceptions or abnormal terminations of console commands.
  *
- * @package Symfony\Component\Console\EventListener;
  * @author  James Halsall <james.t.halsall@googlemail.com>
  */
 class ExceptionListener implements EventSubscriberInterface
@@ -85,7 +84,7 @@ class ExceptionListener implements EventSubscriberInterface
     {
         return array(
             ConsoleEvents::EXCEPTION => array('onKernelException', -128),
-            ConsoleEvents::TERMINATE => array('onKernelTerminate', -128)
+            ConsoleEvents::TERMINATE => array('onKernelTerminate', -128),
         );
     }
 }

--- a/src/Symfony/Component/Console/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/Console/EventListener/ExceptionListener.php
@@ -62,10 +62,7 @@ class ExceptionListener implements EventSubscriberInterface
             return;
         }
 
-        // TODO: replace $_SERVER global usage with data from Input
-        $message = sprintf('Command `%s` exited with status code %d', implode(' ', $_SERVER['argv']), $exitCode);
-
-        $this->logger->error($message);
+        $this->logger->error('Command `{command}` exited with status code {code}', array('command' => implode(' ', $_SERVER['argv']), 'code' => $exitCode));
     }
 
     public static function getSubscribedEvents()

--- a/src/Symfony/Component/Console/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/Console/EventListener/ExceptionListener.php
@@ -18,6 +18,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class ExceptionListener implements EventSubscriberInterface
 {
+    /**
+     * @var LoggerInterface
+     */
     protected $logger;
 
     /**
@@ -65,7 +68,7 @@ class ExceptionListener implements EventSubscriberInterface
 
         $input = new ArgvInput(null, $event->getCommand()->getDefinition());
 
-        $this->logger->error('Command `{command}` exited with status code {code}', array('command' => (string) $input, 'code' => $exitCode));
+        $this->logger->error('Command {command} exited with status code {code}', array('command' => (string) $input, 'code' => $exitCode));
     }
 
     public static function getSubscribedEvents()

--- a/src/Symfony/Component/Console/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/Console/EventListener/ExceptionListener.php
@@ -13,7 +13,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  *
  * Attempts to log exceptions or abnormal terminations of console commands.
  *
- * @author  James Halsall <james.t.halsall@googlemail.com>
+ * @author James Halsall <james.t.halsall@googlemail.com>
  */
 class ExceptionListener implements EventSubscriberInterface
 {
@@ -60,10 +60,6 @@ class ExceptionListener implements EventSubscriberInterface
 
         if ($exitCode === 0) {
             return;
-        }
-
-        if ($exitCode > 255) {
-            $event->setExitCode(255);
         }
 
         $message = sprintf('Command `%s` exited with status code %d');

--- a/src/Symfony/Component/Console/Tests/EventListener/ExceptionListenerTest.php
+++ b/src/Symfony/Component/Console/Tests/EventListener/ExceptionListenerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Symfony\Component\Console\Tests\EventListener;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Event\ConsoleExceptionEvent;
+use Symfony\Component\Console\EventListener\ExceptionListener;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Tests\Output\TestOutput;
+
+class ExceptionListenerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testOnKernelException()
+    {
+        $logger = $this->getLogger();
+        $listener = new ExceptionListener($logger);
+
+        $exception = new \RuntimeException('An error occurred');
+
+        $logger
+            ->expects($this->once())
+            ->method('error')
+            ->with('An error occurred', array('exception' => $exception))
+        ;
+
+        $listener->onKernelException($this->getConsoleExceptionEvent($exception, 0));
+    }
+
+    public function testOnKernelTerminate()
+    {
+        $this->markTestIncomplete();
+    }
+
+    private function getLogger()
+    {
+        return $this->getMockForAbstractClass(LoggerInterface::class);
+    }
+
+    private function getConsoleExceptionEvent(\Exception $exception, $exitCode)
+    {
+        return new ConsoleExceptionEvent(new Command('test'), new ArrayInput([]), new TestOutput(), $exception, $exitCode);
+    }
+}

--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -23,8 +23,7 @@
         "symfony/event-dispatcher": "~2.8|~3.0",
         "symfony/filesystem": "~2.8|~3.0",
         "symfony/process": "~2.8|~3.0",
-        "psr/log": "~1.0",
-        "phpunit/phpunit": "~4.0"
+        "psr/log": "~1.0"
     },
     "suggest": {
         "symfony/event-dispatcher": "",

--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -23,7 +23,8 @@
         "symfony/event-dispatcher": "~2.8|~3.0",
         "symfony/filesystem": "~2.8|~3.0",
         "symfony/process": "~2.8|~3.0",
-        "psr/log": "~1.0"
+        "psr/log": "~1.0",
+        "phpunit/phpunit": "~4.0"
     },
     "suggest": {
         "symfony/event-dispatcher": "",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes (still to write tests for new feature) |
| Fixed tickets | #10895 |
| License | MIT |
| Doc PR | (TO DO) |

This is a quick initial concept for automatic exception logging, it currently takes the 2 listeners outlined in the docs (http://symfony.com/doc/current/cookbook/console/logging.html) and brings them into the standard edition.

I'd like to get some feedback before writing tests and updating the docs in a separate PR.

TODO:
- [x] Confirm messaging
- [x] Write tests
- [ ] Update docs in separate PR
- [ ] Prevent console errors from writing to stderr
