### PR TITLE
[DoctrineBridge] Add a DoctrineTestCase class that rollbacks after each test

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Test/DoctrineTestCase.php
+++ b/src/Symfony/Bridge/Doctrine/Test/DoctrineTestCase.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Test;
+
+use Doctrine\ORM\EntityManager;
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\WebTestCase;
+
+/**
+ * @author Thomas Royer <thomas.royer.12@gmail.com>
+ */
+class DoctrineTestCase extends WebTestCase
+{
+    /**
+     * @var EntityManager
+     */
+    private $entityManager;
+
+    public function setEntityManager(EntityManager $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->entityManager->beginTransaction();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        $this->entityManager->rollback();
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Test/DoctrineTestCaseTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Test/DoctrineTestCaseTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Test;
+
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bridge\Doctrine\Test\DoctrineTestCase;
+use Symfony\Bridge\Doctrine\Test\DoctrineTestHelper;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\User;
+
+class DoctrineTestCaseTest extends DoctrineTestCase
+{
+    private static $em;
+
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+
+        self::$em = DoctrineTestHelper::createTestEntityManager();
+        self::createSchema();
+    }
+
+    public function setUp()
+    {
+        $this->setEntityManager(self::$em);
+
+        parent::setUp();
+    }
+
+    public function testItInsertsData()
+    {
+        $user = new User(1, 1, 'user');
+
+        self::$em->persist($user);
+        self::$em->flush();
+
+        $this->assertEquals(1, count(self::$em->getRepository(User::class)->findAll()));
+    }
+
+    public function testItHasRollbacked()
+    {
+        $user = new User(1, 2, 'user');
+
+        self::$em->persist($user);
+        self::$em->flush();
+
+        $this->assertEquals(1, count(self::$em->getRepository(User::class)->findAll()));
+    }
+
+    private static function createSchema()
+    {
+        $schemaTool = new SchemaTool(self::$em);
+        $schemaTool->createSchema(array(
+            self::$em->getClassMetadata('Symfony\Bridge\Doctrine\Tests\Fixtures\User'),
+        ));
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | no |
| License | MIT |
| Doc PR | not for now |

Usually, with Symfony, people use fixtures that are loaded at the beginning of the test suite. This can sometimes lead to problems after a lot of modifications have been made to the database during the test suite.

Laravel uses a trait that rollbacks after each test to tackle this problem. This is an attempt to add this to Symfony.

In order to use this, people can create a Kernel in their setUp method and set the created entity manager on the class. I'm pretty sure there should be a better way to do that but I'm still a beginner in contributing to Symfony.

What do you think?
