### PR TITLE
Fixed bugs in names of classes and methods.

### DIFF
--- a/src/Symfony/Bridge/Doctrine/HttpFoundation/DbalSessionHandlerSchema.php
+++ b/src/Symfony/Bridge/Doctrine/HttpFoundation/DbalSessionHandlerSchema.php
@@ -38,8 +38,8 @@ final class DbalSessionHandlerSchema extends Schema
     {
         $table = $this->createTable($tableName);
         $table->addColumn('sess_id', 'string');
-        $table->addColumn('sess_data', 'text')->setNotnull(true);
-        $table->addColumn('sess_time', 'integer')->setNotnull(true)->setUnsigned(true);
+        $table->addColumn('sess_data', 'text')->setNotNull(true);
+        $table->addColumn('sess_time', 'integer')->setNotNull(true)->setUnsigned(true);
         $table->setPrimaryKey(array('sess_id'));
     }
 }

--- a/src/Symfony/Bridge/Doctrine/HttpFoundation/DbalSessionHandlerSchema.php
+++ b/src/Symfony/Bridge/Doctrine/HttpFoundation/DbalSessionHandlerSchema.php
@@ -38,8 +38,8 @@ final class DbalSessionHandlerSchema extends Schema
     {
         $table = $this->createTable($tableName);
         $table->addColumn('sess_id', 'string');
-        $table->addColumn('sess_data', 'text')->setNotNull(true);
-        $table->addColumn('sess_time', 'integer')->setNotNull(true)->setUnsigned(true);
+        $table->addColumn('sess_data', 'text')->setNotnull(true);
+        $table->addColumn('sess_time', 'integer')->setNotnull(true)->setUnsigned(true);
         $table->setPrimaryKey(array('sess_id'));
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -823,10 +823,10 @@ class FrameworkExtension extends Extension
 
             if (is_dir($dir = $dirname.'/Resources/config/validation')) {
                 foreach (Finder::create()->files()->in($dir)->name('*.xml') as $file) {
-                    $files[0][] = $file->getRealpath();
+                    $files[0][] = $file->getRealPath();
                 }
                 foreach (Finder::create()->files()->in($dir)->name('*.yml') as $file) {
-                    $files[1][] = $file->getRealpath();
+                    $files[1][] = $file->getRealPath();
                 }
 
                 $container->addResource(new DirectoryResource($dir));
@@ -944,13 +944,13 @@ class FrameworkExtension extends Extension
 
             if (is_dir($dir = $dirname.'/Resources/config/serialization')) {
                 foreach (Finder::create()->files()->in($dir)->name('*.xml') as $file) {
-                    $definition = new Definition('Symfony\Component\Serializer\Mapping\Loader\XmlFileLoader', array($file->getRealpath()));
+                    $definition = new Definition('Symfony\Component\Serializer\Mapping\Loader\XmlFileLoader', array($file->getRealPath()));
                     $definition->setPublic(false);
 
                     $serializerLoaders[] = $definition;
                 }
                 foreach (Finder::create()->files()->in($dir)->name('*.yml') as $file) {
-                    $definition = new Definition('Symfony\Component\Serializer\Mapping\Loader\YamlFileLoader', array($file->getRealpath()));
+                    $definition = new Definition('Symfony\Component\Serializer\Mapping\Loader\YamlFileLoader', array($file->getRealPath()));
                     $definition->setPublic(false);
 
                     $serializerLoaders[] = $definition;

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/TranslationLoader.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/TranslationLoader.php
@@ -58,7 +58,7 @@ class TranslationLoader
             $extension = $catalogue->getLocale().'.'.$format;
             $files = $finder->files()->name('*.'.$extension)->in($directory);
             foreach ($files as $file) {
-                $domain = substr($file->getFileName(), 0, -1 * strlen($extension) - 1);
+                $domain = substr($file->getFilename(), 0, -1 * strlen($extension) - 1);
                 $catalogue->addCatalogue($loader->load($file->getPathname(), $catalogue->getLocale(), $domain));
             }
         }

--- a/src/Symfony/Component/Config/Util/XmlUtils.php
+++ b/src/Symfony/Component/Config/Util/XmlUtils.php
@@ -123,7 +123,7 @@ class XmlUtils
      *
      * @return array A PHP array
      */
-    public static function convertDomElementToArray(\DomElement $element, $checkPrefix = true)
+    public static function convertDomElementToArray(\DOMElement $element, $checkPrefix = true)
     {
         $prefix = (string) $element->prefix;
         $empty = true;

--- a/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
@@ -66,7 +66,7 @@ class SymfonyQuestionHelper extends QuestionHelper
 
                 break;
 
-            case $question instanceof ChoiceQuestion && $question->isMultiSelect():
+            case $question instanceof ChoiceQuestion && $question->isMultiselect():
                 $choices = $question->getChoices();
                 $default = explode(',', $default);
 

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -423,7 +423,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $application->add(new \FooCommand());
         $application->add(new \Foo1Command());
         $application->add(new \Foo2Command());
-        $application->add(new \foo3Command());
+        $application->add(new \Foo3Command());
 
         try {
             $application->find('Unknown-namespace:Unknown-command');

--- a/src/Symfony/Component/Debug/Tests/MockExceptionHandler.php
+++ b/src/Symfony/Component/Debug/Tests/MockExceptionHandler.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Debug\Tests;
 
 use Symfony\Component\Debug\ExceptionHandler;
 
-class MockExceptionHandler extends Exceptionhandler
+class MockExceptionHandler extends ExceptionHandler
 {
     public $e;
 

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -564,7 +564,7 @@ EOF
      *
      * @return array A PHP array
      */
-    public static function convertDomElementToArray(\DomElement $element)
+    public static function convertDomElementToArray(\DOMElement $element)
     {
         return XmlUtils::convertDomElementToArray($element);
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -100,7 +100,7 @@ class PhpDumperTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array(array('foo' => new Definition('stdClass'))),
-            array(array('foo' => new Expression('service("foo").foo() ~ (container.hasparameter("foo") ? parameter("foo") : "default")'))),
+            array(array('foo' => new Expression('service("foo").foo() ~ (container.hasParameter("foo") ? parameter("foo") : "default")'))),
             array(array('foo' => new Reference('foo'))),
             array(array('foo' => new Variable('foo'))),
         );

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container9.php
@@ -50,7 +50,7 @@ $container
     ->addMethodCall('setBar', array(new Reference('foo2', ContainerInterface::NULL_ON_INVALID_REFERENCE)))
     ->addMethodCall('setBar', array(new Reference('foo3', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)))
     ->addMethodCall('setBar', array(new Reference('foobaz', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)))
-    ->addMethodCall('setBar', array(new Expression('service("foo").foo() ~ (container.hasparameter("foo") ? parameter("foo") : "default")')))
+    ->addMethodCall('setBar', array(new Expression('service("foo").foo() ~ (container.hasParameter("foo") ? parameter("foo") : "default")')))
 ;
 $container
     ->register('foo_with_inline', 'Foo')

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
@@ -248,7 +248,7 @@ class ProjectServiceContainer extends Container
         if ($this->has('foobaz')) {
             $instance->setBar($this->get('foobaz', ContainerInterface::NULL_ON_INVALID_REFERENCE));
         }
-        $instance->setBar(($this->get("foo")->foo() . (($this->hasparameter("foo")) ? ($this->getParameter("foo")) : ("default"))));
+        $instance->setBar(($this->get("foo")->foo() . (($this->hasParameter("foo")) ? ($this->getParameter("foo")) : ("default"))));
 
         return $instance;
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
@@ -248,7 +248,7 @@ class ProjectServiceContainer extends Container
         if ($this->has('foobaz')) {
             $instance->setBar($this->get('foobaz', ContainerInterface::NULL_ON_INVALID_REFERENCE));
         }
-        $instance->setBar(($this->get("foo")->foo() . (($this->hasParameter("foo")) ? ($this->getParameter("foo")) : ("default"))));
+        $instance->setBar(($this->get('foo')->foo().(($this->hasParameter('foo')) ? ($this->getParameter('foo')) : ('default'))));
 
         return $instance;
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
@@ -248,7 +248,7 @@ class ProjectServiceContainer extends Container
         if ($this->has('foobaz')) {
             $instance->setBar($this->get('foobaz', ContainerInterface::NULL_ON_INVALID_REFERENCE));
         }
-        $instance->setBar(($this->get('foo')->foo().(($this->hasParameter('foo')) ? ($this->getParameter('foo')) : ('default'))));
+        $instance->setBar(($this->get("foo")->foo() . (($this->hasParameter("foo")) ? ($this->getParameter("foo")) : ("default"))));
 
         return $instance;
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -246,7 +246,7 @@ class ProjectServiceContainer extends Container
 
         $instance->setBar($this->get('foo'));
         $instance->setBar(NULL);
-        $instance->setBar(($this->get("foo")->foo() . (($this->hasparameter("foo")) ? ($this->getParameter("foo")) : ("default"))));
+        $instance->setBar(($this->get("foo")->foo() . (($this->hasParameter("foo")) ? ($this->getParameter("foo")) : ("default"))));
 
         return $instance;
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -245,8 +245,8 @@ class ProjectServiceContainer extends Container
         $this->services['method_call1'] = $instance = new \Bar\FooClass();
 
         $instance->setBar($this->get('foo'));
-        $instance->setBar(NULL);
-        $instance->setBar(($this->get("foo")->foo() . (($this->hasParameter("foo")) ? ($this->getParameter("foo")) : ("default"))));
+        $instance->setBar(null);
+        $instance->setBar(($this->get('foo')->foo().(($this->hasParameter('foo')) ? ($this->getParameter('foo')) : ('default'))));
 
         return $instance;
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -245,8 +245,8 @@ class ProjectServiceContainer extends Container
         $this->services['method_call1'] = $instance = new \Bar\FooClass();
 
         $instance->setBar($this->get('foo'));
-        $instance->setBar(null);
-        $instance->setBar(($this->get('foo')->foo().(($this->hasParameter('foo')) ? ($this->getParameter('foo')) : ('default'))));
+        $instance->setBar(NULL);
+        $instance->setBar(($this->get("foo")->foo() . (($this->hasParameter("foo")) ? ($this->getParameter("foo")) : ("default"))));
 
         return $instance;
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services6.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services6.xml
@@ -32,7 +32,7 @@
     <service id="method_call1" class="FooClass">
       <call method="setBar" />
       <call method="setBar">
-        <argument type="expression">service("foo").foo() ~ (container.hasparameter("foo") ? parameter("foo") : "default")</argument>
+        <argument type="expression">service("foo").foo() ~ (container.hasParameter("foo") ? parameter("foo") : "default")</argument>
       </call>
     </service>
     <service id="method_call2" class="FooClass">

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
@@ -56,7 +56,7 @@
         <argument type="service" id="foobaz" on-invalid="ignore"/>
       </call>
       <call method="setBar">
-        <argument type="expression">service("foo").foo() ~ (container.hasparameter("foo") ? parameter("foo") : "default")</argument>
+        <argument type="expression">service("foo").foo() ~ (container.hasParameter("foo") ? parameter("foo") : "default")</argument>
       </call>
     </service>
     <service id="foo_with_inline" class="Foo">

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services6.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services6.yml
@@ -14,7 +14,7 @@ services:
         calls:
             - [ setBar, [] ]
             - [ setBar ]
-            - [ setBar, ['@=service("foo").foo() ~ (container.hasparameter("foo") ? parameter("foo") : "default")'] ]
+            - [ setBar, ['@=service("foo").foo() ~ (container.hasParameter("foo") ? parameter("foo") : "default")'] ]
     method_call2:
         class: FooClass
         calls:

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
@@ -36,7 +36,7 @@ services:
             - [setBar, ['@?foo2']]
             - [setBar, ['@?foo3']]
             - [setBar, ['@?foobaz']]
-            - [setBar, ['@=service("foo").foo() ~ (container.hasparameter("foo") ? parameter("foo") : "default")']]
+            - [setBar, ['@=service("foo").foo() ~ (container.hasParameter("foo") ? parameter("foo") : "default")']]
 
     foo_with_inline:
         class: Foo

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -260,7 +260,7 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('sc_configure', $services['configurator1']->getConfigurator(), '->load() parses the configurator tag');
         $this->assertEquals(array(new Reference('baz', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false), 'configure'), $services['configurator2']->getConfigurator(), '->load() parses the configurator tag');
         $this->assertEquals(array('BazClass', 'configureStatic'), $services['configurator3']->getConfigurator(), '->load() parses the configurator tag');
-        $this->assertEquals(array(array('setBar', array()), array('setBar', array(new Expression('service("foo").foo() ~ (container.hasparameter("foo") ? parameter("foo") : "default")')))), $services['method_call1']->getMethodCalls(), '->load() parses the method_call tag');
+        $this->assertEquals(array(array('setBar', array()), array('setBar', array(new Expression('service("foo").foo() ~ (container.hasParameter("foo") ? parameter("foo") : "default")')))), $services['method_call1']->getMethodCalls(), '->load() parses the method_call tag');
         $this->assertEquals(array(array('setBar', array('foo', new Reference('foo'), array(true, false)))), $services['method_call2']->getMethodCalls(), '->load() parses the method_call tag');
         $this->assertEquals('factory', $services['new_factory1']->getFactory(), '->load() parses the factory tag');
         $this->assertEquals(array(new Reference('baz', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false), 'getClass'), $services['new_factory2']->getFactory(), '->load() parses the factory tag');

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -157,7 +157,7 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('sc_configure', $services['configurator1']->getConfigurator(), '->load() parses the configurator tag');
         $this->assertEquals(array(new Reference('baz'), 'configure'), $services['configurator2']->getConfigurator(), '->load() parses the configurator tag');
         $this->assertEquals(array('BazClass', 'configureStatic'), $services['configurator3']->getConfigurator(), '->load() parses the configurator tag');
-        $this->assertEquals(array(array('setBar', array()), array('setBar', array()), array('setBar', array(new Expression('service("foo").foo() ~ (container.hasparameter("foo") ? parameter("foo") : "default")')))), $services['method_call1']->getMethodCalls(), '->load() parses the method_call tag');
+        $this->assertEquals(array(array('setBar', array()), array('setBar', array()), array('setBar', array(new Expression('service("foo").foo() ~ (container.hasParameter("foo") ? parameter("foo") : "default")')))), $services['method_call1']->getMethodCalls(), '->load() parses the method_call tag');
         $this->assertEquals(array(array('setBar', array('foo', new Reference('foo'), array(true, false)))), $services['method_call2']->getMethodCalls(), '->load() parses the method_call tag');
         $this->assertEquals('factory', $services['new_factory1']->getFactory(), '->load() parses the factory tag');
         $this->assertEquals(array(new Reference('baz'), 'getClass'), $services['new_factory2']->getFactory(), '->load() parses the factory tag');

--- a/src/Symfony/Component/Finder/Tests/Shell/CommandTest.php
+++ b/src/Symfony/Component/Finder/Tests/Shell/CommandTest.php
@@ -148,7 +148,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInternalType('array', $result);
         $this->assertNotEmpty($result);
-        $this->assertRegexp('/PHP|HipHop/', $result[0]);
+        $this->assertRegExp('/PHP|HipHop/', $result[0]);
     }
 
     public function testCastToString()

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -47,7 +47,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         parent::tearDown();
     }
 
-    protected function assertXpathNodeValue(\DomElement $element, $expression, $nodeValue)
+    protected function assertXpathNodeValue(\DOMElement $element, $expression, $nodeValue)
     {
         $xpath = new \DOMXPath($element->ownerDocument);
         $nodeList = $xpath->evaluate($expression);

--- a/src/Symfony/Component/Intl/Util/IntlTestHelper.php
+++ b/src/Symfony/Component/Intl/Util/IntlTestHelper.php
@@ -31,7 +31,7 @@ class IntlTestHelper
      *
      * @param \PhpUnit_Framework_TestCase $testCase
      */
-    public static function requireIntl(\PhpUnit_Framework_TestCase $testCase)
+    public static function requireIntl(\PHPUnit_Framework_TestCase $testCase)
     {
         // We only run tests if the version is *one specific version*.
         // This condition is satisfied if
@@ -63,7 +63,7 @@ class IntlTestHelper
      *
      * @param \PhpUnit_Framework_TestCase $testCase
      */
-    public static function requireFullIntl(\PhpUnit_Framework_TestCase $testCase)
+    public static function requireFullIntl(\PHPUnit_Framework_TestCase $testCase)
     {
         // We only run tests if the intl extension is loaded...
         if (!Intl::isExtensionLoaded()) {
@@ -92,7 +92,7 @@ class IntlTestHelper
      *
      * @param \PhpUnit_Framework_TestCase $testCase
      */
-    public static function require32Bit(\PhpUnit_Framework_TestCase $testCase)
+    public static function require32Bit(\PHPUnit_Framework_TestCase $testCase)
     {
         if (4 !== PHP_INT_SIZE) {
             $testCase->markTestSkipped('PHP 32 bit is required.');
@@ -104,7 +104,7 @@ class IntlTestHelper
      *
      * @param \PhpUnit_Framework_TestCase $testCase
      */
-    public static function require64Bit(\PhpUnit_Framework_TestCase $testCase)
+    public static function require64Bit(\PHPUnit_Framework_TestCase $testCase)
     {
         if (8 !== PHP_INT_SIZE) {
             $testCase->markTestSkipped('PHP 64 bit is required.');

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1229,7 +1229,7 @@ class ProcessTest extends \PHPUnit_Framework_TestCase
             } catch (RuntimeException $e) {
                 $this->assertSame('This PHP has been compiled with --enable-sigchild. You must use setEnhanceSigchildCompatibility() to use this method.', $e->getMessage());
                 if ($enhance) {
-                    $process->setEnhanceSigChildCompatibility(true);
+                    $process->setEnhanceSigchildCompatibility(true);
                 } else {
                     self::$notEnhancedSigchild = true;
                 }

--- a/src/Symfony/Component/Security/Acl/Resources/bin/generateSql.php
+++ b/src/Symfony/Component/Security/Acl/Resources/bin/generateSql.php
@@ -37,7 +37,7 @@ $reflection = new ReflectionClass('Doctrine\\DBAL\\Platforms\\AbstractPlatform')
 $finder = new Finder();
 $finder->name('*Platform.php')->in(dirname($reflection->getFileName()));
 foreach ($finder as $file) {
-    require_once $file->getPathName();
+    require_once $file->getPathname();
     $className = 'Doctrine\\DBAL\\Platforms\\'.$file->getBasename('.php');
 
     $reflection = new ReflectionClass($className);

--- a/src/Symfony/Component/Translation/DataCollectorTranslator.php
+++ b/src/Symfony/Component/Translation/DataCollectorTranslator.php
@@ -124,14 +124,14 @@ class DataCollectorTranslator implements TranslatorInterface, TranslatorBagInter
         } elseif ($catalogue->has($id, $domain)) {
             $state = self::MESSAGE_EQUALS_FALLBACK;
 
-            $fallbackCatalogue = $catalogue->getFallBackCatalogue();
+            $fallbackCatalogue = $catalogue->getFallbackCatalogue();
             while ($fallbackCatalogue) {
                 if ($fallbackCatalogue->defines($id, $domain)) {
                     $locale = $fallbackCatalogue->getLocale();
                     break;
                 }
 
-                $fallbackCatalogue = $fallbackCatalogue->getFallBackCatalogue();
+                $fallbackCatalogue = $fallbackCatalogue->getFallbackCatalogue();
             }
         } else {
             $state = self::MESSAGE_MISSING;

--- a/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
@@ -44,7 +44,7 @@ abstract class AbstractComparisonValidator extends ConstraintValidator
         // the DateTime constructor:
         // http://php.net/manual/en/datetime.formats.php
         if (is_string($comparedValue)) {
-            if ($value instanceof \DatetimeImmutable) {
+            if ($value instanceof \DateTimeImmutable) {
                 // If $value is immutable, convert the compared value to a
                 // DateTimeImmutable too
                 $comparedValue = new \DatetimeImmutable($comparedValue);

--- a/src/Symfony/Component/VarDumper/Caster/AmqpCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/AmqpCaster.php
@@ -131,7 +131,7 @@ class AmqpCaster
             $prefix.'contentType' => $c->getContentType(),
             $prefix.'contentEncoding' => $c->getContentEncoding(),
             $prefix.'type' => $c->getType(),
-            $prefix.'timestamp' => $c->getTimestamp(),
+            $prefix.'timestamp' => $c->getTimeStamp(),
             $prefix.'priority' => $c->getPriority(),
             $prefix.'expiration' => $c->getExpiration(),
             $prefix.'userId' => $c->getUserId(),


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

It's related to case sensitive.

I changed only calls of names of called methods but not definition of methods because BC.
