### PR TITLE
[Debug] Better error handling

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -117,9 +117,11 @@ FrameworkBundle
  * The `framework.serializer.cache` option and the services
    `serializer.mapping.cache.apc` and `serializer.mapping.cache.doctrine.apc`
    have been removed. APCu should now be automatically used when available.
-   
+
  * The `Controller::getUser()` method has been removed in favor of the ability
    to typehint the security user object in the action.
+
+ * The default value of the `framework.php_errors.log` configuration key is set to true.
 
 HttpKernel
 ----------

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -116,6 +116,7 @@ class Configuration implements ConfigurationInterface
         $this->addPropertyAccessSection($rootNode);
         $this->addPropertyInfoSection($rootNode);
         $this->addCacheSection($rootNode);
+        $this->addPhpErrorsSection($rootNode);
 
         return $treeBuilder;
     }
@@ -686,6 +687,30 @@ class Configuration implements ConfigurationInterface
                                 ->ifTrue(function ($v) { return isset($v['cache.app']) || isset($v['cache.system']); })
                                 ->thenInvalid('"cache.app" and "cache.system" are reserved names')
                             ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+
+    private function addPhpErrorsSection(ArrayNodeDefinition $rootNode)
+    {
+        $rootNode
+            ->children()
+                ->arrayNode('php_errors')
+                    ->info('PHP errors handling configuration')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->booleanNode('log')
+                            ->info('Use the app logger instead of the PHP logger for logging PHP errors.')
+                            ->defaultValue(false)
+                            ->treatNullLike(false)
+                        ->end()
+                        ->booleanNode('throw')
+                            ->info('Throw PHP errors as \ErrorException instances.')
+                            ->defaultValue($this->debug)
+                            ->treatNullLike($this->debug)
                         ->end()
                     ->end()
                 ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
@@ -6,7 +6,6 @@
 
     <parameters>
         <parameter key="debug.container.dump">%kernel.cache_dir%/%kernel.container_class%.xml</parameter>
-        <parameter key="debug.error_handler.throw_at">-1</parameter>
     </parameters>
 
     <services>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug_prod.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug_prod.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="debug.error_handler.throw_at">0</parameter>
+        <parameter key="debug.error_handler.throw_at">-1</parameter>
     </parameters>
 
     <services>
@@ -14,10 +14,11 @@
             <tag name="monolog.logger" channel="php" />
             <argument>null</argument><!-- Exception handler -->
             <argument type="service" id="logger" on-invalid="null" />
-            <argument>null</argument><!-- Log levels map for enabled error levels -->
-            <argument>null</argument>
+            <argument>-1</argument><!-- Log levels map for enabled error levels -->
+            <argument>%debug.error_handler.throw_at%</argument>
             <argument>true</argument>
             <argument>null</argument><!-- %templating.helper.code.file_link_format% -->
+            <argument>true</argument>
         </service>
 
         <service id="debug.stopwatch" class="Symfony\Component\Stopwatch\Stopwatch" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -274,6 +274,10 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 'default_redis_provider' => 'redis://localhost',
             ),
             'workflows' => array(),
+            'php_errors' => array(
+                'log' => false,
+                'throw' => true,
+            ),
         );
     }
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
@@ -6,7 +6,7 @@
     {% if collector.counterrors or collector.countdeprecations or collector.countscreams %}
         {% set icon %}
             {% set status_color = collector.counterrors ? 'red' : collector.countdeprecations ? 'yellow' : '' %}
-            {% set error_count = collector.counterrors + collector.countdeprecations + collector.countscreams %}
+            {% set error_count = collector.counterrors + collector.countdeprecations %}
             {{ include('@WebProfiler/Icon/logger.svg') }}
             <span class="sf-toolbar-value">{{ error_count }}</span>
         {% endset %}
@@ -55,7 +55,7 @@
         {# sort collected logs in groups #}
         {% set deprecation_logs, debug_logs, info_and_error_logs, silenced_logs = [], [], [], [] %}
         {% for log in collector.logs %}
-            {% if log.context.level is defined and log.context.type is defined and log.context.type in [constant('E_DEPRECATED'), constant('E_USER_DEPRECATED')] %}
+            {% if log.context.errorCount is defined and log.context.type is defined and log.context.type in ['E_DEPRECATED', 'E_USER_DEPRECATED'] %}
                 {% set deprecation_logs = deprecation_logs|merge([log]) %}
             {% elseif log.context.scream is defined and log.context.scream == true  %}
                 {% set silenced_logs = silenced_logs|merge([log]) %}
@@ -170,21 +170,22 @@
 {% macro render_log_message(category, log_index, log, is_deprecation = false) %}
     {{ log.message }}
 
+    {% if log.context.errorCount is defined and log.context.errorCount > 1 %}
+        <span class="text-small text-bold">({{ log.context.errorCount }} times)</span>
+    {% endif %}
+
     {% if is_deprecation %}
-        {% set stack = log.context.stack|default([]) %}
-        {% set stack_id = 'sf-call-stack-' ~ category ~ '-' ~ log_index %}
+        {% set trace = log.context.trace|default([]) %}
+        {% set trace_id = 'sf-call-trace-' ~ category ~ '-' ~ log_index %}
 
-        {% if log.context.errorCount is defined %}
-            <span class="text-small text-bold">({{ log.context.errorCount }} times)</span>
+
+        {% if trace %}
+            <button class="btn-link text-small sf-toggle" data-toggle-selector="#{{ trace_id }}" data-toggle-alt-content="Hide stack trace">Show stack trace</button>
         {% endif %}
 
-        {% if stack %}
-            <button class="btn-link text-small sf-toggle" data-toggle-selector="#{{ stack_id }}" data-toggle-alt-content="Hide stack trace">Show stack trace</button>
-        {% endif %}
-
-        {% for index, call in stack if index > 1 %}
+        {% for index, call in trace if index > 1 %}
             {% if index == 2 %}
-                <ul class="sf-call-stack hidden" id="{{ stack_id }}">
+                <ul class="sf-call-trace hidden" id="{{ trace_id }}">
             {% endif %}
 
             {% if call.class is defined %}
@@ -206,7 +207,7 @@
                 {% endif %}
             </li>
 
-            {% if index == stack|length - 1 %}
+            {% if index == trace|length - 1 %}
                 </ul>
             {% endif %}
         {% endfor %}
@@ -224,7 +225,7 @@
                     <a class="btn-link text-small sf-toggle" data-toggle-selector="#{{ context_id }}" data-toggle-alt-content="Hide full context">Show full context</a>
 
                     <div id="{{ context_id }}" class="context">
-                        <pre>{{ context_dump }}</pre>
+                        {{ dump(log.context) }}
                     </div>
                 {% else %}
                     {{ context_dump }}

--- a/src/Symfony/Component/Debug/Exception/SilencedErrorContext.php
+++ b/src/Symfony/Component/Debug/Exception/SilencedErrorContext.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Debug\Exception;
+
+/**
+ * Data Object that represents a Silenced Error.
+ *
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ */
+class SilencedErrorContext implements \JsonSerializable
+{
+    private $severity;
+    private $file;
+    private $line;
+
+    public function __construct($severity, $file, $line)
+    {
+        $this->severity = $severity;
+        $this->file = $file;
+        $this->line = $line;
+    }
+
+    public function getSeverity()
+    {
+        return $this->severity;
+    }
+
+    public function getFile()
+    {
+        return $this->file;
+    }
+
+    public function getLine()
+    {
+        return $this->line;
+    }
+
+    public function JsonSerialize()
+    {
+        return array(
+            'severity' => $this->severity,
+            'file' => $this->file,
+            'line' => $this->line,
+        );
+    }
+}

--- a/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
@@ -12,9 +12,10 @@
 namespace Symfony\Component\Debug\Tests;
 
 use Psr\Log\LogLevel;
-use Symfony\Component\Debug\ErrorHandler;
 use Symfony\Component\Debug\BufferingLogger;
+use Symfony\Component\Debug\ErrorHandler;
 use Symfony\Component\Debug\Exception\ContextErrorException;
+use Symfony\Component\Debug\Exception\SilencedErrorContext;
 
 /**
  * ErrorHandlerTest.
@@ -202,11 +203,12 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
 
             $warnArgCheck = function ($logLevel, $message, $context) {
                 $this->assertEquals('info', $logLevel);
-                $this->assertEquals('foo', $message);
-                $this->assertArrayHasKey('type', $context);
-                $this->assertEquals($context['type'], E_USER_DEPRECATED);
-                $this->assertArrayHasKey('stack', $context);
-                $this->assertInternalType('array', $context['stack']);
+                $this->assertEquals('User Deprecated: foo', $message);
+                $this->assertArrayHasKey('exception', $context);
+                $exception = $context['exception'];
+                $this->assertInstanceOf(\ErrorException::class, $exception);
+                $this->assertSame('User Deprecated: foo', $exception->getMessage());
+                $this->assertSame(E_USER_DEPRECATED, $exception->getSeverity());
             };
 
             $logger
@@ -225,9 +227,11 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
             $logger = $this->getMock('Psr\Log\LoggerInterface');
 
             $logArgCheck = function ($level, $message, $context) {
-                $this->assertEquals('Undefined variable: undefVar', $message);
-                $this->assertArrayHasKey('type', $context);
-                $this->assertEquals($context['type'], E_NOTICE);
+                $this->assertEquals('Notice: Undefined variable: undefVar', $message);
+                $this->assertArrayHasKey('exception', $context);
+                $exception = $context['exception'];
+                $this->assertInstanceOf(SilencedErrorContext::class, $exception);
+                $this->assertSame(E_NOTICE, $exception->getSeverity());
             };
 
             $logger
@@ -278,9 +282,10 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
     {
         $logArgCheck = function ($level, $message, $context) {
             $this->assertEquals(LogLevel::INFO, $level);
-            $this->assertArrayHasKey('level', $context);
-            $this->assertEquals(E_RECOVERABLE_ERROR | E_USER_ERROR | E_DEPRECATED | E_USER_DEPRECATED, $context['level']);
-            $this->assertArrayHasKey('stack', $context);
+            $this->assertArrayHasKey('exception', $context);
+            $exception = $context['exception'];
+            $this->assertInstanceOf(\ErrorException::class, $exception);
+            $this->assertSame('User Deprecated: Foo deprecation', $exception->getMessage());
         };
 
         $logger = $this->getMock('Psr\Log\LoggerInterface');
@@ -305,9 +310,9 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
             $logger = $this->getMock('Psr\Log\LoggerInterface');
 
             $logArgCheck = function ($level, $message, $context) {
-                $this->assertEquals('Uncaught Exception: foo', $message);
-                $this->assertArrayHasKey('type', $context);
-                $this->assertEquals($context['type'], E_ERROR);
+                $this->assertSame('Uncaught Exception: foo', $message);
+                $this->assertArrayHasKey('exception', $context);
+                $this->assertInstanceOf(\Exception::class, $context['exception']);
             };
 
             $logger
@@ -349,7 +354,7 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
                 ->method('log')
                 ->withConsecutive(
                     array($this->equalTo(LogLevel::WARNING), $this->equalTo('Dummy log')),
-                    array($this->equalTo(LogLevel::DEBUG), $this->equalTo('Silenced warning'))
+                    array($this->equalTo(LogLevel::DEBUG), $this->equalTo('User Warning: Silenced warning'))
                 )
             ;
 
@@ -391,19 +396,27 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($loggers, $handler->setLoggers(array()));
 
         $handler->handleError(E_DEPRECATED, 'Foo message', __FILE__, 123, array());
-        $expectedLog = array(LogLevel::INFO, 'Foo message', array('type' => E_DEPRECATED, 'file' => __FILE__, 'line' => 123, 'level' => error_reporting()));
 
         $logs = $bootLogger->cleanLogs();
-        unset($logs[0][2]['stack']);
 
-        $this->assertSame(array($expectedLog), $logs);
+        $this->assertCount(1, $logs);
+        $log = $logs[0];
+        $this->assertSame('info', $log[0]);
+        $this->assertSame('Deprecated: Foo message', $log[1]);
+        $this->assertArrayHasKey('exception', $log[2]);
+        $exception = $log[2]['exception'];
+        $this->assertInstanceOf(\ErrorException::class, $exception);
+        $this->assertSame('Deprecated: Foo message', $exception->getMessage());
+        $this->assertSame(__FILE__, $exception->getFile());
+        $this->assertSame(123, $exception->getLine());
+        $this->assertSame(E_DEPRECATED, $exception->getSeverity());
 
-        $bootLogger->log($expectedLog[0], $expectedLog[1], $expectedLog[2]);
+        $bootLogger->log(LogLevel::WARNING, 'Foo message', array('exception' => $exception));
 
         $mockLogger = $this->getMock('Psr\Log\LoggerInterface');
         $mockLogger->expects($this->once())
             ->method('log')
-            ->with(LogLevel::WARNING, 'Foo message', $expectedLog[2]);
+            ->with(LogLevel::WARNING, 'Foo message', array('exception' => $exception));
 
         $handler->setLoggers(array(E_DEPRECATED => array($mockLogger, LogLevel::WARNING)));
     }
@@ -424,8 +437,8 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
 
             $logArgCheck = function ($level, $message, $context) {
                 $this->assertEquals('Fatal Parse Error: foo', $message);
-                $this->assertArrayHasKey('type', $context);
-                $this->assertEquals($context['type'], E_PARSE);
+                $this->assertArrayHasKey('exception', $context);
+                $this->assertInstanceOf(\Exception::class, $context['exception']);
             };
 
             $logger
@@ -477,14 +490,7 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
                 ->method('log')
                 ->with(
                     $this->equalTo(LogLevel::CRITICAL),
-                    $this->equalTo('Fatal Error: foo'),
-                    $this->equalTo(array(
-                        'type' => 1,
-                        'file' => 'bar',
-                        'line' => 123,
-                        'level' => -1,
-                        'stack' => array(456),
-                    ))
+                    $this->equalTo('Fatal Error: foo')
                 )
             ;
 

--- a/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
@@ -35,6 +35,7 @@ class DebugHandlersListener implements EventSubscriberInterface
     private $throwAt;
     private $scream;
     private $fileLinkFormat;
+    private $scope;
     private $firstCall = true;
 
     /**
@@ -44,8 +45,9 @@ class DebugHandlersListener implements EventSubscriberInterface
      * @param int|null             $throwAt          Thrown errors in a bit field of E_* constants, or null to keep the current value
      * @param bool                 $scream           Enables/disables screaming mode, where even silenced errors are logged
      * @param string               $fileLinkFormat   The format for links to source files
+     * @param bool                 $scope            Enables/disables scoping mode
      */
-    public function __construct(callable $exceptionHandler = null, LoggerInterface $logger = null, $levels = E_ALL, $throwAt = E_ALL, $scream = true, $fileLinkFormat = null)
+    public function __construct(callable $exceptionHandler = null, LoggerInterface $logger = null, $levels = E_ALL, $throwAt = E_ALL, $scream = true, $fileLinkFormat = null, $scope = true)
     {
         $this->exceptionHandler = $exceptionHandler;
         $this->logger = $logger;
@@ -53,6 +55,7 @@ class DebugHandlersListener implements EventSubscriberInterface
         $this->throwAt = is_numeric($throwAt) ? (int) $throwAt : (null === $throwAt ? null : ($throwAt ? E_ALL : null));
         $this->scream = (bool) $scream;
         $this->fileLinkFormat = $fileLinkFormat ?: ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format');
+        $this->scope = (bool) $scope;
     }
 
     /**
@@ -74,15 +77,20 @@ class DebugHandlersListener implements EventSubscriberInterface
                 if ($this->logger) {
                     $handler->setDefaultLogger($this->logger, $this->levels);
                     if (is_array($this->levels)) {
-                        $scream = 0;
+                        $levels = 0;
                         foreach ($this->levels as $type => $log) {
-                            $scream |= $type;
+                            $levels |= $type;
                         }
                     } else {
-                        $scream = $this->levels;
+                        $levels = $this->levels;
                     }
                     if ($this->scream) {
-                        $handler->screamAt($scream);
+                        $handler->screamAt($levels);
+                    }
+                    if ($this->scope) {
+                        $handler->scopeAt($this->levels);
+                    } else {
+                        $handler->scopeAt(0, true);
                     }
                     $this->logger = $this->levels = null;
                 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | - |
| Fixed tickets | - |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/6870 |
1. Send the raw exception in the log context instead of custom formatting
2. Add config option to log/throw in Symfony all PHP errors
3. Always use an exception when a PHP error occurs
4. Expand exception in the log context in the web developer toolbar
5. Use the dumper to dump log context in the web developer toolbar

---

I used the following code to produce screenshots:

``` php
public function indexAction(Request $request)
    {
        $this->get('logger')->info('A log message with an exception', ['exception' => new \Exception('this exception will be logged')]);

        error_reporting(0);
        for ($i=0; $i < 15; $i++) {
            if ($i == 5) {
                error_reporting(E_ALL);
            }
            if ($i == 10) {
                error_reporting(0);
            }

            trigger_error("Trigger error avec E_USER_NOTICE", E_USER_NOTICE);
        }

        error_reporting(E_ALL);

        @trigger_error("trigger_error avec E_USER_DEPRECATED", E_USER_DEPRECATED);
        trigger_error("trigger_error avec E_USER_DEPRECATED (not silent)", E_USER_DEPRECATED);
// ...
```

![screenshot16](https://cloud.githubusercontent.com/assets/408368/17582279/2c4239b0-5fab-11e6-8428-2eaa7372cce3.png)

![screenshot17](https://cloud.githubusercontent.com/assets/408368/17582287/30cad1ea-5fab-11e6-9b0b-de0fa9f3913b.png)

![screenshot18](https://cloud.githubusercontent.com/assets/408368/17582291/348bb574-5fab-11e6-83b0-5bfaac080838.png)
