### PR TITLE
[ExpressionLanguage] Lexer should provide expression information

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Lexer.php
+++ b/src/Symfony/Component/ExpressionLanguage/Lexer.php
@@ -87,7 +87,8 @@ class Lexer
                 $cursor += strlen($match[0]);
             } else {
                 // unlexable
-                throw new SyntaxError(sprintf('Unexpected character "%s"', $expression[$cursor]), $cursor);
+                $message = sprintf('Unexpected character "%s"', $expression[$cursor]);
+                throw new SyntaxError($message, $cursor, $expression);
             }
         }
 
@@ -95,7 +96,7 @@ class Lexer
 
         if (!empty($brackets)) {
             list($expect, $cur) = array_pop($brackets);
-            throw new SyntaxError(sprintf('Unclosed "%s"', $expect), $cur);
+            throw new SyntaxError(sprintf('Unclosed "%s"', $expect), $cur, $expression);
         }
 
         return new TokenStream($tokens);

--- a/src/Symfony/Component/ExpressionLanguage/SyntaxError.php
+++ b/src/Symfony/Component/ExpressionLanguage/SyntaxError.php
@@ -13,8 +13,14 @@ namespace Symfony\Component\ExpressionLanguage;
 
 class SyntaxError extends \LogicException
 {
-    public function __construct($message, $cursor = 0)
+    public function __construct($message, $cursor = 0, $expression = '')
     {
-        parent::__construct(sprintf('%s around position %d.', $message, $cursor));
+        $message = sprintf('%s around position %d', $message, $cursor);
+        if ($expression) {
+            $message = sprintf('%s for expression "%s"', $message, $expression);
+        }
+        $message .= '.';
+
+        parent::__construct($message);
     }
 }

--- a/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
@@ -18,13 +18,42 @@ use Symfony\Component\ExpressionLanguage\TokenStream;
 class LexerTest extends \PHPUnit_Framework_TestCase
 {
     /**
+     * @var Lexer
+     */
+    private $lexer;
+
+    protected function setUp()
+    {
+        $this->lexer = new Lexer();
+    }
+
+    /**
      * @dataProvider getTokenizeData
      */
     public function testTokenize($tokens, $expression)
     {
         $tokens[] = new Token('end of expression', null, strlen($expression) + 1);
-        $lexer = new Lexer();
-        $this->assertEquals(new TokenStream($tokens), $lexer->tokenize($expression));
+        $this->assertEquals(new TokenStream($tokens), $this->lexer->tokenize($expression));
+    }
+
+    /**
+     * @expectedException Symfony\Component\ExpressionLanguage\SyntaxError
+     * @expectedExceptionMessage Unexpected character "'" around position 33 for expression "service(faulty.expression.example').dummyMethod()".
+     */
+    public function testTokenizeThrowsErrorWithMessage()
+    {
+        $expression = "service(faulty.expression.example').dummyMethod()";
+        $this->lexer->tokenize($expression);
+    }
+
+    /**
+     * @expectedException Symfony\Component\ExpressionLanguage\SyntaxError
+     * @expectedExceptionMessage Unclosed "(" around position 7 for expression "service(unclosed.expression.dummyMethod()".
+     */
+    public function testTokenizeThrowsErrorOnUnclosedBrace()
+    {
+        $expression = 'service(unclosed.expression.dummyMethod()';
+        $this->lexer->tokenize($expression);
     }
 
     public function getTokenizeData()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7. |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | symfony suite did not fully pass locally out of the box, ./phpunit src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php passes |
| Fixed tickets | #19445 |
| License | MIT |
| Doc PR | does not apply |
