### PR TITLE
[SecurityBundle] Support autowiring for AccessDecisionManagerInterface

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -68,6 +68,11 @@ class SecurityExtension extends Extension
 
         if ($container->hasParameter('kernel.debug') && $container->getParameter('kernel.debug')) {
             $loader->load('security_debug.xml');
+
+            if ($container->hasDefinition('security.access.decision_manager') && $container->hasDefinition('debug.security.access.decision_manager')) {
+                $container->getDefinition('security.access.decision_manager')->setAutowiringTypes(array());
+                $container->getDefinition('debug.security.access.decision_manager')->setAutowiringTypes(array('Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface'));
+            }
         }
 
         if (!class_exists('Symfony\Component\ExpressionLanguage\ExpressionLanguage')) {

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -66,6 +66,8 @@
         <!-- Authorization related services -->
         <service id="security.access.decision_manager" class="Symfony\Component\Security\Core\Authorization\AccessDecisionManager" public="false">
             <argument type="collection" />
+
+            <autowiring-type>Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface</autowiring-type>
         </service>
 
         <service id="security.role_hierarchy" class="Symfony\Component\Security\Core\Role\RoleHierarchy" public="false">

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AutowiringTypesTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AutowiringTypesTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
+
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
+use Symfony\Component\Security\Core\Authorization\DebugAccessDecisionManager;
+
+class AutowiringTypesTest extends WebTestCase
+{
+    public function testAccessDecisionManagerAutowiring()
+    {
+        static::bootKernel(array('debug' => false));
+        $container = static::$kernel->getContainer();
+
+        $accessDecisionManager = $container->get('test.autowiring_types.autowired_services')->getAccessDecisionManager();
+        $this->assertInstanceOf(AccessDecisionManager::class, $accessDecisionManager);
+    }
+
+    public function testDebugAccessDecisionManagerAutowiring()
+    {
+        static::bootKernel(array('debug' => true));
+        $container = static::$kernel->getContainer();
+
+        $accessDecisionManager = $container->get('test.autowiring_types.autowired_services')->getAccessDecisionManager();
+        $this->assertInstanceOf(DebugAccessDecisionManager::class, $accessDecisionManager);
+    }
+
+    protected static function createKernel(array $options = array())
+    {
+        return parent::createKernel(array('test_case' => 'AutowiringTypes') + $options);
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/TestBundle/AutowiringTypes/AutowiredServices.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/TestBundle/AutowiringTypes/AutowiredServices.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\TestBundle\AutowiringTypes;
+
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
+
+class AutowiredServices
+{
+    private $accessDecisionManager;
+
+    public function __construct(AccessDecisionManagerInterface $accessDecisionManager)
+    {
+        $this->accessDecisionManager = $accessDecisionManager;
+    }
+
+    public function getAccessDecisionManager()
+    {
+        return $this->accessDecisionManager;
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/TestBundle/TestBundle.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/TestBundle/TestBundle.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\TestBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class TestBundle extends Bundle
+{
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AutowiringTypes/bundles.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AutowiringTypes/bundles.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return array(
+    new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+    new Symfony\Bundle\SecurityBundle\SecurityBundle(),
+    new Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\TestBundle\TestBundle(),
+);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AutowiringTypes/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AutowiringTypes/config.yml
@@ -1,0 +1,18 @@
+imports:
+    - { resource: ../config/framework.yml }
+
+
+security:
+    providers:
+        in_memory:
+            memory: ~
+
+    firewalls:
+        test:
+            pattern:  ^/
+            security: false
+
+services:
+    test.autowiring_types.autowired_services:
+        class: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\TestBundle\AutowiringTypes\AutowiredServices
+        autowire: true


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |
