### PR TITLE
[WIP][HttpKernel] Expose bundle hierarchy/metadata as a service

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
@@ -47,6 +47,9 @@ class MergeExtensionConfigurationPass implements CompilerPassInterface
             $tmpContainer = new ContainerBuilder($container->getParameterBag());
             $tmpContainer->setResourceTracking($container->isTrackingResources());
             $tmpContainer->addObjectResource($extension);
+            if ($container->has('kernel.bundles')) {
+                $tmpContainer->set('kernel.bundles', $container->get('kernel.bundles'));
+            }
 
             foreach ($exprLangProviders as $provider) {
                 $tmpContainer->addExpressionLanguageProvider($provider);

--- a/src/Symfony/Component/HttpKernel/Bundle/BundleMetadata.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/BundleMetadata.php
@@ -12,11 +12,11 @@
 namespace Symfony\Component\HttpKernel\Bundle;
 
 /**
- * Bundle value object.
+ * Value object representing bundle metadata.
  *
  * @author Roland Franssen <franssen.roland@gmail.com>
  */
-final class BundleVO
+final class BundleMetadata
 {
     private $name;
     private $namespace;
@@ -27,13 +27,13 @@ final class BundleVO
     /**
      * Constructor.
      *
-     * @param string        $name
-     * @param string        $namespace
-     * @param string        $className
-     * @param string        $path
-     * @param BundleVO|null $parent
+     * @param string              $name
+     * @param string              $namespace
+     * @param string              $className
+     * @param string              $path
+     * @param BundleMetadata|null $parent
      */
-    public function __construct($name, $namespace, $className, $path, BundleVO $parent = null)
+    public function __construct($name, $namespace, $className, $path, BundleMetadata $parent = null)
     {
         $this->name = $name;
         $this->className = $className;
@@ -84,7 +84,7 @@ final class BundleVO
     /**
      * Get parent bundle, if any.
      *
-     * @return BundleVO|null
+     * @return BundleMetadata|null
      */
     public function getParent()
     {

--- a/src/Symfony/Component/HttpKernel/Bundle/BundleVO.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/BundleVO.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Bundle;
+
+/**
+ * Bundle value object.
+ *
+ * @author Roland Franssen <franssen.roland@gmail.com>
+ */
+final class BundleVO
+{
+    private $name;
+    private $namespace;
+    private $className;
+    private $path;
+    private $parent;
+
+    /**
+     * Constructor.
+     *
+     * @param string        $name
+     * @param string        $namespace
+     * @param string        $className
+     * @param string        $path
+     * @param BundleVO|null $parent
+     */
+    public function __construct($name, $namespace, $className, $path, BundleVO $parent = null)
+    {
+        $this->name = $name;
+        $this->className = $className;
+        $this->path = $path;
+        $this->parent = $parent;
+    }
+
+    /**
+     * Get bundle name.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Get bundle namespace.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Get bundle class name.
+     *
+     * @return string
+     */
+    public function getClassName()
+    {
+        return $this->className;
+    }
+
+    /**
+     * Get bundle path.
+     *
+     * @return string
+     */
+    public function getPath()
+    {
+        return $this->path;
+    }
+
+    /**
+     * Get parent bundle, if any.
+     *
+     * @return BundleVO|null
+     */
+    public function getParent()
+    {
+        return $this->parent;
+    }
+
+    /**
+     * Get string representation.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->className;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -26,7 +26,7 @@ use Symfony\Component\DependencyInjection\Loader\ClosureLoader;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
-use Symfony\Component\HttpKernel\Bundle\BundleVO;
+use Symfony\Component\HttpKernel\Bundle\BundleMetadata;
 use Symfony\Component\HttpKernel\Config\EnvParametersResource;
 use Symfony\Component\HttpKernel\Config\FileLocator;
 use Symfony\Component\HttpKernel\DependencyInjection\MergeExtensionConfigurationPass;
@@ -518,7 +518,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
                 }
                 if (!isset($bundles[$name])) {
                     $bundles[$name] = get_class($bundle);
-                    $bundleHierarchy[$name] = new BundleVO($name, $bundle->getNamespace(), $bundles[$name], $bundle->getPath(), isset($bundleHierarchy[$parent]) ? $bundleHierarchy[$parent] : null);
+                    $bundleHierarchy[$name] = new BundleMetadata($name, $bundle->getNamespace(), $bundles[$name], $bundle->getPath(), isset($bundleHierarchy[$parent]) ? $bundleHierarchy[$parent] : null);
                     ++$numProcessedBundles;
                 }
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

This is a proof of concept to expose the bundle hierarchy and metadata in a early phase. For example when needed in a bundle extension. This makes the ecosystem a lot more flexible imho.

``` php
// SomeBundleExtension.php
public function load(array $configs, ContainerBuilder $container) {
    $bundles = $container->get('kernel.bundles');
    $someBundlePath = $bundles['SomeBundle']->getPath();
}
```
- [ ] Useful?
- [ ] Fix caching (service as a definition)
- [ ] Tests
- [ ] Profit.
