### PR TITLE
[Finder] no PHP warning on empty directory iteration

### DIFF
--- a/src/Symfony/Component/Finder/Iterator/RecursiveDirectoryIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/RecursiveDirectoryIterator.php
@@ -137,7 +137,7 @@ class RecursiveDirectoryIterator extends \RecursiveDirectoryIterator
             return $this->rewindable;
         }
 
-        if ($this->getPath() === '') {
+        if ('' === $this->getPath()) {
             return $this->rewindable = false;
         }
 

--- a/src/Symfony/Component/Finder/Iterator/RecursiveDirectoryIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/RecursiveDirectoryIterator.php
@@ -137,6 +137,10 @@ class RecursiveDirectoryIterator extends \RecursiveDirectoryIterator
             return $this->rewindable;
         }
 
+        if (empty($this->getPath())) {
+            return $this->rewindable = false;
+        }
+
         if (false !== $stream = @opendir($this->getPath())) {
             $infos = stream_get_meta_data($stream);
             closedir($stream);

--- a/src/Symfony/Component/Finder/Iterator/RecursiveDirectoryIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/RecursiveDirectoryIterator.php
@@ -137,7 +137,7 @@ class RecursiveDirectoryIterator extends \RecursiveDirectoryIterator
             return $this->rewindable;
         }
 
-        if (empty($this->getPath())) {
+        if ($this->getPath() === '') {
             return $this->rewindable = false;
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | Since RecursiveDirectoryIterator::SKIP_DOTS is set as flag, opendir gets a warning if an empty directory is reached |
