### PR TITLE
[Cache] Fix incorrect timestamps generated by FilesystemAdapter

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/FilesystemAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/FilesystemAdapter.php
@@ -126,7 +126,7 @@ class FilesystemAdapter extends AbstractAdapter
     protected function doSave(array $values, $lifetime)
     {
         $ok = true;
-        $expiresAt = $lifetime ? time() + $lifetime : PHP_INT_MAX;
+        $expiresAt = time() + ($lifetime ?: 31557600); // 31557600s = 1 year
         $tmp = $this->directory.uniqid('', true);
 
         foreach ($values as $id => $value) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #19431 |
| License | MIT |
| Doc PR | - |
