### PR TITLE
Adding the ContainerAwareAuthenticationProviderManager to lazily load…

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -249,12 +249,9 @@ class SecurityExtension extends Extension
         $mapDef->replaceArgument(1, $map);
 
         // add authentication providers to authentication manager
-        $authenticationProviders = array_map(function ($id) {
-            return new Reference($id);
-        }, array_values(array_unique($authenticationProviders)));
         $container
             ->getDefinition('security.authentication.manager')
-            ->replaceArgument(0, $authenticationProviders)
+            ->replaceArgument(0, array_values(array_unique($authenticationProviders)))
         ;
     }
 

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -26,8 +26,9 @@
         </service>
 
         <!-- Authentication related services -->
-        <service id="security.authentication.manager" class="Symfony\Component\Security\Core\Authentication\AuthenticationProviderManager" public="false">
+        <service id="security.authentication.manager" class="Symfony\Component\Security\Core\Authentication\ContainerAwareAuthenticationProviderManager" public="false">
             <argument type="collection" />
+            <argument type="service" id="service_container" />
             <argument>%security.authentication.manager.erase_credentials%</argument>
             <call method="setEventDispatcher">
                 <argument type="service" id="event_dispatcher" />

--- a/src/Symfony/Component/Security/Core/Authentication/AbstractAuthenticationProviderManager.php
+++ b/src/Symfony/Component/Security/Core/Authentication/AbstractAuthenticationProviderManager.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authentication;
+
+use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface;
+use Symfony\Component\Security\Core\Event\AuthenticationFailureEvent;
+use Symfony\Component\Security\Core\Event\AuthenticationEvent;
+use Symfony\Component\Security\Core\AuthenticationEvents;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Security\Core\Exception\AccountStatusException;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\ProviderNotFoundException;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+/**
+ * Abstract class that uses a list of AuthenticationProviderInterface
+ * instances to authenticate a Token.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+abstract class AbstractAuthenticationProviderManager implements AuthenticationManagerInterface
+{
+    private $eventDispatcher;
+
+    /**
+     * @return AuthenticationProviderInterface[]
+     */
+    abstract protected function getProviders();
+
+    /**
+     * Should eraseCredentials() be called on TokenInterface after authentication?
+     *
+     * @return bool
+     */
+    abstract protected function shouldEraseCredentials();
+
+    public function setEventDispatcher(EventDispatcherInterface $dispatcher)
+    {
+        $this->eventDispatcher = $dispatcher;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function authenticate(TokenInterface $token)
+    {
+        $lastException = null;
+        $result = null;
+
+        $providers = $this->getProviders();
+
+        if (!$providers) {
+            throw new \InvalidArgumentException('You must at least add one authentication provider.');
+        }
+
+        foreach ($providers as $provider) {
+            if (!$provider instanceof AuthenticationProviderInterface) {
+                throw new \InvalidArgumentException(sprintf('Provider "%s" must implement the AuthenticationProviderInterface.', get_class($provider)));
+            }
+        }
+
+        foreach ($providers as $provider) {
+            if (!$provider->supports($token)) {
+                continue;
+            }
+
+            try {
+                $result = $provider->authenticate($token);
+
+                if (null !== $result) {
+                    break;
+                }
+            } catch (AccountStatusException $e) {
+                $e->setToken($token);
+
+                throw $e;
+            } catch (AuthenticationException $e) {
+                $lastException = $e;
+            }
+        }
+
+        if (null !== $result) {
+            if (true === $this->shouldEraseCredentials()) {
+                $result->eraseCredentials();
+            }
+
+            if (null !== $this->eventDispatcher) {
+                $this->eventDispatcher->dispatch(AuthenticationEvents::AUTHENTICATION_SUCCESS, new AuthenticationEvent($result));
+            }
+
+            return $result;
+        }
+
+        if (null === $lastException) {
+            $lastException = new ProviderNotFoundException(sprintf('No Authentication Provider found for token of class "%s".', get_class($token)));
+        }
+
+        if (null !== $this->eventDispatcher) {
+            $this->eventDispatcher->dispatch(AuthenticationEvents::AUTHENTICATION_FAILURE, new AuthenticationFailureEvent($token, $lastException));
+        }
+
+        $lastException->setToken($token);
+
+        throw $lastException;
+    }
+}

--- a/src/Symfony/Component/Security/Core/Authentication/AbstractAuthenticationProviderManager.php
+++ b/src/Symfony/Component/Security/Core/Authentication/AbstractAuthenticationProviderManager.php
@@ -67,9 +67,7 @@ abstract class AbstractAuthenticationProviderManager implements AuthenticationMa
             if (!$provider instanceof AuthenticationProviderInterface) {
                 throw new \InvalidArgumentException(sprintf('Provider "%s" must implement the AuthenticationProviderInterface.', get_class($provider)));
             }
-        }
 
-        foreach ($providers as $provider) {
             if (!$provider->supports($token)) {
                 continue;
             }

--- a/src/Symfony/Component/Security/Core/Authentication/AuthenticationProviderManager.php
+++ b/src/Symfony/Component/Security/Core/Authentication/AuthenticationProviderManager.php
@@ -11,28 +11,17 @@
 
 namespace Symfony\Component\Security\Core\Authentication;
 
-use Symfony\Component\Security\Core\Event\AuthenticationFailureEvent;
-use Symfony\Component\Security\Core\Event\AuthenticationEvent;
-use Symfony\Component\Security\Core\AuthenticationEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Security\Core\Exception\AccountStatusException;
-use Symfony\Component\Security\Core\Exception\AuthenticationException;
-use Symfony\Component\Security\Core\Exception\ProviderNotFoundException;
 use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 /**
- * AuthenticationProviderManager uses a list of AuthenticationProviderInterface
- * instances to authenticate a Token.
- *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class AuthenticationProviderManager implements AuthenticationManagerInterface
+class AuthenticationProviderManager extends AbstractAuthenticationProviderManager
 {
     private $providers;
     private $eraseCredentials;
-    private $eventDispatcher;
 
     /**
      * Constructor.
@@ -44,75 +33,17 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
      */
     public function __construct(array $providers, $eraseCredentials = true)
     {
-        if (!$providers) {
-            throw new \InvalidArgumentException('You must at least add one authentication provider.');
-        }
-
-        foreach ($providers as $provider) {
-            if (!$provider instanceof AuthenticationProviderInterface) {
-                throw new \InvalidArgumentException(sprintf('Provider "%s" must implement the AuthenticationProviderInterface.', get_class($provider)));
-            }
-        }
-
         $this->providers = $providers;
         $this->eraseCredentials = (bool) $eraseCredentials;
     }
 
-    public function setEventDispatcher(EventDispatcherInterface $dispatcher)
+    protected function getProviders()
     {
-        $this->eventDispatcher = $dispatcher;
+        return $this->providers;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function authenticate(TokenInterface $token)
+    protected function shouldEraseCredentials()
     {
-        $lastException = null;
-        $result = null;
-
-        foreach ($this->providers as $provider) {
-            if (!$provider->supports($token)) {
-                continue;
-            }
-
-            try {
-                $result = $provider->authenticate($token);
-
-                if (null !== $result) {
-                    break;
-                }
-            } catch (AccountStatusException $e) {
-                $e->setToken($token);
-
-                throw $e;
-            } catch (AuthenticationException $e) {
-                $lastException = $e;
-            }
-        }
-
-        if (null !== $result) {
-            if (true === $this->eraseCredentials) {
-                $result->eraseCredentials();
-            }
-
-            if (null !== $this->eventDispatcher) {
-                $this->eventDispatcher->dispatch(AuthenticationEvents::AUTHENTICATION_SUCCESS, new AuthenticationEvent($result));
-            }
-
-            return $result;
-        }
-
-        if (null === $lastException) {
-            $lastException = new ProviderNotFoundException(sprintf('No Authentication Provider found for token of class "%s".', get_class($token)));
-        }
-
-        if (null !== $this->eventDispatcher) {
-            $this->eventDispatcher->dispatch(AuthenticationEvents::AUTHENTICATION_FAILURE, new AuthenticationFailureEvent($token, $lastException));
-        }
-
-        $lastException->setToken($token);
-
-        throw $lastException;
+        return $this->eraseCredentials;
     }
 }

--- a/src/Symfony/Component/Security/Core/Authentication/AuthenticationProviderManager.php
+++ b/src/Symfony/Component/Security/Core/Authentication/AuthenticationProviderManager.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Security\Core\Authentication;
 
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface;
 
 /**

--- a/src/Symfony/Component/Security/Core/Authentication/ContainerAwareAuthenticationProviderManager.php
+++ b/src/Symfony/Component/Security/Core/Authentication/ContainerAwareAuthenticationProviderManager.php
@@ -35,12 +35,9 @@ class ContainerAwareAuthenticationProviderManager extends AbstractAuthentication
 
     protected function getProviders()
     {
-        $providers = array();
         foreach ($this->providerServiceIds as $serviceId) {
-            $providers[] = $this->container->get($serviceId);
+            yield $this->container->get($serviceId);
         }
-
-        return $providers;
     }
 
     protected function shouldEraseCredentials()

--- a/src/Symfony/Component/Security/Core/Authentication/ContainerAwareAuthenticationProviderManager.php
+++ b/src/Symfony/Component/Security/Core/Authentication/ContainerAwareAuthenticationProviderManager.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authentication;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Uses the Container to lazily instantiate the providers.
+ *
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+class ContainerAwareAuthenticationProviderManager extends AbstractAuthenticationProviderManager
+{
+    private $providerServiceIds;
+
+    private $container;
+
+    private $eraseCredentials;
+
+    public function __construct(array $providerServiceIds, ContainerInterface $container, $eraseCredentials = true)
+    {
+        $this->providerServiceIds = $providerServiceIds;
+        $this->container = $container;
+        $this->eraseCredentials = $eraseCredentials;
+    }
+
+    protected function getProviders()
+    {
+        $providers = array();
+        foreach ($this->providerServiceIds as $serviceId) {
+            $providers[] = $this->container->get($serviceId);
+        }
+
+        return $providers;
+    }
+
+    protected function shouldEraseCredentials()
+    {
+        return $this->eraseCredentials;
+    }
+}

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationProviderManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationProviderManagerTest.php
@@ -24,7 +24,8 @@ class AuthenticationProviderManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testAuthenticateWithoutProviders()
     {
-        new AuthenticationProviderManager(array());
+        $manager = new AuthenticationProviderManager(array());
+        $manager->authenticate($this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface'));
     }
 
     /**
@@ -32,9 +33,10 @@ class AuthenticationProviderManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testAuthenticateWithProvidersWithIncorrectInterface()
     {
-        new AuthenticationProviderManager(array(
+        $manager = new AuthenticationProviderManager(array(
             new \stdClass(),
         ));
+        $manager->authenticate($this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface'));
     }
 
     public function testAuthenticateWhenNoProviderSupportsToken()

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/ContainerAwareAuthenticationProviderManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/ContainerAwareAuthenticationProviderManagerTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Tests\Authentication;
+
+use Symfony\Component\Security\Core\Authentication\AuthenticationProviderManager;
+use Symfony\Component\Security\Core\Authentication\ContainerAwareAuthenticationProviderManager;
+use Symfony\Component\Security\Core\Exception\ProviderNotFoundException;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\AccountStatusException;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+
+class ContainerAwareAuthenticationProviderManagerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testAuthenticateWhenNoProviderSupportsToken()
+    {
+        $container = $this->getContainer(array(
+            'foo_provider' => $this->getAuthenticationProvider(false),
+        ));
+
+        $manager = new ContainerAwareAuthenticationProviderManager(
+            array('foo_provider'),
+            $container
+        );
+
+        try {
+            $manager->authenticate($token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface'));
+            $this->fail();
+        } catch (ProviderNotFoundException $e) {
+            $this->assertSame($token, $e->getToken());
+        }
+    }
+
+    public function testAuthenticateReturnsTokenOfTheFirstMatchingProvider()
+    {
+        $second = $this->getMock('Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface');
+        $second
+            ->expects($this->never())
+            ->method('supports')
+        ;
+
+        $container = $this->getContainer(array(
+            'first_provider' => $this->getAuthenticationProvider(true, $expected = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')),
+            'second_provider' => $second
+        ));
+
+        $manager = new ContainerAwareAuthenticationProviderManager(
+            array('first_provider', 'second_provider'),
+            $container
+        );
+
+        $token = $manager->authenticate($this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface'));
+        $this->assertSame($expected, $token);
+    }
+
+    public function testEraseCredentialFlag()
+    {
+        $container = $this->getContainer(array(
+            'provider_service' => $this->getAuthenticationProvider(true, $token = new UsernamePasswordToken('foo', 'bar', 'key')),
+        ));
+        $manager = new ContainerAwareAuthenticationProviderManager(
+            ['provider_service'],
+            $container
+        );
+
+        $token = $manager->authenticate($this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface'));
+        $this->assertEquals('', $token->getCredentials());
+
+        $container = $this->getContainer(array(
+            'provider_service' => $this->getAuthenticationProvider(true, $token = new UsernamePasswordToken('foo', 'bar', 'key')),
+        ));
+        $manager = new ContainerAwareAuthenticationProviderManager(
+            ['provider_service'],
+            $container,
+            false
+        );
+
+        $token = $manager->authenticate($this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface'));
+        $this->assertEquals('bar', $token->getCredentials());
+    }
+
+    protected function getAuthenticationProvider($supports, $token = null, $exception = null)
+    {
+        $provider = $this->getMock('Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface');
+        $provider->expects($this->once())
+                 ->method('supports')
+                 ->will($this->returnValue($supports))
+        ;
+
+        if (null !== $token) {
+            $provider->expects($this->once())
+                     ->method('authenticate')
+                     ->will($this->returnValue($token))
+            ;
+        } elseif (null !== $exception) {
+            $provider->expects($this->once())
+                     ->method('authenticate')
+                     ->will($this->throwException($this->getMock($exception, null, array(), '')))
+            ;
+        }
+
+        return $provider;
+    }
+
+    public function getContainer(array $servicesMap)
+    {
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container->expects($this->any())
+            ->method('get')
+            ->willReturnCallback(function ($id) use ($servicesMap) {
+                return $servicesMap[$id];
+            });
+
+        return $container;
+    }
+}

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/ContainerAwareAuthenticationProviderManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/ContainerAwareAuthenticationProviderManagerTest.php
@@ -11,11 +11,8 @@
 
 namespace Symfony\Component\Security\Core\Tests\Authentication;
 
-use Symfony\Component\Security\Core\Authentication\AuthenticationProviderManager;
 use Symfony\Component\Security\Core\Authentication\ContainerAwareAuthenticationProviderManager;
 use Symfony\Component\Security\Core\Exception\ProviderNotFoundException;
-use Symfony\Component\Security\Core\Exception\AuthenticationException;
-use Symfony\Component\Security\Core\Exception\AccountStatusException;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class ContainerAwareAuthenticationProviderManagerTest extends \PHPUnit_Framework_TestCase
@@ -49,7 +46,7 @@ class ContainerAwareAuthenticationProviderManagerTest extends \PHPUnit_Framework
 
         $container = $this->getContainer(array(
             'first_provider' => $this->getAuthenticationProvider(true, $expected = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')),
-            'second_provider' => $second
+            'second_provider' => $second,
         ));
 
         $manager = new ContainerAwareAuthenticationProviderManager(
@@ -67,7 +64,7 @@ class ContainerAwareAuthenticationProviderManagerTest extends \PHPUnit_Framework
             'provider_service' => $this->getAuthenticationProvider(true, $token = new UsernamePasswordToken('foo', 'bar', 'key')),
         ));
         $manager = new ContainerAwareAuthenticationProviderManager(
-            ['provider_service'],
+            array('provider_service'),
             $container
         );
 
@@ -78,7 +75,7 @@ class ContainerAwareAuthenticationProviderManagerTest extends \PHPUnit_Framework
             'provider_service' => $this->getAuthenticationProvider(true, $token = new UsernamePasswordToken('foo', 'bar', 'key')),
         ));
         $manager = new ContainerAwareAuthenticationProviderManager(
-            ['provider_service'],
+            array('provider_service'),
             $container,
             false
         );

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/ContainerAwareAuthenticationProviderManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/ContainerAwareAuthenticationProviderManagerTest.php
@@ -38,19 +38,20 @@ class ContainerAwareAuthenticationProviderManagerTest extends \PHPUnit_Framework
 
     public function testAuthenticateReturnsTokenOfTheFirstMatchingProvider()
     {
-        $second = $this->getMock('Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface');
-        $second
+        $third = $this->getMock('Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface');
+        $third
             ->expects($this->never())
             ->method('supports')
         ;
 
         $container = $this->getContainer(array(
-            'first_provider' => $this->getAuthenticationProvider(true, $expected = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')),
-            'second_provider' => $second,
+            'first_provider' => $this->getAuthenticationProvider(false),
+            'second_provider' => $this->getAuthenticationProvider(true, $expected = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')),
+            'third_provider' => $third,
         ));
 
         $manager = new ContainerAwareAuthenticationProviderManager(
-            array('first_provider', 'second_provider'),
+            array('first_provider', 'second_provider', 'third_provider'),
             $container
         );
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes [minor, see below] |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | doctrine/DoctrineBundle#351 |
| License | MIT |
| Doc PR | n/a |

Hi guys!

**Problem** During the cache warming process, a huge chain takes place in the container: Twig->AuthorizationChecker->AuthenticationManager->Authentication Providers -> User Provider -> Doctrine -> ... potentially trigger a database look up :/

This doesn't entirely solve the linked issue, but it does solve a very common case that's caused when you use FOSUserBundle. The same could be done to make the voters lazy in `AccessDecisionManager`.

Do we like this approach? I was taking a shot a breaking the dependency chain.

**BC Breaks**
There are a few BC breaks, potentially

1) (very minor) If you don't have any providers configured or one does not implement the correct interface, the exception is thrown a a different _time_ (not when the object is instantiate, but when authenticate is called). This could be fixed (we'd just have a little bit of duplication)

2) If you are using the FW and type-hinted against `AuthenticationProviderManager`, that will break. If you type-hint the interface, you're fine

Cheers!
