### PR TITLE
[WebProfiler] added support for window.fetch calls in ajax section

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/ajax.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/ajax.html.twig
@@ -15,6 +15,7 @@
                 <thead>
                     <tr>
                         <th>Method</th>
+                        <th>Type</th>
                         <th>Status</th>
                         <th>URL</th>
                         <th>Time</th>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -240,7 +240,7 @@
 
         {% if excluded_ajax_paths is defined %}
 
-            if (window.fetch) {
+            if (window.fetch && window.fetch.polyfill === undefined) {
                 var oldFetch = window.fetch;
                 window.fetch = function () {
                     var promise = oldFetch.apply(this, arguments);

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -124,6 +124,10 @@
                             methodCell.textContent = request.method;
                             row.appendChild(methodCell);
 
+                            var typeCell = document.createElement('td');
+                            typeCell.textContent = request.type;
+                            row.appendChild(typeCell);
+
                             var statusCodeCell = document.createElement('td');
                             var statusCode = document.createElement('span');
                             if (request.statusCode < 300) {
@@ -239,7 +243,7 @@
             if (window.fetch) {
                 var oldFetch = window.fetch;
                 window.fetch = function () {
-                    var promise = oldFetch.apply(null, arguments);
+                    var promise = oldFetch.apply(this, arguments);
                     if (!arguments[0].match(new RegExp({{ excluded_ajax_paths|json_encode|raw }}))) {
                         var method = 'GET';
                         if (arguments[1] && arguments[1].method !== undefined) {
@@ -251,6 +255,7 @@
                             error: false,
                             url: arguments[0],
                             method: method,
+                            type: 'fetch',
                             start: new Date()
                         };
 
@@ -263,7 +268,7 @@
                             stackElement.profile = r.headers.get('x-debug-token');
                             stackElement.profilerUrl = r.headers.get('x-debug-token-link');
                             Sfjs.renderAjaxRequests();
-                        }).catch(function(err) {
+                        }, function (e){
                             stackElement.loading = false;
                             stackElement.error = true;
                         });
@@ -296,6 +301,7 @@
                             error: false,
                             url: url,
                             method: method,
+                            type: 'xhr',
                             start: new Date()
                         };
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -235,18 +235,25 @@
         }
 
         {% if excluded_ajax_paths is defined %}
-            if (window.XMLHttpRequest && XMLHttpRequest.prototype.addEventListener) {
-                if (window.fetch) {
-                    var oldFetch = window.fetch;
-                    window.fetch = function () {
-                        var promise = oldFetch.apply(null, arguments);
+
+            if (window.fetch) {
+                var oldFetch = window.fetch;
+                window.fetch = function () {
+                    var promise = oldFetch.apply(null, arguments);
+                    if (!arguments[0].match(new RegExp({{ excluded_ajax_paths|json_encode|raw }}))) {
+                        var method = 'GET';
+                        if (arguments[1] && arguments[1].method !== undefined) {
+                            method = arguments[1].method;
+                        }
+
                         var stackElement = {
                             loading: true,
                             error: false,
                             url: arguments[0],
-                            method: arguments[1].method,
+                            method: method,
                             start: new Date()
                         };
+
                         requestStack.push(stackElement);
                         promise.then(function (r) {
                             stackElement.duration = new Date() - stackElement.start;
@@ -256,11 +263,17 @@
                             stackElement.profile = r.headers.get('x-debug-token');
                             stackElement.profilerUrl = r.headers.get('x-debug-token-link');
                             Sfjs.renderAjaxRequests();
+                        }).catch(function(err) {
+                            stackElement.loading = false;
+                            stackElement.error = true;
                         });
                         Sfjs.renderAjaxRequests();
-                        return promise;
-                    };
-                }
+                    }
+
+                    return promise;
+                };
+            }
+            if (window.XMLHttpRequest && XMLHttpRequest.prototype.addEventListener) {
                 var proxied = XMLHttpRequest.prototype.open;
 
                 XMLHttpRequest.prototype.open = function(method, url, async, user, pass) {

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -236,6 +236,31 @@
 
         {% if excluded_ajax_paths is defined %}
             if (window.XMLHttpRequest && XMLHttpRequest.prototype.addEventListener) {
+                if (window.fetch) {
+                    var oldFetch = window.fetch;
+                    window.fetch = function () {
+                        var promise = oldFetch.apply(null, arguments);
+                        var stackElement = {
+                            loading: true,
+                            error: false,
+                            url: arguments[0],
+                            method: arguments[1].method,
+                            start: new Date()
+                        };
+                        requestStack.push(stackElement);
+                        promise.then(function (r) {
+                            stackElement.duration = new Date() - stackElement.start;
+                            stackElement.loading = false;
+                            stackElement.error = r.status < 200 || r.status >= 400;
+                            stackElement.statusCode = r.status;
+                            stackElement.profile = r.headers.get('x-debug-token');
+                            stackElement.profilerUrl = r.headers.get('x-debug-token-link');
+                            Sfjs.renderAjaxRequests();
+                        });
+                        Sfjs.renderAjaxRequests();
+                        return promise;
+                    };
+                }
                 var proxied = XMLHttpRequest.prototype.open;
 
                 XMLHttpRequest.prototype.open = function(method, url, async, user, pass) {

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -334,7 +334,7 @@
     padding: 4px;
 }
 .sf-ajax-request-url {
-    max-width: 300px;
+    max-width: 250px;
     line-height: 9px;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17444 |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

This adds support for window.fetch calls to the Ajax section of the WebProfiler toolbar.

Credits to @tbopec for  implementation :)
