### PR TITLE
[TwigBundle] Add a check for choice's attributes emptiness before calling block('attributes')

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -79,8 +79,7 @@
                 {{- block('choice_widget_options') -}}
             </optgroup>
         {%- else -%}
-            {% set attr = choice.attr %}
-            <option value="{{ choice.value }}" {{ block('attributes') }}{% if choice is selectedchoice(value) %} selected="selected"{% endif %}>{{ choice_translation_domain is same as(false) ? choice.label : choice.label|trans({}, choice_translation_domain) }}</option>
+            <option value="{{ choice.value }}" {% if choice.attr %}{% set attr = choice.attr %}{{ block('attributes') }}{% endif %}{% if choice is selectedchoice(value) %} selected="selected"{% endif %}>{{ choice_translation_domain is same as(false) ? choice.label : choice.label|trans({}, choice_translation_domain) }}</option>
         {%- endif -%}
     {% endfor %}
 {%- endblock choice_widget_options -%}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| License | MIT |

Remove unnecessary block calling for choices without "choice_attr" option. This check gain the performance on a large datasets.
