### PR TITLE
[Serializer] enable property info in framework bundle

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
@@ -21,6 +21,7 @@
             <argument type="service" id="serializer.mapping.class_metadata_factory" />
             <argument>null</argument> <!-- name converter -->
             <argument type="service" id="serializer.property_accessor" />
+            <argument type="service" id="property_info" on-invalid="ignore" />
 
             <!-- Run after all custom serializers -->
             <tag name="serializer.normalizer" priority="-1000" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
@@ -68,6 +68,7 @@ $container->loadFromExtension('framework', array(
         'enable_annotations' => true,
         'name_converter' => 'serializer.name_converter.camel_case_to_snake_case',
     ),
+    'property_info' => true,
     'ide' => 'file%%link%%format',
     'request' => array(
         'formats' => array(

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
@@ -41,5 +41,6 @@
         <framework:validation enabled="true" cache="validator.mapping.cache.doctrine.apc" />
         <framework:annotations cache="file" debug="true" file-cache-dir="%kernel.cache_dir%/annotations" />
         <framework:serializer enabled="true" enable-annotations="true" name-converter="serializer.name_converter.camel_case_to_snake_case" />
+        <framework:property-info />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
@@ -53,6 +53,7 @@ framework:
          enabled:        true
          enable_annotations: true
          name_converter: serializer.name_converter.camel_case_to_snake_case
+    property_info: ~
     ide: file%%link%%format
     request:
         formats:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -469,6 +469,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertEquals('Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader', $argument[0]->getClass());
         $this->assertNull($container->getDefinition('serializer.mapping.class_metadata_factory')->getArgument(1));
         $this->assertEquals(new Reference('serializer.name_converter.camel_case_to_snake_case'), $container->getDefinition('serializer.normalizer.object')->getArgument(1));
+        $this->assertEquals(new Reference('property_info', ContainerBuilder::IGNORE_ON_INVALID_REFERENCE), $container->getDefinition('serializer.normalizer.object')->getArgument(3));
     }
 
     public function testRegisterSerializerExtractor()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

I've been wondering why the datetime normalizer won't work in combination with object normalizer in symfony 3.1 by default. I also found nothing in the documentation. Only http://symfony.com/blog/new-in-symfony-3-1-datetime-normalizer but here is not described how to use it with the object normalizer and how to configure the config.yml.

After debugging i found out that the object normalizer don't use the new property info component. With my change, you can enabled it with following config:

``` yml
    serializer:
         enabled: true
    property_info: ~
```

Should i add analog to `enable_annotation` an `enable_property_info` option?

``` yml
    serializer:
         enabled: true
         enable_property_info: true
    property_info: ~
```
