### PR TITLE
[DependencyInjection] Improve ParameterNotFoundException when accessing a nested parameter

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Exception/ParameterNotFoundException.php
+++ b/src/Symfony/Component/DependencyInjection/Exception/ParameterNotFoundException.php
@@ -22,20 +22,23 @@ class ParameterNotFoundException extends InvalidArgumentException
     private $sourceId;
     private $sourceKey;
     private $alternatives;
+    private $nonNestedAlternative;
 
     /**
-     * @param string     $key          The requested parameter key
-     * @param string     $sourceId     The service id that references the non-existent parameter
-     * @param string     $sourceKey    The parameter key that references the non-existent parameter
-     * @param \Exception $previous     The previous exception
-     * @param string[]   $alternatives Some parameter name alternatives
+     * @param string      $key                  The requested parameter key
+     * @param string      $sourceId             The service id that references the non-existent parameter
+     * @param string      $sourceKey            The parameter key that references the non-existent parameter
+     * @param \Exception  $previous             The previous exception
+     * @param string[]    $alternatives         Some parameter name alternatives
+     * @param string|null $nonNestedAlternative The alternative parameter name when the user expected dot notation for nested parameters
      */
-    public function __construct($key, $sourceId = null, $sourceKey = null, \Exception $previous = null, array $alternatives = array())
+    public function __construct($key, $sourceId = null, $sourceKey = null, \Exception $previous = null, array $alternatives = array(), $nonNestedAlternative = null)
     {
         $this->key = $key;
         $this->sourceId = $sourceId;
         $this->sourceKey = $sourceKey;
         $this->alternatives = $alternatives;
+        $this->nonNestedAlternative = $nonNestedAlternative;
 
         parent::__construct('', 0, $previous);
 
@@ -59,6 +62,8 @@ class ParameterNotFoundException extends InvalidArgumentException
                 $this->message .= ' Did you mean one of these: "';
             }
             $this->message .= implode('", "', $this->alternatives).'"?';
+        } elseif (null !== $this->nonNestedAlternative) {
+            $this->message .= ' You cannot access nested array items, do you want to inject "'.$this->nonNestedAlternative.'" instead?';
         }
     }
 

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -81,7 +81,23 @@ class ParameterBag implements ParameterBagInterface
                 }
             }
 
-            throw new ParameterNotFoundException($name, null, null, null, $alternatives);
+            $nonNestedAlternative = null;
+            if (!count($alternatives) && false !== strpos($name, '.')) {
+                $namePartsLength = array_map('strlen', explode('.', $name));
+                $key = substr($name, 0, -1 * (1 + array_pop($namePartsLength)));
+                while (count($namePartsLength)) {
+                    if ($this->has($key)) {
+                        if (is_array($this->get($key))) {
+                            $nonNestedAlternative = $key;
+                        }
+                        break;
+                    }
+
+                    $key = substr($key, 0, -1 * (1 + array_pop($namePartsLength)));
+                }
+            }
+
+            throw new ParameterNotFoundException($name, null, null, null, $alternatives, $nonNestedAlternative);
         }
 
         return $this->parameters[$name];

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
@@ -80,6 +80,7 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
             'foo' => 'foo',
             'bar' => 'bar',
             'baz' => 'baz',
+            'fiz' => array('bar' => array('boo' => 12)),
         ));
 
         $this->setExpectedException('Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException', $exceptionMessage);
@@ -93,6 +94,8 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
             array('foo1', 'You have requested a non-existent parameter "foo1". Did you mean this: "foo"?'),
             array('bag', 'You have requested a non-existent parameter "bag". Did you mean one of these: "bar", "baz"?'),
             array('', 'You have requested a non-existent parameter "".'),
+
+            array('fiz.bar.boo', 'You have requested a non-existent parameter "fiz.bar.boo". You cannot access nested array items, do you want to inject "fiz" instead?'),
         );
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
@@ -71,7 +71,10 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function testGetThrowParameterNotFoundException()
+    /**
+     * @dataProvider provideGetThrowParameterNotFoundExceptionData
+     */
+    public function testGetThrowParameterNotFoundException($parameterKey, $exceptionMessage)
     {
         $bag = new ParameterBag(array(
             'foo' => 'foo',
@@ -79,29 +82,18 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
             'baz' => 'baz',
         ));
 
-        try {
-            $bag->get('foo1');
-            $this->fail('->get() throws an Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException if the key does not exist');
-        } catch (\Exception $e) {
-            $this->assertInstanceOf('Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException', $e, '->get() throws an Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException if the key does not exist');
-            $this->assertEquals('You have requested a non-existent parameter "foo1". Did you mean this: "foo"?', $e->getMessage(), '->get() throws an Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException with some advices');
-        }
+        $this->setExpectedException('Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException', $exceptionMessage);
 
-        try {
-            $bag->get('bag');
-            $this->fail('->get() throws an Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException if the key does not exist');
-        } catch (\Exception $e) {
-            $this->assertInstanceOf('Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException', $e, '->get() throws an Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException if the key does not exist');
-            $this->assertEquals('You have requested a non-existent parameter "bag". Did you mean one of these: "bar", "baz"?', $e->getMessage(), '->get() throws an Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException with some advices');
-        }
+        $bag->get($parameterKey);
+    }
 
-        try {
-            $bag->get('');
-            $this->fail('->get() throws an Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException if the key does not exist');
-        } catch (\Exception $e) {
-            $this->assertInstanceOf('Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException', $e, '->get() throws an Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException if the key does not exist');
-            $this->assertEquals('You have requested a non-existent parameter "".', $e->getMessage(), '->get() throws an Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException with some advices');
-        }
+    public function provideGetThrowParameterNotFoundExceptionData()
+    {
+        return array(
+            array('foo1', 'You have requested a non-existent parameter "foo1". Did you mean this: "foo"?'),
+            array('bag', 'You have requested a non-existent parameter "bag". Did you mean one of these: "bar", "baz"?'),
+            array('', 'You have requested a non-existent parameter "".'),
+        );
     }
 
     public function testHas()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | n/a |

A common problem under beginners is to think that the dot notation is used to access nested arrays saved in parameters (_common here means someone asks help for this problem at least once a week on IRC_). Adding a little extra detail to the exception message and a working alternative should help pointing these people in the right direction before spending time debugging this.

It's quite late in the night over here, so the wording of the exception message probably isn't great. I'm happy to accept better suggestions 😃 
