### PR TITLE
Workaround another buggy PHP warning

### DIFF
--- a/src/Symfony/Component/Process/ExecutableFinder.php
+++ b/src/Symfony/Component/Process/ExecutableFinder.php
@@ -60,7 +60,7 @@ class ExecutableFinder
                 if (@is_dir($path)) {
                     $dirs[] = $path;
                 } else {
-                    if (basename($path) == $name && is_executable($path)) {
+                    if (basename($path) == $name && @is_executable($path)) {
                         return $path;
                     }
                 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Added error-suppression to the `is_executable($path)` call, too, per the bug noted just above.

The cited issue manifests as such without it:

```
ErrorException in ExecutableFinder.php line 63:
is_executable(): open_basedir restriction in effect. File(/usr/share/php) is not within the allowed path(s): (/usr/share/php:/tmp:/usr/share/phpmyadmin:/etc/phpmyadmin:/var/lib/phpmyadmin:/usr/local/zend/var/zray/extensions:/usr/local/zend/share:/usr/local/zend/var/plugins)
```
