### PR TITLE
[Serializer] make datetime_format configurable in config.yml

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -614,6 +614,7 @@ class Configuration implements ConfigurationInterface
                         ->booleanNode('enable_annotations')->defaultFalse()->end()
                         ->scalarNode('cache')->end()
                         ->scalarNode('name_converter')->end()
+                        ->scalarNode('datetime_format')->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -979,6 +979,9 @@ class FrameworkExtension extends Extension
         if (class_exists('Symfony\Component\Serializer\Normalizer\DateTimeNormalizer')) {
             // Run before serializer.normalizer.object
             $definition = $container->register('serializer.normalizer.datetime', DateTimeNormalizer::class);
+            if (isset($config['datetime_format'])) {
+                $definition->addArgument($config['datetime_format']);
+            }
             $definition->setPublic(false);
             $definition->addTag('serializer.normalizer', array('priority' => -910));
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

with this change, you can configure globaly the datetime format for the datetime normilizer in your config.yml

``` yml
framework:
    serializer:
        enabled: true
        datetime_format: "d-m-Y"
```
