### PR TITLE
[Config] Fix YamlReferenceDumper prototyped array support

### DIFF
--- a/src/Symfony/Component/Config/Tests/Definition/Dumper/YamlReferenceDumperTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Dumper/YamlReferenceDumperTest.php
@@ -22,7 +22,6 @@ class YamlReferenceDumperTest extends \PHPUnit_Framework_TestCase
 
         $dumper = new YamlReferenceDumper();
 
-        $this->markTestIncomplete('The Yaml Dumper currently does not support prototyped arrays');
         $this->assertEquals($this->getConfigurationAsString(), $dumper->dump($configuration));
     }
 
@@ -32,7 +31,7 @@ class YamlReferenceDumperTest extends \PHPUnit_Framework_TestCase
 acme_root:
     boolean:              true
     scalar_empty:         ~
-    scalar_null:          ~
+    scalar_null:          null
     scalar_true:          true
     scalar_false:         false
     scalar_default:       default
@@ -60,8 +59,11 @@ acme_root:
         # Prototype
         name:                 ~
     connections:
+
         # Prototype
-        - { user: ~, pass: ~ }
+        -
+            user:                 ~
+            pass:                 ~
 
 EOL;
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Also related to #19480 which fixes another prototype issue, but cannot be tested properly on Travis because marked as skipped by this missing implementation.

Previous output was:

``` yaml
    [...]
    parameters:

        # Prototype
        name:                 ~
    connections:
        user:                 ~
        pass:                 ~
```

instead of:

``` yaml
    [...]
    parameters:

        # Prototype
        name:                 ~
    connections:

        # Prototype
        -
            user:                 ~
            pass:                 ~
```
