### PR TITLE
[Console] Support long option short-cuts (WIP)

### DIFF
--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -213,7 +213,11 @@ class ArgvInput extends Input
     private function addLongOption($name, $value)
     {
         if (!$this->definition->hasOption($name)) {
-            throw new RuntimeException(sprintf('The "--%s" option does not exist.', $name));
+            if ($this->definition->hasShortcut($name)) {
+                $name = $this->definition->getOptionForShortcut($name)->getName();
+            } else {
+                throw new RuntimeException(sprintf('The "--%s" option does not exist.', $name));
+            }
         }
 
         $option = $this->definition->getOption($name);

--- a/src/Symfony/Component/Console/Input/ArrayInput.php
+++ b/src/Symfony/Component/Console/Input/ArrayInput.php
@@ -169,7 +169,11 @@ class ArrayInput extends Input
     private function addLongOption($name, $value)
     {
         if (!$this->definition->hasOption($name)) {
-            throw new InvalidOptionException(sprintf('The "--%s" option does not exist.', $name));
+            if ($this->definition->hasShortcut($name)) {
+                $name = $this->definition->getOptionForShortcut($name)->getName();
+            } else {
+                throw new InvalidOptionException(sprintf('The "--%s" option does not exist.', $name));
+            }
         }
 
         $option = $this->definition->getOption($name);

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -61,7 +61,7 @@ class InputOption
             if (is_array($shortcut)) {
                 $shortcut = implode('|', $shortcut);
             }
-            $shortcuts = preg_split('{(\|)-?}', ltrim($shortcut, '-'));
+            $shortcuts = preg_split('{(\|)-{0,2}}', ltrim($shortcut, '-'));
             $shortcuts = array_filter($shortcuts);
             $shortcut = implode('|', $shortcuts);
 

--- a/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
@@ -72,6 +72,30 @@ class ArgvInputTest extends \PHPUnit_Framework_TestCase
                 '->parse() parses long options with a required value (with a space separator)',
             ),
             array(
+                array('cli.php', '--bar'),
+                array(new InputOption('foo', 'bar')),
+                array('foo' => true),
+                '->parse() parses long option shortcuts without a value',
+            ),
+            array(
+                array('cli.php', '--bar-baz'),
+                array(new InputOption('foo', 'bar-baz')),
+                array('foo' => true),
+                '->parse() parses hyphenated long option shortcuts without a value',
+            ),
+            array(
+                array('cli.php', '--bar=baz'),
+                array(new InputOption('foo', 'bar', InputOption::VALUE_REQUIRED)),
+                array('foo' => 'baz'),
+                '->parse() parses long option shortcuts with a required value (with a = separator)',
+            ),
+            array(
+                array('cli.php', '--bar', 'baz'),
+                array(new InputOption('foo', 'bar', InputOption::VALUE_REQUIRED)),
+                array('foo' => 'baz'),
+                '->parse() parses long option shortcuts with a required value (with a space separator)',
+            ),
+            array(
                 array('cli.php', '-f'),
                 array(new InputOption('foo', 'f')),
                 array('foo' => true),

--- a/src/Symfony/Component/Console/Tests/Input/ArrayInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArrayInputTest.php
@@ -95,6 +95,30 @@ class ArrayInputTest extends \PHPUnit_Framework_TestCase
                 '->parse() parses long options with a default value',
             ),
             array(
+                array('--bar' => 'baz'),
+                array(new InputOption('foo', 'bar')),
+                array('foo' => 'baz'),
+                '->parse() parses long option shortcuts',
+            ),
+            array(
+                array('--bar-baz' => 'qux'),
+                array(new InputOption('foo', 'bar-baz')),
+                array('foo' => 'qux'),
+                '->parse() parses hyphenated long option shortcuts',
+            ),
+            array(
+                array('--bar' => 'baz'),
+                array(new InputOption('foo', 'bar', InputOption::VALUE_OPTIONAL, '', 'default')),
+                array('foo' => 'baz'),
+                '->parse() parses long option shortcuts with a default value',
+            ),
+            array(
+                array('--bar' => null),
+                array(new InputOption('foo', 'bar', InputOption::VALUE_OPTIONAL, '', 'default')),
+                array('foo' => 'default'),
+                '->parse() parses long option shortcuts with a default value',
+            ),
+            array(
                 array('-f' => 'bar'),
                 array(new InputOption('foo', 'f')),
                 array('foo' => 'bar'),

--- a/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
@@ -36,10 +36,10 @@ class InputOptionTest extends \PHPUnit_Framework_TestCase
     {
         $option = new InputOption('foo', 'f');
         $this->assertEquals('f', $option->getShortcut(), '__construct() can take a shortcut as its second argument');
-        $option = new InputOption('foo', '-f|-ff|fff');
-        $this->assertEquals('f|ff|fff', $option->getShortcut(), '__construct() removes the leading - of the shortcuts');
-        $option = new InputOption('foo', array('f', 'ff', '-fff'));
-        $this->assertEquals('f|ff|fff', $option->getShortcut(), '__construct() removes the leading - of the shortcuts');
+        $option = new InputOption('foo', '-f|-ff|fff|--ffff');
+        $this->assertEquals('f|ff|fff|ffff', $option->getShortcut(), '__construct() removes the leading - of the shortcuts');
+        $option = new InputOption('foo', array('f', 'ff', '-fff', '--ffff'));
+        $this->assertEquals('f|ff|fff|ffff', $option->getShortcut(), '__construct() removes the leading - of the shortcuts');
         $option = new InputOption('foo');
         $this->assertNull($option->getShortcut(), '__construct() makes the shortcut null by default');
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | maybe |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

I very often provide aliases/variants of long options when writing CLI utilities, generally for the following reasons:
- Supporting variant spelling (`--colour` and `--color`)
- Supporting variant hyphenation (`--no-colour` and `--nocolour`)
- Maintaining 'API compatibility' with a third-party tool 
- Maintaining BC when the canonical name of an option has changed

This is very easy to do with Perl's `Getopt::Long`, Python's `argparse`, the shell's GNU-enhanced `getopt`, &c..

Console's input definitions mostly support long option short-cuts, but the input parsers (`ArgvInput` and friends) do not. This PR is an attempt at making Console support both short and long short-cuts.

The basic functionality is done — if you add an option like `InputOption('foo', 'f|bar')`, you can now pass `--bar` on the command line and have it work (previously it'd say the option didn't exist). These changes don't introduce any BC issues as far as i can tell. However, i don't think the PR is acceptable as-is for the following reasons, the solutions to which (if any) may require a BC break:
- It's currently not possible to differentiate between 'short' short-cuts and single-letter 'long' short-cuts. In other words, with `InputOption('foo', 'f|bar')`, the input parser will now accept both `-f` and `--f`. The uniqueness check still works (so if you have another option called `f` it'll fail), but this seems undesirable.
- The synopsis and option descriptor output feel weird with long short-cuts. For example, again with `InputOption('foo', 'f|bar')`, the synopsis will show `[-f|bar|--foo]`. It's confusing.
- Maybe slightly outside scope, but the display of options with multiple long variants, at least in the way i want to use them, is really poor in terms of screen space / readability. I generally don't want these variants showing up in the usage help, and especially not the synopsis — it's not necessary to communicate to the user in an error message that i accept every possible combination of the phrase `no colour` (or whatever).

I can't think of any super elegant solutions to these problems tbh. Maybe a different direction would be to add a separate aliasing method, so you could do like `$this->addOption('foo')->addOptionAlias('foo', 'bar')`. idk.

Do you think any of this is worth pursuing further, or am i trying to change things nobody wants changed?
