### PR TITLE
[TwigBundle] Fix bug where namespaced paths don't take parent bundles in account

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -88,18 +88,19 @@ class TwigExtension extends Extension
             }
         }
 
-        // register bundles as Twig namespaces
-        foreach ($container->getParameter('kernel.bundles_metadata') as $name => $bundle) {
-            if (is_dir($dir = $container->getParameter('kernel.root_dir').'/Resources/'.$name.'/views')) {
-                $this->addTwigPath($twigFilesystemLoaderDefinition, $dir, $name);
+        $bundleHierarchy = $this->getBundleHierarchy($container);
+
+        foreach ($bundleHierarchy as $name => $bundle) {
+            $namespace = $this->normalizeBundleName($name);
+
+            foreach ($bundle['children'] as $child) {
+                foreach ($bundleHierarchy[$child]['paths'] as $path) {
+                    $twigFilesystemLoaderDefinition->addMethodCall('addPath', array($path, $namespace));
+                }
             }
 
-            if (is_dir($dir = $bundle['path'].'/Resources/views')) {
-                $this->addTwigPath($twigFilesystemLoaderDefinition, $dir, $name);
-            }
-
-            if (null !== $bundle['parent']) {
-                $this->prependParentPaths($twigFilesystemLoaderDefinition, $container, $name, $bundle['parent']);
+            foreach ($bundle['paths'] as $path) {
+                $twigFilesystemLoaderDefinition->addMethodCall('addPath', array($path, $namespace));
             }
         }
 
@@ -143,36 +144,60 @@ class TwigExtension extends Extension
         ));
     }
 
+    private function getBundleHierarchy(ContainerBuilder $container)
+    {
+        $bundleHierarchy = array();
+
+        foreach ($container->getParameter('kernel.bundles_metadata') as $name => $bundle) {
+            if (!array_key_exists($name, $bundleHierarchy)) {
+                $bundleHierarchy[$name] = array(
+                    'paths' => array(),
+                    'parents' => array(),
+                    'children' => array(),
+                );
+            }
+
+            if (is_dir($dir = $container->getParameter('kernel.root_dir').'/Resources/'.$name.'/views')) {
+                $bundleHierarchy[$name]['paths'][] = $dir;
+            }
+
+            if (is_dir($dir = $bundle['path'].'/Resources/views')) {
+                $bundleHierarchy[$name]['paths'][] = $dir;
+            }
+
+            if (null === $bundle['parent']) {
+                continue;
+            }
+
+            $bundleHierarchy[$name]['parents'][] = $bundle['parent'];
+
+            if (!array_key_exists($bundle['parent'], $bundleHierarchy)) {
+                $bundleHierarchy[$bundle['parent']] = array(
+                    'paths' => array(),
+                    'parents' => array(),
+                    'children' => array(),
+                );
+            }
+
+            $bundleHierarchy[$bundle['parent']]['children'] = array_merge($bundleHierarchy[$name]['children'], array($name), $bundleHierarchy[$bundle['parent']]['children']);
+
+            foreach ($bundleHierarchy[$bundle['parent']]['parents'] as $parent) {
+                $bundleHierarchy[$name]['parents'][] = $parent;
+                $bundleHierarchy[$parent]['children'] = array_merge($bundleHierarchy[$name]['children'], array($name), $bundleHierarchy[$parent]['children']);
+            }
+
+            foreach ($bundleHierarchy[$name]['children'] as $child) {
+                $bundleHierarchy[$child]['parents'] = array_merge($bundleHierarchy[$child]['parents'], $bundleHierarchy[$name]['parents']);
+            }
+        }
+
+        return $bundleHierarchy;
+    }
+
     private function addTwigPath($twigFilesystemLoaderDefinition, $dir, $bundle)
     {
         $name = $this->normalizeBundleName($bundle);
         $twigFilesystemLoaderDefinition->addMethodCall('addPath', array($dir, $name));
-    }
-
-    private function prependTwigPath($twigFilesystemLoaderDefinition, $dir, $bundle)
-    {
-        $name = $this->normalizeBundleName($bundle);
-        $twigFilesystemLoaderDefinition->addMethodCall('prependPath', array($dir, $name));
-    }
-
-    private function prependParentPaths($twigFilesystemLoaderDefinition, ContainerBuilder $container, $name, $parentName)
-    {
-        $bundleMetadata = $container->getParameter('kernel.bundles_metadata');
-        $bundle = $bundleMetadata[$name];
-
-        if (is_dir($dir = $container->getParameter('kernel.root_dir').'/Resources/'.$name.'/views')) {
-            $this->prependTwigPath($twigFilesystemLoaderDefinition, $dir, $parentName);
-        }
-
-        if (is_dir($dir = $bundle['path'].'/Resources/views')) {
-            $this->prependTwigPath($twigFilesystemLoaderDefinition, $dir, $parentName);
-        }
-
-        $parentBundle = $bundleMetadata[$parentName];
-
-        if (null !== $parentBundle['parent']) {
-            $this->prependParentPaths($twigFilesystemLoaderDefinition, $container, $name, $parentBundle['parent']);
-        }
     }
 
     private function normalizeBundleName($name)

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/Bundle/ChildChildChildChildTwigBundle/Resources/views/layout.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/Bundle/ChildChildChildChildTwigBundle/Resources/views/layout.html.twig
@@ -1,0 +1,1 @@
+This is a layout

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/Bundle/ChildChildChildTwigBundle/Resources/views/layout.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/Bundle/ChildChildChildTwigBundle/Resources/views/layout.html.twig
@@ -1,0 +1,1 @@
+This is a layout

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/Bundle/ChildChildTwigBundle/Resources/views/layout.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/Bundle/ChildChildTwigBundle/Resources/views/layout.html.twig
@@ -1,0 +1,1 @@
+This is a layout

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/Bundle/ChildTwigBundle/Resources/views/layout.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/Bundle/ChildTwigBundle/Resources/views/layout.html.twig
@@ -1,0 +1,1 @@
+This is a layout

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
@@ -189,9 +189,12 @@ class TwigExtensionTest extends TestCase
 
         $def = $container->getDefinition('twig.loader.filesystem');
         $paths = array();
+        $prependPaths = array();
         foreach ($def->getMethodCalls() as $call) {
             if ('addPath' === $call[0] && false === strpos($call[1][0], 'Form')) {
                 $paths[] = $call[1];
+            } elseif ('prependPath' === $call[0]) {
+                $prependPaths[] = $call[1];
             }
         }
 
@@ -203,8 +206,16 @@ class TwigExtensionTest extends TestCase
             array('namespaced_path3', 'namespace3'),
             array(__DIR__.'/Fixtures/Resources/TwigBundle/views', 'Twig'),
             array(realpath(__DIR__.'/../..').'/Resources/views', 'Twig'),
+            array(__DIR__.'/Fixtures/Bundle/ChildTwigBundle/Resources/views', 'ChildTwig'),
+            array(__DIR__.'/Fixtures/Bundle/ChildChildTwigBundle/Resources/views', 'ChildChildTwig'),
             array(__DIR__.'/Fixtures/Resources/views'),
         ), $paths);
+
+        $this->assertEquals(array(
+            array(__DIR__.'/Fixtures/Bundle/ChildTwigBundle/Resources/views', 'Twig'),
+            array(__DIR__.'/Fixtures/Bundle/ChildChildTwigBundle/Resources/views', 'ChildTwig'),
+            array(__DIR__.'/Fixtures/Bundle/ChildChildTwigBundle/Resources/views', 'Twig'),
+        ), $prependPaths);
     }
 
     public function getFormats()
@@ -254,8 +265,28 @@ class TwigExtensionTest extends TestCase
             'kernel.root_dir' => __DIR__.'/Fixtures',
             'kernel.charset' => 'UTF-8',
             'kernel.debug' => false,
-            'kernel.bundles' => array('TwigBundle' => 'Symfony\\Bundle\\TwigBundle\\TwigBundle'),
-            'kernel.bundles_metadata' => array('TwigBundle' => array('namespace' => 'Symfony\\Bundle\\TwigBundle', 'parent' => null, 'path' => realpath(__DIR__.'/../..'))),
+            'kernel.bundles' => array(
+                'TwigBundle' => 'Symfony\\Bundle\\TwigBundle\\TwigBundle',
+                'ChildTwigBundle' => 'Symfony\\Bundle\\TwigBundle\\Tests\\DependencyInjection\\Fixtures\\Bundle\\ChildTwigBundle\\ChildTwigBundle',
+                'ChildChildTwigBundle' => 'Symfony\\Bundle\\TwigBundle\\Tests\\DependencyInjection\\Fixtures\\Bundle\\ChildChildTwigBundle\\ChildChildTwigBundle',
+            ),
+            'kernel.bundles_metadata' => array(
+                'TwigBundle' => array(
+                    'namespace' => 'Symfony\\Bundle\\TwigBundle',
+                    'parent' => null,
+                    'path' => realpath(__DIR__.'/../..'),
+                ),
+                'ChildTwigBundle' => array(
+                    'namespace' => 'Symfony\\Bundle\\TwigBundle\\Tests\\DependencyInjection\\Fixtures\\Bundle\\ChildTwigBundle\\ChildTwigBundle',
+                    'parent' => 'TwigBundle',
+                    'path' => __DIR__.'/Fixtures/Bundle/ChildTwigBundle',
+                ),
+                'ChildChildTwigBundle' => array(
+                    'namespace' => 'Symfony\\Bundle\\TwigBundle\\Tests\\DependencyInjection\\Fixtures\\Bundle\\ChildChildTwigBundle\\ChildChildTwigBundle',
+                    'parent' => 'ChildTwigBundle',
+                    'path' => __DIR__.'/Fixtures/Bundle/ChildChildTwigBundle',
+                ),
+            ),
         )));
 
         return $container;

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
@@ -189,12 +189,9 @@ class TwigExtensionTest extends TestCase
 
         $def = $container->getDefinition('twig.loader.filesystem');
         $paths = array();
-        $prependPaths = array();
         foreach ($def->getMethodCalls() as $call) {
             if ('addPath' === $call[0] && false === strpos($call[1][0], 'Form')) {
                 $paths[] = $call[1];
-            } elseif ('prependPath' === $call[0]) {
-                $prependPaths[] = $call[1];
             }
         }
 
@@ -204,18 +201,24 @@ class TwigExtensionTest extends TestCase
             array('namespaced_path1', 'namespace1'),
             array('namespaced_path2', 'namespace2'),
             array('namespaced_path3', 'namespace3'),
+            array(__DIR__.'/Fixtures/Bundle/ChildChildChildChildTwigBundle/Resources/views', 'ChildChildChildChildTwig'),
+            array(__DIR__.'/Fixtures/Bundle/ChildChildChildChildTwigBundle/Resources/views', 'ChildChildChildTwig'),
+            array(__DIR__.'/Fixtures/Bundle/ChildChildChildTwigBundle/Resources/views', 'ChildChildChildTwig'),
+            array(__DIR__.'/Fixtures/Bundle/ChildChildChildChildTwigBundle/Resources/views', 'Twig'),
+            array(__DIR__.'/Fixtures/Bundle/ChildChildChildTwigBundle/Resources/views', 'Twig'),
+            array(__DIR__.'/Fixtures/Bundle/ChildChildTwigBundle/Resources/views', 'Twig'),
+            array(__DIR__.'/Fixtures/Bundle/ChildTwigBundle/Resources/views', 'Twig'),
             array(__DIR__.'/Fixtures/Resources/TwigBundle/views', 'Twig'),
             array(realpath(__DIR__.'/../..').'/Resources/views', 'Twig'),
+            array(__DIR__.'/Fixtures/Bundle/ChildChildChildChildTwigBundle/Resources/views', 'ChildTwig'),
+            array(__DIR__.'/Fixtures/Bundle/ChildChildChildTwigBundle/Resources/views', 'ChildTwig'),
+            array(__DIR__.'/Fixtures/Bundle/ChildChildTwigBundle/Resources/views', 'ChildTwig'),
             array(__DIR__.'/Fixtures/Bundle/ChildTwigBundle/Resources/views', 'ChildTwig'),
+            array(__DIR__.'/Fixtures/Bundle/ChildChildChildChildTwigBundle/Resources/views', 'ChildChildTwig'),
+            array(__DIR__.'/Fixtures/Bundle/ChildChildChildTwigBundle/Resources/views', 'ChildChildTwig'),
             array(__DIR__.'/Fixtures/Bundle/ChildChildTwigBundle/Resources/views', 'ChildChildTwig'),
             array(__DIR__.'/Fixtures/Resources/views'),
         ), $paths);
-
-        $this->assertEquals(array(
-            array(__DIR__.'/Fixtures/Bundle/ChildTwigBundle/Resources/views', 'Twig'),
-            array(__DIR__.'/Fixtures/Bundle/ChildChildTwigBundle/Resources/views', 'ChildTwig'),
-            array(__DIR__.'/Fixtures/Bundle/ChildChildTwigBundle/Resources/views', 'Twig'),
-        ), $prependPaths);
     }
 
     public function getFormats()
@@ -269,8 +272,15 @@ class TwigExtensionTest extends TestCase
                 'TwigBundle' => 'Symfony\\Bundle\\TwigBundle\\TwigBundle',
                 'ChildTwigBundle' => 'Symfony\\Bundle\\TwigBundle\\Tests\\DependencyInjection\\Fixtures\\Bundle\\ChildTwigBundle\\ChildTwigBundle',
                 'ChildChildTwigBundle' => 'Symfony\\Bundle\\TwigBundle\\Tests\\DependencyInjection\\Fixtures\\Bundle\\ChildChildTwigBundle\\ChildChildTwigBundle',
+                'ChildChildChildTwigBundle' => 'Symfony\\Bundle\\TwigBundle\\Tests\\DependencyInjection\\Fixtures\\Bundle\\ChildChildChildTwigBundle\\ChildChildChildTwigBundle',
+                'ChildChildChildChildTwigBundle' => 'Symfony\\Bundle\\TwigBundle\\Tests\\DependencyInjection\\Fixtures\\Bundle\\ChildChildChildChildTwigBundle\\ChildChildChildChildTwigBundle',
             ),
             'kernel.bundles_metadata' => array(
+                'ChildChildChildChildTwigBundle' => array(
+                    'namespace' => 'Symfony\\Bundle\\TwigBundle\\Tests\\DependencyInjection\\Fixtures\\Bundle\\ChildChildChildChildTwigBundle\\ChildChildChildChildTwigBundle',
+                    'parent' => 'ChildChildChildTwigBundle',
+                    'path' => __DIR__.'/Fixtures/Bundle/ChildChildChildChildTwigBundle',
+                ),
                 'TwigBundle' => array(
                     'namespace' => 'Symfony\\Bundle\\TwigBundle',
                     'parent' => null,
@@ -280,6 +290,11 @@ class TwigExtensionTest extends TestCase
                     'namespace' => 'Symfony\\Bundle\\TwigBundle\\Tests\\DependencyInjection\\Fixtures\\Bundle\\ChildTwigBundle\\ChildTwigBundle',
                     'parent' => 'TwigBundle',
                     'path' => __DIR__.'/Fixtures/Bundle/ChildTwigBundle',
+                ),
+                'ChildChildChildTwigBundle' => array(
+                    'namespace' => 'Symfony\\Bundle\\TwigBundle\\Tests\\DependencyInjection\\Fixtures\\Bundle\\ChildChildChildTwigBundle\\ChildChildChildTwigBundle',
+                    'parent' => 'ChildChildTwigBundle',
+                    'path' => __DIR__.'/Fixtures/Bundle/ChildChildChildTwigBundle',
                 ),
                 'ChildChildTwigBundle' => array(
                     'namespace' => 'Symfony\\Bundle\\TwigBundle\\Tests\\DependencyInjection\\Fixtures\\Bundle\\ChildChildTwigBundle\\ChildChildTwigBundle',


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6919 |
| License | MIT |
| Doc PR |  |

Currently namespaced paths for templates such as `{% extends '@App/Layout/layout.html.twig' %}` do not work with bundles that have overruled templates using the `getParent()` method in another bundle. See attached ticket. This change prepends the path of the bundle implementing `getParent()` to the paths of the namespace of bundle returned as a parent.
