### PR TITLE
[FrameworkBundle] Added friendly exception when constraint validator class does not exist

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Validator/ConstraintValidatorFactoryTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Validator/ConstraintValidatorFactoryTest.php
@@ -62,4 +62,19 @@ class ConstraintValidatorFactoryTest extends \PHPUnit_Framework_TestCase
         $factory = new ConstraintValidatorFactory($container, array('validator_constraint_alias' => 'validator_constraint_service'));
         $this->assertSame($validator, $factory->getInstance($constraint));
     }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\ValidatorException
+     */
+    public function testGetInstanceInvalidValidatorClass()
+    {
+        $constraint = $this->getMock('Symfony\\Component\\Validator\\Constraint');
+        $constraint
+            ->expects($this->once())
+            ->method('validatedBy')
+            ->will($this->returnValue('Fully\\Qualified\\ConstraintValidator\\Class\\Name'));
+
+        $factory = new ConstraintValidatorFactory(new Container());
+        $factory->getInstance($constraint);
+    }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Validator/ConstraintValidatorFactory.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Validator/ConstraintValidatorFactory.php
@@ -15,6 +15,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidatorFactoryInterface;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
+use Symfony\Component\Validator\Exception\ValidatorException;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
@@ -61,6 +62,7 @@ class ConstraintValidatorFactory implements ConstraintValidatorFactoryInterface
      *
      * @return ConstraintValidatorInterface A validator for the supplied constraint
      *
+     * @throws ValidatorException      When the validator class does not exist
      * @throws UnexpectedTypeException When the validator is not an instance of ConstraintValidatorInterface
      */
     public function getInstance(Constraint $constraint)
@@ -68,6 +70,10 @@ class ConstraintValidatorFactory implements ConstraintValidatorFactoryInterface
         $name = $constraint->validatedBy();
 
         if (!isset($this->validators[$name])) {
+            if (!class_exists($name)) {
+                throw new ValidatorException(sprintf('Constraint validator "%s" does not exist or it is not enabled. Check the "validatedBy" method in your constraint class "%s".', $name, get_class($constraint)));
+            }
+
             $this->validators[$name] = new $name();
         } elseif (is_string($this->validators[$name])) {
             $this->validators[$name] = $this->container->get($this->validators[$name]);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Currently when mistakenly we type a [Custom Constraint Validator class](http://symfony.com/doc/current/validation/custom_constraint.html#creating-the-validator-itself) or the "alias name" from [validator service](http://symfony.com/doc/current/validation/custom_constraint.html#constraint-validators-with-dependencies)  (which would occurs frequently for newcomers) is shown `ClassNotFoundException`:

> Attempted to load class "alias_name" from namespace "Symfony\Component\Validator".
> Did you forget a "use" statement for another namespace? 
> 500 Internal Server Error - ClassNotFoundException

**This PR tries to improve the error message when this happen.**

But I'm not sure about the exception class used ([`InvalidArgumentException`](https://github.com/yceruto/symfony/blob/master/src/Symfony/Component/Validator/Exception/InvalidArgumentException.php)) : ?
-  [`ConstraintDefinitionException`](https://github.com/yceruto/symfony/blob/master/src/Symfony/Component/Validator/Exception/ConstraintDefinitionException.php) would be another option, because the source of the error comes from the custom [`Constraint`](https://github.com/yceruto/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/Validator/ConstraintValidatorFactory.php#L68) definition.

The text message more convenient from this little mistake: ?
- This mistake happen for two reason: FQCN or alias name supplied by constraint not found.
- The constraint validator service was declared incorrectly (missing alias)
- Perhaps some hint how the developer should resolve the mistake.

Maybe some documentation core member would help me ?
