### PR TITLE
[HttpFoundation] fixed Request::getContent() reusage bug

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1505,7 +1505,7 @@ class Request
                 return $resource;
             }
 
-            $this->content = null;
+            $this->content = false;
 
             return fopen('php://input', 'rb');
         }
@@ -1516,7 +1516,7 @@ class Request
             return stream_get_contents($this->content);
         }
 
-        if (null === $this->content) {
+        if (null === $this->content || false === $this->content) {
             $this->content = file_get_contents('php://input');
         }
 

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1505,7 +1505,7 @@ class Request
                 return $resource;
             }
 
-            $this->content = false;
+            $this->content = null;
 
             return fopen('php://input', 'rb');
         }

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1042,8 +1042,16 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $req->getContent($second);
     }
 
+    public function getContentCantBeCalledTwiceWithResourcesProvider()
+    {
+        return array(
+            'Resource then fetch' => array(true, false),
+            'Resource then resource' => array(true, true),
+        );
+    }
+
     /**
-     * @dataProvider getContentCantBeCalledTwiceWithResourcesProvider
+     * @dataProvider getContentCanBeCalledTwiceWithResourcesProvider
      * @requires PHP 5.6
      */
     public function testGetContentCanBeCalledTwiceWithResources($first, $second)
@@ -1063,7 +1071,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($a, $b);
     }
 
-    public function getContentCantBeCalledTwiceWithResourcesProvider()
+    public function getContentCanBeCalledTwiceWithResourcesProvider()
     {
         return array(
             'Fetch then fetch' => array(false, false),

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1060,12 +1060,14 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             $b = stream_get_contents($b);
         }
 
-        $this->assertEquals($a, $b);
+        $this->assertSame($a, $b);
     }
 
     public function getContentCantBeCalledTwiceWithResourcesProvider()
     {
         return array(
+            'Fetch then fetch' => array(false, false),
+            'Fetch then resource' => array(false, true),
             'Resource then fetch' => array(true, false),
             'Resource then resource' => array(true, true),
         );


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

After calling `Request::getContent(true)`, subsequent calls to the
same instance method (withouth the `$asResource` flag) always returned
`false` instead of the request body as a plain string.

A unit test already existed to guard against this behaviour (the 'Resource then fetch' case) but it
yielded a false positive because it was comparing `''` to `false` using
PHPUnit's `assertEquals` method instead of `assertSame`.

For completeness sake I also added the missing usage permutations in
the data provider, which already worked OK.
