### PR TITLE
[HttpFoundation] Add named constructor on JsonResponse

### DIFF
--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -59,6 +59,14 @@ class JsonResponse extends Response
     }
 
     /**
+     * Make easier the creation of JsonResponse from raw json.
+     */
+    public static function fromJsonString($data = null, $status = 200, $headers = array())
+    {
+        return new static($data, $status, $headers, true);
+    }
+
+    /**
      * Sets the JSONP callback.
      *
      * @param string|null $callback The JSONP callback or null to use none

--- a/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
@@ -198,6 +198,12 @@ class JsonResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('{"0":{"0":1,"1":2,"2":3}}', $response->getContent());
     }
 
+    public function testItAcceptsJsonAsString()
+    {
+        $response = JsonResponse::fromJsonString('{"foo":"bar"}');
+        $this->assertSame('{"foo":"bar"}', $response->getContent());
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

To make easier construction with raw json. It is a simple addition but having something like : 

``` php
return new JsonResponse($content, Response::HTTP_OK, [], true);
```

and

``` php
return new JsonResponse($content, Response::HTTP_OK, []);
```

is not very obvious to get the difference without going to read the JsonResponse constructor.
