### PR TITLE
[Cache] Add hierarchical invalidation with ContextAwareAdapterInterface

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/ApcuAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ApcuAdapter.php
@@ -37,9 +37,9 @@ class ApcuAdapter extends AbstractAdapter
         if (null !== $version) {
             CacheItem::validateKey($version);
 
-            if (!apcu_exists($version.':'.$namespace)) {
+            if (!apcu_exists($version.'@'.$namespace)) {
                 $this->clear($namespace);
-                apcu_add($version.':'.$namespace, null);
+                apcu_add($version.'@'.$namespace, null);
             }
         }
     }

--- a/src/Symfony/Component/Cache/Adapter/ContextAwareAdapterInterface.php
+++ b/src/Symfony/Component/Cache/Adapter/ContextAwareAdapterInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Adapter;
+
+use Psr\Cache\CacheException;
+use Psr\Cache\InvalidArgumentException;
+
+/**
+ * Interface for creating contextualized key spaces from existing pools.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+interface ContextAwareAdapterInterface extends AdapterInterface
+{
+    /**
+     * Derivates a new cache pool from an existing one by contextualizing its key space.
+     *
+     * Contexts add to each others.
+     * Clearing a parent also clears all its derivated
+     * pools (but not necessarily their deferred items).
+     *
+     * @param string $context A context identifier.
+     *
+     * @return self A clone of the current instance, where cache keys are isolated from its parent
+     *
+     * @throws InvalidArgumentException When $context contains invalid characters
+     * @throws CacheException           When the adapter can't be forked
+     */
+    public function withContext($context);
+}

--- a/src/Symfony/Component/Cache/Adapter/DoctrineAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/DoctrineAdapter.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Cache\Adapter;
 
 use Doctrine\Common\Cache\CacheProvider;
+use Symfony\Component\Cache\Exception\CacheException;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
@@ -25,6 +26,14 @@ class DoctrineAdapter extends AbstractAdapter
         parent::__construct('', $defaultLifetime);
         $this->provider = $provider;
         $provider->setNamespace($namespace);
+    }
+
+    /**
+     * @inheritdoc}
+     */
+    public function withContext($context)
+    {
+        throw new CacheException(sprintf('%s does not implement ContextAwareAdapterInterface.', get_class($this)));
     }
 
     /**

--- a/src/Symfony/Component/Cache/Adapter/FilesystemAdapterTrait.php
+++ b/src/Symfony/Component/Cache/Adapter/FilesystemAdapterTrait.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Adapter;
 
+use Symfony\Component\Cache\CacheItem;
 use Symfony\Component\Cache\Exception\InvalidArgumentException;
 
 /**
@@ -77,6 +78,19 @@ trait FilesystemAdapterTrait
         }
 
         return $ok;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function withContext($context)
+    {
+        CacheItem::validateKey($context);
+
+        $fork = clone $this;
+        $fork->init($context, $this->directory);
+
+        return $fork;
     }
 
     private function write($file, $data, $expiresAt = null)

--- a/src/Symfony/Component/Cache/Adapter/NullAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/NullAdapter.php
@@ -17,7 +17,7 @@ use Symfony\Component\Cache\CacheItem;
 /**
  * @author Titouan Galopin <galopintitouan@gmail.com>
  */
-class NullAdapter implements AdapterInterface
+class NullAdapter implements ContextAwareAdapterInterface
 {
     private $createCacheItem;
 
@@ -108,6 +108,14 @@ class NullAdapter implements AdapterInterface
     public function commit()
     {
         return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function withContext($context)
+    {
+        return clone $this;
     }
 
     private function generateItems(array $keys)

--- a/src/Symfony/Component/Cache/Tests/Adapter/ChainAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ChainAdapterTest.php
@@ -22,6 +22,10 @@ use Symfony\Component\Cache\Tests\Fixtures\ExternalAdapter;
  */
 class ChainAdapterTest extends AdapterTestCase
 {
+    protected $skippedTests = array(
+        'testBadContext' => 'ContextAwareAdapterInterface not implemented by ExternalAdapter.',
+    );
+
     public function createCachePool($defaultLifetime = 0)
     {
         return new ChainAdapter(array(new ArrayAdapter($defaultLifetime), new ExternalAdapter(), new FilesystemAdapter('', $defaultLifetime)), $defaultLifetime);
@@ -43,5 +47,14 @@ class ChainAdapterTest extends AdapterTestCase
     public function testInvalidAdapterException()
     {
         new ChainAdapter(array(new \stdClass()));
+    }
+
+    /**
+     * @expectedException Symfony\Component\Cache\Exception\CacheException
+     * @expectedExceptionMessage Symfony\Component\Cache\Adapter\ProxyAdapter does not implement ContextAwareAdapterInterface.
+     */
+    public function testContext()
+    {
+        parent::testContext();
     }
 }

--- a/src/Symfony/Component/Cache/Tests/Adapter/DoctrineAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/DoctrineAdapterTest.php
@@ -23,10 +23,20 @@ class DoctrineAdapterTest extends AdapterTestCase
         'testDeferredSaveWithoutCommit' => 'Assumes a shared cache which ArrayCache is not.',
         'testSaveWithoutExpire' => 'Assumes a shared cache which ArrayCache is not.',
         'testNotUnserializable' => 'ArrayCache does not use serialize/unserialize',
+        'testBadContext' => 'ContextAwareAdapterInterface not implemented.',
     );
 
     public function createCachePool($defaultLifetime = 0)
     {
         return new DoctrineAdapter(new ArrayCache($defaultLifetime), '', $defaultLifetime);
+    }
+
+    /**
+     * @expectedException Symfony\Component\Cache\Exception\CacheException
+     * @expectedExceptionMessage Symfony\Component\Cache\Adapter\DoctrineAdapter does not implement ContextAwareAdapterInterface.
+     */
+    public function testContext()
+    {
+        parent::testContext();
     }
 }

--- a/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
@@ -97,4 +97,30 @@ class TagAwareAdapterTest extends AdapterTestCase
 
         $this->assertTrue($pool->getItem('k')->isHit());
     }
+
+    public function testTagsImpactSubContexts()
+    {
+        $pool = $this->createCachePool();
+        $fork = $pool->withContext('ns');
+
+        $poolItem = $pool->getItem('i1');
+        $forkItem = $fork->getItem('i2');
+
+        $poolItem->tag('foo');
+        $forkItem->tag('foo');
+
+        $pool->save($poolItem);
+        $fork->save($forkItem);
+
+        $this->assertTrue($pool->hasItem('i1'));
+        $this->assertTrue($fork->hasItem('i2'));
+
+        $this->assertTrue($fork->invalidateTags('foo'));
+
+        $this->assertFalse($pool->hasItem('i1'));
+        $this->assertFalse($fork->hasItem('i2'));
+
+        $this->assertFalse($pool->getItem('i1')->isHit());
+        $this->assertFalse($fork->getItem('i2')->isHit());
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/6858 |

This PR adds a public interface to do hierachical invalidation. By using the new `withContext()` method, one is able to create a contextualized set of cache keys. Invalidating is as easy as changing the context identifier provided as argument.
Contexts can be chained to create subcontexts inside contexts.
All subcontexts share the same adapter implementation + connection state.
Clearing a parent clears all subcontexts.

This feature is already implemented by e.g. Drupal 8, and it plays nice with tags: all forks share the same tags space.
