### PR TITLE
[DomCrawler] Inherit the namespace cache in subcrawlers

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -1151,6 +1151,7 @@ class Crawler extends \SplObjectStorage
         $crawler = new static($nodes, $this->uri, $this->baseHref);
         $crawler->isHtml = $this->isHtml;
         $crawler->document = $this->document;
+        $crawler->namespaces = $this->namespaces;
 
         return $crawler;
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #12298 |
| License | MIT |
| Doc PR | n/a |

This inherits any already discovered/registered namespace with subcrawlers, improving performance when using namespaces.

I submitted to 2.8 rather than 2.7, because the namespace mapping feature was actually buggy in 2.x, because of the fact that nodes could belong to different documents in the same Crawler while the namespace map was shared. The fact that the map was not inherited in subcrawler mitigated this issue (by reducing changes to have multiple documents in the same subcrawler). 2.8 deprecated this possibility to have multiple documents, so I'm fine with applying this here.

Note that the subcrawler inherits the namespace cache at the time it is created, but the cache is not shared between instance (so if a subcrawler discovers an additional namespace of the document, it will not be available for the parent crawler of other subcrawlers of the parent). Sharing the cache would be totally possible (as they share the same document anyway) and would make the experience even better (removing the need to ensure that the root crawler discovers namespace before filtering). But it would require moving from an array to an object. I'm not sure we want to do this in a patch release. What do you think @symfony/deciders ?
