### PR TITLE
[Cache] Skip tests that sleep() but can't be clock-mocked

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/AbstractRedisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AbstractRedisAdapterTest.php
@@ -15,6 +15,12 @@ use Symfony\Component\Cache\Adapter\RedisAdapter;
 
 abstract class AbstractRedisAdapterTest extends AdapterTestCase
 {
+    protected $skippedTests = array(
+        'testExpiration' => 'Testing expiration slows down the test suite',
+        'testHasItemReturnsFalseWhenDeferredItemIsExpired' => 'Testing expiration slows down the test suite',
+        'testDefaultLifeTime' => 'Testing expiration slows down the test suite',
+    );
+
     protected static $redis;
 
     public function createCachePool($defaultLifetime = 0)

--- a/src/Symfony/Component/Cache/Tests/Adapter/ApcuAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ApcuAdapterTest.php
@@ -15,6 +15,12 @@ use Symfony\Component\Cache\Adapter\ApcuAdapter;
 
 class ApcuAdapterTest extends AdapterTestCase
 {
+    protected $skippedTests = array(
+        'testExpiration' => 'Testing expiration slows down the test suite',
+        'testHasItemReturnsFalseWhenDeferredItemIsExpired' => 'Testing expiration slows down the test suite',
+        'testDefaultLifeTime' => 'Testing expiration slows down the test suite',
+    );
+
     public function createCachePool($defaultLifetime = 0)
     {
         if (!function_exists('apcu_fetch') || !ini_get('apc.enabled') || ('cli' === PHP_SAPI && !ini_get('apc.enable_cli'))) {

--- a/src/Symfony/Component/Cache/Tests/Adapter/ChainAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ChainAdapterTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Cache\Tests\Fixtures\ExternalAdapter;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
+ * @group time-sensitive
  */
 class ChainAdapterTest extends AdapterTestCase
 {

--- a/src/Symfony/Component/Cache/Tests/Adapter/DoctrineAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/DoctrineAdapterTest.php
@@ -26,6 +26,6 @@ class DoctrineAdapterTest extends AdapterTestCase
 
     public function createCachePool($defaultLifetime = 0)
     {
-        return new DoctrineAdapter(new ArrayCache(), '', $defaultLifetime);
+        return new DoctrineAdapter(new ArrayCache($defaultLifetime), '', $defaultLifetime);
     }
 }

--- a/src/Symfony/Component/Cache/Tests/Adapter/NamespacedProxyAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/NamespacedProxyAdapterTest.php
@@ -21,6 +21,6 @@ class NamespacedProxyAdapterTest extends ProxyAdapterTest
 {
     public function createCachePool($defaultLifetime = 0)
     {
-        return new ProxyAdapter(new ArrayAdapter(), 'foo', $defaultLifetime);
+        return new ProxyAdapter(new ArrayAdapter($defaultLifetime), 'foo', $defaultLifetime);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Skip tests that require real calls to `sleep()`: they slow down the test suite too much and don't test much.
`@group time-sensitive` tests will run these test cases just fine, but they can't be used on tests that use an external source for time, i.e. for redis or apcu.
