### PR TITLE
Remove 3.0 from branch suggestions for fixes in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 | Q             | A
 | ------------- | ---
-| Branch?       | "master" for new features / 2.7, 2.8, 3.0 or 3.1 for fixes
+| Branch?       | "master" for new features / 2.7, 2.8 or 3.1 for fixes
 | Bug fix?      | yes/no
 | New feature?  | yes/no
 | BC breaks?    | yes/no


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Appart from security fixes, the 3.0.9 patch release was the last one for the 3.0 branch.
I'd suggest not proposing anymore to submit fixes on this branch.
