### PR TITLE
[Console] Overcomplete argument exception message tweak.

### DIFF
--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -176,10 +176,10 @@ class ArgvInput extends Input
         } else {
             $all = $this->definition->getArguments();
             if (count($all)) {
-                throw new \RuntimeException(sprintf('Too many arguments, expected arguments "%s".', implode(', ', array_keys($all))));
+                throw new \RuntimeException(sprintf('Too many arguments, expected arguments "%s".', implode('" "', array_keys($all))));
             }
 
-            throw new \RuntimeException(sprintf('No argument expected, got "%s".', $token));
+            throw new \RuntimeException(sprintf('No arguments expected got "%s".', $token));
         }
     }
 

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -174,7 +174,12 @@ class ArgvInput extends Input
 
         // unexpected argument
         } else {
-            throw new \RuntimeException('Too many arguments.');
+            $all = $this->definition->getArguments();
+            if (count($all)) {
+                throw new \RuntimeException(sprintf('Too many arguments, expected arguments "%s".', implode(', ', array_keys($all))));
+            }
+
+            throw new \RuntimeException(sprintf('No argument expected, got "%s".', $token));
         }
     }
 

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -179,7 +179,7 @@ class ArgvInput extends Input
                 throw new \RuntimeException(sprintf('Too many arguments, expected arguments "%s".', implode('" "', array_keys($all))));
             }
 
-            throw new \RuntimeException(sprintf('No arguments expected got "%s".', $token));
+            throw new \RuntimeException(sprintf('No arguments expected, got "%s".', $token));
         }
     }
 

--- a/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
@@ -183,7 +183,7 @@ class ArgvInputTest extends \PHPUnit_Framework_TestCase
             array(
                 array('cli.php', 'foo', 'bar'),
                 new InputDefinition(),
-                'No argument expected, got "foo".',
+                'No argument expected got "foo".',
             ),
             array(
                 array('cli.php', 'foo', 'bar'),
@@ -193,7 +193,7 @@ class ArgvInputTest extends \PHPUnit_Framework_TestCase
             array(
                 array('cli.php', 'foo', 'bar', 'zzz'),
                 new InputDefinition(array(new InputArgument('number'), new InputArgument('county'))),
-                'Too many arguments, expected arguments "number, county".',
+                'Too many arguments, expected arguments "number" "county".',
             ),
             array(
                 array('cli.php', '--foo'),

--- a/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
@@ -183,7 +183,17 @@ class ArgvInputTest extends \PHPUnit_Framework_TestCase
             array(
                 array('cli.php', 'foo', 'bar'),
                 new InputDefinition(),
-                'Too many arguments.',
+                'No argument expected, got "foo".',
+            ),
+            array(
+                array('cli.php', 'foo', 'bar'),
+                new InputDefinition(array(new InputArgument('number'))),
+                'Too many arguments, expected arguments "number".',
+            ),
+            array(
+                array('cli.php', 'foo', 'bar', 'zzz'),
+                new InputDefinition(array(new InputArgument('number'), new InputArgument('county'))),
+                'Too many arguments, expected arguments "number, county".',
             ),
             array(
                 array('cli.php', '--foo'),

--- a/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
@@ -183,7 +183,7 @@ class ArgvInputTest extends \PHPUnit_Framework_TestCase
             array(
                 array('cli.php', 'foo', 'bar'),
                 new InputDefinition(),
-                'No argument expected got "foo".',
+                'No arguments expected, got "foo".',
             ),
             array(
                 array('cli.php', 'foo', 'bar'),


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

Updates the exception message when to many arguments are passed.
From;

``` php
'Too many arguments.'
```

To:

``` php
'No argument expected, got "foo".'
// or
'Too many arguments, expected arguments "foo".'
// or
'Too many arguments, expected arguments "foo, bar".'
// ... turtles all the way down
```
