### PR TITLE
[Config] Avoid unnecessary encoding of scalars in ExprBuilder::thenInvalid()

### DIFF
--- a/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
@@ -176,7 +176,7 @@ class ExprBuilder
      */
     public function thenInvalid($message)
     {
-        $this->thenPart = function ($v) use ($message) {throw new \InvalidArgumentException(sprintf($message, json_encode($v))); };
+        $this->thenPart = function ($v) use ($message) { throw new \InvalidArgumentException(sprintf($message, is_scalar($v) ? $v : json_encode($v))); };
 
         return $this;
     }

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/ExprBuilderTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/ExprBuilderTest.php
@@ -131,12 +131,13 @@ class ExprBuilderTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage Invalid configuration for path "test.key": Invalid value "value"
      */
     public function testThenInvalid()
     {
         $test = $this->getTestBuilder()
             ->ifString()
-            ->thenInvalid('Invalid value')
+            ->thenInvalid('Invalid value "%s"')
         ->end();
         $this->finalizeTestBuilder($test);
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

When using `ExprBuilder::thenInvalid()` with a placeholder representing the invalid value, the invalid value is json encoded.

For example, the following:

``` php
->thenInvalid('Invalid value "%s"')
```

Gives:

> Invalid value ""value""

The output has extra quotes.
Note that the feature [is documented](http://symfony.com/doc/current/components/config/definition.html#validation-rules) as is, giving the same result.

This prevents scalars from being json encoded, so users have a better control over the outputted message.
