### PR TITLE
[Cache] Handle unserialize() failures gracefully

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/ApcuAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ApcuAdapter.php
@@ -49,7 +49,11 @@ class ApcuAdapter extends AbstractAdapter
      */
     protected function doFetch(array $ids)
     {
-        return apcu_fetch($ids);
+        try {
+            return apcu_fetch($ids);
+        } catch (\Error $e) {
+            throw new \ErrorException($e->getMessage(), $e->getCode(), E_ERROR, $e->getFile(), $e->getLine());
+        }
     }
 
     /**

--- a/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
@@ -55,12 +55,22 @@ class ArrayAdapter implements AdapterInterface, LoggerAwareInterface
      */
     public function getItem($key)
     {
-        if (!$isHit = $this->hasItem($key)) {
+        $isHit = $this->hasItem($key);
+        try {
+            if (!$isHit) {
+                $value = null;
+            } elseif (!$this->storeSerialized) {
+                $value = $this->values[$key];
+            } elseif ('b:0;' === $value = $this->values[$key]) {
+                $value = false;
+            } elseif (false === $value = unserialize($value)) {
+                $value = null;
+                $isHit = false;
+            }
+        } catch (\Exception $e) {
+            CacheItem::log($this->logger, 'Failed to unserialize key "{key}"', array('key' => $key, 'exception' => $e));
             $value = null;
-        } elseif ($this->storeSerialized) {
-            $value = unserialize($this->values[$key]);
-        } else {
-            $value = $this->values[$key];
+            $isHit = false;
         }
         $f = $this->createCacheItem;
 
@@ -181,16 +191,30 @@ class ArrayAdapter implements AdapterInterface, LoggerAwareInterface
     {
         $f = $this->createCacheItem;
 
-        foreach ($keys as $key) {
-            if (!$isHit = isset($this->expiries[$key]) && ($this->expiries[$key] >= $now || !$this->deleteItem($key))) {
+        foreach ($keys as $i => $key) {
+            try {
+                if (!$isHit = isset($this->expiries[$key]) && ($this->expiries[$key] >= $now || !$this->deleteItem($key))) {
+                    $value = null;
+                } elseif (!$this->storeSerialized) {
+                    $value = $this->values[$key];
+                } elseif ('b:0;' === $value = $this->values[$key]) {
+                    $value = false;
+                } elseif (false === $value = unserialize($value)) {
+                    $value = null;
+                    $isHit = false;
+                }
+            } catch (\Exception $e) {
+                CacheItem::log($this->logger, 'Failed to unserialize key "{key}"', array('key' => $key, 'exception' => $e));
                 $value = null;
-            } elseif ($this->storeSerialized) {
-                $value = unserialize($this->values[$key]);
-            } else {
-                $value = $this->values[$key];
+                $isHit = false;
             }
+            unset($keys[$i]);
 
             yield $key => $f($key, $value, $isHit);
+        }
+
+        foreach ($keys as $key) {
+            yield $key => $f($key, null, false);
         }
     }
 }

--- a/src/Symfony/Component/Cache/Adapter/FilesystemAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/FilesystemAdapter.php
@@ -60,7 +60,7 @@ class FilesystemAdapter extends AbstractAdapter
 
         foreach ($ids as $id) {
             $file = $this->getFile($id);
-            if (!$h = @fopen($file, 'rb')) {
+            if (!file_exists($file) || !$h = @fopen($file, 'rb')) {
                 continue;
             }
             if ($now >= (int) $expiresAt = fgets($h)) {
@@ -73,7 +73,7 @@ class FilesystemAdapter extends AbstractAdapter
                 $value = stream_get_contents($h);
                 fclose($h);
                 if ($i === $id) {
-                    $values[$id] = unserialize($value);
+                    $values[$id] = parent::unserialize($value);
                 }
             }
         }

--- a/src/Symfony/Component/Cache/Adapter/RedisAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/RedisAdapter.php
@@ -134,19 +134,15 @@ class RedisAdapter extends AbstractAdapter
      */
     protected function doFetch(array $ids)
     {
-        $result = array();
-
         if ($ids) {
             $values = $this->redis->mGet($ids);
             $index = 0;
             foreach ($ids as $id) {
                 if ($value = $values[$index++]) {
-                    $result[$id] = unserialize($value);
+                    yield $id => parent::unserialize($value);
                 }
             }
         }
-
-        return $result;
     }
 
     /**

--- a/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
@@ -46,4 +46,42 @@ abstract class AdapterTestCase extends CachePoolTest
         $item = $cache->getItem('key.dlt');
         $this->assertFalse($item->isHit());
     }
+
+    public function testNotUnserializable()
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+
+            return;
+        }
+
+        $cache = $this->createCachePool();
+
+        $item = $cache->getItem('foo');
+        $cache->save($item->set(new NotUnserializable()));
+
+        $item = $cache->getItem('foo');
+        $this->assertFalse($item->isHit());
+
+        foreach ($cache->getItems(array('foo')) as $item) {
+        }
+        $cache->save($item->set(new NotUnserializable()));
+
+        foreach ($cache->getItems(array('foo')) as $item) {
+        }
+        $this->assertFalse($item->isHit());
+    }
+}
+
+class NotUnserializable implements \Serializable
+{
+    public function serialize()
+    {
+        return serialize(123);
+    }
+
+    public function unserialize($ser)
+    {
+        throw new \Exception(__CLASS__);
+    }
 }

--- a/src/Symfony/Component/Cache/Tests/Adapter/DoctrineAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/DoctrineAdapterTest.php
@@ -22,6 +22,7 @@ class DoctrineAdapterTest extends AdapterTestCase
     protected $skippedTests = array(
         'testDeferredSaveWithoutCommit' => 'Assumes a shared cache which ArrayCache is not.',
         'testSaveWithoutExpire' => 'Assumes a shared cache which ArrayCache is not.',
+        'testNotUnserializable' => 'ArrayCache does not use serialize/unserialize',
     );
 
     public function createCachePool($defaultLifetime = 0)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This makes fetching cached items more resilient: `__PHP_Incomplete_Class` "objects" and other errors triggered by unserialize should be turned to cache misses.
