### PR TITLE
[Security] Expose the required roles in AccessDeniedException

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -192,7 +192,11 @@ abstract class Controller implements ContainerAwareInterface
     protected function denyAccessUnlessGranted($attributes, $object = null, $message = 'Access Denied.')
     {
         if (!$this->isGranted($attributes, $object)) {
-            throw $this->createAccessDeniedException($message);
+            $exception = $this->createAccessDeniedException($message);
+            $exception->setAttributes($attributes);
+            $exception->setObject($object);
+
+            throw $exception;
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -29,7 +29,7 @@
         "symfony/filesystem": "~2.8|~3.0",
         "symfony/finder": "~2.8|~3.0",
         "symfony/routing": "~3.0",
-        "symfony/security-core": "~2.8|~3.0",
+        "symfony/security-core": "~3.2",
         "symfony/security-csrf": "~2.8|~3.0",
         "symfony/stopwatch": "~2.8|~3.0",
         "symfony/templating": "~2.8|~3.0",

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.2.0
+-----
+
+ * added `attributes` and `object` with getters/setters to `Symfony\Component\Security\Core\Exception\AccessDeniedException`
+
 3.0.0
 -----
 

--- a/src/Symfony/Component/Security/Core/Exception/AccessDeniedException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AccessDeniedException.php
@@ -18,8 +18,43 @@ namespace Symfony\Component\Security\Core\Exception;
  */
 class AccessDeniedException extends \RuntimeException
 {
+    private $attributes = array();
+    private $object;
+
     public function __construct($message = 'Access Denied.', \Exception $previous = null)
     {
         parent::__construct($message, 403, $previous);
+    }
+
+    /**
+     * @return array
+     */
+    public function getAttributes()
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * @param array|string $attributes
+     */
+    public function setAttributes($attributes)
+    {
+        $this->attributes = (array) $attributes;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getObject()
+    {
+        return $this->object;
+    }
+
+    /**
+     * @param mixed $object
+     */
+    public function setObject($object)
+    {
+        $this->object = $object;
     }
 }

--- a/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
@@ -67,7 +67,11 @@ class AccessListener implements ListenerInterface
         }
 
         if (!$this->accessDecisionManager->decide($token, $attributes, $request)) {
-            throw new AccessDeniedException();
+            $exception = new AccessDeniedException();
+            $exception->setAttributes($attributes);
+            $exception->setObject($request);
+
+            throw $exception;
         }
     }
 }

--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -122,7 +122,10 @@ class SwitchUserListener implements ListenerInterface
         }
 
         if (false === $this->accessDecisionManager->decide($token, array($this->role))) {
-            throw new AccessDeniedException();
+            $exception = new AccessDeniedException();
+            $exception->setAttributes($this->role);
+
+            throw $exception;
         }
 
         $username = $request->get($this->usernameParameter);

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "symfony/security-core": "~2.8|~3.0",
+        "symfony/security-core": "~3.2",
         "symfony/event-dispatcher": "~2.8|~3.0",
         "symfony/http-foundation": "~2.8|~3.0",
         "symfony/http-kernel": "~2.8|~3.0",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

Nowadays it is more and more common to protect some sensitive actions and part of a website using 2FA or some re-authentication mechanism (per example, on Github you have to enter your password again when you add an ssh key). But currently, in Symfony, it is really hard to implement without having to duplicate the logic, provide an explicit list of URLs to protect or hack into the security component.

A good way to achieve that would be to add a special role (like IS_AUTHENTICATED_FULLY) and use it in the access map. But it requires us to be able to have a custom logic in an ExceptionListener depending on the roles behind an AccessDeniedException.

With this patch we could write an ExceptionListener of this kind (a similar logic could also be used in an AccessDeniedHandler):

``` php
    public function onKernelException(GetResponseForExceptionEvent $event)
    {
        $exception = $event->getException();
        do {
            if ($exception instanceof AccessDeniedException) {
                foreach ($exception->getAttributes() as $role) {
                    if ($role === 'IS_AUTHENTICATED_2FA' && !$this->accessDecisionManager->decide($this->tokenStorage->getToken(), $role, $exception->getObject())) {
                        // Start 2FA
                    }
                }
            }
        } while (null !== $exception = $exception->getPrevious());
    }
```

Replaces #18661 
