### PR TITLE
[Security] Inject the current request instance into the getLoginUrl() method.

### DIFF
--- a/src/Symfony/Component/Security/Guard/Authenticator/AbstractFormLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Guard/Authenticator/AbstractFormLoginAuthenticator.php
@@ -32,9 +32,11 @@ abstract class AbstractFormLoginAuthenticator extends AbstractGuardAuthenticator
     /**
      * Return the URL to the login page.
      *
+     * @param Request $request
+     *
      * @return string
      */
-    abstract protected function getLoginUrl();
+    abstract protected function getLoginUrl(Request $request);
 
     /**
      * Override to change what happens after a bad username/password is submitted.
@@ -50,7 +52,7 @@ abstract class AbstractFormLoginAuthenticator extends AbstractGuardAuthenticator
             $request->getSession()->set(Security::AUTHENTICATION_ERROR, $exception);
         }
 
-        $url = $this->getLoginUrl();
+        $url = $this->getLoginUrl($request);
 
         return new RedirectResponse($url);
     }
@@ -103,7 +105,7 @@ abstract class AbstractFormLoginAuthenticator extends AbstractGuardAuthenticator
      */
     public function start(Request $request, AuthenticationException $authException = null)
     {
-        $url = $this->getLoginUrl();
+        $url = $this->getLoginUrl($request);
 
         return new RedirectResponse($url);
     }

--- a/src/Symfony/Component/Security/Guard/Tests/Authenticator/FormLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/Authenticator/FormLoginAuthenticatorTest.php
@@ -182,7 +182,7 @@ class TestFormLoginAuthenticator extends AbstractFormLoginAuthenticator
     /**
      * {@inheritdoc}
      */
-    protected function getLoginUrl()
+    protected function getLoginUrl(Request $request)
     {
         return $this->loginUrl;
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Hi there,

I've injected the current request instance into the getLoginUrl() method, so you can generate an url based on the request scope. My specific use case was that I tried to generate an url with the `security.http_utils` service (which needs the request instance) so I can generate an url with either a path or a route.

Cheers!
Robin
