### PR TITLE
[POC] [VarDumper] Added StringDumper to export dump as string

### DIFF
--- a/src/Symfony/Component/VarDumper/CHANGELOG.md
+++ b/src/Symfony/Component/VarDumper/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.2.0
+-----
+
+ * added `ToStringDumper`
+
 2.7.0
 -----
 

--- a/src/Symfony/Component/VarDumper/Dumper/ToStringDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/ToStringDumper.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Dumper;
+
+use Symfony\Component\VarDumper\Cloner\Data;
+
+/**
+ * A dumper decorator to return the dump as string.
+ *
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ */
+class ToStringDumper implements DataDumperInterface
+{
+    private $dumper;
+
+    public function __construct(AbstractDumper $dumper)
+    {
+        $this->dumper = $dumper;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function dump(Data $data)
+    {
+        $dump = fopen('php://memory', 'r+b');
+        $prevOutput = $this->dumper->setOutput($dump);
+
+        $this->dumper->dump($data);
+
+        $this->dumper->setOutput($prevOutput);
+        rewind($dump);
+
+        return stream_get_contents($dump);
+    }
+}

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/ToStringDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/ToStringDumperTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Tests\Dumper;
+
+use Symfony\Component\VarDumper\Cloner\Data;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\ToStringDumper;
+use Symfony\Component\VarDumper\Dumper\CliDumper;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class ToStringDumperTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDecoratesDump()
+    {
+        $data = new Data(array());
+        $stubDumper = $this->getMock('Symfony\Component\VarDumper\Dumper\AbstractDumper');
+        $stubDumper->expects($this->exactly(2))->method('setOutput');
+
+        $dumper = new ToStringDumper($stubDumper);
+        $stubDumper->expects($this->once())->method('dump')->with($data);
+
+        $dumper->dump($data);
+    }
+
+    public function testReturnsStreamContents()
+    {
+        $innerDumper = new CliDumper(null, null, CliDumper::DUMP_LIGHT_ARRAY);
+        $cloner = new VarCloner();
+
+        $dumper = new ToStringDumper($innerDumper);
+
+        $this->assertEquals("[\n  \"a\" => 1\n  0 => 2\n]\n", $dumper->dump($cloner->cloneVar(array('a' => 1, 2))));
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18149 |
| License | MIT |
| Doc PR | todo |

This allows to export dumps as a string, instead of having it dumped to a stream. This is usefull when using the VarDumper as var exporter (e.g. in #19614 & see referenced issue).
## Todo
- [ ] Fix TwigBridge usage
