### PR TITLE
[DI] Deprecate Container::set for nulls, initialized and alias services

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/PhpEngineTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/PhpEngineTest.php
@@ -38,8 +38,7 @@ class PhpEngineTest extends TestCase
         $loader = $this->getMockForAbstractClass('Symfony\Component\Templating\Loader\Loader');
         $engine = new PhpEngine(new TemplateNameParser(), $container, $loader, new GlobalVariables($container));
 
-        $container->set('request_stack', null);
-
+        $this->assertFalse($container->has('request_stack'));
         $globals = $engine->getGlobals();
         $this->assertEmpty($globals['app']->getRequest());
     }

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -161,9 +161,6 @@ class Container implements ResettableContainerInterface
     /**
      * Sets a service.
      *
-     * Setting a service to null resets the service: has() returns false and get()
-     * behaves in the same way as if the service was never created.
-     *
      * @param string $id      The service identifier
      * @param object $service The service instance
      */
@@ -175,16 +172,6 @@ class Container implements ResettableContainerInterface
             throw new InvalidArgumentException('You cannot set service "service_container".');
         }
 
-        if (isset($this->aliases[$id])) {
-            unset($this->aliases[$id]);
-        }
-
-        $this->services[$id] = $service;
-
-        if (null === $service) {
-            unset($this->services[$id]);
-        }
-
         if (isset($this->privates[$id])) {
             if (null === $service) {
                 @trigger_error(sprintf('Unsetting the "%s" private service is deprecated since Symfony 3.2 and won\'t be supported anymore in Symfony 4.0.', $id), E_USER_DEPRECATED);
@@ -192,7 +179,24 @@ class Container implements ResettableContainerInterface
             } else {
                 @trigger_error(sprintf('Setting the "%s" private service is deprecated since Symfony 3.2 and won\'t be supported anymore in Symfony 4.0. A new public service will be created instead.', $id), E_USER_DEPRECATED);
             }
+        } elseif (null === $service) {
+            @trigger_error(sprintf('Unsetting the "%s" service is deprecated since Symfony 3.3 and won\'t be supported anymore in Symfony 4.0.', $id), E_USER_DEPRECATED);
+            unset($this->services[$id], $this->aliases[$id], $this->methodMap[$id]);
+
+            return;
         }
+
+        if (isset($this->aliases[$id])) {
+            @trigger_error(sprintf('Replacing the "%s" service alias is deprecated since Symfony 3.3 and will set the aliased service instead in Symfony 4.0.', $id), E_USER_DEPRECATED);
+            unset($this->aliases[$id]);
+        } elseif (isset($this->services[$id])) {
+            @trigger_error(sprintf('Replacing the initialized "%s" service is deprecated since Symfony 3.3 and won\'t be supported anymore in Symfony 4.0.', $id), E_USER_DEPRECATED);
+        } elseif (isset($this->methodMap[$id])) {
+            @trigger_error(sprintf('Replacing the pre-defined "%s" service is deprecated since Symfony 3.3 and won\'t be supported anymore in Symfony 4.0.', $id), E_USER_DEPRECATED);
+            unset($this->methodMap[$id]);
+        }
+
+        $this->services[$id] = $service;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -240,12 +240,13 @@ class PhpDumperTest extends \PHPUnit_Framework_TestCase
     public function testAliases()
     {
         $container = include self::$fixturesPath.'/containers/container9.php';
+        $container->setParameter('foo_bar', 'foo_bar');
         $container->compile();
         $dumper = new PhpDumper($container);
         eval('?>'.$dumper->dump(array('class' => 'Symfony_DI_PhpDumper_Test_Aliases')));
 
         $container = new \Symfony_DI_PhpDumper_Test_Aliases();
-        $container->set('foo', $foo = new \stdClass());
+        $foo = $container->get('foo');
         $this->assertSame($foo, $container->get('foo'));
         $this->assertSame($foo, $container->get('alias_for_foo'));
         $this->assertSame($foo, $container->get('alias_for_alias'));
@@ -263,6 +264,10 @@ class PhpDumperTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($container->has('foo'));
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Replacing the pre-defined "bar" service is deprecated since Symfony 3.3 and won't be supported anymore in Symfony 4.0.
+     */
     public function testOverrideServiceWhenUsingADumpedContainer()
     {
         require_once self::$fixturesPath.'/php/services9.php';
@@ -275,6 +280,10 @@ class PhpDumperTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($bar, $container->get('bar'), '->set() overrides an already defined service');
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Replacing the pre-defined "bar" service is deprecated since Symfony 3.3 and won't be supported anymore in Symfony 4.0.
+     */
     public function testOverrideServiceWhenUsingADumpedContainerAndServiceIsUsedFromAnotherOne()
     {
         require_once self::$fixturesPath.'/php/services9.php';

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container9.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once __DIR__.'/../includes/classes.php';
+require_once __DIR__.'/../includes/foo.php';
 
 use Symfony\Component\DependencyInjection\Argument\ClosureProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | not yet |
| Fixed tickets | #19192 |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

Not sure what i got myself into, it's a true adventure so far. But this deprecates
`Container::set('id', null)` :scream: and `Container::set('id', $previousSetService)`
- We violate the [contract](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/DependencyInjection/ContainerInterface.php#L34), which we are also fixing at the same time: #19203 
  - We can consider `ContainerInterface::remove` if we need to support it (so far im not sure really)
- This somewhat relates to the `ContainerBuilder` - #19673, #19715

Before/After:
- `set('id', null)`
  - Resets the service, but is deprecated as of 3.2
  - In 4.0 we can remove the case (expecting it to be an object as documented) or throw. This is yet to be decided.
- `set('id', $instance)`
  - Allowed if, and only if the service is not **initialized** previously. This is recommended by design, and keeps the dependency graph trusty. Breaking this rule is deprecated as of 3.2.
  - In 4.0 this should throw an exception.
- `set('alias', $instance)`
  - Set a new "alias" service, but is deprecated in 3.2
  - In 4.0 this sets the _aliased_ service, following the rule above
