### PR TITLE
[RFC][DependencyInjection][HttpKernel] Kernel as a service

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
@@ -53,12 +53,8 @@ class MergeExtensionConfigurationPass implements CompilerPassInterface
                 $tmpContainer->addExpressionLanguageProvider($provider);
             }
 
-            foreach ($container->getDefinitions() as $id => $definition) {
-                if ($definition instanceof ServiceAwareDefinition) {
-                    // definitions are not transferred by design
-                    $tmpContainer->set($id, $definition->getService());
-                }
-                // @TODO allow for available synthetic services to be transferred?
+            foreach ($container->getSynthetics() as $id => $service) {
+                $tmpContainer->set($id, $service);
             }
 
             $extension->load($config, $tmpContainer);

--- a/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
+use Symfony\Component\DependencyInjection\ServiceAwareDefinition;
 
 /**
  * Merges extension configs into the container builder.
@@ -50,6 +51,14 @@ class MergeExtensionConfigurationPass implements CompilerPassInterface
 
             foreach ($exprLangProviders as $provider) {
                 $tmpContainer->addExpressionLanguageProvider($provider);
+            }
+
+            foreach ($container->getDefinitions() as $id => $definition) {
+                if ($definition instanceof ServiceAwareDefinition) {
+                    // definitions are not transferred by design
+                    $tmpContainer->set($id, $definition->getService());
+                }
+                // @TODO allow for available synthetic services to be transferred?
             }
 
             $extension->load($config, $tmpContainer);

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -423,6 +423,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         if (null !== $definition && $definition instanceof ServiceAwareDefinition) {
             return $definition->getService();
         }
+        // @TODO allow for available synthetic services?
 
         if (!$this->compiled) {
             @trigger_error(sprintf('Calling %s() before compiling the container is deprecated since version 3.2 and will throw an exception in 4.0.', __METHOD__), E_USER_DEPRECATED);

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -419,15 +419,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      */
     public function get($id, $invalidBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE)
     {
-        try {
-            $definition = $this->getDefinition($id);
-        } catch (ServiceNotFoundException $e) {
-            if (ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE === $invalidBehavior) {
-                throw $e;
-            }
-            $definition = null;
-        }
-
+        $definition = $this->hasDefinition($id) ? $this->getDefinition($id) : null;
         if (null !== $definition && $definition instanceof ServiceAwareDefinition) {
             return $definition->getService();
         }
@@ -446,9 +438,10 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             return $this->get($this->aliasDefinitions[$id]);
         }
 
-        if (null === $definition) {
+        if (null === $definition && ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE !== $invalidBehavior) {
             return;
         }
+        $definition = $this->getDefinition($id);
 
         $this->loading[$id] = true;
 

--- a/src/Symfony/Component/DependencyInjection/ServiceAwareDefinition.php
+++ b/src/Symfony/Component/DependencyInjection/ServiceAwareDefinition.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection;
+
+/**
+ * Definition that is aware of its service.
+ *
+ * The definition and service must remain in sync, in a way the created service object from definition is interchangeable with the aware service object.
+ *
+ * @author Roland Franssen <franssen.roland@gmail.com>
+ */
+class ServiceAwareDefinition extends Definition
+{
+    private $service;
+
+    /**
+     * Sets the service this definition is aware of.
+     *
+     * @param object $service The service object tight to this definition
+     *
+     * @return ServiceAwareDefinition The current instance
+     */
+    public function setService($object)
+    {
+        $this->service = $object;
+
+        return $this;
+    }
+
+    /**
+     * Gets the aware service.
+     *
+     * @return object
+     *
+     * @throws \DomainException If the definition is not aware of a service object or the service object is invalid.
+     */
+    public function getService()
+    {
+        if (null === $this->service) {
+            throw new \DomainException('A service aware definition must have a service object.');
+        }
+        $class = $this->getClass();
+        if (null !== $class && !$this->service instanceof $class) {
+            throw new \DomainException('The service object must be an instance of "'.$class.'", "'.get_class($this->service).'" given.');
+        }
+
+        return $this->service;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \BadMethodCallException When trying to prototype this definition
+     */
+    public function setShared($shared)
+    {
+        if ($shared) {
+            throw new \BadMethodCallException('A service aware definition must always be shared.');
+        }
+
+        return parent::setShared($shared);
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/ServiceAwareDefinition.php
+++ b/src/Symfony/Component/DependencyInjection/ServiceAwareDefinition.php
@@ -63,7 +63,7 @@ class ServiceAwareDefinition extends Definition
      */
     public function setShared($shared)
     {
-        if ($shared) {
+        if (!$shared) {
             throw new \BadMethodCallException('A service aware definition must always be shared.');
         }
 

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -23,6 +23,7 @@ use Symfony\Component\DependencyInjection\Loader\IniFileLoader;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Loader\DirectoryLoader;
 use Symfony\Component\DependencyInjection\Loader\ClosureLoader;
+use Symfony\Component\DependencyInjection\ServiceAwareDefinition;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
@@ -448,6 +449,16 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     }
 
     /**
+     * Gets the kernel service class.
+     *
+     * @return string The service class
+     */
+    protected function getServiceClass()
+    {
+        return __NAMESPACE__.'\\Service\\Kernel';
+    }
+
+    /**
      * Gets the container class.
      *
      * @return string The container class
@@ -481,7 +492,21 @@ abstract class Kernel implements KernelInterface, TerminableInterface
         $cache = new ConfigCache($this->getCacheDir().'/'.$class.'.php', $this->debug);
         $fresh = true;
         if (!$cache->isFresh()) {
+            $serviceClass = $this->getServiceClass();
+            $bundles = array();
+            foreach ($this->bundles as $name => $bundle) {
+                $bundles[$name] = array(
+                    'service_class' => method_exists($bundle, 'getServiceClass') ? $bundle->getServiceClass() : __NAMESPACE__.'\\Service\Bundle',
+                    'class' => get_class($bundle),
+                    'namespace' => $bundle->getNamespace(),
+                    'parent' => $bundle->getParent(),
+                    'path' => $bundle->getPath(),
+                );
+            }
+            $serviceDefinition = new ServiceAwareDefinition($serviceClass, array($this->environment, $this->debug, $bundles));
+            $serviceDefinition->setService(new $serviceClass($this->environment, $this->debug, $bundles));
             $container = $this->buildContainer();
+            $container->setDefinition('kernel_as_a_service', $serviceDefinition);
             $container->compile();
             $this->dumpContainer($cache, $container, $class, $this->getContainerBaseClass());
 

--- a/src/Symfony/Component/HttpKernel/Service/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Service/Bundle.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Service;
+
+/**
+ * The bundle service represents a bundle as a service throughout the ecosystem.
+ *
+ * @author Roland Franssen <franssen.roland@gmail.com>
+ */
+class Bundle
+{
+    private $name;
+    private $namespace;
+    private $className;
+    private $path;
+    private $parent;
+
+    /**
+     * Constructor.
+     *
+     * @param string      $name
+     * @param string      $namespace
+     * @param string      $className
+     * @param string      $path
+     * @param Bundle|null $parent
+     */
+    public function __construct($name, $namespace, $className, $path, Bundle $parent = null)
+    {
+        $this->name = $name;
+        $this->className = $className;
+        $this->path = $path;
+        $this->parent = $parent;
+    }
+
+    final public function getName()
+    {
+        return $this->name;
+    }
+
+    final public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    final public function getClassName()
+    {
+        return $this->className;
+    }
+
+    final public function getPath()
+    {
+        return $this->path;
+    }
+
+    final public function getParent()
+    {
+        return $this->parent;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Service/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Service/Kernel.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Service;
+
+/**
+ * The kernel service represents a kernel as a service throughout the ecosystem.
+ *
+ * @author Roland Franssen <franssen.roland@gmail.com>
+ */
+class Kernel
+{
+    private $environment;
+    private $debug;
+    private $bundles;
+
+    /**
+     * Constructor.
+     *
+     * @param string $environment
+     * @param bool   $debug
+     * @param array  $bundles
+     */
+    public function __construct($environment, $debug, array $bundles = array())
+    {
+        $this->environment = $environment;
+        $this->debug = $debug;
+        $this->bundles = array();
+        $numBundles = count($bundles);
+        $numProcessedBundles = 0;
+        do {
+            foreach ($bundles as $name => $bundle) {
+                $parent = $bundle['parent'];
+                if (null !== $parent && !isset($this->bundles[$parent])) {
+                    continue;
+                }
+                if (!isset($this->bundles[$name])) {
+                    $parentBundle = isset($this->bundles[$parent]) ? $this->bundles[$parent] : null;
+                    $this->bundles[$name] = new $bundle['service_class']($name, $bundle['namespace'], $bundle['class'], $bundle['path'], $parentBundle);
+                    ++$numProcessedBundles;
+                }
+            }
+        } while ($numProcessedBundles < $numBundles);
+    }
+
+    final public function getEnvironment()
+    {
+        return $this->environment;
+    }
+
+    final public function isDebug()
+    {
+        return $this->debug;
+    }
+
+    final public function getBundles()
+    {
+        return $this->bundles;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Service/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Service/Kernel.php
@@ -43,8 +43,9 @@ class Kernel
                     continue;
                 }
                 if (!isset($this->bundles[$name])) {
+                    $serviceClass = $bundle['service_class'];
                     $parentBundle = isset($this->bundles[$parent]) ? $this->bundles[$parent] : null;
-                    $this->bundles[$name] = new $bundle['service_class']($name, $bundle['namespace'], $bundle['class'], $bundle['path'], $parentBundle);
+                    $this->bundles[$name] = new $serviceClass($name, $bundle['namespace'], $bundle['class'], $bundle['path'], $parentBundle);
                     ++$numProcessedBundles;
                 }
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | yessish |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | not yet |
| Fixed tickets | #18563, #19586 |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

TLDR; This allows for ready to use service objects during container compilation~~.~~, and now also extension loading.

How i did it;
After my first [attempt](https://github.com/symfony/symfony/pull/19594) i think i got a viable solution now that allows to work with _safe_ service objects during container compilation, basically it introduces a `ServiceAwareDefinition`; a service definition aware of its service object, which is allowed for in `ContainerBuilder::get`. It's bulletproof, in a way it's developer responsibility to keep the definition+service in sync. This also plays well with synthetic services perhaps...

This is feature 1, which can be a separate PR. Feature 2 is introducing the kernel as a service (aware definition). For now i think it's good mainly because of pragmatic reasons; we can fix bugs in a normal way. In the long run it allows for separation of concerns; kernel/bundles in the ecosystem (booting, building, terminating) and kernel/bundles in userland (paths, names, utility).

The second concept is far from ready, but what about this approach?
