### PR TITLE
[SwiftMailerBridge] Fix flawed deprecation message

### DIFF
--- a/src/Symfony/Bridge/Swiftmailer/DataCollector/MessageDataCollector.php
+++ b/src/Symfony/Bridge/Swiftmailer/DataCollector/MessageDataCollector.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bridge\Swiftmailer\DataCollector;
 
-@trigger_error(__CLASS__.' class is deprecated since version 2.4 and will be removed in 3.0. Use the Symfony\Bundle\SwiftmailerBundle\DataCollector\MessageDataCollector class from SwiftmailerBundle instead. Require symfony/swiftmailer-bundle package to download SwiftmailerBundle with Composer.', E_USER_DEPRECATED);
+@trigger_error('The '.__NAMESPACE__.'\MessageDataCollector class is deprecated since version 2.4 and will be removed in 3.0. Use the Symfony\Bundle\SwiftmailerBundle\DataCollector\MessageDataCollector class from SwiftmailerBundle instead. Require symfony/swiftmailer-bundle package to download SwiftmailerBundle with Composer.', E_USER_DEPRECATED);
 
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 use Symfony\Component\HttpFoundation\Request;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Given `__CLASS__` returns null outside of a class, the deprecation message is incomplete.
