### PR TITLE
Simplify AccessDecisionManager logic

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
@@ -80,7 +80,6 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
      */
     private function decideAffirmative(TokenInterface $token, array $attributes, $object = null)
     {
-        $deny = 0;
         foreach ($this->voters as $voter) {
             $result = $voter->vote($token, $object, $attributes);
             switch ($result) {
@@ -88,17 +87,11 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
                     return true;
 
                 case VoterInterface::ACCESS_DENIED:
-                    ++$deny;
-
-                    break;
+                    return false;
 
                 default:
                     break;
             }
-        }
-
-        if ($deny > 0) {
-            return false;
         }
 
         return $this->allowIfAllAbstainDecisions;
@@ -161,16 +154,13 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
      */
     private function decideUnanimous(TokenInterface $token, array $attributes, $object = null)
     {
-        $grant = 0;
         foreach ($attributes as $attribute) {
             foreach ($this->voters as $voter) {
                 $result = $voter->vote($token, $object, array($attribute));
 
                 switch ($result) {
                     case VoterInterface::ACCESS_GRANTED:
-                        ++$grant;
-
-                        break;
+                        return true;
 
                     case VoterInterface::ACCESS_DENIED:
                         return false;
@@ -179,11 +169,6 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
                         break;
                 }
             }
-        }
-
-        // no deny votes
-        if ($grant > 0) {
-            return true;
         }
 
         return $this->allowIfAllAbstainDecisions;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no, but same number of failed tests |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The reason: we don't need to count `$deny`/`$grant` in these cases. It's confusing.
