### PR TITLE
[DX][Form][Validator] Add ability check if cocrete constraint fails.

### DIFF
--- a/src/Symfony/Component/Form/FormErrorIterator.php
+++ b/src/Symfony/Component/Form/FormErrorIterator.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Form;
 use Symfony\Component\Form\Exception\InvalidArgumentException;
 use Symfony\Component\Form\Exception\OutOfBoundsException;
 use Symfony\Component\Form\Exception\BadMethodCallException;
+use Symfony\Component\Validator\ConstraintViolation;
 
 /**
  * Iterates over the errors of a form.
@@ -263,6 +264,27 @@ class FormErrorIterator implements \RecursiveIterator, \SeekableIterator, \Array
         while ($position !== key($this->errors)) {
             next($this->errors);
         }
+    }
+
+    /**
+     * Creates iterator for errors with specific codes.
+     *
+     * @param string|string[] $codes The codes to find
+     *
+     * @return static New instance which contains only specific errors.
+     */
+    public function findByCodes($codes)
+    {
+        $codes = (array) $codes;
+        $errors = array();
+        foreach ($this as $error) {
+            $cause = $error->getCause();
+            if ($cause instanceof ConstraintViolation && in_array($cause->getCode(), $codes, true)) {
+                $errors[] = $error;
+            }
+        }
+
+        return new static($this->form, $errors);
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/FormErrorIteratorTest.php
+++ b/src/Symfony/Component/Form/Tests/FormErrorIteratorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests;
+
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormErrorIterator;
+use Symfony\Component\Validator\ConstraintViolation;
+
+class FormErrorIteratorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider findByCodesProvider
+     */
+    public function testFindByCodes($code, $violationsCount)
+    {
+        if (!class_exists(ConstraintViolation::class)) {
+            $this->markTestSkipped('Validator component required.');
+        }
+
+        $formBuilder = new FormBuilder(
+            'form',
+            null,
+            new EventDispatcher(),
+            $this->getMock('Symfony\Component\Form\FormFactoryInterface'),
+            array()
+        );
+
+        $form = $formBuilder->getForm();
+
+        $cause = new ConstraintViolation('Error 1!', null, array(), null, '', null, null, 'code1');
+        $form->addError(new FormError('Error 1!', null, array(), null, $cause));
+        $cause = new ConstraintViolation('Error 2!', null, array(), null, '', null, null, 'code1');
+        $form->addError(new FormError('Error 2!', null, array(), null, $cause));
+        $cause = new ConstraintViolation('Error 3!', null, array(), null, '', null, null, 'code2');
+        $form->addError(new FormError('Error 3!', null, array(), null, $cause));
+        $formErrors = $form->getErrors();
+
+        $specificFormErrors = $formErrors->findByCodes($code);
+        $this->assertInstanceOf(FormErrorIterator::class, $specificFormErrors);
+        $this->assertCount($violationsCount, $specificFormErrors);
+    }
+
+    public function findByCodesProvider()
+    {
+        return array(
+            array('code1', 2),
+            array(array('code1', 'code2'), 3),
+            array('code3', 0),
+        );
+    }
+}

--- a/src/Symfony/Component/Validator/ConstraintViolationList.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationList.php
@@ -158,4 +158,24 @@ class ConstraintViolationList implements \IteratorAggregate, ConstraintViolation
     {
         $this->remove($offset);
     }
+
+    /**
+     * Creates iterator for errors with specific codes.
+     *
+     * @param string|string[] $codes The codes to find
+     *
+     * @return static New instance which contains only specific errors.
+     */
+    public function findByCodes($codes)
+    {
+        $codes = (array) $codes;
+        $violations = array();
+        foreach ($this as $violation) {
+            if (in_array($violation->getCode(), $codes, true)) {
+                $violations[] = $violation;
+            }
+        }
+
+        return new static($violations);
+    }
 }

--- a/src/Symfony/Component/Validator/Tests/ConstraintViolationListTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintViolationListTest.php
@@ -127,8 +127,35 @@ EOF;
         $this->assertEquals($expected, (string) $this->list);
     }
 
-    protected function getViolation($message, $root = null, $propertyPath = null)
+    /**
+     * @dataProvider findByCodesProvider
+     */
+    public function testFindByCodes($code, $violationsCount)
     {
-        return new ConstraintViolation($message, $message, array(), $root, $propertyPath, null);
+        $violations = array(
+            $this->getViolation('Error', null, null, 'code1'),
+            $this->getViolation('Error', null, null, 'code1'),
+            $this->getViolation('Error', null, null, 'code2'),
+        );
+        $list = new ConstraintViolationList($violations);
+
+        $specificErrors = $list->findByCodes($code);
+
+        $this->assertInstanceOf(ConstraintViolationList::class, $specificErrors);
+        $this->assertCount($violationsCount, $specificErrors);
+    }
+
+    public function findByCodesProvider()
+    {
+        return array(
+            array('code1', 2),
+            array(array('code1', 'code2'), 3),
+            array('code3', 0),
+        );
+    }
+
+    protected function getViolation($message, $root = null, $propertyPath = null, $code = null)
+    {
+        return new ConstraintViolation($message, $message, array(), $root, $propertyPath, null, null, $code);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | wait for travis |
| Fixed tickets | #15154 |
| License | MIT |
| Doc PR | should open |

Sometimes for big forms with multiple constraints we should handle some errors separately.

``` php
// when using validator
$constraintViolations = $validator->validate(...);
if (count($constraintViolations->findByCodes(UniqueEntity::NOT_UNIQUE_ERROR))) {
  // display some message or send email or etc
}

// when using forms
if (count($form->getErrors()->findByCodes(UniqueEntity::NOT_UNIQUE_ERROR))) {
  // display some message or send email or etc
}
```

This PR add some useful methods to handle this. Before we should iterate all failed constraints using foreach.

Feel free to suggest better names for new methods.
