### PR TITLE
[BrowserKit] Added test for followRedirect method (POST method)

### DIFF
--- a/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
@@ -490,6 +490,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('myfile.foo', $client->getRequest()->getFiles(), '->followRedirect() keeps files with POST method');
         $this->assertArrayHasKey('X_TEST_FOO', $client->getRequest()->getServer(), '->followRedirect() keeps $_SERVER with POST method');
         $this->assertEquals($content, $client->getRequest()->getContent(), '->followRedirect() keeps content with POST method');
+        $this->assertEquals('POST', $client->getRequest()->getMethod(), '->followRedirect() keeps request method');
     }
 
     public function testBack()

--- a/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
@@ -473,6 +473,25 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($headers, $client->getRequest()->getServer());
     }
 
+    public function testFollowRedirectWithPostMethod()
+    {
+        $parameters = array('foo' => 'bar');
+        $files = array('myfile.foo' => 'baz');
+        $server = array('X_TEST_FOO' => 'bazbar');
+        $content = 'foobarbaz';
+
+        $client = new TestClient();
+
+        $client->setNextResponse(new Response('', 307, array('Location' => 'http://www.example.com/redirected')));
+        $client->request('POST', 'http://www.example.com/foo/foobar', $parameters, $files, $server, $content);
+
+        $this->assertEquals('http://www.example.com/redirected', $client->getRequest()->getUri(), '->followRedirect() follows a redirect with POST method');
+        $this->assertArrayHasKey('foo', $client->getRequest()->getParameters(), '->followRedirect() keeps parameters with POST method');
+        $this->assertArrayHasKey('myfile.foo', $client->getRequest()->getFiles(), '->followRedirect() keeps files with POST method');
+        $this->assertArrayHasKey('X_TEST_FOO', $client->getRequest()->getServer(), '->followRedirect() keeps $_SERVER with POST method');
+        $this->assertEquals($content, $client->getRequest()->getContent(), '->followRedirect() keeps content with POST method');
+    }
+
     public function testBack()
     {
         $client = new TestClient();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

Test covers 'else' branches in these conditions:

``` php
if (in_array($this->internalResponse->getStatus(), array(302, 303))) {
    $method = 'get';
    $files = array();
    $content = null;
} else {
    $method = $request->getMethod();
    $files = $request->getFiles();
    $content = $request->getContent();
}

if ('get' === strtolower($method)) {
    // Don't forward parameters for GET request as it should reach the redirection URI
    $parameters = array();
} else {
    $parameters = $request->getParameters();
}
```
