### PR TITLE
[Process] Fix AbstractPipes::write() for a situation seen on HHVM (at least)

### DIFF
--- a/src/Symfony/Component/Process/Pipes/AbstractPipes.php
+++ b/src/Symfony/Component/Process/Pipes/AbstractPipes.php
@@ -134,9 +134,7 @@ abstract class AbstractPipes implements PipesInterface
         if (null === $this->input && !isset($this->inputBuffer[0])) {
             fclose($this->pipes[0]);
             unset($this->pipes[0]);
-        }
-
-        if (!$w) {
+        } elseif (!$w) {
             return array($this->pipes[0]);
         }
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/composer/composer/issues/5381, https://github.com/composer/composer/issues/5566 |
| License | MIT |
| Doc PR | - |

Even if I tried with my local hhvm, I can't reproduce the reported issues, yet it looks like some versions of HHVM trigger a notice here.
