### PR TITLE
[Form] Fix typo, php-doc and argument in form methods

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/src/Symfony/Component/Form/ChoiceList/ArrayChoiceList.php
+++ b/src/Symfony/Component/Form/ChoiceList/ArrayChoiceList.php
@@ -177,12 +177,13 @@ class ArrayChoiceList implements ChoiceListInterface
     /**
      * Flattens an array into the given output variables.
      *
-     * @param array    $choices         The array to flatten
-     * @param callable $value           The callable for generating choice values
-     * @param array    $choicesByValues The flattened choices indexed by the
-     *                                  corresponding values
-     * @param array    $keysByValues    The original keys indexed by the
-     *                                  corresponding values
+     * @param array    $choices          The array to flatten
+     * @param callable $value            The callable for generating choice values
+     * @param array    $choicesByValues  The flattened choices indexed by the
+     *                                   corresponding values
+     * @param array    $keysByValues     The original keys indexed by the
+     *                                   corresponding values
+     * @param array    $structuredValues
      *
      * @internal Must not be used by user-land code
      */

--- a/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
+++ b/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
@@ -38,9 +38,6 @@ class CoreExtension extends AbstractExtension
 
     /**
      * CoreExtension constructor.
-     *
-     * @param PropertyAccessorInterface|null  $propertyAccessor
-     * @param ChoiceListFactoryInterface|null $choiceListFactory
      */
     public function __construct(PropertyAccessorInterface $propertyAccessor = null, ChoiceListFactoryInterface $choiceListFactory = null)
     {

--- a/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
+++ b/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
@@ -36,12 +36,21 @@ class CoreExtension extends AbstractExtension
      */
     private $choiceListFactory;
 
+    /**
+     * CoreExtension constructor.
+     *
+     * @param PropertyAccessorInterface|null  $propertyAccessor
+     * @param ChoiceListFactoryInterface|null $choiceListFactory
+     */
     public function __construct(PropertyAccessorInterface $propertyAccessor = null, ChoiceListFactoryInterface $choiceListFactory = null)
     {
         $this->propertyAccessor = $propertyAccessor ?: PropertyAccess::createPropertyAccessor();
         $this->choiceListFactory = $choiceListFactory ?: new CachingFactoryDecorator(new PropertyAccessDecorator(new DefaultChoiceListFactory(), $this->propertyAccessor));
     }
 
+    /**
+     * @return array
+     */
     protected function loadTypes()
     {
         return array(

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php
@@ -23,6 +23,14 @@ class MoneyToLocalizedStringTransformer extends NumberToLocalizedStringTransform
 {
     private $divisor;
 
+    /**
+     * MoneyToLocalizedStringTransformer constructor.
+     * 
+     * @param int  $scale
+     * @param bool $grouping
+     * @param int  $roundingMode
+     * @param int  $divisor
+     */
     public function __construct($scale = 2, $grouping = true, $roundingMode = self::ROUND_HALF_UP, $divisor = 1)
     {
         if (null === $grouping) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
@@ -72,12 +72,28 @@ class NumberToLocalizedStringTransformer implements DataTransformerInterface
      */
     const ROUND_HALF_DOWN = \NumberFormatter::ROUND_HALFDOWN;
 
+    /**
+     * @var bool
+     */
     protected $grouping;
 
+    /**
+     * @var int
+     */
     protected $roundingMode;
 
+    /**
+     * @var null
+     */
     private $scale;
 
+    /**
+     * NumberToLocalizedStringTransformer constructor.
+     *
+     * @param null $scale
+     * @param bool $grouping
+     * @param int  $roundingMode
+     */
     public function __construct($scale = null, $grouping = false, $roundingMode = self::ROUND_HALF_UP)
     {
         if (null === $grouping) {
@@ -96,7 +112,7 @@ class NumberToLocalizedStringTransformer implements DataTransformerInterface
     /**
      * Transforms a number type into localized number.
      *
-     * @param int|float $value Number value
+     * @param int|float|null $value Number value
      *
      * @return string Localized value
      *

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/PercentToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/PercentToLocalizedStringTransformer.php
@@ -31,8 +31,14 @@ class PercentToLocalizedStringTransformer implements DataTransformerInterface
         self::INTEGER,
     );
 
+    /**
+     * @var null|string
+     */
     private $type;
 
+    /**
+     * @var int|null
+     */
     private $scale;
 
     /**
@@ -40,8 +46,8 @@ class PercentToLocalizedStringTransformer implements DataTransformerInterface
      *
      * @see self::$types for a list of supported types
      *
-     * @param int    $scale The scale
-     * @param string $type  One of the supported types
+     * @param int|null    $scale The scale
+     * @param string|null $type  One of the supported types
      *
      * @throws UnexpectedTypeException if the given value of type is unknown
      */
@@ -66,7 +72,7 @@ class PercentToLocalizedStringTransformer implements DataTransformerInterface
     /**
      * Transforms between a normalized format (integer or float) into a percentage value.
      *
-     * @param int|float $value Normalized value
+     * @param int|float|null $value Normalized value
      *
      * @return string Percentage value
      *

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/FixUrlProtocolListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/FixUrlProtocolListener.php
@@ -22,6 +22,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class FixUrlProtocolListener implements EventSubscriberInterface
 {
+    /**
+     * @var null|string
+     */
     private $defaultProtocol;
 
     /**
@@ -34,6 +37,9 @@ class FixUrlProtocolListener implements EventSubscriberInterface
         $this->defaultProtocol = $defaultProtocol;
     }
 
+    /**
+     * @param FormEvent $event
+     */
     public function onSubmit(FormEvent $event)
     {
         $data = $event->getData();
@@ -43,6 +49,9 @@ class FixUrlProtocolListener implements EventSubscriberInterface
         }
     }
 
+    /**
+     * @return array
+     */
     public static function getSubscribedEvents()
     {
         return array(FormEvents::SUBMIT => 'onSubmit');

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/MergeCollectionListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/MergeCollectionListener.php
@@ -49,6 +49,9 @@ class MergeCollectionListener implements EventSubscriberInterface
         $this->allowDelete = $allowDelete;
     }
 
+    /**
+     * @return array
+     */
     public static function getSubscribedEvents()
     {
         return array(
@@ -56,6 +59,9 @@ class MergeCollectionListener implements EventSubscriberInterface
         );
     }
 
+    /**
+     * @param FormEvent $event
+     */
     public function onSubmit(FormEvent $event)
     {
         $dataToMergeInto = $event->getForm()->getNormData();

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
@@ -52,6 +52,15 @@ class ResizeFormListener implements EventSubscriberInterface
      */
     private $deleteEmpty;
 
+    /**
+     * ResizeFormListener constructor.
+     *
+     * @param $type
+     * @param array $options
+     * @param bool  $allowAdd
+     * @param bool  $allowDelete
+     * @param bool  $deleteEmpty
+     */
     public function __construct($type, array $options = array(), $allowAdd = false, $allowDelete = false, $deleteEmpty = false)
     {
         $this->type = $type;
@@ -61,6 +70,9 @@ class ResizeFormListener implements EventSubscriberInterface
         $this->deleteEmpty = $deleteEmpty;
     }
 
+    /**
+     * @return array
+     */
     public static function getSubscribedEvents()
     {
         return array(
@@ -71,6 +83,9 @@ class ResizeFormListener implements EventSubscriberInterface
         );
     }
 
+    /**
+     * @param FormEvent $event
+     */
     public function preSetData(FormEvent $event)
     {
         $form = $event->getForm();
@@ -97,6 +112,9 @@ class ResizeFormListener implements EventSubscriberInterface
         }
     }
 
+    /**
+     * @param FormEvent $event
+     */
     public function preSubmit(FormEvent $event)
     {
         $form = $event->getForm();
@@ -131,6 +149,9 @@ class ResizeFormListener implements EventSubscriberInterface
         }
     }
 
+    /**
+     * @param FormEvent $event
+     */
     public function onSubmit(FormEvent $event)
     {
         $form = $event->getForm();
@@ -162,8 +183,7 @@ class ResizeFormListener implements EventSubscriberInterface
             }
         }
 
-        // The data mapper only adds, but does not remove items, so do this
-        // here
+        // The data mapper only adds, but does not remove items, so do this here
         if ($this->allowDelete) {
             $toDelete = array();
 

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/TrimListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/TrimListener.php
@@ -23,6 +23,9 @@ use Symfony\Component\Form\Util\StringUtil;
  */
 class TrimListener implements EventSubscriberInterface
 {
+    /**
+     * @param FormEvent $event
+     */
     public function preSubmit(FormEvent $event)
     {
         $data = $event->getData();
@@ -34,6 +37,9 @@ class TrimListener implements EventSubscriberInterface
         $event->setData(StringUtil::trim($data));
     }
 
+    /**
+     * @return array
+     */
     public static function getSubscribedEvents()
     {
         return array(FormEvents::PRE_SUBMIT => 'preSubmit');

--- a/src/Symfony/Component/Form/Extension/Csrf/EventListener/CsrfValidationListener.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/EventListener/CsrfValidationListener.php
@@ -65,6 +65,9 @@ class CsrfValidationListener implements EventSubscriberInterface
      */
     private $translationDomain;
 
+    /**
+     * @return array
+     */
     public static function getSubscribedEvents()
     {
         return array(
@@ -72,6 +75,16 @@ class CsrfValidationListener implements EventSubscriberInterface
         );
     }
 
+    /**
+     * CsrfValidationListener constructor.
+     *
+     * @param $fieldName
+     * @param CsrfTokenManagerInterface $tokenManager
+     * @param $tokenId
+     * @param $errorMessage
+     * @param TranslatorInterface|null $translator
+     * @param null                     $translationDomain
+     */
     public function __construct($fieldName, CsrfTokenManagerInterface $tokenManager, $tokenId, $errorMessage, TranslatorInterface $translator = null, $translationDomain = null)
     {
         $this->fieldName = $fieldName;
@@ -82,6 +95,9 @@ class CsrfValidationListener implements EventSubscriberInterface
         $this->translationDomain = $translationDomain;
     }
 
+    /**
+     * @param FormEvent $event
+     */
     public function preSubmit(FormEvent $event)
     {
         $form = $event->getForm();

--- a/src/Symfony/Component/Form/Extension/DataCollector/FormDataCollector.php
+++ b/src/Symfony/Component/Form/Extension/DataCollector/FormDataCollector.php
@@ -75,6 +75,10 @@ class FormDataCollector extends DataCollector implements FormDataCollectorInterf
 
     /**
      * Does nothing. The data is collected during the form event listeners.
+     *
+     * @param Request         $request
+     * @param Response        $response
+     * @param \Exception|null $exception
      */
     public function collect(Request $request, Response $response, \Exception $exception = null)
     {
@@ -215,6 +219,11 @@ class FormDataCollector extends DataCollector implements FormDataCollectorInterf
         return $this->data;
     }
 
+    /**
+     * @param FormInterface $form
+     * @param $output
+     * @param array $outputByHash
+     */
     private function recursiveBuildPreliminaryFormTree(FormInterface $form, &$output, array &$outputByHash)
     {
         $hash = spl_object_hash($form);
@@ -234,6 +243,12 @@ class FormDataCollector extends DataCollector implements FormDataCollectorInterf
         }
     }
 
+    /**
+     * @param FormInterface|null $form
+     * @param FormView           $view
+     * @param $output
+     * @param array $outputByHash
+     */
     private function recursiveBuildFinalFormTree(FormInterface $form = null, FormView $view, &$output, array &$outputByHash)
     {
         $viewHash = spl_object_hash($view);

--- a/src/Symfony/Component/Form/Extension/DependencyInjection/DependencyInjectionExtension.php
+++ b/src/Symfony/Component/Form/Extension/DependencyInjection/DependencyInjectionExtension.php
@@ -18,13 +18,41 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class DependencyInjectionExtension implements FormExtensionInterface
 {
+    /**
+     * @var ContainerInterface
+     */
     private $container;
+
+    /**
+     * @var array
+     */
     private $typeServiceIds;
+
+    /**
+     * @var array
+     */
     private $typeExtensionServiceIds;
+
+    /**
+     * @var array
+     */
     private $guesserServiceIds;
+
     private $guesser;
+
+    /**
+     * @var bool
+     */
     private $guesserLoaded = false;
 
+    /**
+     * DependencyInjectionExtension constructor.
+     *
+     * @param ContainerInterface $container
+     * @param array              $typeServiceIds
+     * @param array              $typeExtensionServiceIds
+     * @param array              $guesserServiceIds
+     */
     public function __construct(ContainerInterface $container, array $typeServiceIds, array $typeExtensionServiceIds, array $guesserServiceIds)
     {
         $this->container = $container;
@@ -33,6 +61,11 @@ class DependencyInjectionExtension implements FormExtensionInterface
         $this->guesserServiceIds = $guesserServiceIds;
     }
 
+    /**
+     * @param string $name
+     *
+     * @return object
+     */
     public function getType($name)
     {
         if (!isset($this->typeServiceIds[$name])) {
@@ -42,11 +75,21 @@ class DependencyInjectionExtension implements FormExtensionInterface
         return $this->container->get($this->typeServiceIds[$name]);
     }
 
+    /**
+     * @param string $name
+     *
+     * @return bool
+     */
     public function hasType($name)
     {
         return isset($this->typeServiceIds[$name]);
     }
 
+    /**
+     * @param string $name
+     *
+     * @return array
+     */
     public function getTypeExtensions($name)
     {
         $extensions = array();
@@ -71,11 +114,19 @@ class DependencyInjectionExtension implements FormExtensionInterface
         return $extensions;
     }
 
+    /**
+     * @param string $name
+     *
+     * @return bool
+     */
     public function hasTypeExtensions($name)
     {
         return isset($this->typeExtensionServiceIds[$name]);
     }
 
+    /**
+     * @return FormTypeGuesserChain
+     */
     public function getTypeGuesser()
     {
         if (!$this->guesserLoaded) {

--- a/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationExtension.php
+++ b/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationExtension.php
@@ -20,6 +20,9 @@ use Symfony\Component\Form\AbstractExtension;
  */
 class HttpFoundationExtension extends AbstractExtension
 {
+    /**
+     * @return array
+     */
     protected function loadTypeExtensions()
     {
         return array(

--- a/src/Symfony/Component/Form/Extension/Validator/EventListener/ValidationListener.php
+++ b/src/Symfony/Component/Form/Extension/Validator/EventListener/ValidationListener.php
@@ -23,8 +23,14 @@ use Symfony\Component\Form\Extension\Validator\Constraints\Form;
  */
 class ValidationListener implements EventSubscriberInterface
 {
+    /**
+     * @var ValidatorInterface
+     */
     private $validator;
 
+    /**
+     * @var ViolationMapperInterface
+     */
     private $violationMapper;
 
     /**

--- a/src/Symfony/Component/Form/Extension/Validator/Type/UploadValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/UploadValidatorExtension.php
@@ -22,7 +22,14 @@ use Symfony\Component\Translation\TranslatorInterface;
  */
 class UploadValidatorExtension extends AbstractTypeExtension
 {
+    /**
+     * @var TranslatorInterface
+     */
     private $translator;
+
+    /**
+     * @var null|string
+     */
     private $translationDomain;
 
     /**

--- a/src/Symfony/Component/Form/Extension/Validator/Type/UploadValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/UploadValidatorExtension.php
@@ -22,9 +22,6 @@ use Symfony\Component\Translation\TranslatorInterface;
  */
 class UploadValidatorExtension extends AbstractTypeExtension
 {
-    /**
-     * @var TranslatorInterface
-     */
     private $translator;
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | no |
| License | MIT |
- Fix php-doc on methods
- Fix typo in variables
- Run php cs-fixer
