### PR TITLE
[HttpFoundation] Added configurable permissions on File::move()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -82,14 +82,15 @@ class File extends \SplFileInfo
     /**
      * Moves the file to a new location.
      *
-     * @param string $directory The destination folder
-     * @param string $name      The new file name
+     * @param string  $directory   The destination folder
+     * @param string  $name        The new file name
+     * @param integer $permissions The desired file permissions
      *
      * @return File A File object representing the new file
      *
      * @throws FileException if the target file could not be created
      */
-    public function move($directory, $name = null)
+    public function move($directory, $name = null, $permissions = 0666)
     {
         $target = $this->getTargetFile($directory, $name);
 
@@ -98,7 +99,7 @@ class File extends \SplFileInfo
             throw new FileException(sprintf('Could not move the file "%s" to "%s" (%s)', $this->getPathname(), $target, strip_tags($error['message'])));
         }
 
-        @chmod($target, 0666 & ~umask());
+        @chmod($target, $permissions & ~umask());
 
         return $target;
     }

--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -82,9 +82,9 @@ class File extends \SplFileInfo
     /**
      * Moves the file to a new location.
      *
-     * @param string  $directory   The destination folder
-     * @param string  $name        The new file name
-     * @param integer $permissions The desired file permissions
+     * @param string $directory   The destination folder
+     * @param string $name        The new file name
+     * @param int    $permissions The desired file permissions
      *
      * @return File A File object representing the new file
      *

--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -206,9 +206,9 @@ class UploadedFile extends File
     /**
      * Moves the file to a new location.
      *
-     * @param string  $directory   The destination folder
-     * @param string  $name        The new file name
-     * @param integer $permissions The desired file permissions
+     * @param string $directory   The destination folder
+     * @param string $name        The new file name
+     * @param int    $permissions The desired file permissions
      *
      * @return File A File object representing the new file
      *

--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -206,14 +206,15 @@ class UploadedFile extends File
     /**
      * Moves the file to a new location.
      *
-     * @param string $directory The destination folder
-     * @param string $name      The new file name
+     * @param string  $directory   The destination folder
+     * @param string  $name        The new file name
+     * @param integer $permissions The desired file permissions
      *
      * @return File A File object representing the new file
      *
      * @throws FileException if, for any reason, the file could not have been moved
      */
-    public function move($directory, $name = null)
+    public function move($directory, $name = null, $permissions = 0666)
     {
         if ($this->isValid()) {
             if ($this->test) {
@@ -227,7 +228,7 @@ class UploadedFile extends File
                 throw new FileException(sprintf('Could not move the file "%s" to "%s" (%s)', $this->getPathname(), $target, strip_tags($error['message'])));
             }
 
-            @chmod($target, 0666 & ~umask());
+            @chmod($target, $permissions & ~umask());
 
             return $target;
         }

--- a/src/Symfony/Component/HttpFoundation/Tests/File/FileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/FileTest.php
@@ -109,6 +109,10 @@ class FileTest extends \PHPUnit_Framework_TestCase
 
     public function testMoveWithPermissions()
     {
+        if ('\\' === DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('Can not verify chmod operations on Windows');
+        }
+
         $path = __DIR__.'/Fixtures/test.copy.gif';
         $targetDir = __DIR__.'/Fixtures/directory';
         $targetPath = $targetDir.'/test.copy.gif';

--- a/src/Symfony/Component/HttpFoundation/Tests/File/FileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/FileTest.php
@@ -124,8 +124,8 @@ class FileTest extends \PHPUnit_Framework_TestCase
         $this->assertFileNotExists($path);
         $this->assertEquals(realpath($targetPath), $movedFile->getRealPath());
         $this->assertEquals(
-            substr(sprintf('%o', 0660 & ~umask()), -4),
-            substr(sprintf('%o', fileperms($targetPath)), -4)
+            substr(sprintf('%o', 0660 & ~umask()), -3),
+            substr(sprintf('%o', fileperms($targetPath)), -3)
         );
 
         @unlink($targetPath);

--- a/src/Symfony/Component/HttpFoundation/Tests/File/FileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/FileTest.php
@@ -107,6 +107,30 @@ class FileTest extends \PHPUnit_Framework_TestCase
         @unlink($targetPath);
     }
 
+    public function testMoveWithPermissions()
+    {
+        $path = __DIR__.'/Fixtures/test.copy.gif';
+        $targetDir = __DIR__.'/Fixtures/directory';
+        $targetPath = $targetDir.'/test.copy.gif';
+        @unlink($path);
+        @unlink($targetPath);
+        copy(__DIR__.'/Fixtures/test.gif', $path);
+
+        $file = new File($path);
+        $movedFile = $file->move($targetDir, null, 0660);
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\File\File', $movedFile);
+
+        $this->assertFileExists($targetPath);
+        $this->assertFileNotExists($path);
+        $this->assertEquals(realpath($targetPath), $movedFile->getRealPath());
+        $this->assertEquals(
+            substr(sprintf('%o', 0660 & ~umask()), -4),
+            substr(sprintf('%o', fileperms($targetPath)), -4)
+        );
+
+        @unlink($targetPath);
+    }
+
     public function getFilenameFixtures()
     {
         return array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #19347 |
| License | MIT |
| Doc PR | n/a |

Added the possibility to explicitly specify the file permissions on file move in the HttpFoundation & the tests for it as demanded in #19347.
