### PR TITLE
[Validator][GroupSequence] fixed GroupSequence validation ignores PropetyMetadata of parent classes

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -350,6 +350,7 @@ class ClassMetadata extends ElementMetadata implements ClassMetadataInterface
                 $member = clone $member;
 
                 foreach ($member->getConstraints() as $constraint) {
+                    $member->constraintsByGroup[$this->getDefaultGroup()][] = $constraint;
                     $constraint->addImplicitGroupName($this->getDefaultGroup());
                 }
 

--- a/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
@@ -138,16 +138,33 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
         $this->metadata->mergeConstraints($parent);
         $this->metadata->addPropertyConstraint('firstName', new ConstraintA());
 
+        $constraintA1 = new ConstraintA(array('groups' => array(
+            'Default',
+            'EntityParent',
+            'Entity',
+        )));
+        $constraintA2 = new ConstraintA(array('groups' => array(
+            'Default',
+            'Entity',
+        )));
+
         $constraints = array(
-            new ConstraintA(array('groups' => array(
-                'Default',
-                'EntityParent',
-                'Entity',
-            ))),
-            new ConstraintA(array('groups' => array(
-                'Default',
-                'Entity',
-            ))),
+            $constraintA1,
+            $constraintA2,
+        );
+
+        $constraintsByGroup = array(
+            'Default' => array(
+                $constraintA1,
+                $constraintA2,
+            ),
+            'EntityParent' => array(
+                $constraintA1,
+            ),
+            'Entity' => array(
+                $constraintA1,
+                $constraintA2,
+            ),
         );
 
         $members = $this->metadata->getPropertyMetadata('firstName');
@@ -155,6 +172,7 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $members);
         $this->assertEquals(self::PARENTCLASS, $members[0]->getClassName());
         $this->assertEquals($constraints, $members[0]->getConstraints());
+        $this->assertEquals($constraintsByGroup, $members[0]->constraintsByGroup);
     }
 
     public function testMemberMetadatas()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #19387 |
| License | MIT |
| Doc PR | N/A |
