### PR TITLE
[travis][appveyor] Put composer.lock in cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ matrix:
 cache:
     directories:
         - .phpunit
+        - .composer
         - php-$MIN_PHP
 
 services: mongodb
@@ -71,7 +72,11 @@ install:
     # Legacy tests are skipped when deps=high and when the current branch version has not the same major version number than the next one
     - if [[ $deps = high && ${SYMFONY_VERSION%.*} != $(git show $(git ls-remote --heads | grep -FA1 /$SYMFONY_VERSION | tail -n 1):composer.json | grep '^ *"dev-master". *"[1-9]' | grep -o '[0-9]*' | head -n 1) ]]; then LEGACY=,legacy; fi
     - export COMPOSER_ROOT_VERSION=$SYMFONY_VERSION.x-dev
-    - if [[ ! $deps ]]; then composer update; else export SYMFONY_DEPRECATIONS_HELPER=weak; fi
+    - if [[ ! $deps ]]; then COMPOSER_LOCK=.composer/$PHP.$(md5sum composer.json | cut -f1 -d' ').lock; fi
+    - if [[ ! $deps ]]; then find .composer/ -name '*.lock' -mmin +720 -delete; fi
+    - if [[ ! $deps && -f $COMPOSER_LOCK ]]; then cp -a $COMPOSER_LOCK composer.lock; fi
+    - if [[ ! $deps ]]; then composer install; else export SYMFONY_DEPRECATIONS_HELPER=weak; fi
+    - if [[ ! $deps ]]; then cp -a composer.lock $COMPOSER_LOCK; fi
     - if [[ $TRAVIS_BRANCH = master ]]; then export SYMFONY_PHPUNIT_OVERLOAD=1; fi
     - if [[ ! $PHP = hhvm* ]]; then php -i; else hhvm --php -r 'print_r($_SERVER);print_r(ini_get_all());'; fi
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ clone_depth: 1
 clone_folder: c:\projects\symfony
 
 cache:
+    - c:\projects\symfony\.composer
     - c:\projects\symfony\composer.phar
     - .phpunit -> phpunit
 
@@ -53,7 +54,12 @@ install:
     - copy /Y .composer\* %APPDATA%\Composer\
     - php phpunit install
     - IF %APPVEYOR_REPO_BRANCH%==master (SET COMPOSER_ROOT_VERSION=dev-master) ELSE (SET COMPOSER_ROOT_VERSION=%APPVEYOR_REPO_BRANCH%.x-dev)
-    - php composer.phar update --no-progress --ansi
+    - FOR /F "tokens=*" %%i IN ('md5sum composer.json ^| cut -f1 -d" "') DO SET COMPOSER_LOCK=.composer/php-5.3.%%i.lock
+    - c:\cygwin\bin\find .composer/ -name '*.lock' -exec sh -c 'touch -d $(cat {}.mtime) {} {}.mtime' ';'
+    - c:\cygwin\bin\find .composer/ -name '*.lock' -mmin +720 -delete
+    - IF EXIST %COMPOSER_LOCK% (cp %COMPOSER_LOCK% composer.lock)
+    - php composer.phar install --no-progress --ansi
+    - IF NOT EXIST %COMPOSER_LOCK% (cp composer.lock %COMPOSER_LOCK% && c:\cygwin\bin\date -Iseconds > %COMPOSER_LOCK%.mtime)
 
 test_script:
     - cd c:\projects\symfony


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Should save >40 seconds per line (deps=low/high excluded).
Cache is pruned every 12 hours.
