### PR TITLE
[Console] Fix indentation of Help: section of txt usage help

### DIFF
--- a/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
@@ -156,7 +156,7 @@ class TextDescriptor extends Descriptor
             $this->writeText("\n");
             $this->writeText('<comment>Help:</comment>', $options);
             $this->writeText("\n");
-            $this->writeText(' '.str_replace("\n", "\n ", $help), $options);
+            $this->writeText('  '.str_replace("\n", "\n  ", $help), $options);
             $this->writeText("\n");
         }
     }

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run2.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run2.txt
@@ -9,18 +9,18 @@ Options:
       --format=FORMAT  The output format (txt, xml, json, or md) [default: "txt"]
 
 Help:
- The list command lists all commands:
- 
-   php app/console list
- 
- You can also display the commands for a specific namespace:
- 
-   php app/console list test
- 
- You can also output the information in other formats by using the --format option:
- 
-   php app/console list --format=xml
- 
- It's also possible to get raw list of commands (useful for embedding command runner):
- 
-   php app/console list --raw
+  The list command lists all commands:
+  
+    php app/console list
+  
+  You can also display the commands for a specific namespace:
+  
+    php app/console list test
+  
+  You can also output the information in other formats by using the --format option:
+  
+    php app/console list --format=xml
+  
+  It's also possible to get raw list of commands (useful for embedding command runner):
+  
+    php app/console list --raw

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run3.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run3.txt
@@ -9,18 +9,18 @@ Options:
       --format=FORMAT  The output format (txt, xml, json, or md) [default: "txt"]
 
 Help:
- The list command lists all commands:
- 
-   php app/console list
- 
- You can also display the commands for a specific namespace:
- 
-   php app/console list test
- 
- You can also output the information in other formats by using the --format option:
- 
-   php app/console list --format=xml
- 
- It's also possible to get raw list of commands (useful for embedding command runner):
- 
-   php app/console list --raw
+  The list command lists all commands:
+  
+    php app/console list
+  
+  You can also display the commands for a specific namespace:
+  
+    php app/console list test
+  
+  You can also output the information in other formats by using the --format option:
+  
+    php app/console list --format=xml
+  
+  It's also possible to get raw list of commands (useful for embedding command runner):
+  
+    php app/console list --raw

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_1.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_1.txt
@@ -4,4 +4,4 @@
   alias2
 
 <comment>Help:</comment>
- command 1 help
+  command 1 help

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_2.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_2.txt
@@ -10,4 +10,4 @@
   <info>-o, --option_name</info>  
 
 <comment>Help:</comment>
- command 2 help
+  command 2 help

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_astext.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_astext.txt
@@ -15,4 +15,4 @@
   <info>-v|vv|vvv, --verbose</info>  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 
 <comment>Help:</comment>
- help
+  help


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

I noticed that all of the sections output by `TextDescriptor` (_Usage_, _Arguments_, _Options_, _Available commands_, &c.) are indented by 2 spaces, except for the _Help_ section, which is indented by only 1 space:

<img width="1039" alt="screen shot 2016-08-07 at 08 53 53" src="https://cloud.githubusercontent.com/assets/122095/17462818/34c99cfc-5c7e-11e6-9674-9324c537fc01.png">

This PR makes the indentation consistent with the other sections. (I don't _think_ that qualifies as a BC break?)
