### PR TITLE
[PropertyInfo] Fix an error in PropertyInfoCacheExtractor

### DIFF
--- a/src/Symfony/Component/PropertyInfo/PropertyInfoCacheExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoCacheExtractor.php
@@ -86,7 +86,7 @@ class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface
      */
     public function getTypes($class, $property, array $context = array())
     {
-        return $this->extract('getTypes', array($class, $context));
+        return $this->extract('getTypes', array($class, $property, $context));
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/PropertyInfoCacheExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoCacheExtractor.php
@@ -108,7 +108,7 @@ class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface
 
         $key = $this->escape($method.'.'.$serializedArguments);
 
-        if (isset($this->arrayCache[$key])) {
+        if (array_key_exists($key, $this->arrayCache)) {
             return $this->arrayCache[$key];
         }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/NullExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/NullExtractor.php
@@ -79,7 +79,7 @@ class NullExtractor implements PropertyListExtractorInterface, PropertyDescripti
     private function assertIsString($string)
     {
         if (!is_string($string)) {
-            throw new \Exception(sprintf('"%s" expects strings, given "%s".', __CLASS__, gettype($string)));
+            throw new \InvalidArgumentException(sprintf('"%s" expects strings, given "%s".', __CLASS__, gettype($string)));
         }
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/NullExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/NullExtractor.php
@@ -28,6 +28,8 @@ class NullExtractor implements PropertyListExtractorInterface, PropertyDescripti
      */
     public function getShortDescription($class, $property, array $context = array())
     {
+        $this->assertIsString($class);
+        $this->assertIsString($property);
     }
 
     /**
@@ -35,6 +37,8 @@ class NullExtractor implements PropertyListExtractorInterface, PropertyDescripti
      */
     public function getLongDescription($class, $property, array $context = array())
     {
+        $this->assertIsString($class);
+        $this->assertIsString($property);
     }
 
     /**
@@ -42,6 +46,8 @@ class NullExtractor implements PropertyListExtractorInterface, PropertyDescripti
      */
     public function getTypes($class, $property, array $context = array())
     {
+        $this->assertIsString($class);
+        $this->assertIsString($property);
     }
 
     /**
@@ -49,6 +55,8 @@ class NullExtractor implements PropertyListExtractorInterface, PropertyDescripti
      */
     public function isReadable($class, $property, array $context = array())
     {
+        $this->assertIsString($class);
+        $this->assertIsString($property);
     }
 
     /**
@@ -56,6 +64,8 @@ class NullExtractor implements PropertyListExtractorInterface, PropertyDescripti
      */
     public function isWritable($class, $property, array $context = array())
     {
+        $this->assertIsString($class);
+        $this->assertIsString($property);
     }
 
     /**
@@ -63,5 +73,13 @@ class NullExtractor implements PropertyListExtractorInterface, PropertyDescripti
      */
     public function getProperties($class, array $context = array())
     {
+        $this->assertIsString($class);
+    }
+
+    private function assertIsString($string)
+    {
+        if (!is_string($string)) {
+            throw new \Exception(sprintf('"%s" expects strings, given "%s".', __CLASS__, gettype($string)));
+        }
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/PropertyInfoCacheExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/PropertyInfoCacheExtractorTest.php
@@ -26,15 +26,40 @@ class PropertyInfoCacheExtractorTest extends AbstractPropertyInfoExtractorTest
         $this->propertyInfo = new PropertyInfoCacheExtractor($this->propertyInfo, new ArrayAdapter());
     }
 
-    public function testCache()
+    public function testGetShortDescription()
     {
-        $this->assertSame('short', $this->propertyInfo->getShortDescription('Foo', 'bar', array()));
-        $this->assertSame('short', $this->propertyInfo->getShortDescription('Foo', 'bar', array()));
+        parent::testGetShortDescription();
+        parent::testGetShortDescription();
     }
 
-    public function testNotSerializableContext()
+    public function testGetLongDescription()
     {
-        $this->assertSame('short', $this->propertyInfo->getShortDescription('Foo', 'bar', array('foo' => function () {})));
+        parent::testGetLongDescription();
+        parent::testGetLongDescription();
+    }
+
+    public function testGetTypes()
+    {
+        parent::testGetTypes();
+        parent::testGetTypes();
+    }
+
+    public function testIsReadable()
+    {
+        parent::testIsReadable();
+        parent::testIsReadable();
+    }
+
+    public function testIsWritable()
+    {
+        parent::testIsWritable();
+        parent::testIsWritable();
+    }
+
+    public function testGetProperties()
+    {
+        parent::testGetProperties();
+        parent::testGetProperties();
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

An argument was forgotten in the `PropertyInfoCacheExtractor` class leading to exceptions such as

```
PHP Warning:  ucfirst() expects parameter 1 to be string, array given in /home/guilhem/github/ast-test/vendor/symfony/symfony/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php on line 318
```

and making it unusable.

ping @dunglas 
