### PR TITLE
[Process] Fix double-fread() when reading unix pipes

### DIFF
--- a/src/Symfony/Component/Process/Pipes/UnixPipes.php
+++ b/src/Symfony/Component/Process/Pipes/UnixPipes.php
@@ -120,7 +120,7 @@ class UnixPipes extends AbstractPipes
             do {
                 $data = fread($pipe, self::CHUNK_SIZE);
                 $read[$type] .= $data;
-            } while (isset($data[0]));
+            } while (isset($data[0]) && ($close || isset($data[self::CHUNK_SIZE - 1])));
 
             if (!isset($read[$type][0])) {
                 unset($read[$type]);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

While looking at the blackfire profile of a `composer install`, I was able to reduce the number of calls to `fread` from 90k to 60k using this patch (and from 60k to <1k with https://github.com/composer/composer/pull/5569 but that's another story).

In fact, we should continue reading only if there might be something next, which won't be the case if the buffer has not been filled.
