### PR TITLE
Add Yaml::PARSE_EXCEPTION_ON_DUPLICATE to throw exceptions on duplicates

### DIFF
--- a/UPGRADE-3.2.md
+++ b/UPGRADE-3.2.md
@@ -70,3 +70,9 @@ Validator
        // ...
    }
    ```
+
+Yaml
+----
+
+ * Support for silently ignoring duplicate keys in YAML has been deprecated and
+   will lead to a `ParseException` in Symfony 4.0.

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -230,6 +230,10 @@ Yaml
  * The `!!php/object` tag to indicate dumped PHP objects was removed in favor of
    the `!php/object` tag.
 
+ * Support for silently ignoring duplicate keys in YAML has been deprecated and
+   will lead to a `ParseException` in Symfony 4.0.
+
+
 Validator
 ---------
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -230,8 +230,7 @@ Yaml
  * The `!!php/object` tag to indicate dumped PHP objects was removed in favor of
    the `!php/object` tag.
 
- * Support for silently ignoring duplicate keys in YAML has been deprecated and
-   will lead to a `ParseException` in Symfony 4.0.
+ * Duplicate keys in YAML leads to a `ParseException`.
 
 
 Validator

--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -10,6 +10,9 @@ CHANGELOG
    Yaml::parse('!php/const:PHP_INT_MAX', Yaml::PARSE_CONSTANT);
    ```
 
+ * Support for silently ignoring duplicate keys in YAML has been deprecated and
+   will lead to a `ParseException` in Symfony 4.0.
+
 3.1.0
 -----
 

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -477,8 +477,7 @@ class Inline
                         // are processed sequentially.
                         if (!isset($output[$key])) {
                             $output[$key] = $value;
-                        }
-                        elseif (static::$exceptionOnDuplicate) {
+                        } elseif (static::$exceptionOnDuplicate) {
                             throw new ParseException(sprintf('Duplicate key "%s" detected whilst parsing YAML', $key));
                         }
                         $done = true;
@@ -491,8 +490,7 @@ class Inline
                         // are processed sequentially.
                         if (!isset($output[$key])) {
                             $output[$key] = $value;
-                        }
-                        elseif (static::$exceptionOnDuplicate) {
+                        } elseif (static::$exceptionOnDuplicate) {
                             throw new ParseException(sprintf('Duplicate key "%s" detected whilst parsing YAML', $key));
                         }
                         $done = true;
@@ -507,8 +505,7 @@ class Inline
                         // are processed sequentially.
                         if (!isset($output[$key])) {
                             $output[$key] = $value;
-                        }
-                        elseif (static::$exceptionOnDuplicate) {
+                        } elseif (static::$exceptionOnDuplicate) {
                             throw new ParseException(sprintf('Duplicate key "%s" detected whilst parsing YAML', $key));
                         }
                         $done = true;

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -476,7 +476,7 @@ class Inline
                         if (!isset($output[$key])) {
                             $output[$key] = $value;
                         } else {
-                            @trigger_error(sprintf('Duplicate key "%s" detected whilst parsing YAML. Silent handling of duplicates in YAML is deprecated since version 3.3 and will cause an exception in 4.0.', $key), E_USER_DEPRECATED);
+                            @trigger_error(sprintf('Duplicate key "%s" detected whilst parsing YAML. Silent handling of duplicates in YAML is deprecated since version 3.2 and will throw \Symfony\Component\Yaml\Exception\ParseException in 4.0.', $key), E_USER_DEPRECATED);
                         }
                         $done = true;
                         break;
@@ -489,7 +489,7 @@ class Inline
                         if (!isset($output[$key])) {
                             $output[$key] = $value;
                         } else {
-                            @trigger_error(sprintf('Duplicate key "%s" detected whilst parsing YAML. Silent handling of duplicates in YAML is deprecated since version 3.3 and will cause an exception in 4.0.', $key), E_USER_DEPRECATED);
+                            @trigger_error(sprintf('Duplicate key "%s" detected whilst parsing YAML. Silent handling of duplicates in YAML is deprecated since version 3.2 and will throw \Symfony\Component\Yaml\Exception\ParseException in 4.0.', $key), E_USER_DEPRECATED);
                         }
                         $done = true;
                         break;
@@ -504,7 +504,7 @@ class Inline
                         if (!isset($output[$key])) {
                             $output[$key] = $value;
                         } else {
-                            @trigger_error(sprintf('Duplicate key "%s" detected whilst parsing YAML. Silent handling of duplicates in YAML is deprecated since version 3.3 and will cause an exception in 4.0.', $key), E_USER_DEPRECATED);
+                            @trigger_error(sprintf('Duplicate key "%s" detected whilst parsing YAML. Silent handling of duplicates in YAML is deprecated since version 3.2 and will throw \Symfony\Component\Yaml\Exception\ParseException in 4.0.', $key), E_USER_DEPRECATED);
                         }
                         $done = true;
                         --$i;

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -29,7 +29,6 @@ class Inline
     private static $objectSupport = false;
     private static $objectForMap = false;
     private static $constantSupport = false;
-    private static $exceptionOnDuplicate = false;
 
     /**
      * Converts a YAML string to a PHP array.
@@ -80,7 +79,6 @@ class Inline
         self::$objectSupport = (bool) (Yaml::PARSE_OBJECT & $flags);
         self::$objectForMap = (bool) (Yaml::PARSE_OBJECT_FOR_MAP & $flags);
         self::$constantSupport = (bool) (Yaml::PARSE_CONSTANT & $flags);
-        self::$exceptionOnDuplicate = (bool) (Yaml::PARSE_EXCEPTION_ON_DUPLICATE & $flags);
 
         $value = trim($value);
 
@@ -477,8 +475,9 @@ class Inline
                         // are processed sequentially.
                         if (!isset($output[$key])) {
                             $output[$key] = $value;
-                        } elseif (static::$exceptionOnDuplicate) {
-                            throw new ParseException(sprintf('Duplicate key "%s" detected whilst parsing YAML', $key));
+                        }
+                        else {
+                            @trigger_error(sprintf('Duplicate key "%s" detected whilst parsing YAML. Silent handling of duplicates in YAML is deprecated since version 3.3 and will cause an exception in 4.0.', $key), E_USER_DEPRECATED);
                         }
                         $done = true;
                         break;
@@ -490,8 +489,8 @@ class Inline
                         // are processed sequentially.
                         if (!isset($output[$key])) {
                             $output[$key] = $value;
-                        } elseif (static::$exceptionOnDuplicate) {
-                            throw new ParseException(sprintf('Duplicate key "%s" detected whilst parsing YAML', $key));
+                        } else {
+                            @trigger_error(sprintf('Duplicate key "%s" detected whilst parsing YAML. Silent handling of duplicates in YAML is deprecated since version 3.3 and will cause an exception in 4.0.', $key), E_USER_DEPRECATED);
                         }
                         $done = true;
                         break;
@@ -505,8 +504,8 @@ class Inline
                         // are processed sequentially.
                         if (!isset($output[$key])) {
                             $output[$key] = $value;
-                        } elseif (static::$exceptionOnDuplicate) {
-                            throw new ParseException(sprintf('Duplicate key "%s" detected whilst parsing YAML', $key));
+                        } else {
+                            @trigger_error(sprintf('Duplicate key "%s" detected whilst parsing YAML. Silent handling of duplicates in YAML is deprecated since version 3.3 and will cause an exception in 4.0.', $key), E_USER_DEPRECATED);
                         }
                         $done = true;
                         --$i;

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -29,6 +29,7 @@ class Inline
     private static $objectSupport = false;
     private static $objectForMap = false;
     private static $constantSupport = false;
+    private static $exceptionOnDuplicate = false;
 
     /**
      * Converts a YAML string to a PHP array.
@@ -79,6 +80,7 @@ class Inline
         self::$objectSupport = (bool) (Yaml::PARSE_OBJECT & $flags);
         self::$objectForMap = (bool) (Yaml::PARSE_OBJECT_FOR_MAP & $flags);
         self::$constantSupport = (bool) (Yaml::PARSE_CONSTANT & $flags);
+        self::$exceptionOnDuplicate = (bool) (Yaml::PARSE_EXCEPTION_ON_DUPLICATE & $flags);
 
         $value = trim($value);
 
@@ -476,6 +478,9 @@ class Inline
                         if (!isset($output[$key])) {
                             $output[$key] = $value;
                         }
+                        elseif (static::$exceptionOnDuplicate) {
+                            throw new ParseException(sprintf('Duplicate key "%s" detected whilst parsing YAML', $key));
+                        }
                         $done = true;
                         break;
                     case '{':
@@ -486,6 +491,9 @@ class Inline
                         // are processed sequentially.
                         if (!isset($output[$key])) {
                             $output[$key] = $value;
+                        }
+                        elseif (static::$exceptionOnDuplicate) {
+                            throw new ParseException(sprintf('Duplicate key "%s" detected whilst parsing YAML', $key));
                         }
                         $done = true;
                         break;
@@ -499,6 +507,9 @@ class Inline
                         // are processed sequentially.
                         if (!isset($output[$key])) {
                             $output[$key] = $value;
+                        }
+                        elseif (static::$exceptionOnDuplicate) {
+                            throw new ParseException(sprintf('Duplicate key "%s" detected whilst parsing YAML', $key));
                         }
                         $done = true;
                         --$i;

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -475,8 +475,7 @@ class Inline
                         // are processed sequentially.
                         if (!isset($output[$key])) {
                             $output[$key] = $value;
-                        }
-                        else {
+                        } else {
                             @trigger_error(sprintf('Duplicate key "%s" detected whilst parsing YAML. Silent handling of duplicates in YAML is deprecated since version 3.3 and will cause an exception in 4.0.', $key), E_USER_DEPRECATED);
                         }
                         $done = true;

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -242,7 +242,7 @@ class Parser
                         if ($allowOverwrite || !isset($data[$key])) {
                             $data[$key] = null;
                         } else {
-                            @trigger_error(sprintf('Duplicate key "%s" detected whilst parsing YAML. Silent handling of duplicates in YAML is deprecated since version 3.3 and will cause an exception in 4.0.', $key), E_USER_DEPRECATED);
+                            @trigger_error(sprintf('Duplicate key "%s" detected whilst parsing YAML. Silent handling of duplicates in YAML is deprecated since version 3.2 and will throw \Symfony\Component\Yaml\Exception\ParseException in 4.0.', $key), E_USER_DEPRECATED);
                         }
                     } else {
                         $value = $this->parseBlock($this->getRealCurrentLineNb() + 1, $this->getNextEmbedBlock(), $flags);
@@ -251,7 +251,7 @@ class Parser
                         if ($allowOverwrite || !isset($data[$key])) {
                             $data[$key] = $value;
                         } else {
-                            @trigger_error(sprintf('Duplicate key "%s" detected whilst parsing YAML. Silent handling of duplicates in YAML is deprecated since version 3.3 and will cause an exception in 4.0.', $key), E_USER_DEPRECATED);
+                            @trigger_error(sprintf('Duplicate key "%s" detected whilst parsing YAML. Silent handling of duplicates in YAML is deprecated since version 3.2 and will throw \Symfony\Component\Yaml\Exception\ParseException in 4.0.', $key), E_USER_DEPRECATED);
                         }
                     }
                 } else {
@@ -261,7 +261,7 @@ class Parser
                     if ($allowOverwrite || !isset($data[$key])) {
                         $data[$key] = $value;
                     } else {
-                        @trigger_error(sprintf('Duplicate key "%s" detected whilst parsing YAML. Silent handling of duplicates in YAML is deprecated since version 3.3 and will cause an exception in 4.0.', $key), E_USER_DEPRECATED);
+                        @trigger_error(sprintf('Duplicate key "%s" detected whilst parsing YAML. Silent handling of duplicates in YAML is deprecated since version 3.2 and will throw \Symfony\Component\Yaml\Exception\ParseException in 4.0.', $key), E_USER_DEPRECATED);
                     }
                 }
                 if ($isRef) {

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -104,7 +104,6 @@ class Parser
         $data = array();
         $context = null;
         $allowOverwrite = false;
-        $exceptionOnDuplicate = (bool) (Yaml::PARSE_EXCEPTION_ON_DUPLICATE & $flags);
         while ($this->moveToNextLine()) {
             if ($this->isCurrentLineEmpty()) {
                 continue;
@@ -242,8 +241,8 @@ class Parser
                         // But overwriting is allowed when a merge node is used in current block.
                         if ($allowOverwrite || !isset($data[$key])) {
                             $data[$key] = null;
-                        } elseif ($exceptionOnDuplicate) {
-                            throw new ParseException(sprintf('Duplicate key "%s" detected whilst parsing YAML', $key));
+                        } elseif (!$allowOverwrite) {
+                            @trigger_error(sprintf('Duplicate key "%s" detected whilst parsing YAML. Silent handling of duplicates in YAML is deprecated since version 3.3 and will cause an exception in 4.0.', $key), E_USER_DEPRECATED);
                         }
                     } else {
                         $value = $this->parseBlock($this->getRealCurrentLineNb() + 1, $this->getNextEmbedBlock(), $flags);
@@ -251,8 +250,8 @@ class Parser
                         // But overwriting is allowed when a merge node is used in current block.
                         if ($allowOverwrite || !isset($data[$key])) {
                             $data[$key] = $value;
-                        } elseif ($exceptionOnDuplicate) {
-                            throw new ParseException(sprintf('Duplicate key "%s" detected whilst parsing YAML', $key));
+                        } elseif (!$allowOverwrite) {
+                            @trigger_error(sprintf('Duplicate key "%s" detected whilst parsing YAML. Silent handling of duplicates in YAML is deprecated since version 3.3 and will cause an exception in 4.0.', $key), E_USER_DEPRECATED);
                         }
                     }
                 } else {
@@ -261,8 +260,8 @@ class Parser
                     // But overwriting is allowed when a merge node is used in current block.
                     if ($allowOverwrite || !isset($data[$key])) {
                         $data[$key] = $value;
-                    } elseif ($exceptionOnDuplicate) {
-                        throw new ParseException(sprintf('Duplicate key "%s" detected whilst parsing YAML', $key));
+                    } elseif (!$allowOverwrite) {
+                        @trigger_error(sprintf('Duplicate key "%s" detected whilst parsing YAML. Silent handling of duplicates in YAML is deprecated since version 3.3 and will cause an exception in 4.0.', $key), E_USER_DEPRECATED);
                     }
                 }
                 if ($isRef) {

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -241,7 +241,7 @@ class Parser
                         // But overwriting is allowed when a merge node is used in current block.
                         if ($allowOverwrite || !isset($data[$key])) {
                             $data[$key] = null;
-                        } elseif (!$allowOverwrite) {
+                        } else {
                             @trigger_error(sprintf('Duplicate key "%s" detected whilst parsing YAML. Silent handling of duplicates in YAML is deprecated since version 3.3 and will cause an exception in 4.0.', $key), E_USER_DEPRECATED);
                         }
                     } else {
@@ -250,7 +250,7 @@ class Parser
                         // But overwriting is allowed when a merge node is used in current block.
                         if ($allowOverwrite || !isset($data[$key])) {
                             $data[$key] = $value;
-                        } elseif (!$allowOverwrite) {
+                        } else {
                             @trigger_error(sprintf('Duplicate key "%s" detected whilst parsing YAML. Silent handling of duplicates in YAML is deprecated since version 3.3 and will cause an exception in 4.0.', $key), E_USER_DEPRECATED);
                         }
                     }
@@ -260,7 +260,7 @@ class Parser
                     // But overwriting is allowed when a merge node is used in current block.
                     if ($allowOverwrite || !isset($data[$key])) {
                         $data[$key] = $value;
-                    } elseif (!$allowOverwrite) {
+                    } else {
                         @trigger_error(sprintf('Duplicate key "%s" detected whilst parsing YAML. Silent handling of duplicates in YAML is deprecated since version 3.3 and will cause an exception in 4.0.', $key), E_USER_DEPRECATED);
                     }
                 }

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -242,8 +242,7 @@ class Parser
                         // But overwriting is allowed when a merge node is used in current block.
                         if ($allowOverwrite || !isset($data[$key])) {
                             $data[$key] = null;
-                        }
-                        elseif ($exceptionOnDuplicate) {
+                        } elseif ($exceptionOnDuplicate) {
                             throw new ParseException(sprintf('Duplicate key "%s" detected whilst parsing YAML', $key));
                         }
                     } else {
@@ -252,8 +251,7 @@ class Parser
                         // But overwriting is allowed when a merge node is used in current block.
                         if ($allowOverwrite || !isset($data[$key])) {
                             $data[$key] = $value;
-                        }
-                        elseif ($exceptionOnDuplicate) {
+                        } elseif ($exceptionOnDuplicate) {
                             throw new ParseException(sprintf('Duplicate key "%s" detected whilst parsing YAML', $key));
                         }
                     }
@@ -263,8 +261,7 @@ class Parser
                     // But overwriting is allowed when a merge node is used in current block.
                     if ($allowOverwrite || !isset($data[$key])) {
                         $data[$key] = $value;
-                    }
-                    elseif ($exceptionOnDuplicate) {
+                    } elseif ($exceptionOnDuplicate) {
                         throw new ParseException(sprintf('Duplicate key "%s" detected whilst parsing YAML', $key));
                     }
                 }

--- a/src/Symfony/Component/Yaml/Tests/Fixtures/YtsSpecificationExamples.yml
+++ b/src/Symfony/Component/Yaml/Tests/Fixtures/YtsSpecificationExamples.yml
@@ -1574,6 +1574,7 @@ php: |
   array(
     'fixed' => 1230.15,
   )
+---
 test: Float
 yaml: |
    canonical: 1.23015e+3

--- a/src/Symfony/Component/Yaml/Tests/Fixtures/sfMergeKey.yml
+++ b/src/Symfony/Component/Yaml/Tests/Fixtures/sfMergeKey.yml
@@ -18,11 +18,7 @@ yaml: |
         x: Oren
         c:
             foo: bar
-            foo: ignore
             bar: foo
-    duplicate:
-        foo: bar
-        foo: ignore
     foo2: &foo2
         a: Ballmer
     ding: &dong [ fi, fei, fo, fam]
@@ -48,7 +44,6 @@ php: |
     array(
         'foo' => array('a' => 'Steve', 'b' => 'Clark', 'c' => 'Brian'),
         'bar' => array('a' => 'before', 'd' => 'other', 'b' => 'new', 'c' => array('foo' => 'bar', 'bar' => 'foo'), 'x' => 'Oren'),
-        'duplicate' => array('foo' => 'bar'),
         'foo2' => array('a' => 'Ballmer'),
         'ding' => array('fi', 'fei', 'fo', 'fam'),
         'check' => array('a' => 'Steve', 'b' => 'Clark', 'c' => 'Brian', 'fi', 'fei', 'fo', 'fam', 'isit' => 'tested'),

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -821,7 +821,7 @@ EOD;
 
         Yaml::parse($input);
         restore_error_handler();
-        $this->assertEquals(array(sprintf('Duplicate key "%s" detected whilst parsing YAML. Silent handling of duplicates in YAML is deprecated since version 3.3 and will cause an exception in 4.0.', $duplicate_key)), $deprecations);
+        $this->assertEquals(array(sprintf('Duplicate key "%s" detected whilst parsing YAML. Silent handling of duplicates in YAML is deprecated since version 3.2 and will throw \Symfony\Component\Yaml\Exception\ParseException in 4.0.', $duplicate_key)), $deprecations);
     }
 
     public function getParseExceptionOnDuplicateData()

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -818,7 +818,9 @@ EOD;
 
             $deprecations[] = $msg;
         });
+
         Yaml::parse($input);
+        restore_error_handler();
         $this->assertEquals(array(sprintf('Duplicate key "%s" detected whilst parsing YAML. Silent handling of duplicates in YAML is deprecated since version 3.3 and will cause an exception in 4.0.', $duplicate_key)), $deprecations);
     }
 

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -806,36 +806,38 @@ EOD;
     /**
      * @dataProvider getParseExceptionOnDuplicateData
      */
-    public function testParseExceptionOnDuplicate($input, $duplicate_key) {
-        $this->setExpectedException('\Symfony\Component\Yaml\Exception\ParseException', 'Duplicate key "' . $duplicate_key . '" detected whilst parsing YAML');
+    public function testParseExceptionOnDuplicate($input, $duplicate_key)
+    {
+        $this->setExpectedException('\Symfony\Component\Yaml\Exception\ParseException', 'Duplicate key "'.$duplicate_key.'" detected whilst parsing YAML');
         Yaml::parse($input, Yaml::PARSE_EXCEPTION_ON_DUPLICATE);
     }
 
-    public function getParseExceptionOnDuplicateData() {
+    public function getParseExceptionOnDuplicateData()
+    {
         $tests = array();
 
         $yaml = <<<EOD
 parent: { child: first, child: duplicate }
 EOD;
-        $tests[] = [$yaml, 'child'];
+        $tests[] = array($yaml, 'child');
 
         $yaml = <<<EOD
 parent:
   child: first,
   child: duplicate
 EOD;
-        $tests[] = [$yaml, 'child'];
+        $tests[] = array($yaml, 'child');
 
         $yaml = <<<EOD
 parent: { child: foo }
 parent: { child: bar }
 EOD;
-        $tests[] = [$yaml, 'parent'];
+        $tests[] = array($yaml, 'parent');
 
         $yaml = <<<EOD
 parent: { child_mapping: { value: bar},  child_mapping: { value: bar} }
 EOD;
-        $tests[] = [$yaml, 'child_mapping'];
+        $tests[] = array($yaml, 'child_mapping');
 
         $yaml = <<<EOD
 parent:
@@ -844,12 +846,12 @@ parent:
   child_mapping:
     value: bar
 EOD;
-        $tests[] = [$yaml, 'child_mapping'];
+        $tests[] = array($yaml, 'child_mapping');
 
         $yaml = <<<EOD
 parent: { child_sequence: ['key1', 'key2', 'key3'],  child_sequence: ['key1', 'key2', 'key3'] }
 EOD;
-        $tests[] = [$yaml, 'child_sequence'];
+        $tests[] = array($yaml, 'child_sequence');
 
         $yaml = <<<EOD
 parent:
@@ -862,7 +864,7 @@ parent:
     - key2
     - key3
 EOD;
-        $tests[] = [$yaml, 'child_sequence'];
+        $tests[] = array($yaml, 'child_sequence');
 
         return $tests;
     }

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -803,6 +803,70 @@ EOD;
         $this->assertSame($expected, Yaml::parse($input));
     }
 
+    /**
+     * @dataProvider getParseExceptionOnDuplicateData
+     */
+    public function testParseExceptionOnDuplicate($input, $duplicate_key) {
+        $this->setExpectedException('\Symfony\Component\Yaml\Exception\ParseException', 'Duplicate key "' . $duplicate_key . '" detected whilst parsing YAML');
+        Yaml::parse($input, Yaml::PARSE_EXCEPTION_ON_DUPLICATE);
+    }
+
+    public function getParseExceptionOnDuplicateData() {
+        $tests = array();
+
+        $yaml = <<<EOD
+parent: { child: first, child: duplicate }
+EOD;
+        $tests[] = [$yaml, 'child'];
+
+        $yaml = <<<EOD
+parent:
+  child: first,
+  child: duplicate
+EOD;
+        $tests[] = [$yaml, 'child'];
+
+        $yaml = <<<EOD
+parent: { child: foo }
+parent: { child: bar }
+EOD;
+        $tests[] = [$yaml, 'parent'];
+
+        $yaml = <<<EOD
+parent: { child_mapping: { value: bar},  child_mapping: { value: bar} }
+EOD;
+        $tests[] = [$yaml, 'child_mapping'];
+
+        $yaml = <<<EOD
+parent:
+  child_mapping:
+    value: bar
+  child_mapping:
+    value: bar
+EOD;
+        $tests[] = [$yaml, 'child_mapping'];
+
+        $yaml = <<<EOD
+parent: { child_sequence: ['key1', 'key2', 'key3'],  child_sequence: ['key1', 'key2', 'key3'] }
+EOD;
+        $tests[] = [$yaml, 'child_sequence'];
+
+        $yaml = <<<EOD
+parent:
+  child_sequence:
+    - key1
+    - key2
+    - key3
+  child_sequence:
+    - key1
+    - key2
+    - key3
+EOD;
+        $tests[] = [$yaml, 'child_sequence'];
+
+        return $tests;
+    }
+
     public function testEmptyValue()
     {
         $input = <<<'EOF'

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -808,7 +808,7 @@ EOD;
      */
     public function testParseExceptionOnDuplicate($input, $duplicate_key)
     {
-        $deprecations = [];
+        $deprecations = array();
         set_error_handler(function ($type, $msg) use (&$deprecations) {
             if (E_USER_DEPRECATED !== $type) {
                 restore_error_handler();
@@ -819,7 +819,7 @@ EOD;
             $deprecations[] = $msg;
         });
         Yaml::parse($input);
-        $this->assertEquals([sprintf('Duplicate key "%s" detected whilst parsing YAML. Silent handling of duplicates in YAML is deprecated since version 3.3 and will cause an exception in 4.0.', $duplicate_key)], $deprecations);
+        $this->assertEquals(array(sprintf('Duplicate key "%s" detected whilst parsing YAML. Silent handling of duplicates in YAML is deprecated since version 3.3 and will cause an exception in 4.0.', $duplicate_key)), $deprecations);
     }
 
     public function getParseExceptionOnDuplicateData()

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -808,8 +808,18 @@ EOD;
      */
     public function testParseExceptionOnDuplicate($input, $duplicate_key)
     {
-        $this->setExpectedException('\Symfony\Component\Yaml\Exception\ParseException', 'Duplicate key "'.$duplicate_key.'" detected whilst parsing YAML');
-        Yaml::parse($input, Yaml::PARSE_EXCEPTION_ON_DUPLICATE);
+        $deprecations = [];
+        set_error_handler(function ($type, $msg) use (&$deprecations) {
+            if (E_USER_DEPRECATED !== $type) {
+                restore_error_handler();
+
+                return call_user_func_array('PHPUnit_Util_ErrorHandler::handleError', func_get_args());
+            }
+
+            $deprecations[] = $msg;
+        });
+        Yaml::parse($input);
+        $this->assertEquals([sprintf('Duplicate key "%s" detected whilst parsing YAML. Silent handling of duplicates in YAML is deprecated since version 3.3 and will cause an exception in 4.0.', $duplicate_key)], $deprecations);
     }
 
     public function getParseExceptionOnDuplicateData()

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -771,7 +771,7 @@ EOF
      * @see http://yaml.org/spec/1.2/spec.html#id2759572
      * @see http://yaml.org/spec/1.1/#id932806
      */
-    public function testMappingDuplicateKeyBlock()
+    public function testLegacyMappingDuplicateKeyBlock()
     {
         $input = <<<EOD
 parent:
@@ -789,7 +789,7 @@ EOD;
         $this->assertSame($expected, Yaml::parse($input));
     }
 
-    public function testMappingDuplicateKeyFlow()
+    public function testLegacyMappingDuplicateKeyFlow()
     {
         $input = <<<EOD
 parent: { child: first, child: duplicate }

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -810,6 +810,8 @@ EOD;
 
     /**
      * @dataProvider getParseExceptionOnDuplicateData
+     * @requires function Symfony\Bridge\PhpUnit\ErrorAssert::assertDeprecationsAreTriggered
+     * throws \Symfony\Component\Yaml\Exception\ParseException in 4.0
      */
     public function testParseExceptionOnDuplicate($input, $duplicate_key)
     {

--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -29,7 +29,6 @@ class Yaml
     const DUMP_OBJECT_AS_MAP = 64;
     const DUMP_MULTI_LINE_LITERAL_BLOCK = 128;
     const PARSE_CONSTANT = 256;
-    const PARSE_EXCEPTION_ON_DUPLICATE = 512;
 
     /**
      * Parses YAML into a PHP value.

--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -29,6 +29,7 @@ class Yaml
     const DUMP_OBJECT_AS_MAP = 64;
     const DUMP_MULTI_LINE_LITERAL_BLOCK = 128;
     const PARSE_CONSTANT = 256;
+    const PARSE_EXCEPTION_ON_DUPLICATE = 512;
 
     /**
      * Parses YAML into a PHP value.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/issues/19526 |
| License | MIT |
| Doc PR |  |
