### PR TITLE
[Form] Fix the money form type render with Bootstrap3

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_3_layout.html.twig
@@ -21,12 +21,12 @@
 
 {% block money_widget -%}
     <div class="input-group">
-        {% set prepend = '{{' == money_pattern[0:2] %}
-        {% if not prepend %}
+        {% set append = money_pattern starts with '{{' %}
+        {% if not append %}
             <span class="input-group-addon">{{ money_pattern|replace({ '{{ widget }}':''}) }}</span>
         {% endif %}
         {{- block('form_widget_simple') -}}
-        {% if prepend %}
+        {% if append %}
             <span class="input-group-addon">{{ money_pattern|replace({ '{{ widget }}':''}) }}</span>
         {% endif %}
     </div>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | Part fixing https://github.com/symfony/symfony/issues/19424 |
| License | MIT |
| Doc PR | none |

There is a confusion between the variable naming, and the result expected.

When prepend variable is false, the currency symbol must be add after the widget.
When the `money_pattern`starts with `{{`, `prepend` variable must be `false`.
