### PR TITLE
[HttpKernel] Fix too strict test

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
@@ -49,11 +49,7 @@ class DumpDataCollectorTest extends \PHPUnit_Framework_TestCase
         );
         $this->assertSame($xDump, $dump);
 
-        $this->assertStringMatchesFormat(
-            'a:1:{i:0;a:5:{s:4:"data";O:39:"Symfony\Component\VarDumper\Cloner\Data":4:{s:45:"Symfony\Component\VarDumper\Cloner\Datadata";a:1:{i:0;a:1:{i:0;i:123;}}s:49:"Symfony\Component\VarDumper\Cloner\DatamaxDepth";i:%i;s:57:"Symfony\Component\VarDumper\Cloner\DatamaxItemsPerDepth";i:%i;s:54:"Symfony\Component\VarDumper\Cloner\DatauseRefHandles";i:%i;}s:4:"name";s:25:"DumpDataCollectorTest.php";s:4:"file";s:%a',
-            str_replace("\0", '', $collector->serialize())
-        );
-
+        $this->assertStringMatchesFormat('a:1:{i:0;a:5:{s:4:"data";O:39:"Symfony\Component\VarDumper\Cloner\Data":%a', $collector->serialize());
         $this->assertSame(0, $collector->getDumpsCount());
         $this->assertSame('a:0:{}', $collector->serialize());
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Tests pass? | yes |
| License | MIT |

This test is too strict and prevents adding properties to Data objects for no reason.
