### PR TITLE
[SecurityBundle] Add missing deprecation notice for form_login.intention

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FormLoginFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FormLoginFactory.php
@@ -30,6 +30,7 @@ class FormLoginFactory extends AbstractFactory
         $this->addOption('password_parameter', '_password');
         $this->addOption('csrf_parameter', '_csrf_token');
         $this->addOption('csrf_token_id', 'authenticate');
+        $this->addOption('intention', 'authenticate'); // for BC
         $this->addOption('post_only', true);
     }
 
@@ -53,6 +54,10 @@ class FormLoginFactory extends AbstractFactory
                 ->thenInvalid("You should define a value for only one of 'csrf_provider' and 'csrf_token_generator' on a security firewall. Use 'csrf_token_generator' as this replaces 'csrf_provider'.")
             ->end()
             ->beforeNormalization()
+                ->ifTrue(function ($v) { return isset($v['intention']) && isset($v['csrf_token_id']); })
+                ->thenInvalid("You should define a value for only one of 'intention' and 'csrf_token_id' on a security firewall. Use 'csrf_token_id' as this replaces 'intention'.")
+            ->end()
+            ->beforeNormalization()
                 ->ifTrue(function ($v) { return isset($v['csrf_provider']); })
                 ->then(function ($v) {
                     @trigger_error("Setting the 'csrf_provider' configuration key on a security firewall is deprecated since version 2.8 and will be removed in 3.0. Use the 'csrf_token_generator' configuration key instead.", E_USER_DEPRECATED);
@@ -62,7 +67,18 @@ class FormLoginFactory extends AbstractFactory
 
                     return $v;
                 })
-                ->end()
+            ->end()
+            ->beforeNormalization()
+                ->ifTrue(function ($v) { return isset($v['intention']); })
+                ->then(function ($v) {
+                    @trigger_error("Setting the 'intention' configuration key on a security firewall is deprecated since version 2.8 and will be removed in 3.0. Use the 'csrf_token_id' key instead.", E_USER_DEPRECATED);
+
+                    $v['csrf_token_id'] = $v['intention'];
+                    unset($v['intention']);
+
+                    return $v;
+                })
+            ->end()
             ->children()
                 ->scalarNode('csrf_token_generator')->cannotBeEmpty()->end()
             ->end()

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FormLoginFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FormLoginFactory.php
@@ -30,7 +30,6 @@ class FormLoginFactory extends AbstractFactory
         $this->addOption('password_parameter', '_password');
         $this->addOption('csrf_parameter', '_csrf_token');
         $this->addOption('csrf_token_id', 'authenticate');
-        $this->addOption('intention', 'authenticate'); // for BC
         $this->addOption('post_only', true);
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #19664, #19661, #19652 |
| License | MIT |
| Doc PR | - |

By the grace of @chalasr 

ping @fabpot 
