### PR TITLE
[Asset] Versionize assets according to a Manifest

### DIFF
--- a/src/Symfony/Component/Asset/Tests/VersionStrategy/ManifestVersionStrategyTest.php
+++ b/src/Symfony/Component/Asset/Tests/VersionStrategy/ManifestVersionStrategyTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Asset\Tests\VersionStrategy;
+
+use Symfony\Component\Asset\VersionStrategy\ManifestVersionStrategy;
+
+class ManifestVersionStrategyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetVersion()
+    {
+        $path = 'foo';
+        $versionized = 'foo-versionized';
+        $manifestVersionStrategy = new ManifestVersionStrategy(array($path => $versionized));
+        $this->assertEquals('', $manifestVersionStrategy->getVersion($path));
+    }
+
+    public function testApplyVersion()
+    {
+        $path = 'foo';
+        $versionized = 'foo-versionized';
+        $manifestVersionStrategy = new ManifestVersionStrategy(array($path => $versionized));
+        $this->assertEquals($versionized, $manifestVersionStrategy->applyVersion($path));
+    }
+
+    public function testApplyVersionMissing()
+    {
+        $path = 'foo';
+        $manifestVersionStrategy = new ManifestVersionStrategy(array());
+        $this->assertEquals($path, $manifestVersionStrategy->applyVersion($path));
+    }
+}

--- a/src/Symfony/Component/Asset/VersionStrategy/ManifestVersionStrategy.php
+++ b/src/Symfony/Component/Asset/VersionStrategy/ManifestVersionStrategy.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Asset\VersionStrategy;
+
+/**
+ * Returns the version according to a manifest.
+ *
+ * @author Paulo Rodrigues Pinto <regularjack@gmail.com>
+ */
+class ManifestVersionStrategy implements VersionStrategyInterface
+{
+    private $manifest;
+
+    /**
+     * @param array $manifest Asset manifest
+     */
+    public function __construct(array $manifest)
+    {
+        $this->manifest = $manifest;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getVersion($path)
+    {
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function applyVersion($path)
+    {
+        if (array_key_exists($path, $this->manifest)) {
+            return $this->manifest[$path];
+        }
+
+        return $path;
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
## Overview

Add the ability for the Asset component to version assets according to a _Manifest_. A manifest is simply a map of paths to their versioned selves, for example:

```
/images/foo.png => /images/foo-123abc.png
/css/bar.css    => /css/bar-789xyz.css
```

This is achieved by a `ManifestVersionStrategy` class whose constructor takes an array representing the manifest:

``` php
$manifest = array(
    '/images/foo.png' => '/images/foo-123abc.png',
    '/css/bar.css'    => '/css/bar-789xyz.css',
);

$versionStrategy = new ManifestVersionStrategy($manifest);

// Returns '/images/foo-123abc.png'
$versionStrategy->applyVersion('/images/foo.png');

// Returns '/css/bar-789xyz.css'
$versionStrategy->applyVersion('/css/bar.css');

// Returns an empty string
$versionStrategy->getVersion('/images/foo.png');
```
## Motivation

To optimize client-side caching, an asset's URL should only change when its contents change. A simple way to achieve this is to append a hash of the file's content to the name of the file, as part of the build process.

Many frontend build tools do this and at the same time generate a _manifest_ that maps the file's original name to its versioned name.

Supporting this use case would make it easy to "hook" frontend build tools with the Asset component.
## A starting point

This PR is deliberately simple because it's not the concern of the Asset component to produce the manifest or even to parse it. However, having the Asset component include a `ManifestVersionStrategy` would pave the way for improved support further up the stack (framework-bundle? symfony-standard?).

If this PR is accepted and/or if its usefulness is acknowleged I'm willing to further contribute "up the stack" to better support this use case.
