### PR TITLE
Make IDEs handle the configuration tree

### DIFF
--- a/src/Symfony/Component/Config/Definition/Builder/NodeBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NodeBuilder.php
@@ -138,7 +138,7 @@ class NodeBuilder implements NodeParentInterface
     /**
      * Returns the parent node.
      *
-     * @return ParentNodeDefinitionInterface The parent node
+     * @return ParentNodeDefinitionInterface|NodeDefinition The parent node
      */
     public function end()
     {

--- a/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
@@ -107,7 +107,7 @@ abstract class NodeDefinition implements NodeParentInterface
     /**
      * Returns the parent node.
      *
-     * @return NodeParentInterface|null The builder of the parent node
+     * @return NodeParentInterface|NodeBuilder|NodeDefinition|null The builder of the parent node
      */
     public function end()
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

When defining a configuration tree, my IDE (PhpStorm) gives me a lot of `Method 'scalarNode' not found in null|\Symfony\Component\Config\Definition\Builder\NodeParentInterface` warnings. This can easily be fixed by adding more return types to the phpDoc comments of the `end()` methods of the `NodeBuilder` and `NodeDefinition` classes.
