### PR TITLE
[Translation] [TwigBridge] [FrameworkBundle] Uses a Default 'Number' Index on Translation Pluralisation Methods

### DIFF
--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -29,7 +29,7 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
  * bug #19118 [Process] Fix pipes cleaning on Windows (nicolas-grekas)
  * bug #19128 Avoid phpunit 5.4 warnings on getMock (2.7+) (iltar)
  * bug #19120 [FrameworkBundle] templating can be fully disabled (xabbuh)
- * bug #19114 [HttpKernel] Dont close the reponse stream in debug (nicolas-grekas)
+ * bug #19114 [HttpKernel] Dont close the response stream in debug (nicolas-grekas)
  * bug #19101 [Session] fix PDO transaction aborted under PostgreSQL (Tobion)
  * bug #18501 [HttpFoundation] changed MERGE queries (hjkl)
  * bug #19081 [YAML] Fixed parsing problem with nested DateTime lists (jkphl, xabbuh)

--- a/CHANGELOG-3.1.md
+++ b/CHANGELOG-3.1.md
@@ -217,3 +217,4 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
  * feature #17133 [DependencyInjection] Make YamlFileLoader raise a deprecation notice if a service definition contains unsupported keywords. (hhamon)
  * feature #17191 [Serializer] Move the normalization logic in an abstract class (dunglas)
  * feature #16994 [Form] Deprecate the "choices_as_values" option of ChoiceType (nicolas-grekas)
+ * feature #19432 [Translation] [TwigBridge] [FrameworkBundle] Uses a Default 'Number' Index on Translation Pluralisation Methods

--- a/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
@@ -93,7 +93,7 @@ class TranslationExtension extends \Twig_Extension
         return $this->translator->trans($message, $arguments, $domain, $locale);
     }
 
-    public function transchoice($message, $count, array $arguments = array(), $domain = null, $locale = null)
+    public function transchoice($message, $count = 1, array $arguments = array(), $domain = null, $locale = null)
     {
         return $this->translator->transChoice($message, $count, array_merge(array('%count%' => $count), $arguments), $domain, $locale);
     }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/StubTranslator.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/Fixtures/StubTranslator.php
@@ -20,7 +20,7 @@ class StubTranslator implements TranslatorInterface
         return '[trans]'.$id.'[/trans]';
     }
 
-    public function transChoice($id, $number, array $parameters = array(), $domain = null, $locale = null)
+    public function transChoice($id, $number = 1, array $parameters = array(), $domain = null, $locale = null)
     {
         return '[trans]'.$id.'[/trans]';
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/TranslatorHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/TranslatorHelper.php
@@ -44,7 +44,7 @@ class TranslatorHelper extends Helper
     /**
      * @see TranslatorInterface::transChoice()
      */
-    public function transChoice($id, $number, array $parameters = array(), $domain = 'messages', $locale = null)
+    public function transChoice($id, $number = 1, array $parameters = array(), $domain = 'messages', $locale = null)
     {
         return $this->translator->transChoice($id, $number, $parameters, $domain, $locale);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/Fixtures/StubTranslator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/Fixtures/StubTranslator.php
@@ -20,7 +20,7 @@ class StubTranslator implements TranslatorInterface
         return '[trans]'.$id.'[/trans]';
     }
 
-    public function transChoice($id, $number, array $parameters = array(), $domain = null, $locale = null)
+    public function transChoice($id, $number = 1, array $parameters = array(), $domain = null, $locale = null)
     {
         return '[trans]'.$id.'[/trans]';
     }

--- a/src/Symfony/Component/Translation/DataCollectorTranslator.php
+++ b/src/Symfony/Component/Translation/DataCollectorTranslator.php
@@ -56,7 +56,7 @@ class DataCollectorTranslator implements TranslatorInterface, TranslatorBagInter
     /**
      * {@inheritdoc}
      */
-    public function transChoice($id, $number, array $parameters = array(), $domain = null, $locale = null)
+    public function transChoice($id, $number = 1, array $parameters = array(), $domain = null, $locale = null)
     {
         $trans = $this->translator->transChoice($id, $number, $parameters, $domain, $locale);
         $this->collectMessage($locale, $domain, $id, $trans, $parameters, $number);

--- a/src/Symfony/Component/Translation/IdentityTranslator.php
+++ b/src/Symfony/Component/Translation/IdentityTranslator.php
@@ -58,7 +58,7 @@ class IdentityTranslator implements TranslatorInterface
     /**
      * {@inheritdoc}
      */
-    public function transChoice($id, $number, array $parameters = array(), $domain = null, $locale = null)
+    public function transChoice($id, $number = 1, array $parameters = array(), $domain = null, $locale = null)
     {
         return strtr($this->selector->choose((string) $id, (int) $number, $locale ?: $this->getLocale()), $parameters);
     }

--- a/src/Symfony/Component/Translation/LoggingTranslator.php
+++ b/src/Symfony/Component/Translation/LoggingTranslator.php
@@ -56,7 +56,7 @@ class LoggingTranslator implements TranslatorInterface, TranslatorBagInterface
     /**
      * {@inheritdoc}
      */
-    public function transChoice($id, $number, array $parameters = array(), $domain = null, $locale = null)
+    public function transChoice($id, $number = 1, array $parameters = array(), $domain = null, $locale = null)
     {
         $trans = $this->translator->transChoice($id, $number, $parameters, $domain, $locale);
         $this->log($id, $domain, $locale);

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -196,7 +196,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
     /**
      * {@inheritdoc}
      */
-    public function transChoice($id, $number, array $parameters = array(), $domain = null, $locale = null)
+    public function transChoice($id, $number = 1, array $parameters = array(), $domain = null, $locale = null)
     {
         if (null === $domain) {
             $domain = 'messages';

--- a/src/Symfony/Component/Translation/TranslatorInterface.php
+++ b/src/Symfony/Component/Translation/TranslatorInterface.php
@@ -36,7 +36,7 @@ interface TranslatorInterface
      * Translates the given choice message by choosing a translation according to a number.
      *
      * @param string      $id         The message id (may also be an object that can be cast to string)
-     * @param int         $number     The number to use to find the indice of the message
+     * @param int         $number     The number to use to find the indice of the message, defaults to 1
      * @param array       $parameters An array of parameters for the message
      * @param string|null $domain     The domain for the message or null to use the default
      * @param string|null $locale     The locale or null to use the default
@@ -45,7 +45,7 @@ interface TranslatorInterface
      *
      * @throws \InvalidArgumentException If the locale contains invalid characters
      */
-    public function transChoice($id, $number, array $parameters = array(), $domain = null, $locale = null);
+    public function transChoice($id, $number = 1, array $parameters = array(), $domain = null, $locale = null);
 
     /**
      * Sets the current locale.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |
## PR Purpose

This adds the default index to the `transchoice` twig filter, and the `transChoice` methods within the Translation Extension.
## Why?

This is mainly syntactic sugar. Example:

``` php
// messages.en.php
return [
    'entity' => [
        'category' => 'Category|Categories'
    ]
];
```

``` twig
{{ 'entity.category' | trans }} // Outputs 'Category|Categories'
```

``` twig
{{ 'entity.category' | transchoice(1) }} // Outputs 'Category'
```

If, in my template, or in my backend code, I only ever wish to display the singular of a translation, this PR allows me to to specify it as follows:

``` twig
{{ 'entity.category' | transchoice }} // Outputs 'Category'
```

This mirrors the functionality of `trans` but allows you to utilise the singular of a translation.

This retains the ability to fully configure the arguments of the `transchoice` filter and `transChoice` translation methods but, allows you to quickly and easily call your translation methods for singulars when your message is defined as a pluralised message. 
