### PR TITLE
[DependencyInjection] Do not trigger deprecation when injecting private services

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -235,6 +235,11 @@ class Container implements ResettableContainerInterface
      */
     public function get($id, $invalidBehavior = self::EXCEPTION_ON_INVALID_REFERENCE)
     {
+        $triggerPrivateDeprecations = true;
+        if (func_num_args() > 2) {
+            $triggerPrivateDeprecations = func_get_arg(2);
+        }
+
         // Attempt to retrieve the service by checking first aliases then
         // available services. Service IDs are case insensitive, however since
         // this method can be called thousands of times during a request, avoid
@@ -281,7 +286,7 @@ class Container implements ResettableContainerInterface
 
                 return;
             }
-            if (isset($this->privates[$id])) {
+            if ($triggerPrivateDeprecations && isset($this->privates[$id])) {
                 @trigger_error(sprintf('Requesting the "%s" private service is deprecated since Symfony 3.2 and won\'t be supported anymore in Symfony 4.0.', $id), E_USER_DEPRECATED);
             }
 

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1377,13 +1377,13 @@ EOF;
         }
 
         if (null !== $reference && ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE !== $reference->getInvalidBehavior()) {
-            return sprintf('$this->get(\'%s\', ContainerInterface::NULL_ON_INVALID_REFERENCE)', $id);
+            return sprintf('$this->get(\'%s\', ContainerInterface::NULL_ON_INVALID_REFERENCE, false)', $id);
         } else {
             if ($this->container->hasAlias($id)) {
                 $id = (string) $this->container->getAlias($id);
             }
 
-            return sprintf('$this->get(\'%s\')', $id);
+            return sprintf('$this->get(\'%s\', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false)', $id);
         }
     }
 

--- a/src/Symfony/Component/DependencyInjection/ExpressionLanguageProvider.php
+++ b/src/Symfony/Component/DependencyInjection/ExpressionLanguageProvider.php
@@ -28,9 +28,9 @@ class ExpressionLanguageProvider implements ExpressionFunctionProviderInterface
     {
         return array(
             new ExpressionFunction('service', function ($arg) {
-                return sprintf('$this->get(%s)', $arg);
+                return sprintf('$this->get(%s, ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false)', $arg);
             }, function (array $variables, $value) {
-                return $variables['container']->get($value);
+                return $variables['container']->get($value, ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false);
             }),
 
             new ExpressionFunction('parameter', function ($arg) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
@@ -72,7 +72,7 @@ class ProjectServiceContainer extends Container
      */
     protected function getBarService()
     {
-        $a = $this->get('foo.baz');
+        $a = $this->get('foo.baz', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false);
 
         $this->services['bar'] = $instance = new \Bar\FooClass('foo', $a, $this->getParameter('foo_bar'));
 
@@ -93,7 +93,7 @@ class ProjectServiceContainer extends Container
     {
         $this->services['baz'] = $instance = new \Baz();
 
-        $instance->setFoo($this->get('foo_with_inline'));
+        $instance->setFoo($this->get('foo_with_inline', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false));
 
         return $instance;
     }
@@ -110,7 +110,7 @@ class ProjectServiceContainer extends Container
     {
         $this->services['configured_service'] = $instance = new \stdClass();
 
-        $this->get('configurator_service')->configureStdClass($instance);
+        $this->get('configurator_service', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false)->configureStdClass($instance);
 
         return $instance;
     }
@@ -127,7 +127,7 @@ class ProjectServiceContainer extends Container
     {
         $this->services['configured_service_simple'] = $instance = new \stdClass();
 
-        $this->get('configurator_service_simple')->configureStdClass($instance);
+        $this->get('configurator_service_simple', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false)->configureStdClass($instance);
 
         return $instance;
     }
@@ -198,7 +198,7 @@ class ProjectServiceContainer extends Container
      */
     protected function getFactoryServiceService()
     {
-        return $this->services['factory_service'] = $this->get('foo.baz')->getInstance();
+        return $this->services['factory_service'] = $this->get('foo.baz', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false)->getInstance();
     }
 
     /**
@@ -211,7 +211,7 @@ class ProjectServiceContainer extends Container
      */
     protected function getFactoryServiceSimpleService()
     {
-        return $this->services['factory_service_simple'] = $this->get('factory_simple')->getInstance();
+        return $this->services['factory_service_simple'] = $this->get('factory_simple', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false)->getInstance();
     }
 
     /**
@@ -224,11 +224,11 @@ class ProjectServiceContainer extends Container
      */
     protected function getFooService()
     {
-        $a = $this->get('foo.baz');
+        $a = $this->get('foo.baz', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false);
 
         $this->services['foo'] = $instance = \Bar\FooClass::getInstance('foo', $a, array($this->getParameter('foo') => 'foo is '.$this->getParameter('foo').'', 'foobar' => $this->getParameter('foo')), true, $this);
 
-        $instance->setBar($this->get('bar'));
+        $instance->setBar($this->get('bar', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false));
         $instance->initialize();
         $instance->foo = 'bar';
         $instance->moo = $a;
@@ -279,7 +279,7 @@ class ProjectServiceContainer extends Container
     {
         $this->services['foo_with_inline'] = $instance = new \Foo();
 
-        $instance->setBar($this->get('inlined'));
+        $instance->setBar($this->get('inlined', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false));
 
         return $instance;
     }
@@ -298,15 +298,15 @@ class ProjectServiceContainer extends Container
 
         $this->services['method_call1'] = $instance = new \Bar\FooClass();
 
-        $instance->setBar($this->get('foo'));
-        $instance->setBar($this->get('foo2', ContainerInterface::NULL_ON_INVALID_REFERENCE));
+        $instance->setBar($this->get('foo', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false));
+        $instance->setBar($this->get('foo2', ContainerInterface::NULL_ON_INVALID_REFERENCE, false));
         if ($this->has('foo3')) {
-            $instance->setBar($this->get('foo3', ContainerInterface::NULL_ON_INVALID_REFERENCE));
+            $instance->setBar($this->get('foo3', ContainerInterface::NULL_ON_INVALID_REFERENCE, false));
         }
         if ($this->has('foobaz')) {
-            $instance->setBar($this->get('foobaz', ContainerInterface::NULL_ON_INVALID_REFERENCE));
+            $instance->setBar($this->get('foobaz', ContainerInterface::NULL_ON_INVALID_REFERENCE, false));
         }
-        $instance->setBar(($this->get("foo")->foo() . (($this->hasParameter("foo")) ? ($this->getParameter("foo")) : ("default"))));
+        $instance->setBar(($this->get("foo", ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false)->foo() . (($this->hasParameter("foo")) ? ($this->getParameter("foo")) : ("default"))));
 
         return $instance;
     }
@@ -321,7 +321,7 @@ class ProjectServiceContainer extends Container
      */
     protected function getNewFactoryServiceService()
     {
-        $this->services['new_factory_service'] = $instance = $this->get('new_factory')->getInstance();
+        $this->services['new_factory_service'] = $instance = $this->get('new_factory', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false)->getInstance();
 
         $instance->foo = 'bar';
 
@@ -370,7 +370,7 @@ class ProjectServiceContainer extends Container
     {
         $this->services['configurator_service'] = $instance = new \ConfClass();
 
-        $instance->setFoo($this->get('baz'));
+        $instance->setFoo($this->get('baz', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false));
 
         return $instance;
     }
@@ -425,7 +425,7 @@ class ProjectServiceContainer extends Container
     {
         $this->services['inlined'] = $instance = new \Bar();
 
-        $instance->setBaz($this->get('baz'));
+        $instance->setBaz($this->get('baz', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false));
         $instance->pub = 'pub';
 
         return $instance;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -70,7 +70,7 @@ class ProjectServiceContainer extends Container
      */
     protected function getBarService()
     {
-        $a = $this->get('foo.baz');
+        $a = $this->get('foo.baz', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false);
 
         $this->services['bar'] = $instance = new \Bar\FooClass('foo', $a, $this->getParameter('foo_bar'));
 
@@ -91,7 +91,7 @@ class ProjectServiceContainer extends Container
     {
         $this->services['baz'] = $instance = new \Baz();
 
-        $instance->setFoo($this->get('foo_with_inline'));
+        $instance->setFoo($this->get('foo_with_inline', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false));
 
         return $instance;
     }
@@ -107,7 +107,7 @@ class ProjectServiceContainer extends Container
     protected function getConfiguredServiceService()
     {
         $a = new \ConfClass();
-        $a->setFoo($this->get('baz'));
+        $a->setFoo($this->get('baz', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false));
 
         $this->services['configured_service'] = $instance = new \stdClass();
 
@@ -186,7 +186,7 @@ class ProjectServiceContainer extends Container
      */
     protected function getFactoryServiceService()
     {
-        return $this->services['factory_service'] = $this->get('foo.baz')->getInstance();
+        return $this->services['factory_service'] = $this->get('foo.baz', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false)->getInstance();
     }
 
     /**
@@ -212,11 +212,11 @@ class ProjectServiceContainer extends Container
      */
     protected function getFooService()
     {
-        $a = $this->get('foo.baz');
+        $a = $this->get('foo.baz', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false);
 
         $this->services['foo'] = $instance = \Bar\FooClass::getInstance('foo', $a, array('bar' => 'foo is bar', 'foobar' => 'bar'), true, $this);
 
-        $instance->setBar($this->get('bar'));
+        $instance->setBar($this->get('bar', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false));
         $instance->initialize();
         $instance->foo = 'bar';
         $instance->moo = $a;
@@ -267,7 +267,7 @@ class ProjectServiceContainer extends Container
 
         $this->services['foo_with_inline'] = $instance = new \Foo();
 
-        $a->setBaz($this->get('baz'));
+        $a->setBaz($this->get('baz', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false));
         $a->pub = 'pub';
 
         $instance->setBar($a);
@@ -289,9 +289,9 @@ class ProjectServiceContainer extends Container
 
         $this->services['method_call1'] = $instance = new \Bar\FooClass();
 
-        $instance->setBar($this->get('foo'));
+        $instance->setBar($this->get('foo', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false));
         $instance->setBar(NULL);
-        $instance->setBar(($this->get("foo")->foo() . (($this->hasParameter("foo")) ? ($this->getParameter("foo")) : ("default"))));
+        $instance->setBar(($this->get("foo", ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, false)->foo() . (($this->hasParameter("foo")) ? ($this->getParameter("foo")) : ("default"))));
 
         return $instance;
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #19680 |
| License | MIT |
| Doc PR | - |

The deprecation notice should not be triggered when a private service is injected. This PR adds a virtual third argument to `get()` to disable triggering the deprecation notice when getting from the dumped container.
