### PR TITLE
[Config] Allow validating values using callables in ExprBuilder

### DIFF
--- a/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
@@ -38,11 +38,11 @@ class ExprBuilder
     /**
      * Marks the expression as being always used.
      *
-     * @param \Closure $then
+     * @param callable $then
      *
      * @return ExprBuilder
      */
-    public function always(\Closure $then = null)
+    public function always(callable $then = null)
     {
         $this->ifPart = function ($v) { return true; };
 
@@ -54,21 +54,21 @@ class ExprBuilder
     }
 
     /**
-     * Sets a closure to use as tests.
+     * Sets a callable to use as tests.
      *
      * The default one tests if the value is true.
      *
-     * @param \Closure $closure
+     * @param callable $callback
      *
      * @return ExprBuilder
      */
-    public function ifTrue(\Closure $closure = null)
+    public function ifTrue(callable $callback = null)
     {
-        if (null === $closure) {
-            $closure = function ($v) { return true === $v; };
+        if (null === $callback) {
+            $callback = function ($v) { return true === $v; };
         }
 
-        $this->ifPart = $closure;
+        $this->ifPart = $callback;
 
         return $this;
     }
@@ -138,15 +138,15 @@ class ExprBuilder
     }
 
     /**
-     * Sets the closure to run if the test pass.
+     * Sets the callable to run if the test pass.
      *
-     * @param \Closure $closure
+     * @param callable $callback
      *
      * @return ExprBuilder
      */
-    public function then(\Closure $closure)
+    public function then(callable $callback)
     {
-        $this->thenPart = $closure;
+        $this->thenPart = $callback;
 
         return $this;
     }
@@ -228,7 +228,7 @@ class ExprBuilder
                 $if = $expr->ifPart;
                 $then = $expr->thenPart;
                 $expressions[$k] = function ($v) use ($if, $then) {
-                    return $if($v) ? $then($v) : $v;
+                    return call_user_func($if, $v) ? call_user_func($then, $v) : $v;
                 };
             }
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This PR is a proposal for adding the ability to pass any callable for validating values using the ExprBuilder, which accepts only closures ATM.

The problem with closures is they often involve to write redundant code such as useless assignments or intermediate methods or lots of arguments in the `use()` part of the closure, as soon as the validation logic is decoupled from the configuration for instance.

**Before**

``` php
public function getConfigTreeBuilder()
{
    // ...
    $validator = $this->validator;
    $rootNode
        ->children()
            ->scalarNode('foo')
                ->validate()
                ->ifString()
                    ->then(function ($v) use ($validator) { return $validator->validate($v); })
                ->end()
            ->end()
        ->end()
    ->end()
}
```

**After**

``` php
    // ...
    $rootNode
        ->children()
            ->scalarNode('foo')
                ->validate()
                ->ifString()
                    ->then([$this->validator, 'validate'])
                ->end()
            ->end()
        ->end()
    ->end()
```

It is a BC break but IMHO it worths it, ATM I don't see any use case where this would have a negative impact, except when overriding the changed methods (never saw such case).
