### PR TITLE
[RFC][DependencyInjection][HttpKernel] Introduce a contextualized ContainerBuilder & BootingKernel

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
@@ -44,7 +44,7 @@ class MergeExtensionConfigurationPass implements CompilerPassInterface
             }
             $config = $container->getParameterBag()->resolveValue($config);
 
-            $tmpContainer = new ContainerBuilder($container->getParameterBag());
+            $tmpContainer = new ContainerBuilder($container->getParameterBag(), $container->getContext());
             $tmpContainer->setResourceTracking($container->isTrackingResources());
             $tmpContainer->addObjectResource($extension);
 

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -102,7 +102,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface, Co
     {
         parent::__construct($parameterBag);
 
-        $this->context = $context ?: new Context();
+        $this->context = $context ?: Context::create();
     }
 
     /**
@@ -482,10 +482,6 @@ class ContainerBuilder extends Container implements TaggedContainerInterface, Co
         $this->addAliases($container->getAliases());
         $this->getParameterBag()->add($container->getParameterBag()->all());
 
-        if (!$this->context->isLocked()) {
-            $this->context->merge($container->getContext());
-        }
-
         if ($this->trackResources) {
             foreach ($container->getResources() as $resource) {
                 $this->addResource($resource);
@@ -555,8 +551,6 @@ class ContainerBuilder extends Container implements TaggedContainerInterface, Co
                 $this->addObjectResource($pass);
             }
         }
-
-        $this->getContext()->lock();
 
         $compiler->compile($this);
         $this->compiled = true;

--- a/src/Symfony/Component/DependencyInjection/Context.php
+++ b/src/Symfony/Component/DependencyInjection/Context.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Exception\BadMethodCallException;
+use Symfony\Component\DependencyInjection\Exception\ContextElementNotFoundException;
+
+/**
+ * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
+ */
+final class Context
+{
+    private $elements;
+    private $locked = false;
+
+    /**
+     * Creates a new context allowing to share elements during the container building phase.
+     *
+     * Context elements is an array where the values are the elements to share
+     * and the keys are strings allowing to retrieve an element.
+     *
+     * For instance:
+     *
+     * new Context(array('kernel' => new BootingKernel($kernel)));
+     *
+     * @param array $elements An array of elements indexed by a string.
+     */
+    public function __construct(array $elements = array())
+    {
+        $this->elements = $elements;
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return bool
+     */
+    public function has($key)
+    {
+        return isset($this->elements[$key]);
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return mixed
+     *
+     * @throws ContextElementNotFoundException When no element exists for this key.
+     */
+    public function get($key)
+    {
+        if (!$this->has($key)) {
+            throw new ContextElementNotFoundException($key);
+        }
+
+        return $this->elements[$key];
+    }
+
+    /**
+     * @param string $key
+     * @param mixed  $element
+     *
+     * @throws BadMethodCallException When trying to set an element on a locked context.
+     */
+    public function set($key, $element)
+    {
+        if ($this->isLocked()) {
+            throw new BadMethodCallException(sprintf('Setting element "%s" on a locked context is not allowed.', $key));
+        }
+
+        $this->elements[$key] = $element;
+    }
+
+    /**
+     * Locks the context making it immutable.
+     */
+    public function lock()
+    {
+        $this->locked = true;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isLocked()
+    {
+        return $this->locked;
+    }
+
+    /**
+     * Merges elements found in the given context into the current one.
+     *
+     * @param Context $context
+     *
+     * @throws BadMethodCallException When trying to merge into a locked context.
+     */
+    public function merge(Context $context)
+    {
+        if ($this->isLocked()) {
+            throw new BadMethodCallException('Cannot merge on a locked context.');
+        }
+
+        foreach ($context->elements as $key => $element) {
+            $this->set($key, $element);
+        }
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/ContextualizedContainerBuilderInterface.php
+++ b/src/Symfony/Component/DependencyInjection/ContextualizedContainerBuilderInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection;
+
+/**
+ * Implemented by a ContainerBuilder sharing a context during build time.
+ *
+ * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
+ */
+interface ContextualizedContainerBuilderInterface extends ContainerInterface
+{
+    /**
+     * @return Context
+     */
+    public function getContext();
+}

--- a/src/Symfony/Component/DependencyInjection/Exception/ContextElementNotFoundException.php
+++ b/src/Symfony/Component/DependencyInjection/Exception/ContextElementNotFoundException.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Exception;
+
+/**
+ * This exception is thrown when a non-existent context element is used.
+ *
+ * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
+ */
+class ContextElementNotFoundException extends InvalidArgumentException
+{
+    private $key;
+
+    /**
+     * @param string $key
+     */
+    public function __construct($key)
+    {
+        $this->key = $key;
+
+        parent::__construct(sprintf('Context element not found for "%s" key', $key));
+    }
+
+    /**
+     * @return string
+     */
+    public function getKey()
+    {
+        return $this->key;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/BootingKernel.php
+++ b/src/Symfony/Component/HttpKernel/BootingKernel.php
@@ -1,0 +1,191 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel;
+
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\Exception\BadMethodCallException;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Bundle\BootingBundle;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+
+/**
+ * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
+ */
+class BootingKernel implements KernelInterface
+{
+    private $innerKernel;
+
+    public function __construct(KernelInterface $innerKernel)
+    {
+        $this->innerKernel = $innerKernel;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize()
+    {
+        return $this->innerKernel->serialize();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize($serialized)
+    {
+        $this->innerKernel->unserialize($serialized);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(Request $request, $type = self::MASTER_REQUEST, $catch = true)
+    {
+        throw new BadMethodCallException(sprintf('Calling "%s()" is not allowed.', __METHOD__));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function registerBundles()
+    {
+        throw new BadMethodCallException(sprintf('Calling "%s()" is not allowed.', __METHOD__));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        throw new BadMethodCallException(sprintf('Calling "%s()" is not allowed.', __METHOD__));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function boot()
+    {
+        throw new BadMethodCallException(sprintf('Calling "%s()" is not allowed.', __METHOD__));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function shutdown()
+    {
+        throw new BadMethodCallException(sprintf('Calling "%s()" is not allowed.', __METHOD__));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBundles()
+    {
+        return array_map(function (BundleInterface $bundle) {
+            return new BootingBundle($bundle);
+        }, $this->innerKernel->getBundles());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBundle($name, $first = true)
+    {
+        if (is_array($bundle = $this->innerKernel->getBundle($name, $first))) {
+            return array_map(function (BundleInterface $bundle) {
+                return new BootingBundle($bundle);
+            }, $bundle);
+        }
+
+        return new BootingBundle($bundle);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function locateResource($name, $dir = null, $first = true)
+    {
+        return $this->innerKernel->locateResource($name, $dir, $first);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return $this->innerKernel->getName();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getEnvironment()
+    {
+        return $this->innerKernel->getEnvironment();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isDebug()
+    {
+        return $this->innerKernel->isDebug();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRootDir()
+    {
+        return $this->innerKernel->getRootDir();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getContainer()
+    {
+        throw new BadMethodCallException(sprintf('Calling "%s()" is not allowed.', __METHOD__));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStartTime()
+    {
+        return $this->innerKernel->getStartTime();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCacheDir()
+    {
+        return $this->innerKernel->getCacheDir();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLogDir()
+    {
+        return $this->innerKernel->getLogDir();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCharset()
+    {
+        return $this->innerKernel->getCharset();
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Bundle/BootingBundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/BootingBundle.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Bundle;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Exception\BadMethodCallException;
+
+/**
+ * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
+ */
+class BootingBundle implements BundleInterface
+{
+    private $innerBundle;
+
+    public function __construct(BundleInterface $innerBundle)
+    {
+        $this->innerBundle = $innerBundle;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function boot()
+    {
+        throw new BadMethodCallException(sprintf('Calling "%s()" is not allowed.', __METHOD__));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function shutdown()
+    {
+        throw new BadMethodCallException(sprintf('Calling "%s()" is not allowed.', __METHOD__));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container)
+    {
+        throw new BadMethodCallException(sprintf('Calling "%s()" is not allowed.', __METHOD__));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getContainerExtension()
+    {
+        throw new BadMethodCallException(sprintf('Calling "%s()" is not allowed.', __METHOD__));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent()
+    {
+        return $this->innerBundle->getParent();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return $this->innerBundle->getName();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNamespace()
+    {
+        return $this->innerBundle->getNamespace();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPath()
+    {
+        return $this->innerBundle->getPath();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setContainer(ContainerInterface $container = null)
+    {
+        throw new BadMethodCallException(sprintf('Calling "%s()" is not allowed.', __METHOD__));
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -15,6 +15,7 @@ use Symfony\Bridge\ProxyManager\LazyProxy\Instantiator\RuntimeInstantiator;
 use Symfony\Bridge\ProxyManager\LazyProxy\PhpDumper\ProxyDumper;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Context;
 use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -611,7 +612,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
      */
     protected function getContainerBuilder()
     {
-        $container = new ContainerBuilder(new ParameterBag($this->getKernelParameters()));
+        $container = new ContainerBuilder(new ParameterBag($this->getKernelParameters()), Context::create(array('kernel' => new BootingKernel($this))));
 
         if (class_exists('ProxyManager\Configuration') && class_exists('Symfony\Bridge\ProxyManager\LazyProxy\Instantiator\RuntimeInstantiator')) {
             $container->setProxyInstantiator(new RuntimeInstantiator());

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -28,7 +28,7 @@
         "symfony/config": "~2.8|~3.0",
         "symfony/console": "~2.8|~3.0",
         "symfony/css-selector": "~2.8|~3.0",
-        "symfony/dependency-injection": "~2.8|~3.0",
+        "symfony/dependency-injection": "3.2.x-dev",
         "symfony/dom-crawler": "~2.8|~3.0",
         "symfony/expression-language": "~2.8|~3.0",
         "symfony/finder": "~2.8|~3.0",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Supersedes #19606 by giving another more generalist approach.
It follows discussions in #19619. 

As the `ContainerBuilder` should probably not behaves as a `Container` until compiled (see #19644) and as services set directly using `ContainerBuilder::set()` are vanished and cannot be got during the building phase, this POC exposes the idea of separating clearly the needs of using a service and sharing a context somehow while the container is building.

Apparently, it should help to fix issues like #18563 which needs to access the bundle instances during the extensions loading.
- [ ] Useful ? Is the approach legit ?
- [ ] Should the `Context` instance be locked before or after extensions are loaded ?  
  I.e: Should we allow extensions to mutate the context and consider it "safe to use" only in compiler passes, or should we only allow to initially set the context from the `KernelInterface::getContainerBuilder()` ?
- [ ] If the answer to the previous question is "Do not allow extensions to mutate the context", what about simply making the `Context` class immutable (Thus cannot be changed after creating the `ContainerBuilder` instance) ? No more `lock`, no more `set`.  
- [ ] Add tests if approved.

---

Another solution only focused on the need to access the kernel & bundles instances from an extension could be to create a `KernelAwareInterface`. If an extension implements this interface, then we inject a `BootingKernel` instance.
