### PR TITLE
[Cache] Fix abstract AdapterTestCase cache property

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
@@ -23,18 +23,18 @@ abstract class AdapterTestCase extends CachePoolTest
             return;
         }
 
-        $this->cache = $this->createCachePool(2);
+        $cache = $this->createCachePool(2);
 
-        $item = $this->cache->getItem('key.dlt');
+        $item = $cache->getItem('key.dlt');
         $item->set('value');
-        $this->cache->save($item);
+        $cache->save($item);
         sleep(1);
 
-        $item = $this->cache->getItem('key.dlt');
+        $item = $cache->getItem('key.dlt');
         $this->assertTrue($item->isHit());
 
         sleep(2);
-        $item = $this->cache->getItem('key.dlt');
+        $item = $cache->getItem('key.dlt');
         $this->assertFalse($item->isHit());
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | Sort of |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

The `AdapterTestCase` extends the `CachePoolTest` from the [cache/integration-tests package](https://packagist.org/packages/cache/integration-tests) in order to test cache pools but it tries to reuse a private variable from its parent class.

As there is no need to use a property in this case, I simply replace the variable by a local one.
