### PR TITLE
remove use of LazyChoiceList #19575

### DIFF
--- a/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Form\ChoiceList\Factory;
 
 use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
 use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
-use Symfony\Component\Form\ChoiceList\LazyChoiceList;
 use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\Form\ChoiceList\View\ChoiceGroupView;
 use Symfony\Component\Form\ChoiceList\View\ChoiceListView;
@@ -40,13 +39,11 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
     public function createListFromLoader(ChoiceLoaderInterface $loader, $value = null)
     {
         $choiceList = $loader->loadChoiceList($value);
-        
-        if(!$choiceList instanceof ChoiceListInterface){
-            
+
+        if (!$choiceList instanceof ChoiceListInterface) {
             throw new \UnexpectedValueException(get_class($loader).'::loadChoiceList method should return a ChoiceListInterface');
-        
         }
-        
+
         return $choiceList;
     }
 

--- a/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
@@ -40,9 +40,13 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
     public function createListFromLoader(ChoiceLoaderInterface $loader, $value = null)
     {
         $choiceList = $loader->loadChoiceList($value);
+        
         if(!$choiceList instanceof ChoiceListInterface){
+            
             throw new \UnexpectedValueException(get_class($loader).'::loadChoiceList method should return a ChoiceListInterface');
+        
         }
+        
         return $choiceList;
     }
 

--- a/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
@@ -39,7 +39,11 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
      */
     public function createListFromLoader(ChoiceLoaderInterface $loader, $value = null)
     {
-        return new LazyChoiceList($loader, $value);
+        $choiceList = $loader->loadChoiceList($value);
+        if(!$choiceList instanceof ChoiceListInterface){
+            throw new \UnexpectedValueException(get_class($loader).'::loadChoiceList method should return a ChoiceListInterface');
+        }
+        return $choiceList;
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" for new features / 3.1 for fixes |
| Bug fix | yes |
| New feature | no |
| BC breaks | no |
| Deprecations | no |
| Tests pass | no |
| Fixed tickets | 19575 |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

Invalid test 
1) Symfony\Component\Form\Tests\ChoiceList\Factory\DefaultChoiceListFactoryTest::testCreateFromLoader
UnexpectedValueException: Mock_ChoiceLoaderInterface_4dc7ab78::loadChoiceList method should return a ChoiceListInterface

/home/CO_V7/vendor/symfony/symfony/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php:44
/home/CO_V7/vendor/symfony/symfony/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php:198

2) Symfony\Component\Form\Tests\ChoiceList\Factory\DefaultChoiceListFactoryTest::testCreateFromLoaderWithValues
UnexpectedValueException: Mock_ChoiceLoaderInterface_4dc7ab78::loadChoiceList method should return a ChoiceListInterface
