### PR TITLE
Exception details break the layout

### DIFF
--- a/src/Symfony/Component/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/Debug/ExceptionHandler.php
@@ -299,6 +299,7 @@ EOF;
                 border-bottom:1px solid #ccc;
                 border-right:1px solid #ccc;
                 border-left:1px solid #ccc;
+                word-wrap: break-word;
             }
             .sf-reset .block_exception { background-color:#ddd; color: #333; padding:20px;
                 -webkit-border-top-left-radius: 16px;


### PR DESCRIPTION
Exception details break the layout 

| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | yes |
| License | MIT |

By adding `word-wrap: break-word;` the exception details will wrap inside the block.
