### PR TITLE
[Process] Provide interactive input.

### DIFF
--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1396,6 +1396,20 @@ class ProcessTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expected, $env);
     }
 
+    public function testInteractiveInput()
+    {
+        $p = $this->getProcess('read && read && echo done');
+        $p->setInputInteractive(true);
+        $p->start();
+        $p->setInput(PHP_EOL);
+        $this->assertTrue($p->isRunning()); // trigger read/write
+        $p->appendInputBuffer(PHP_EOL);
+        $this->assertTrue($p->isRunning()); // trigger read/write
+        usleep(100000); // allow a tenth of a second to complete
+        $this->assertFalse($p->isRunning());
+        $this->assertTrue(false !== strpos($p->getOutput(), 'done'));
+    }
+
     /**
      * @param string      $commandline
      * @param null|string $cwd


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

Instead of always closing the input pipe after exhausting the input buffer or
resource leave the input pipe open.
- setInputInteractive(): controls interactivity
- appendInputBuffer(): convenience method for writing additional input
- setInput(): now allows setting new input if interactive
