### PR TITLE
[DI] Deprecate ContainerBuilder::set

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -349,6 +349,10 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      */
     public function set($id, $service)
     {
+        if (!$this->compiled) {
+            @trigger_error(sprintf('Calling %s() before compiling the container is deprecated since version 3.2 and will throw an exception in 4.0.', __METHOD__), E_USER_DEPRECATED);
+        }
+
         $id = strtolower($id);
 
         if ($this->isFrozen() && (!isset($this->definitions[$id]) || !$this->definitions[$id]->isSynthetic())) {
@@ -401,18 +405,18 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      */
     public function get($id, $invalidBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE)
     {
+        $id = strtolower($id);
+
+        if (!array_key_exists($id, $this->definitions) && isset($this->aliasDefinitions[$id])) {
+            return $this->get($this->aliasDefinitions[$id]);
+        }
+
         if (!$this->compiled) {
             @trigger_error(sprintf('Calling %s() before compiling the container is deprecated since version 3.2 and will throw an exception in 4.0.', __METHOD__), E_USER_DEPRECATED);
         }
 
-        $id = strtolower($id);
-
         if ($service = parent::get($id, ContainerInterface::NULL_ON_INVALID_REFERENCE)) {
             return $service;
-        }
-
-        if (!array_key_exists($id, $this->definitions) && isset($this->aliasDefinitions[$id])) {
-            return $this->get($this->aliasDefinitions[$id]);
         }
 
         try {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | not yet |
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

Currently the behavior for synthetic services and the container builder is unclear;
- `set()` is always allowed (when mapped to a defintion)
- `get()` is disallowed, but only before compilation (we ignore a potential synthetic service being validly available at this point)

This lead to some discussion in #19619 

IMO there are 2 acceptable/consistent solutions, either disallow `set` fully/before compilation, or allow `get` for synthetic services at all time. This reflects simple `set/get` behavior.

Deprecating `set` before compilation would make it clear the `ContainerBuilder` only works as as `Container` after compilation. Ie. you'd still have best of both.
