### PR TITLE
[FrameworkBundle] Introduce a cache warmer for Serializer based on PhpArrayAdapter

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/SerializerCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/SerializerCacheWarmer.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\CacheWarmer;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
+use Symfony\Component\Cache\Adapter\ProxyAdapter;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+use Symfony\Component\Serializer\Mapping\Factory\CacheClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Loader\LoaderChain;
+use Symfony\Component\Serializer\Mapping\Loader\LoaderInterface;
+use Symfony\Component\Serializer\Mapping\Loader\XmlFileLoader;
+use Symfony\Component\Serializer\Mapping\Loader\YamlFileLoader;
+
+/**
+ * Warms up XML and YAML serializer metadata.
+ *
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+class SerializerCacheWarmer implements CacheWarmerInterface
+{
+    private $loaders;
+    private $phpArrayFile;
+    private $fallbackPool;
+
+    /**
+     * @param LoaderInterface[]      $loaders      The serializer metadata loaders.
+     * @param string                 $phpArrayFile The PHP file where metadata are cached.
+     * @param CacheItemPoolInterface $fallbackPool The pool where runtime-discovered metadata are cached.
+     */
+    public function __construct(array $loaders, $phpArrayFile, CacheItemPoolInterface $fallbackPool)
+    {
+        $this->loaders = $loaders;
+        $this->phpArrayFile = $phpArrayFile;
+        if (!$fallbackPool instanceof AdapterInterface) {
+            $fallbackPool = new ProxyAdapter($fallbackPool);
+        }
+        $this->fallbackPool = $fallbackPool;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function warmUp($cacheDir)
+    {
+        if (!class_exists(CacheClassMetadataFactory::class) || !method_exists(XmlFileLoader::class, 'getMappedClasses') || !method_exists(YamlFileLoader::class, 'getMappedClasses')) {
+            return;
+        }
+
+        $adapter = new PhpArrayAdapter($this->phpArrayFile, $this->fallbackPool);
+        $arrayPool = new ArrayAdapter(0, false);
+
+        $metadataFactory = new CacheClassMetadataFactory(new ClassMetadataFactory(new LoaderChain($this->loaders)), $arrayPool);
+
+        foreach ($this->extractSupportedLoaders($this->loaders) as $loader) {
+            foreach ($loader->getMappedClasses() as $mappedClass) {
+                $metadataFactory->getMetadataFor($mappedClass);
+            }
+        }
+
+        $values = $arrayPool->getValues();
+        $adapter->warmUp($values);
+
+        foreach ($values as $k => $v) {
+            $item = $this->fallbackPool->getItem($k);
+            $this->fallbackPool->saveDeferred($item->set($v));
+        }
+        $this->fallbackPool->commit();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isOptional()
+    {
+        return true;
+    }
+
+    /**
+     * @param LoaderInterface[] $loaders
+     *
+     * @return XmlFileLoader[]|YamlFileLoader[]
+     */
+    private function extractSupportedLoaders(array $loaders)
+    {
+        $supportedLoaders = array();
+
+        foreach ($loaders as $loader) {
+            if ($loader instanceof XmlFileLoader || $loader instanceof YamlFileLoader) {
+                $supportedLoaders[] = $loader;
+            } elseif ($loader instanceof LoaderChain) {
+                $supportedLoaders = array_merge($supportedLoaders, $this->extractSupportedLoaders($loader->getDelegatedLoaders()));
+            }
+        }
+
+        return $supportedLoaders;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1067,6 +1067,7 @@ class FrameworkExtension extends Extension
         }
 
         $chainLoader->replaceArgument(0, $serializerLoaders);
+        $container->getDefinition('serializer.mapping.cache_warmer')->replaceArgument(0, $serializerLoaders);
 
         if (isset($config['cache']) && $config['cache']) {
             @trigger_error('The "framework.serializer.cache" option is deprecated since Symfony 3.1 and will be removed in 4.0. Configure the "cache.serializer" service under "framework.cache.pools" instead.', E_USER_DEPRECATED);
@@ -1079,12 +1080,12 @@ class FrameworkExtension extends Extension
             $container->getDefinition('serializer.mapping.class_metadata_factory')->replaceArgument(
                 1, new Reference($config['cache'])
             );
-        } elseif (!$container->getParameter('kernel.debug')) {
+        } elseif (!$container->getParameter('kernel.debug') && class_exists(CacheClassMetadataFactory::class)) {
             $cacheMetadataFactory = new Definition(
                 CacheClassMetadataFactory::class,
                 array(
                     new Reference('serializer.mapping.cache_class_metadata_factory.inner'),
-                    new Reference('cache.serializer'),
+                    new Reference('serializer.mapping.cache.symfony'),
                 )
             );
             $cacheMetadataFactory->setPublic(false);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
@@ -5,6 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
+        <parameter key="serializer.mapping.cache.file">%kernel.cache_dir%/serialization.php</parameter>
         <parameter key="serializer.mapping.cache.prefix" />
     </parameters>
 
@@ -39,6 +40,19 @@
         </service>
 
         <!-- Cache -->
+        <service id="serializer.mapping.cache_warmer" class="Symfony\Bundle\FrameworkBundle\CacheWarmer\SerializerCacheWarmer" public="false">
+            <argument type="collection" /><!-- Loaders injected by the extension -->
+            <argument>%serializer.mapping.cache.file%</argument>
+            <argument type="service" id="cache.serializer" />
+            <tag name="kernel.cache_warmer" />
+        </service>
+
+        <service id="serializer.mapping.cache.symfony" class="Symfony\Component\Cache\Adapter\PhpArrayAdapter">
+            <factory class="Symfony\Component\Cache\Adapter\PhpArrayAdapter" method="create" />
+            <argument>%serializer.mapping.cache.file%</argument>
+            <argument type="service" id="cache.serializer" />
+        </service>
+
         <service id="serializer.mapping.cache.doctrine.apc" class="Doctrine\Common\Cache\ApcCache" public="false">
             <call method="setNamespace">
                 <argument>%serializer.mapping.cache.prefix%</argument>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/SerializerCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/SerializerCacheWarmerTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\CacheWarmer;
+
+use Symfony\Bundle\FrameworkBundle\CacheWarmer\SerializerCacheWarmer;
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Serializer\Mapping\Factory\CacheClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Loader\XmlFileLoader;
+use Symfony\Component\Serializer\Mapping\Loader\YamlFileLoader;
+
+class SerializerCacheWarmerTest extends TestCase
+{
+    public function testWarmUp()
+    {
+        if (!class_exists(CacheClassMetadataFactory::class) || !method_exists(XmlFileLoader::class, 'getMappedClasses') || !method_exists(YamlFileLoader::class, 'getMappedClasses')) {
+            $this->markTestSkipped('The Serializer default cache warmer has been introduced in the Serializer Component version 3.2.');
+        }
+
+        $loaders = array(
+            new XmlFileLoader(__DIR__.'/../Fixtures/Serialization/Resources/person.xml'),
+            new YamlFileLoader(__DIR__.'/../Fixtures/Serialization/Resources/author.yml'),
+        );
+
+        $file = sys_get_temp_dir().'/cache-serializer.php';
+        @unlink($file);
+
+        $fallbackPool = new ArrayAdapter();
+
+        $warmer = new SerializerCacheWarmer($loaders, $file, $fallbackPool);
+        $warmer->warmUp(dirname($file));
+
+        $this->assertFileExists($file);
+
+        $values = require $file;
+
+        $this->assertInternalType('array', $values);
+        $this->assertCount(2, $values);
+        $this->assertArrayHasKey('Symfony_Bundle_FrameworkBundle_Tests_Fixtures_Serialization_Person', $values);
+        $this->assertArrayHasKey('Symfony_Bundle_FrameworkBundle_Tests_Fixtures_Serialization_Author', $values);
+
+        $values = $fallbackPool->getValues();
+
+        $this->assertInternalType('array', $values);
+        $this->assertCount(2, $values);
+        $this->assertArrayHasKey('Symfony_Bundle_FrameworkBundle_Tests_Fixtures_Serialization_Person', $values);
+        $this->assertArrayHasKey('Symfony_Bundle_FrameworkBundle_Tests_Fixtures_Serialization_Author', $values);
+    }
+
+    public function testWarmUpWithoutLoader()
+    {
+        if (!class_exists(CacheClassMetadataFactory::class) || !method_exists(XmlFileLoader::class, 'getMappedClasses') || !method_exists(YamlFileLoader::class, 'getMappedClasses')) {
+            $this->markTestSkipped('The Serializer default cache warmer has been introduced in the Serializer Component version 3.2.');
+        }
+
+        $file = sys_get_temp_dir().'/cache-serializer-without-loader.php';
+        @unlink($file);
+
+        $fallbackPool = new ArrayAdapter();
+
+        $warmer = new SerializerCacheWarmer(array(), $file, $fallbackPool);
+        $warmer->warmUp(dirname($file));
+
+        $this->assertFileExists($file);
+
+        $values = require $file;
+
+        $this->assertInternalType('array', $values);
+        $this->assertCount(0, $values);
+
+        $values = $fallbackPool->getValues();
+
+        $this->assertInternalType('array', $values);
+        $this->assertCount(0, $values);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Serialization/Author.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Serialization/Author.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Serialization;
+
+class Author
+{
+    public $gender;
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Serialization/Person.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Serialization/Person.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Serialization;
+
+class Person
+{
+    public $gender;
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Serialization/Resources/author.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Serialization/Resources/author.yml
@@ -1,0 +1,4 @@
+Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Serialization\Author:
+    attributes:
+        gender:
+            groups: ['group1', 'group2']

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Serialization/Resources/person.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Serialization/Resources/person.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<serializer xmlns="http://symfony.com/schema/dic/serializer-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping
+        http://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd"
+>
+    <class name="Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Serialization\Person">
+        <attribute name="gender">
+            <group>group1</group>
+            <group>group2</group>
+        </attribute>
+    </class>
+</serializer>

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -47,7 +47,7 @@
         "symfony/form": "~2.8|~3.0",
         "symfony/expression-language": "~2.8|~3.0",
         "symfony/process": "~2.8|~3.0",
-        "symfony/serializer": "~2.8|^3.0",
+        "symfony/serializer": "~2.8|~3.0",
         "symfony/validator": "~3.1",
         "symfony/yaml": "~3.2",
         "symfony/property-info": "~2.8|~3.0",

--- a/src/Symfony/Component/Serializer/Mapping/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/XmlFileLoader.php
@@ -36,12 +36,11 @@ class XmlFileLoader extends FileLoader
     public function loadClassMetadata(ClassMetadataInterface $classMetadata)
     {
         if (null === $this->classes) {
-            $this->classes = array();
-            $xml = $this->parseFile($this->file);
+            $this->classes = $this->getClassesFromXml();
+        }
 
-            foreach ($xml->class as $class) {
-                $this->classes[(string) $class['name']] = $class;
-            }
+        if (!$this->classes) {
+            return false;
         }
 
         $attributesMetadata = $classMetadata->getAttributesMetadata();
@@ -75,6 +74,20 @@ class XmlFileLoader extends FileLoader
     }
 
     /**
+     * Return the names of the classes mapped in this file.
+     *
+     * @return string[] The classes names
+     */
+    public function getMappedClasses()
+    {
+        if (null === $this->classes) {
+            $this->classes = $this->getClassesFromXml();
+        }
+
+        return array_keys($this->classes);
+    }
+
+    /**
      * Parses a XML File.
      *
      * @param string $file Path of file
@@ -92,5 +105,17 @@ class XmlFileLoader extends FileLoader
         }
 
         return simplexml_import_dom($dom);
+    }
+
+    private function getClassesFromXml()
+    {
+        $xml = $this->parseFile($this->file);
+        $classes = array();
+
+        foreach ($xml->class as $class) {
+            $classes[(string) $class['name']] = $class;
+        }
+
+        return $classes;
     }
 }

--- a/src/Symfony/Component/Serializer/Mapping/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/YamlFileLoader.php
@@ -38,26 +38,11 @@ class YamlFileLoader extends FileLoader
     public function loadClassMetadata(ClassMetadataInterface $classMetadata)
     {
         if (null === $this->classes) {
-            if (!stream_is_local($this->file)) {
-                throw new MappingException(sprintf('This is not a local file "%s".', $this->file));
-            }
+            $this->classes = $this->getClassesFromYaml();
+        }
 
-            if (null === $this->yamlParser) {
-                $this->yamlParser = new Parser();
-            }
-
-            $classes = $this->yamlParser->parse(file_get_contents($this->file));
-
-            if (empty($classes)) {
-                return false;
-            }
-
-            // not an array
-            if (!is_array($classes)) {
-                throw new MappingException(sprintf('The file "%s" must contain a YAML array.', $this->file));
-            }
-
-            $this->classes = $classes;
+        if (!$this->classes) {
+            return false;
         }
 
         if (isset($this->classes[$classMetadata->getName()])) {
@@ -102,5 +87,42 @@ class YamlFileLoader extends FileLoader
         }
 
         return false;
+    }
+
+    /**
+     * Return the names of the classes mapped in this file.
+     *
+     * @return string[] The classes names
+     */
+    public function getMappedClasses()
+    {
+        if (null === $this->classes) {
+            $this->classes = $this->getClassesFromYaml();
+        }
+
+        return array_keys($this->classes);
+    }
+
+    private function getClassesFromYaml()
+    {
+        if (!stream_is_local($this->file)) {
+            throw new MappingException(sprintf('This is not a local file "%s".', $this->file));
+        }
+
+        if (null === $this->yamlParser) {
+            $this->yamlParser = new Parser();
+        }
+
+        $classes = $this->yamlParser->parse(file_get_contents($this->file));
+
+        if (empty($classes)) {
+            return array();
+        }
+
+        if (!is_array($classes)) {
+            throw new MappingException(sprintf('The file "%s" must contain a YAML array.', $this->file));
+        }
+
+        return $classes;
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Following the cache warmer for annotations (#18533) and for the validator (#19485), this PR introduces a cache warmer for the Serializer YAML and XML metadata configuration (mainly groups).

Based on the PhpArrayAdapter, it uses the naming conventions (Resources/config/serialization) to find the files and compile them into a single PHP file stored in the cache directory. This file uses shared memory on PHP 7.

The benefit of this PR are the same than the ones of the previous PR:
- serialization metadata cache can be warmed up offline
- on PHP 7, there is no need for user extension to get maximum performances (ie. if you use this PR and the other one, you probably won't need to enable APCu to have great performances)
- on PHP 7 again, we are not sensitive to APCu memory fragmentation
  last but not least, global performance is slightly better (I get 30us per class gain in Blackfire)

As previous work on the Serializer cache system introduced issues (see https://github.com/symfony/symfony/commit/96e418a14fd8dc83d5b8bfa0e5a6181544b49666), it would be interesting to pay careful attention to the backward compatibility during the review (ping @Ener-Getick).
