### PR TITLE
[SecurityBundle] BasicAuthenticationListener: simpler getting value from Request

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/BasicAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/BasicAuthenticationListener.php
@@ -56,7 +56,7 @@ class BasicAuthenticationListener implements ListenerInterface
     {
         $request = $event->getRequest();
 
-        if (false === $username = $request->headers->get('PHP_AUTH_USER', false)) {
+        if (null === $username = $request->headers->get('PHP_AUTH_USER')) {
             return;
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

Unless I'm mistaken, the default `null` should be OK. If it's not, I will create a new PR with a test proving that `false` or other "special" value must be used.
