### PR TITLE
[Workflow] Added failing test

### DIFF
--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -134,11 +134,11 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
         $workflow = new Workflow($definition, new PropertyAccessorMarkingStore());
         $subject = new \stdClass();
 
-        $subject->marking = array('b'=>1, 'c'=>1);
+        $subject->marking = array('b' => 1, 'c' => 1);
         $this->assertTrue($workflow->can($subject, 't2'));
 
         // If you are in place b you should be able to apply t2
-        $subject->marking = array('b'=>1);
+        $subject->marking = array('b' => 1);
         $this->assertTrue($workflow->can($subject, 't2'));
     }
 

--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -128,6 +128,20 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($workflow->can($subject, 't2'));
     }
 
+    public function testCanWithInitialState()
+    {
+        $definition = $this->createComplexWorkflow();
+        $workflow = new Workflow($definition, new PropertyAccessorMarkingStore());
+        $subject = new \stdClass();
+
+        $subject->marking = array('b'=>1, 'c'=>1);
+        $this->assertTrue($workflow->can($subject, 't2'));
+
+        // If you are in place b you should be able to apply t2
+        $subject->marking = array('b'=>1);
+        $this->assertTrue($workflow->can($subject, 't2'));
+    }
+
     public function testCanWithGuard()
     {
         $definition = $this->createComplexWorkflow();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no, I show a bug |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | related to https://github.com/symfony/symfony/issues/19605 |
| License | MIT |
| Doc PR |  |

This PR adds a test for the `Workflow` class in the Workflow component. The test is added to show that the current implementation is broken (or at least suboptimal). 

I describe the issue in https://github.com/symfony/symfony/issues/19605
