### PR TITLE
[VarDumper] Enhance dumping __PHP_Incomplete_Class objects

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/Caster.php
+++ b/src/Symfony/Component/VarDumper/Caster/Caster.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\VarDumper\Caster;
 
+use Symfony\Component\VarDumper\Cloner\Stub;
+
 /**
  * Helper for filtering out properties in casters.
  *
@@ -49,6 +51,9 @@ class Caster
             $a = array();
         } else {
             $a = (array) $obj;
+        }
+        if ($obj instanceof \__PHP_Incomplete_Class) {
+            return $a;
         }
 
         if ($a) {
@@ -116,6 +121,14 @@ class Caster
                 ++$count;
             }
         }
+
+        return $a;
+    }
+
+    public static function castPhpIncompleteClass(\__PHP_Incomplete_Class $c, array $a, Stub $stub, $isNested)
+    {
+        $stub->class .= '('.$a['__PHP_Incomplete_Class_Name'].')';
+        unset($a['__PHP_Incomplete_Class_Name']);
 
         return $a;
     }

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -22,6 +22,8 @@ use Symfony\Component\VarDumper\Exception\ThrowingCasterException;
 abstract class AbstractCloner implements ClonerInterface
 {
     public static $defaultCasters = array(
+        '__PHP_Incomplete_Class' => 'Symfony\Component\VarDumper\Caster\Caster::castPhpIncompleteClass',
+
         'Symfony\Component\VarDumper\Caster\CutStub' => 'Symfony\Component\VarDumper\Caster\StubCaster::castStub',
         'Symfony\Component\VarDumper\Caster\CutArrayStub' => 'Symfony\Component\VarDumper\Caster\StubCaster::castCutArray',
         'Symfony\Component\VarDumper\Caster\ConstStub' => 'Symfony\Component\VarDumper\Caster\StubCaster::castStub',

--- a/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
@@ -461,6 +461,21 @@ EOTXT
         );
     }
 
+    public function testIncompleteClass()
+    {
+        $unserializeCallbackHandler = ini_set('unserialize_callback_func', null);
+        $var = unserialize('O:8:"Foo\Buzz":0:{}');
+        ini_set('unserialize_callback_func', $unserializeCallbackHandler);
+
+        $this->assertDumpMatchesFormat(
+            <<<EOTXT
+__PHP_Incomplete_Class(Foo\Buzz) {}
+EOTXT
+            ,
+            $var
+        );
+    }
+
     private function getSpecialVars()
     {
         foreach (array_keys($GLOBALS) as $var) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Before:

```
__PHP_Incomplete_Class {
  +"__PHP_Incomplete_Class_Name": "Foo\Buzz"
}
```

after:

```
__PHP_Incomplete_Class(Foo\Buzz) {}
```

The new output is less confusing: no dynamic property exists on incomplete class objects, yet the `+` prefix suggests that.
