### PR TITLE
[DI] Randomize private services

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -65,6 +65,10 @@ class PassConfig
             )),
             new CheckExceptionOnInvalidReferenceBehaviorPass(),
         ));
+
+        $this->afterRemovingPasses = array(array(
+            new RandomizePrivateServiceIdentifiers(),
+        ));
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Compiler/RandomizePrivateServiceIdentifiers.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RandomizePrivateServiceIdentifiers.php
@@ -33,6 +33,7 @@ class RandomizePrivateServiceIdentifiers implements CompilerPassInterface
             if (!$definition->isPublic()) {
                 $this->idMap[$id] = $this->randomizer ? (string) call_user_func($this->randomizer, $id) : hash('sha256', mt_rand().$id);
                 $definition->setOriginId($id);
+                $definition->setPublic(true);
             }
         }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/RandomizePrivateServiceIdentifiers.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RandomizePrivateServiceIdentifiers.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Randomizes private service identifiers, effectively making them unaccessable from outside.
+ *
+ * @author Roland Franssen <franssen.roland@gmail.com>
+ */
+class RandomizePrivateServiceIdentifiers implements CompilerPassInterface
+{
+    private $idMap;
+
+    public function process(ContainerBuilder $container)
+    {
+        // build id map
+        $this->idMap = array();
+        foreach ($container->getDefinitions() as $id => $definition) {
+            if (!$definition->isPublic()) {
+                $this->idMap[$id] = md5(uniqid($id));
+            }
+        }
+
+        // update private definitions + alias map
+        $aliases = $container->getAliases();
+        foreach ($this->idMap as $id => $randId) {
+            $definition = $container->getDefinition($id);
+            Definition::markAsPrivateOrigin($id, $definition);
+            $container->setDefinition($randId, $definition);
+            $container->removeDefinition($id);
+            foreach ($aliases as $aliasId => $aliasedId) {
+                if ((string) $aliasedId === $id) {
+                    $aliases[$aliasId] = new Alias($randId, $aliasedId->isPublic());
+                }
+            }
+        }
+        $container->setAliases($aliases);
+
+        // update referencing definitions
+        foreach ($container->getDefinitions() as $id => $definition) {
+            $definition->setArguments($this->processArguments($definition->getArguments()));
+            $definition->setMethodCalls($this->processArguments($definition->getMethodCalls()));
+            $definition->setProperties($this->processArguments($definition->getProperties()));
+            $definition->setFactory($this->processFactory($definition->getFactory()));
+            if (null !== ($decorated = $definition->getDecoratedService()) && isset($this->idMap[$decorated[0]])) {
+                $definition->setDecoratedService($this->idMap[$decorated[0]], $decorated[1], $decorated[2]);
+            }
+        }
+    }
+
+    private function processArguments(array $arguments)
+    {
+        foreach ($arguments as $k => $argument) {
+            if (is_array($argument)) {
+                $arguments[$k] = $this->processArguments($argument);
+            } elseif ($argument instanceof Reference && isset($this->idMap[$id = (string) $argument])) {
+                $arguments[$k] = new Reference($this->idMap[$id], $argument->getInvalidBehavior());
+            }
+        }
+
+        return $arguments;
+    }
+
+    private function processFactory($factory)
+    {
+        if (null === $factory || !is_array($factory) || !$factory[0] instanceof Reference) {
+            return $factory;
+        }
+        if (isset($this->idMap[$id = (string) $factory[0]])) {
+            $factory[0] = new Reference($this->idMap[$id], $factory[0]->getInvalidBehavior());
+        }
+
+        return $factory;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Compiler/RandomizePrivateServiceIdentifiers.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RandomizePrivateServiceIdentifiers.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -25,6 +24,7 @@ use Symfony\Component\DependencyInjection\Reference;
 class RandomizePrivateServiceIdentifiers implements CompilerPassInterface
 {
     private $idMap;
+    private $randomizer;
 
     public function process(ContainerBuilder $container)
     {
@@ -32,7 +32,7 @@ class RandomizePrivateServiceIdentifiers implements CompilerPassInterface
         $this->idMap = array();
         foreach ($container->getDefinitions() as $id => $definition) {
             if (!$definition->isPublic()) {
-                $this->idMap[$id] = md5(uniqid($id));
+                $this->idMap[$id] = $this->randomizer ? (string) call_user_func($this->randomizer, $id) : md5(uniqid($id));
             }
         }
 
@@ -61,6 +61,11 @@ class RandomizePrivateServiceIdentifiers implements CompilerPassInterface
                 $definition->setDecoratedService($this->idMap[$decorated[0]], $decorated[1], $decorated[2]);
             }
         }
+    }
+
+    public function setRandomizer(callable $randomizer = null)
+    {
+        $this->randomizer = $randomizer;
     }
 
     private function processArguments(array $arguments)

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -67,7 +67,7 @@ class Container implements ResettableContainerInterface
     protected $methodMap = array();
     protected $aliases = array();
     protected $loading = array();
-    protected $serviceMetadata = array();
+    protected $privateOriginIds = array(); // for BC
 
     private $underscoreMap = array('_' => '', '.' => '_', '\\' => '_');
 
@@ -172,19 +172,18 @@ class Container implements ResettableContainerInterface
             unset($this->aliases[$id]);
         }
 
-        if ($this->isPrivateService($id)) {
+        if (isset($this->privateOriginIds[$id])) {
             if (null === $service) {
                 @trigger_error(sprintf('Unsetting the "%s" private service is deprecated since Symfony 3.2 and won\'t be supported anymore in Symfony 4.0.', $id), E_USER_DEPRECATED);
+                unset($this->privateOriginIds[$id]);
             } else {
                 @trigger_error(sprintf('Setting the "%s" private service is deprecated since Symfony 3.2 and won\'t be supported anymore in Symfony 4.0. A new public service will be created instead.', $id), E_USER_DEPRECATED);
+                $id = $this->privateOriginIds[$id];
             }
         }
 
         if (null === $service) {
-            if (null !== $originId = $this->getServiceOriginId($id)) {
-                unset($this->services[$originId], $this->serviceMetadata[$originId]);
-            }
-            unset($this->services[$id], $this->serviceMetadata[$id]);
+            unset($this->services[$id]);
         } else {
             $this->services[$id] = $service;
         }
@@ -210,9 +209,9 @@ class Container implements ResettableContainerInterface
             if (--$i && $id !== $lcId = strtolower($id)) {
                 $id = $lcId;
             } else {
-                if ($this->isPrivateService($id)) {
+                if (isset($this->privateOriginIds[$id])) {
                     @trigger_error(sprintf('Checking for the existence of the "%s" private service is deprecated since Symfony 3.2 and won\'t be supported anymore in Symfony 4.0.', $id), E_USER_DEPRECATED);
-                    $id = $this->getServiceOriginId($id) ?: $id;
+                    $id = $this->privateOriginIds[$id];
                 }
 
                 return method_exists($this, 'get'.strtr($id, $this->underscoreMap).'Service');
@@ -267,13 +266,10 @@ class Container implements ResettableContainerInterface
             } elseif (method_exists($this, $method = 'get'.strtr($id, $this->underscoreMap).'Service')) {
                 // $method is set to the right value, proceed
             } else {
-                if ($this->isPrivateService($id) && null === $this->getServiceOriginId($id)) {
+                if (isset($this->privateOriginIds[$id])) {
                     @trigger_error(sprintf('Requesting the "%s" private service is deprecated since Symfony 3.2 and won\'t be supported anymore in Symfony 4.0.', $id), E_USER_DEPRECATED);
-                    foreach ($this->serviceMetadata as $serviceId => $metadata) {
-                        if (isset($metadata['origin_id']) && $id === $metadata['origin_id']) {
-                            return $this->get($serviceId, $invalidBehavior);
-                        }
-                    }
+
+                    return $this->get($this->privateOriginIds[$id]);
                 }
 
                 if (self::EXCEPTION_ON_INVALID_REFERENCE === $invalidBehavior) {
@@ -349,11 +345,12 @@ class Container implements ResettableContainerInterface
     public function getServiceIds()
     {
         $ids = array();
+        $reversedPrivateOriginIds = array_flip($this->privateOriginIds);
         foreach (get_class_methods($this) as $method) {
             if (preg_match('/^get(.+)Service$/', $method, $match)) {
                 $id = self::underscore($match[1]);
-                if ($this->isPrivateService($id)) {
-                    $id = $this->getServiceOriginId($id) ?: $id;
+                if (isset($reversedPrivateOriginIds[$id])) {
+                    $id = $reversedPrivateOriginIds[$id];
                 }
                 $ids[] = $id;
             }
@@ -385,16 +382,6 @@ class Container implements ResettableContainerInterface
     public static function underscore($id)
     {
         return strtolower(preg_replace(array('/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'), array('\\1_\\2', '\\1_\\2'), str_replace('_', '.', $id)));
-    }
-
-    final protected function isPrivateService($id)
-    {
-        return isset($this->serviceMetadata[$id]['private']) && true === $this->serviceMetadata[$id]['private'];
-    }
-
-    final protected function getServiceOriginId($id)
-    {
-        return isset($this->serviceMetadata[$id]['origin_id']) ? $this->serviceMetadata[$id]['origin_id'] : null;
     }
 
     private function __clone()

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -541,12 +541,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         $compiler->compile($this);
         $this->compiled = true;
 
-        $this->privateOriginIds = array();
-
         foreach ($this->definitions as $id => $definition) {
-            if (null !== $originId = $definition->getOriginId()) {
-                $this->privateOriginIds[$originId] = $id;
-            }
             if ($this->trackResources && $definition->isLazy() && ($class = $definition->getClass()) && class_exists($class)) {
                 $this->addClassResource(new \ReflectionClass($class));
             }

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -541,17 +541,11 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         $compiler->compile($this);
         $this->compiled = true;
 
-        $this->serviceMetadata = array();
+        $this->privateOriginIds = array();
 
         foreach ($this->definitions as $id => $definition) {
-            if (!$definition->isPublic()) {
-                $this->serviceMetadata[$id]['private'] = true;
-            }
             if (null !== $originId = $definition->getOriginId()) {
-                $this->serviceMetadata[$id]['origin_id'] = $originId;
-                if (!$definition->isPublic()) {
-                    $this->serviceMetadata[$originId]['private'] = true;
-                }
+                $this->privateOriginIds[$originId] = $id;
             }
             if ($this->trackResources && $definition->isLazy() && ($class = $definition->getClass()) && class_exists($class)) {
                 $this->addClassResource(new \ReflectionClass($class));

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -38,6 +38,7 @@ class Definition
     private $decoratedService;
     private $autowired = false;
     private $autowiringTypes = array();
+    private $privateOriginId;
 
     protected $arguments;
 
@@ -49,6 +50,17 @@ class Definition
     {
         $this->class = $class;
         $this->arguments = $arguments;
+    }
+
+    public static function markAsPrivateOrigin($id, Definition $origin)
+    {
+        $origin->public = false;
+        $origin->privateOriginId = $id;
+    }
+
+    final public function getPrivateOriginId()
+    {
+        return !$this->isPublic() ? $this->privateOriginId : null;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -38,7 +38,6 @@ class Definition
     private $decoratedService;
     private $autowired = false;
     private $autowiringTypes = array();
-    private $originId;
 
     protected $arguments;
 
@@ -50,16 +49,6 @@ class Definition
     {
         $this->class = $class;
         $this->arguments = $arguments;
-    }
-
-    public function setOriginId($id)
-    {
-        $this->originId = $id;
-    }
-
-    public function getOriginId()
-    {
-        return $this->originId;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -38,7 +38,7 @@ class Definition
     private $decoratedService;
     private $autowired = false;
     private $autowiringTypes = array();
-    private $privateOriginId;
+    private $originId;
 
     protected $arguments;
 
@@ -52,15 +52,14 @@ class Definition
         $this->arguments = $arguments;
     }
 
-    public static function markAsPrivateOrigin($id, Definition $origin)
+    public function setOriginId($id)
     {
-        $origin->public = false;
-        $origin->privateOriginId = $id;
+        $this->originId = $id;
     }
 
-    final public function getPrivateOriginId()
+    public function getOriginId()
     {
-        return !$this->isPublic() ? $this->privateOriginId : null;
+        return $this->originId;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -24,7 +24,6 @@ use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceExce
 use Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\DumperInterface as ProxyDumper;
 use Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\NullDumper;
 use Symfony\Component\DependencyInjection\ExpressionLanguage;
-use Symfony\Component\DependencyInjection\ExpressionLanguageProvider;
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\HttpKernel\Kernel;
 

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -804,7 +804,7 @@ EOF;
 EOF;
 
         $code .= $this->addMethodMap();
-        $code .= $this->addPrivateOriginIdServices();
+        $code .= $this->addPrivateServices();
         $code .= $this->addAliases();
 
         $code .= <<<'EOF'
@@ -839,7 +839,7 @@ EOF;
 
         $code .= "\n        \$this->services = array();\n";
         $code .= $this->addMethodMap();
-        $code .= $this->addPrivateOriginIdServices();
+        $code .= $this->addPrivateServices();
         $code .= $this->addAliases();
 
         $code .= <<<'EOF'
@@ -891,29 +891,32 @@ EOF;
     }
 
     /**
-     * Adds the service metadata property definition.
+     * Adds the privates property definition.
+     *
+     * This method is intented for BC only.
      *
      * @return string
      */
-    private function addPrivateOriginIdServices()
+    private function addPrivateServices()
     {
         if (!$definitions = $this->container->getDefinitions()) {
             return '';
         }
 
+        $reflectionProperty = new \ReflectionProperty(ContainerBuilder::class, 'privates');
+        $reflectionProperty->setAccessible(true);
+
         $code = '';
         ksort($definitions);
-        foreach ($definitions as $id => $definition) {
-            if (null !== $originId = $definition->getOriginId()) {
-                $code .= '            '.var_export($originId, true).' => '.var_export($id, true).",\n";
-            }
+        foreach ($reflectionProperty->getValue($this->container) as $originId => $id) {
+            $code .= '            '.var_export($originId, true).' => '.var_export($id, true).",\n";
         }
 
         if (empty($code)) {
             return '';
         }
 
-        $out = "        \$this->privateOriginIds = array(\n";
+        $out = "        \$this->privates = array(\n";
         $out .= $code;
         $out .= "        );\n";
 

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -24,6 +24,7 @@ use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceExce
 use Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\DumperInterface as ProxyDumper;
 use Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\NullDumper;
 use Symfony\Component\DependencyInjection\ExpressionLanguage;
+use Symfony\Component\DependencyInjection\ExpressionLanguageProvider;
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\HttpKernel\Kernel;
 
@@ -839,6 +840,7 @@ EOF;
 
         $code .= "\n        \$this->services = array();\n";
         $code .= $this->addMethodMap();
+        $code .= $this->addPrivateServices();
         $code .= $this->addAliases();
 
         $code .= <<<'EOF'
@@ -903,8 +905,8 @@ EOF;
         $code = '';
         ksort($definitions);
         foreach ($definitions as $id => $definition) {
-            if (!$definition->isPublic()) {
-                $code .= '            '.var_export($id, true)." => true,\n";
+            if (null !== $privateOriginId = $definition->getPrivateOriginId()) {
+                $code .= '            '.var_export($id, true).' => '.var_export($privateOriginId, true).",\n";
             }
         }
 
@@ -912,7 +914,7 @@ EOF;
             return '';
         }
 
-        $out = "        \$this->privates = array(\n";
+        $out = "        \$this->privateOriginIds = array(\n";
         $out .= $code;
         $out .= "        );\n";
 

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -804,7 +804,7 @@ EOF;
 EOF;
 
         $code .= $this->addMethodMap();
-        $code .= $this->addServiceMetadata();
+        $code .= $this->addPrivateOriginIdServices();
         $code .= $this->addAliases();
 
         $code .= <<<'EOF'
@@ -839,7 +839,7 @@ EOF;
 
         $code .= "\n        \$this->services = array();\n";
         $code .= $this->addMethodMap();
-        $code .= $this->addServiceMetadata();
+        $code .= $this->addPrivateOriginIdServices();
         $code .= $this->addAliases();
 
         $code .= <<<'EOF'
@@ -895,7 +895,7 @@ EOF;
      *
      * @return string
      */
-    private function addServiceMetadata()
+    private function addPrivateOriginIdServices()
     {
         if (!$definitions = $this->container->getDefinitions()) {
             return '';
@@ -904,30 +904,8 @@ EOF;
         $code = '';
         ksort($definitions);
         foreach ($definitions as $id => $definition) {
-            $metadata = array();
-            if (!$definition->isPublic()) {
-                $metadata['private'] = true;
-            }
             if (null !== $originId = $definition->getOriginId()) {
-                $metadata['origin_id'] = $originId;
-            }
-            if ($metadata) {
-                $code .= '            '.var_export($id, true)." => array(\n";
-                foreach ($metadata as $k => $v) {
-                    $code .= '                '.var_export($k, true).' => '.var_export($v, true).",\n";
-                }
-                $code .= "            ),\n";
-            }
-            if (null === $originId) {
-                continue;
-            }
-            unset($metadata['origin_id']);
-            if ($metadata) {
-                $code .= '            '.var_export($originId, true)." => array(\n";
-                foreach ($metadata as $k => $v) {
-                    $code .= '                '.var_export($k, true).' => '.var_export($v, true).",\n";
-                }
-                $code .= "            ),\n";
+                $code .= '            '.var_export($originId, true).' => '.var_export($id, true).",\n";
             }
         }
 
@@ -935,7 +913,7 @@ EOF;
             return '';
         }
 
-        $out = "        \$this->serviceMetadata = array(\n";
+        $out = "        \$this->privateOriginIds = array(\n";
         $out .= $code;
         $out .= "        );\n";
 

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -400,7 +400,7 @@ class ProjectServiceContainer extends Container
         $this->__internal = new \stdClass();
         $this->__sharing_internal = new \stdClass();
         $this->aliases = array('alias' => 'bar');
-        $this->privateOriginIds = array('internal' => 'semirandom_internal');
+        $this->privates = array('internal' => 'semirandom_internal');
     }
 
     protected function getSemirandomInternalService()

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -397,21 +397,29 @@ class ProjectServiceContainer extends Container
         $this->__bar = new \stdClass();
         $this->__foo_bar = new \stdClass();
         $this->__foo_baz = new \stdClass();
-        $this->__rand1_internal = new \stdClass();
+        $this->__internal = new \stdClass();
         $this->__sharing_internal = new \stdClass();
-        $this->privateOriginIds = array('rand1_internal' => 'internal');
         $this->aliases = array('alias' => 'bar');
+        $this->serviceMetadata = array(
+            'semirandom_internal' => array(
+                'private' => true,
+                'origin_id' => 'internal',
+            ),
+            'internal' => array(
+                'private' => true,
+            ),
+        );
     }
 
-    protected function getRand1InternalService()
+    protected function getSemirandomInternalService()
     {
-        return $this->__rand1_internal;
+        return $this->__internal;
     }
 
     protected function getSharingInternalService()
     {
         $instance = $this->__sharing_internal;
-        $instance->internal = $this->get('rand1_internal'); // simulates dumped behavior
+        $instance->internal = $this->get('semirandom_internal'); // simulates dumped behavior
 
         return $instance;
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -400,15 +400,7 @@ class ProjectServiceContainer extends Container
         $this->__internal = new \stdClass();
         $this->__sharing_internal = new \stdClass();
         $this->aliases = array('alias' => 'bar');
-        $this->serviceMetadata = array(
-            'semirandom_internal' => array(
-                'private' => true,
-                'origin_id' => 'internal',
-            ),
-            'internal' => array(
-                'private' => true,
-            ),
-        );
+        $this->privateOriginIds = array('internal' => 'semirandom_internal');
     }
 
     protected function getSemirandomInternalService()

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Tests\Dumper;
 
+use Symfony\Component\DependencyInjection\Compiler\RandomizePrivateServiceIdentifiers;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
@@ -122,6 +123,13 @@ class PhpDumperTest extends \PHPUnit_Framework_TestCase
 
         // with compilation
         $container = include self::$fixturesPath.'/containers/container9.php';
+        foreach ($container->getCompiler()->getPassConfig()->getPasses() as $pass) {
+            if ($pass instanceof RandomizePrivateServiceIdentifiers) {
+                $pass->setRandomizer(function ($id) {
+                    return 'shared_private' === $id ? 'semirandom_'.$id : md5(uniqid($id));
+                });
+            }
+        }
         $container->compile();
         $dumper = new PhpDumper($container);
         $this->assertEquals(str_replace('%path%', str_replace('\\', '\\\\', self::$fixturesPath.DIRECTORY_SEPARATOR.'includes'.DIRECTORY_SEPARATOR), file_get_contents(self::$fixturesPath.'/php/services9_compiled.php')), $dumper->dump(), '->dump() dumps services');

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container9.php
@@ -129,5 +129,14 @@ $container
     ->register('factory_service_simple', 'Bar')
     ->setFactory(array(new Reference('factory_simple'), 'getInstance'))
 ;
+$container
+    ->register('shared_private', 'stdClass')
+    ->setPublic(false);
+$container
+    ->register('shared_private_dep1', 'stdClass')
+    ->setProperty('dep', new Reference('shared_private'));
+$container
+    ->register('shared_private_dep2', 'stdClass')
+    ->setProperty('dep', new Reference('shared_private'));
 
 return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services9.dot
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/graphviz/services9.dot
@@ -26,6 +26,9 @@ digraph sc {
   node_service_from_static_method [label="service_from_static_method\nBar\\FooClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_factory_simple [label="factory_simple\nSimpleFactoryClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_factory_service_simple [label="factory_service_simple\nBar\n", shape=record, fillcolor="#eeeeee", style="filled"];
+  node_shared_private [label="shared_private\nstdClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
+  node_shared_private_dep1 [label="shared_private_dep1\nstdClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
+  node_shared_private_dep2 [label="shared_private_dep2\nstdClass\n", shape=record, fillcolor="#eeeeee", style="filled"];
   node_service_container [label="service_container\nSymfony\\Component\\DependencyInjection\\ContainerBuilder\n", shape=record, fillcolor="#9999ff", style="filled"];
   node_foo2 [label="foo2\n\n", shape=record, fillcolor="#ff9999", style="filled"];
   node_foo3 [label="foo3\n\n", shape=record, fillcolor="#ff9999", style="filled"];
@@ -43,4 +46,6 @@ digraph sc {
   node_inlined -> node_baz [label="setBaz()" style="dashed"];
   node_baz -> node_foo_with_inline [label="setFoo()" style="dashed"];
   node_configurator_service -> node_baz [label="setFoo()" style="dashed"];
+  node_shared_private_dep1 -> node_shared_private [label="" style="dashed"];
+  node_shared_private_dep2 -> node_shared_private [label="" style="dashed"];
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
@@ -48,13 +48,9 @@ class ProjectServiceContainer extends Container
             'new_factory_service' => 'getNewFactoryServiceService',
             'request' => 'getRequestService',
             'service_from_static_method' => 'getServiceFromStaticMethodService',
-        );
-        $this->privates = array(
-            'configurator_service' => true,
-            'configurator_service_simple' => true,
-            'factory_simple' => true,
-            'inlined' => true,
-            'new_factory' => true,
+            'shared_private' => 'getSharedPrivateService',
+            'shared_private_dep1' => 'getSharedPrivateDep1Service',
+            'shared_private_dep2' => 'getSharedPrivateDep2Service',
         );
         $this->aliases = array(
             'alias_for_alias' => 'foo',
@@ -355,6 +351,40 @@ class ProjectServiceContainer extends Container
     }
 
     /**
+     * Gets the 'shared_private_dep1' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return \stdClass A stdClass instance
+     */
+    protected function getSharedPrivateDep1Service()
+    {
+        $this->services['shared_private_dep1'] = $instance = new \stdClass();
+
+        $instance->dep = $this->get('shared_private');
+
+        return $instance;
+    }
+
+    /**
+     * Gets the 'shared_private_dep2' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return \stdClass A stdClass instance
+     */
+    protected function getSharedPrivateDep2Service()
+    {
+        $this->services['shared_private_dep2'] = $instance = new \stdClass();
+
+        $instance->dep = $this->get('shared_private');
+
+        return $instance;
+    }
+
+    /**
      * Gets the 'configurator_service' service.
      *
      * This service is shared.
@@ -450,6 +480,23 @@ class ProjectServiceContainer extends Container
         $instance->foo = 'bar';
 
         return $instance;
+    }
+
+    /**
+     * Gets the 'shared_private' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * This service is private.
+     * If you want to be able to request this service from the container directly,
+     * make it public, otherwise you might end up with broken code.
+     *
+     * @return \stdClass A stdClass instance
+     */
+    protected function getSharedPrivateService()
+    {
+        return $this->services['shared_private'] = new \stdClass();
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
@@ -52,6 +52,26 @@ class ProjectServiceContainer extends Container
             'shared_private_dep1' => 'getSharedPrivateDep1Service',
             'shared_private_dep2' => 'getSharedPrivateDep2Service',
         );
+        $this->serviceMetadata = array(
+            'configurator_service' => array(
+                'private' => true,
+            ),
+            'configurator_service_simple' => array(
+                'private' => true,
+            ),
+            'factory_simple' => array(
+                'private' => true,
+            ),
+            'inlined' => array(
+                'private' => true,
+            ),
+            'new_factory' => array(
+                'private' => true,
+            ),
+            'shared_private' => array(
+                'private' => true,
+            ),
+        );
         $this->aliases = array(
             'alias_for_alias' => 'foo',
             'alias_for_foo' => 'foo',

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9.php
@@ -52,26 +52,6 @@ class ProjectServiceContainer extends Container
             'shared_private_dep1' => 'getSharedPrivateDep1Service',
             'shared_private_dep2' => 'getSharedPrivateDep2Service',
         );
-        $this->serviceMetadata = array(
-            'configurator_service' => array(
-                'private' => true,
-            ),
-            'configurator_service_simple' => array(
-                'private' => true,
-            ),
-            'factory_simple' => array(
-                'private' => true,
-            ),
-            'inlined' => array(
-                'private' => true,
-            ),
-            'new_factory' => array(
-                'private' => true,
-            ),
-            'shared_private' => array(
-                'private' => true,
-            ),
-        );
         $this->aliases = array(
             'alias_for_alias' => 'foo',
             'alias_for_foo' => 'foo',

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -43,10 +43,13 @@ class ProjectServiceContainer extends Container
             'method_call1' => 'getMethodCall1Service',
             'new_factory_service' => 'getNewFactoryServiceService',
             'request' => 'getRequestService',
+            'semirandom_shared_private' => 'getSemirandomSharedPrivateService',
             'service_from_static_method' => 'getServiceFromStaticMethodService',
-            'shared_private' => 'getSharedPrivateService',
             'shared_private_dep1' => 'getSharedPrivateDep1Service',
             'shared_private_dep2' => 'getSharedPrivateDep2Service',
+        );
+        $this->privateOriginIds = array(
+            'semirandom_shared_private' => 'shared_private',
         );
         $this->aliases = array(
             'alias_for_alias' => 'foo',
@@ -357,7 +360,7 @@ class ProjectServiceContainer extends Container
     {
         $this->services['shared_private_dep1'] = $instance = new \stdClass();
 
-        $instance->dep = $this->get('shared_private');
+        $instance->dep = $this->get('semirandom_shared_private');
 
         return $instance;
     }
@@ -374,13 +377,13 @@ class ProjectServiceContainer extends Container
     {
         $this->services['shared_private_dep2'] = $instance = new \stdClass();
 
-        $instance->dep = $this->get('shared_private');
+        $instance->dep = $this->get('semirandom_shared_private');
 
         return $instance;
     }
 
     /**
-     * Gets the 'shared_private' service.
+     * Gets the 'semirandom_shared_private' service.
      *
      * This service is shared.
      * This method always returns the same instance of the service.
@@ -391,9 +394,9 @@ class ProjectServiceContainer extends Container
      *
      * @return \stdClass A stdClass instance
      */
-    protected function getSharedPrivateService()
+    protected function getSemirandomSharedPrivateService()
     {
-        return $this->services['shared_private'] = new \stdClass();
+        return $this->services['semirandom_shared_private'] = new \stdClass();
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -48,7 +48,7 @@ class ProjectServiceContainer extends Container
             'shared_private_dep1' => 'getSharedPrivateDep1Service',
             'shared_private_dep2' => 'getSharedPrivateDep2Service',
         );
-        $this->privateOriginIds = array(
+        $this->privates = array(
             'shared_private' => 'semirandom_shared_private',
         );
         $this->aliases = array(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -44,6 +44,9 @@ class ProjectServiceContainer extends Container
             'new_factory_service' => 'getNewFactoryServiceService',
             'request' => 'getRequestService',
             'service_from_static_method' => 'getServiceFromStaticMethodService',
+            'shared_private' => 'getSharedPrivateService',
+            'shared_private_dep1' => 'getSharedPrivateDep1Service',
+            'shared_private_dep2' => 'getSharedPrivateDep2Service',
         );
         $this->aliases = array(
             'alias_for_alias' => 'foo',
@@ -340,6 +343,57 @@ class ProjectServiceContainer extends Container
     protected function getServiceFromStaticMethodService()
     {
         return $this->services['service_from_static_method'] = \Bar\FooClass::getInstance();
+    }
+
+    /**
+     * Gets the 'shared_private_dep1' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return \stdClass A stdClass instance
+     */
+    protected function getSharedPrivateDep1Service()
+    {
+        $this->services['shared_private_dep1'] = $instance = new \stdClass();
+
+        $instance->dep = $this->get('shared_private');
+
+        return $instance;
+    }
+
+    /**
+     * Gets the 'shared_private_dep2' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return \stdClass A stdClass instance
+     */
+    protected function getSharedPrivateDep2Service()
+    {
+        $this->services['shared_private_dep2'] = $instance = new \stdClass();
+
+        $instance->dep = $this->get('shared_private');
+
+        return $instance;
+    }
+
+    /**
+     * Gets the 'shared_private' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * This service is private.
+     * If you want to be able to request this service from the container directly,
+     * make it public, otherwise you might end up with broken code.
+     *
+     * @return \stdClass A stdClass instance
+     */
+    protected function getSharedPrivateService()
+    {
+        return $this->services['shared_private'] = new \stdClass();
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -48,8 +48,14 @@ class ProjectServiceContainer extends Container
             'shared_private_dep1' => 'getSharedPrivateDep1Service',
             'shared_private_dep2' => 'getSharedPrivateDep2Service',
         );
-        $this->privateOriginIds = array(
-            'semirandom_shared_private' => 'shared_private',
+        $this->serviceMetadata = array(
+            'semirandom_shared_private' => array(
+                'private' => true,
+                'origin_id' => 'shared_private',
+            ),
+            'shared_private' => array(
+                'private' => true,
+            ),
         );
         $this->aliases = array(
             'alias_for_alias' => 'foo',

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -48,14 +48,8 @@ class ProjectServiceContainer extends Container
             'shared_private_dep1' => 'getSharedPrivateDep1Service',
             'shared_private_dep2' => 'getSharedPrivateDep2Service',
         );
-        $this->serviceMetadata = array(
-            'semirandom_shared_private' => array(
-                'private' => true,
-                'origin_id' => 'shared_private',
-            ),
-            'shared_private' => array(
-                'private' => true,
-            ),
+        $this->privateOriginIds = array(
+            'shared_private' => 'semirandom_shared_private',
         );
         $this->aliases = array(
             'alias_for_alias' => 'foo',
@@ -342,6 +336,19 @@ class ProjectServiceContainer extends Container
     }
 
     /**
+     * Gets the 'semirandom_shared_private' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return \stdClass A stdClass instance
+     */
+    protected function getSemirandomSharedPrivateService()
+    {
+        return $this->services['semirandom_shared_private'] = new \stdClass();
+    }
+
+    /**
      * Gets the 'service_from_static_method' service.
      *
      * This service is shared.
@@ -386,23 +393,6 @@ class ProjectServiceContainer extends Container
         $instance->dep = $this->get('semirandom_shared_private');
 
         return $instance;
-    }
-
-    /**
-     * Gets the 'semirandom_shared_private' service.
-     *
-     * This service is shared.
-     * This method always returns the same instance of the service.
-     *
-     * This service is private.
-     * If you want to be able to request this service from the container directly,
-     * make it public, otherwise you might end up with broken code.
-     *
-     * @return \stdClass A stdClass instance
-     */
-    protected function getSemirandomSharedPrivateService()
-    {
-        return $this->services['semirandom_shared_private'] = new \stdClass();
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
@@ -115,6 +115,13 @@
     <service id="factory_service_simple" class="Bar">
       <factory service="factory_simple" method="getInstance"/>
     </service>
+    <service id="shared_private" class="stdClass" public="false"/>
+    <service id="shared_private_dep1" class="stdClass">
+      <property name="dep" type="service" id="shared_private"/>
+    </service>
+    <service id="shared_private_dep2" class="stdClass">
+      <property name="dep" type="service" id="shared_private"/>
+    </service>
     <service id="alias_for_foo" alias="foo"/>
     <service id="alias_for_alias" alias="foo"/>
   </services>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
@@ -107,5 +107,14 @@ services:
     factory_service_simple:
         class: Bar
         factory: ['@factory_simple', getInstance]
+    shared_private:
+        class: stdClass
+        public: false
+    shared_private_dep1:
+        class: stdClass
+        properties: { dep: '@shared_private' }
+    shared_private_dep2:
+        class: stdClass
+        properties: { dep: '@shared_private' }
     alias_for_foo: '@foo'
     alias_for_alias: '@foo'

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -220,7 +220,7 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $services = $container->getDefinitions();
         $fooArgs = $services['foo']->getArguments();
         $barArgs = $services['bar']->getArguments();
-        $this->assertSame($fooArgs[0], $barArgs[0]);
+        $this->assertEquals($fooArgs[0], $barArgs[0]);
     }
 
     public function testLoadServices()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | not yet |
| Fixed tickets | #19680 |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

Alternative approach compared to #19682 

Thanks to @wouterj for explaining this approach.

Theory of operation;
- compiler pass
  - build a map of `private id` => `random id`
  - remap private definitions to its new id
  - update references and aliases
  - inject id map into container builder (for BC)
- container
  - id's found in the (injected) map are forwarded to the new id + deprecation notice
- todo
  - add tests
  - fix tests due randomization
  - dump the container with orignal id's in generated docs, etc. for convenience.

The deprecation now only happens after compilation(!). This can be seen a design choice, i guess.
