### PR TITLE
Fix the calendar exception to handle null

### DIFF
--- a/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
+++ b/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
@@ -143,7 +143,7 @@ class IntlDateFormatter
      * @see http://userguide.icu-project.org/formatparse/datetime
      *
      * @throws MethodArgumentValueNotImplementedException When $locale different than "en" or null is passed
-     * @throws MethodArgumentValueNotImplementedException When $calendar different than GREGORIAN is passed
+     * @throws MethodArgumentValueNotImplementedException When $calendar different than GREGORIAN is passed or null is passed
      */
     public function __construct($locale, $datetype, $timetype, $timezone = null, $calendar = self::GREGORIAN, $pattern = null)
     {
@@ -151,7 +151,7 @@ class IntlDateFormatter
             throw new MethodArgumentValueNotImplementedException(__METHOD__, 'locale', $locale, 'Only the locale "en" is supported');
         }
 
-        if (self::GREGORIAN !== $calendar) {
+        if (self::GREGORIAN !== $calendar && null !== $calendar) {
             throw new MethodArgumentValueNotImplementedException(__METHOD__, 'calendar', $calendar, 'Only the GREGORIAN calendar is supported');
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7, 2.8 and 3.1 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #19688 |
| License | MIT |
| Doc PR | none |

Fix the calendar exception to handle null, error was raised while exporting from akeneo

The Symfony\Component\Intl\DateFormatter\IntlDateFormatter::__construct() method's argument $calendar value NULL behavior is not implemented. Only the GREGORIAN calendar is supported. Please install the "intl" extension for full localization capabilities.

https://cloud.githubusercontent.com/assets/4486133/17287404/81f951cc-57e0-11e6-9f6f-e231bbf00bf4.png
