### PR TITLE
Use a dedicated exception in the file locator

### DIFF
--- a/src/Symfony/Component/Config/Exception/FileLocatorFileNotFoundException.php
+++ b/src/Symfony/Component/Config/Exception/FileLocatorFileNotFoundException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Exception;
+
+/**
+ * File locator exception if a file does not exist.
+ *
+ * @author Leo Feyer <https://github.com/leofeyer>
+ */
+class FileLocatorFileNotFoundException extends \InvalidArgumentException
+{
+}

--- a/src/Symfony/Component/Config/FileLocator.php
+++ b/src/Symfony/Component/Config/FileLocator.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Config;
 
+use Symfony\Component\Config\Exception\FileLocatorFileNotFoundException;
+
 /**
  * FileLocator uses an array of pre-defined paths to find files.
  *
@@ -41,7 +43,7 @@ class FileLocator implements FileLocatorInterface
 
         if ($this->isAbsolutePath($name)) {
             if (!file_exists($name)) {
-                throw new \InvalidArgumentException(sprintf('The file "%s" does not exist.', $name));
+                throw new FileLocatorFileNotFoundException(sprintf('The file "%s" does not exist.', $name));
             }
 
             return $name;
@@ -66,7 +68,7 @@ class FileLocator implements FileLocatorInterface
         }
 
         if (!$filepaths) {
-            throw new \InvalidArgumentException(sprintf('The file "%s" does not exist (in: %s).', $name, implode(', ', $paths)));
+            throw new FileLocatorFileNotFoundException(sprintf('The file "%s" does not exist (in: %s).', $name, implode(', ', $paths)));
         }
 
         return $filepaths;

--- a/src/Symfony/Component/Config/FileLocatorInterface.php
+++ b/src/Symfony/Component/Config/FileLocatorInterface.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Config;
 
+use Symfony\Component\Config\Exception\FileLocatorFileNotFoundException;
+
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
@@ -25,7 +27,8 @@ interface FileLocatorInterface
      *
      * @return string|array The full path to the file or an array of file paths
      *
-     * @throws \InvalidArgumentException When file is not found
+     * @throws \InvalidArgumentException        If $name is empty
+     * @throws FileLocatorFileNotFoundException If a file is not found
      */
     public function locate($name, $currentPath = null, $first = true);
 }

--- a/src/Symfony/Component/Config/Tests/FileLocatorTest.php
+++ b/src/Symfony/Component/Config/Tests/FileLocatorTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Config\Tests;
 
-use Symfony\Component\Config\Exception\FileLocatorFileNotFoundException;
 use Symfony\Component\Config\FileLocator;
 
 class FileLocatorTest extends \PHPUnit_Framework_TestCase
@@ -87,7 +86,7 @@ class FileLocatorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException FileLocatorFileNotFoundException
+     * @expectedException \Symfony\Component\Config\Exception\FileLocatorFileNotFoundException
      * @expectedExceptionMessage The file "foobar.xml" does not exist
      */
     public function testLocateThrowsAnExceptionIfTheFileDoesNotExists()
@@ -98,7 +97,7 @@ class FileLocatorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException FileLocatorFileNotFoundException
+     * @expectedException \Symfony\Component\Config\Exception\FileLocatorFileNotFoundException
      */
     public function testLocateThrowsAnExceptionIfTheFileDoesNotExistsInAbsolutePath()
     {

--- a/src/Symfony/Component/Config/Tests/FileLocatorTest.php
+++ b/src/Symfony/Component/Config/Tests/FileLocatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Config\Tests;
 
+use Symfony\Component\Config\Exception\FileLocatorFileNotFoundException;
 use Symfony\Component\Config\FileLocator;
 
 class FileLocatorTest extends \PHPUnit_Framework_TestCase
@@ -86,7 +87,7 @@ class FileLocatorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
+     * @expectedException FileLocatorFileNotFoundException
      * @expectedExceptionMessage The file "foobar.xml" does not exist
      */
     public function testLocateThrowsAnExceptionIfTheFileDoesNotExists()
@@ -97,7 +98,7 @@ class FileLocatorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
+     * @expectedException FileLocatorFileNotFoundException
      */
     public function testLocateThrowsAnExceptionIfTheFileDoesNotExistsInAbsolutePath()
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This PR adds a dedicated `FileLocatorFileNotFoundException` class to the file locator, so it is possible to catch file locator exceptions separately from invalid argument exceptions.

``` php
try {
    foreach ($container->get('file_locator')->locate('file.php', null, false) as $file) {
        include $file;
    }
} catch (\InvalidArgumentException $e) {
    // this will catch both file locator exceptions as well as
    // any invalid argument exception thrown in an included file
}
```

With the dedicated exceptions, we could do this:

``` php
try {
    foreach ($container->get('file_locator')->locate('file.php', null, false) as $file) {
        include $file;
    }
} catch (FileLocatorFileNotFoundException $e) {
    // this will only ignore file locator exceptions
}
```
