### PR TITLE
[master] Ignore traces from the vendor dir

### DIFF
--- a/src/Symfony/Component/Debug/Exception/FlattenException.php
+++ b/src/Symfony/Component/Debug/Exception/FlattenException.php
@@ -200,8 +200,6 @@ class FlattenException
             ) {
                 continue;
             }
-            
-            
             $class = '';
             $namespace = '';
             if (isset($entry['class'])) {

--- a/src/Symfony/Component/Debug/Exception/FlattenException.php
+++ b/src/Symfony/Component/Debug/Exception/FlattenException.php
@@ -201,6 +201,7 @@ class FlattenException
                 continue;
             }
             
+            
             $class = '';
             $namespace = '';
             if (isset($entry['class'])) {

--- a/src/Symfony/Component/Debug/Exception/FlattenException.php
+++ b/src/Symfony/Component/Debug/Exception/FlattenException.php
@@ -195,7 +195,9 @@ class FlattenException
         );
         foreach ($trace as $entry) {
             // Let's ignore traces from the vendor folder; they're usually not relevant.
-            if ((isset($entry['file']) && strpos($entry['file'],'/vendor/') !== false || isset($entry['type']) && $entry['type'] == '->')) {
+            if ((isset($entry['file']) && strpos($entry['file'],
+                    '/vendor/') !== false || isset($entry['type']) && $entry['type'] == '->')
+            ) {
                 continue;
             }
             

--- a/src/Symfony/Component/Debug/Exception/FlattenException.php
+++ b/src/Symfony/Component/Debug/Exception/FlattenException.php
@@ -194,6 +194,11 @@ class FlattenException
             'args' => array(),
         );
         foreach ($trace as $entry) {
+            // Let's ignore traces from the vendor folder; they're usually not relevant.
+            if ((isset($entry['file']) && strpos($entry['file'],'/vendor/') !== false || isset($entry['type']) && $entry['type'] == '->')) {
+                continue;
+            }
+            
             $class = '';
             $namespace = '';
             if (isset($entry['class'])) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

It's usually not relevant to see traces from the vendor folder; It clutters the stack trace.
The last trace is always added to the stack so if you in fact encounter an vendor folder exception, it will appear.
