### PR TITLE
[Debug] Swap dumper services at bootstrap

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/DebugBundle.php
+++ b/src/Symfony/Bundle/DebugBundle/DebugBundle.php
@@ -30,7 +30,7 @@ class DebugBundle extends Bundle
             // configuration for CLI mode is overridden in HTTP mode on
             // 'kernel.request' event
             VarDumper::setHandler(function ($var) use ($container) {
-                $dumper = $container->get('var_dumper.cli_dumper');
+                $dumper = $container->get('data_collector.dump');
                 $cloner = $container->get('var_dumper.cloner');
                 $handler = function ($var) use ($dumper, $cloner) {
                     $dumper->dump($cloner->cloneVar($var));

--- a/src/Symfony/Bundle/DebugBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/DebugBundle/Resources/config/services.xml
@@ -22,7 +22,7 @@
         <service id="debug.dump_listener" class="Symfony\Component\HttpKernel\EventListener\DumpListener">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="var_dumper.cloner" />
-            <argument type="service" id="data_collector.dump" />
+            <argument type="service" id="var_dumper.cli_dumper" />
         </service>
 
         <service id="var_dumper.cloner" class="Symfony\Component\VarDumper\Cloner\VarCloner" />

--- a/src/Symfony/Component/HttpKernel/EventListener/DumpListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/DumpListener.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\HttpKernel\EventListener;
 
+use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\VarDumper\Cloner\ClonerInterface;
 use Symfony\Component\VarDumper\Dumper\DataDumperInterface;
 use Symfony\Component\VarDumper\VarDumper;
@@ -50,6 +50,6 @@ class DumpListener implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         // Register early to have a working dump() as early as possible
-        return array(KernelEvents::REQUEST => array('configure', 1024));
+        return array(ConsoleEvents::COMMAND => array('configure', 1024));
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/DumpListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/DumpListenerTest.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\HttpKernel\Tests\EventListener;
 
+use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\HttpKernel\EventListener\DumpListener;
-use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\VarDumper\Cloner\ClonerInterface;
 use Symfony\Component\VarDumper\Cloner\Data;
 use Symfony\Component\VarDumper\Dumper\DataDumperInterface;
@@ -28,7 +28,7 @@ class DumpListenerTest extends \PHPUnit_Framework_TestCase
     public function testSubscribedEvents()
     {
         $this->assertSame(
-            array(KernelEvents::REQUEST => array('configure', 1024)),
+            array(ConsoleEvents::COMMAND => array('configure', 1024)),
             DumpListener::getSubscribedEvents()
         );
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

---

This commit fix a bug when using debug function too soon.
For example, if you call dump function during kernel::boot() the
dump output will be sent to stderr, even in a web context.

With this patch, the data collector is used by default, so the
dump output is send to the WDT. In a CLI context, if dump is used
too soon, the datacollector will buffer it, and release it at the
end of the script. So in this case everything will be visible by the
end used.
