### PR TITLE
[VarDumper] Relax 1 test failing with latest PHP versions

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -59,12 +59,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '2.8.9';
-    const VERSION_ID = 20809;
+    const VERSION = '2.8.10-DEV';
+    const VERSION_ID = 20810;
     const MAJOR_VERSION = 2;
     const MINOR_VERSION = 8;
-    const RELEASE_VERSION = 9;
-    const EXTRA_VERSION = '';
+    const RELEASE_VERSION = 10;
+    const EXTRA_VERSION = 'DEV';
 
     const END_OF_MAINTENANCE = '11/2018';
     const END_OF_LIFE = '11/2019';

--- a/src/Symfony/Component/VarDumper/Tests/Caster/SplCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/SplCasterTest.php
@@ -94,10 +94,10 @@ SplFileObject {
   file: true
   dir: false
   link: false
-%AcsvControl: array:2 [
+%AcsvControl: array:%d [
     0 => ","
     1 => """
-  ]
+%A]
   flags: DROP_NEW_LINE|SKIP_EMPTY
   maxLineLen: 0
   fstat: array:26 [


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | no |
| New feature? | o |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

Related to php bug https://bugs.php.net/72646 which is fixed in 5.6.25RC1, 7.0.10RC1, 7.1.0beta2

Detected in Fedora CI, failed since 7.0.10RC1, see
https://apps.fedoraproject.org/koschei/package/php-symfony
