### PR TITLE
UPDATE check if path is set to prevent warning on empty directory

### DIFF
--- a/src/Symfony/Component/Finder/Iterator/RecursiveDirectoryIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/RecursiveDirectoryIterator.php
@@ -137,6 +137,10 @@ class RecursiveDirectoryIterator extends \RecursiveDirectoryIterator
             return $this->rewindable;
         }
 
+        if (empty($this->getPath())) {
+            return $this->rewindable = false;
+        }
+
         if (false !== $stream = @opendir($this->getPath())) {
             $infos = stream_get_meta_data($stream);
             closedir($stream);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | Since RecursiveDirectoryIterator::SKIP_DOTS is set as flag, opendir gets a warning if an empty directory is reached |
