### PR TITLE
[FrameworkBundle] Inject the PropertyInfo in the ObjectNormalizer

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
@@ -16,11 +16,14 @@
 
         <service id="serializer.property_accessor" alias="property_accessor" public="false" />
 
+        <service id="serializer.property_info" alias="property_info" public="false" />
+
         <!-- Normalizer -->
         <service id="serializer.normalizer.object" class="Symfony\Component\Serializer\Normalizer\ObjectNormalizer" public="false">
             <argument type="service" id="serializer.mapping.class_metadata_factory" />
             <argument>null</argument> <!-- name converter -->
             <argument type="service" id="serializer.property_accessor" />
+            <argument type="service" id="serializer.property_info" on-invalid="ignore" />
 
             <!-- Run after all custom serializers -->
             <tag name="serializer.normalizer" priority="-1000" />


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

https://github.com/symfony/symfony/pull/17660 allowed to deserialize object relations but users can't use it easily as it is not available in the framework yet.
We only need to pass the `PropertyInfoExtractor` to the `ObjectNormalizer` when it is available and this feature will be available for everyone !
