### PR TITLE
[Validator] Used "::class" name resolution instead of "__NAMESPACE__" constant

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
@@ -29,7 +29,7 @@ abstract class AbstractComparisonValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof AbstractComparison) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\AbstractComparison');
+            throw new UnexpectedTypeException($constraint, AbstractComparison::class);
         }
 
         if (null === $value) {

--- a/src/Symfony/Component/Validator/Constraints/AllValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AllValidator.php
@@ -26,7 +26,7 @@ class AllValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof All) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\All');
+            throw new UnexpectedTypeException($constraint, All::class);
         }
 
         if (null === $value) {

--- a/src/Symfony/Component/Validator/Constraints/BlankValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/BlankValidator.php
@@ -26,7 +26,7 @@ class BlankValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Blank) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Blank');
+            throw new UnexpectedTypeException($constraint, Blank::class);
         }
 
         if ('' !== $value && null !== $value) {

--- a/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
@@ -29,7 +29,7 @@ class CallbackValidator extends ConstraintValidator
     public function validate($object, Constraint $constraint)
     {
         if (!$constraint instanceof Callback) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Callback');
+            throw new UnexpectedTypeException($constraint, Callback::class);
         }
 
         $method = $constraint->callback;

--- a/src/Symfony/Component/Validator/Constraints/CardSchemeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CardSchemeValidator.php
@@ -85,15 +85,12 @@ class CardSchemeValidator extends ConstraintValidator
     );
 
     /**
-     * Validates a creditcard belongs to a specified scheme.
-     *
-     * @param mixed      $value
-     * @param Constraint $constraint
+     * {@inheritdoc}
      */
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof CardScheme) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\CardScheme');
+            throw new UnexpectedTypeException($constraint, CardScheme::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
@@ -31,7 +31,7 @@ class ChoiceValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Choice) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Choice');
+            throw new UnexpectedTypeException($constraint, Choice::class);
         }
 
         if (!is_array($constraint->choices) && !$constraint->callback) {

--- a/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
@@ -26,7 +26,7 @@ class CollectionValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Collection) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Collection');
+            throw new UnexpectedTypeException($constraint, Collection::class);
         }
 
         if (null === $value) {

--- a/src/Symfony/Component/Validator/Constraints/CountryValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CountryValidator.php
@@ -29,7 +29,7 @@ class CountryValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Country) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Country');
+            throw new UnexpectedTypeException($constraint, Country::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/CurrencyValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CurrencyValidator.php
@@ -30,7 +30,7 @@ class CurrencyValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Currency) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Currency');
+            throw new UnexpectedTypeException($constraint, Currency::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
@@ -31,7 +31,7 @@ class DateTimeValidator extends DateValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof DateTime) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\DateTime');
+            throw new UnexpectedTypeException($constraint, DateTime::class);
         }
 
         if (null === $value || '' === $value || $value instanceof \DateTimeInterface) {

--- a/src/Symfony/Component/Validator/Constraints/DateValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateValidator.php
@@ -44,7 +44,7 @@ class DateValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Date) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Date');
+            throw new UnexpectedTypeException($constraint, Date::class);
         }
 
         if (null === $value || '' === $value || $value instanceof \DateTimeInterface) {

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -37,7 +37,7 @@ class EmailValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Email) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Email');
+            throw new UnexpectedTypeException($constraint, Email::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/ExpressionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionValidator.php
@@ -39,7 +39,7 @@ class ExpressionValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Expression) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Expression');
+            throw new UnexpectedTypeException($constraint, Expression::class);
         }
 
         $variables = array();

--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -41,7 +41,7 @@ class FileValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof File) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\File');
+            throw new UnexpectedTypeException($constraint, File::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/IbanValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IbanValidator.php
@@ -142,7 +142,7 @@ class IbanValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Iban) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Iban');
+            throw new UnexpectedTypeException($constraint, Iban::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/ImageValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ImageValidator.php
@@ -31,7 +31,7 @@ class ImageValidator extends FileValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Image) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Image');
+            throw new UnexpectedTypeException($constraint, Image::class);
         }
 
         $violations = count($this->context->getViolations());

--- a/src/Symfony/Component/Validator/Constraints/IpValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IpValidator.php
@@ -29,7 +29,7 @@ class IpValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Ip) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Ip');
+            throw new UnexpectedTypeException($constraint, Ip::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/IsFalseValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IsFalseValidator.php
@@ -26,7 +26,7 @@ class IsFalseValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof IsFalse) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\IsFalse');
+            throw new UnexpectedTypeException($constraint, IsFalse::class);
         }
 
         if (null === $value || false === $value || 0 === $value || '0' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/IsNullValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IsNullValidator.php
@@ -26,7 +26,7 @@ class IsNullValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof IsNull) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\IsNull');
+            throw new UnexpectedTypeException($constraint, IsNull::class);
         }
 
         if (null !== $value) {

--- a/src/Symfony/Component/Validator/Constraints/IsTrueValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IsTrueValidator.php
@@ -26,7 +26,7 @@ class IsTrueValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof IsTrue) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\IsTrue');
+            throw new UnexpectedTypeException($constraint, IsTrue::class);
         }
 
         if (null === $value) {

--- a/src/Symfony/Component/Validator/Constraints/IsbnValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IsbnValidator.php
@@ -32,7 +32,7 @@ class IsbnValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Isbn) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Isbn');
+            throw new UnexpectedTypeException($constraint, Isbn::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/IssnValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IssnValidator.php
@@ -31,7 +31,7 @@ class IssnValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Issn) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Issn');
+            throw new UnexpectedTypeException($constraint, Issn::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/LanguageValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LanguageValidator.php
@@ -29,7 +29,7 @@ class LanguageValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Language) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Language');
+            throw new UnexpectedTypeException($constraint, Language::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/LengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LengthValidator.php
@@ -26,7 +26,7 @@ class LengthValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Length) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Length');
+            throw new UnexpectedTypeException($constraint, Length::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/LocaleValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LocaleValidator.php
@@ -29,7 +29,7 @@ class LocaleValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Locale) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Locale');
+            throw new UnexpectedTypeException($constraint, Locale::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/LuhnValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LuhnValidator.php
@@ -30,17 +30,12 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 class LuhnValidator extends ConstraintValidator
 {
     /**
-     * Validates a credit card number with the Luhn algorithm.
-     *
-     * @param mixed      $value
-     * @param Constraint $constraint
-     *
-     * @throws UnexpectedTypeException when the given credit card number is no string
+     * {@inheritdoc}
      */
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Luhn) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Luhn');
+            throw new UnexpectedTypeException($constraint, Luhn::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
@@ -26,7 +26,7 @@ class NotBlankValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof NotBlank) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\NotBlank');
+            throw new UnexpectedTypeException($constraint, NotBlank::class);
         }
 
         if (false === $value || (empty($value) && '0' != $value)) {

--- a/src/Symfony/Component/Validator/Constraints/NotNullValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotNullValidator.php
@@ -26,7 +26,7 @@ class NotNullValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof NotNull) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\NotNull');
+            throw new UnexpectedTypeException($constraint, NotNull::class);
         }
 
         if (null === $value) {

--- a/src/Symfony/Component/Validator/Constraints/RangeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/RangeValidator.php
@@ -26,7 +26,7 @@ class RangeValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Range) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Range');
+            throw new UnexpectedTypeException($constraint, Range::class);
         }
 
         if (null === $value) {

--- a/src/Symfony/Component/Validator/Constraints/RegexValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/RegexValidator.php
@@ -29,7 +29,7 @@ class RegexValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Regex) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Regex');
+            throw new UnexpectedTypeException($constraint, Regex::class);
         }
 
         if (null === $value || '' === $value) {

--- a/src/Symfony/Component/Validator/Constraints/TimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TimeValidator.php
@@ -44,7 +44,7 @@ class TimeValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Time) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Time');
+            throw new UnexpectedTypeException($constraint, Time::class);
         }
 
         if (null === $value || '' === $value || $value instanceof \DateTime) {

--- a/src/Symfony/Component/Validator/Constraints/TypeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TypeValidator.php
@@ -26,7 +26,7 @@ class TypeValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Type) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Type');
+            throw new UnexpectedTypeException($constraint, Type::class);
         }
 
         if (null === $value) {

--- a/src/Symfony/Component/Validator/Constraints/UrlValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UrlValidator.php
@@ -42,7 +42,7 @@ class UrlValidator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         if (!$constraint instanceof Url) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Url');
+            throw new UnexpectedTypeException($constraint, Url::class);
         }
 
         if (null === $value) {

--- a/src/Symfony/Component/Validator/Constraints/UuidValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UuidValidator.php
@@ -65,7 +65,7 @@ class UuidValidator extends ConstraintValidator
         }
 
         if (!$constraint instanceof Uuid) {
-            throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Uuid');
+            throw new UnexpectedTypeException($constraint, Uuid::class);
         }
 
         if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString'))) {

--- a/src/Symfony/Component/Validator/Tests/Constraints/EqualToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EqualToValidatorTest.php
@@ -62,7 +62,7 @@ class EqualToValidatorTest extends AbstractComparisonValidatorTestCase
             array(new \DateTime('2001-01-01'), 'Jan 1, 2001, 12:00 AM', new \DateTime('2000-01-01'), 'Jan 1, 2000, 12:00 AM', 'DateTime'),
             array(new \DateTime('2001-01-01'), 'Jan 1, 2001, 12:00 AM', '2000-01-01', 'Jan 1, 2000, 12:00 AM', 'DateTime'),
             array(new \DateTime('2001-01-01 UTC'), 'Jan 1, 2001, 12:00 AM', '2000-01-01 UTC', 'Jan 1, 2000, 12:00 AM', 'DateTime'),
-            array(new ComparisonTest_Class(4), '4', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'),
+            array(new ComparisonTest_Class(4), '4', new ComparisonTest_Class(5), '5', ComparisonTest_Class::class),
         );
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorTest.php
@@ -64,8 +64,8 @@ class GreaterThanValidatorTest extends AbstractComparisonValidatorTestCase
             array(new \DateTime('2000/01/01'), 'Jan 1, 2000, 12:00 AM', '2000/01/01', 'Jan 1, 2000, 12:00 AM', 'DateTime'),
             array(new \DateTime('2000/01/01 UTC'), 'Jan 1, 2000, 12:00 AM', '2005/01/01 UTC', 'Jan 1, 2005, 12:00 AM', 'DateTime'),
             array(new \DateTime('2000/01/01 UTC'), 'Jan 1, 2000, 12:00 AM', '2000/01/01 UTC', 'Jan 1, 2000, 12:00 AM', 'DateTime'),
-            array(new ComparisonTest_Class(4), '4', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'),
-            array(new ComparisonTest_Class(5), '5', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'),
+            array(new ComparisonTest_Class(4), '4', new ComparisonTest_Class(5), '5', ComparisonTest_Class::class),
+            array(new ComparisonTest_Class(5), '5', new ComparisonTest_Class(5), '5', ComparisonTest_Class::class),
             array('22', '"22"', '333', '"333"', 'string'),
             array('22', '"22"', '22', '"22"', 'string'),
         );

--- a/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToValidatorTest.php
@@ -80,7 +80,7 @@ class IdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
             array('22', '"22"', '333', '"333"', 'string'),
             array(new \DateTime('2001-01-01'), 'Jan 1, 2001, 12:00 AM', new \DateTime('2001-01-01'), 'Jan 1, 2001, 12:00 AM', 'DateTime'),
             array(new \DateTime('2001-01-01'), 'Jan 1, 2001, 12:00 AM', new \DateTime('1999-01-01'), 'Jan 1, 1999, 12:00 AM', 'DateTime'),
-            array(new ComparisonTest_Class(4), '4', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'),
+            array(new ComparisonTest_Class(4), '4', new ComparisonTest_Class(5), '5', ComparisonTest_Class::class),
         );
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorTest.php
@@ -66,7 +66,7 @@ class LessThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
             array(new \DateTime('2010-01-01'), 'Jan 1, 2010, 12:00 AM', new \DateTime('2000-01-01'), 'Jan 1, 2000, 12:00 AM', 'DateTime'),
             array(new \DateTime('2010-01-01'), 'Jan 1, 2010, 12:00 AM', '2000-01-01', 'Jan 1, 2000, 12:00 AM', 'DateTime'),
             array(new \DateTime('2010-01-01 UTC'), 'Jan 1, 2010, 12:00 AM', '2000-01-01 UTC', 'Jan 1, 2000, 12:00 AM', 'DateTime'),
-            array(new ComparisonTest_Class(5), '5', new ComparisonTest_Class(4), '4', __NAMESPACE__.'\ComparisonTest_Class'),
+            array(new ComparisonTest_Class(5), '5', new ComparisonTest_Class(4), '4', ComparisonTest_Class::class),
             array('c', '"c"', 'b', '"b"', 'string'),
         );
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorTest.php
@@ -64,8 +64,8 @@ class LessThanValidatorTest extends AbstractComparisonValidatorTestCase
             array(new \DateTime('2000-01-01'), 'Jan 1, 2000, 12:00 AM', '2000-01-01', 'Jan 1, 2000, 12:00 AM', 'DateTime'),
             array(new \DateTime('2010-01-01 UTC'), 'Jan 1, 2010, 12:00 AM', '2000-01-01 UTC', 'Jan 1, 2000, 12:00 AM', 'DateTime'),
             array(new \DateTime('2000-01-01 UTC'), 'Jan 1, 2000, 12:00 AM', '2000-01-01 UTC', 'Jan 1, 2000, 12:00 AM', 'DateTime'),
-            array(new ComparisonTest_Class(5), '5', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'),
-            array(new ComparisonTest_Class(6), '6', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'),
+            array(new ComparisonTest_Class(5), '5', new ComparisonTest_Class(5), '5', ComparisonTest_Class::class),
+            array(new ComparisonTest_Class(6), '6', new ComparisonTest_Class(5), '5', ComparisonTest_Class::class),
             array('333', '"333"', '22', '"22"', 'string'),
         );
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToValidatorTest.php
@@ -62,7 +62,7 @@ class NotEqualToValidatorTest extends AbstractComparisonValidatorTestCase
             array(new \DateTime('2000-01-01'), 'Jan 1, 2000, 12:00 AM', new \DateTime('2000-01-01'), 'Jan 1, 2000, 12:00 AM', 'DateTime'),
             array(new \DateTime('2000-01-01'), 'Jan 1, 2000, 12:00 AM', '2000-01-01', 'Jan 1, 2000, 12:00 AM', 'DateTime'),
             array(new \DateTime('2000-01-01 UTC'), 'Jan 1, 2000, 12:00 AM', '2000-01-01 UTC', 'Jan 1, 2000, 12:00 AM', 'DateTime'),
-            array(new ComparisonTest_Class(5), '5', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'),
+            array(new ComparisonTest_Class(5), '5', new ComparisonTest_Class(5), '5', ComparisonTest_Class::class),
         );
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToValidatorTest.php
@@ -78,7 +78,7 @@ class NotIdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
             array(3, '3', 3, '3', 'integer'),
             array('a', '"a"', 'a', '"a"', 'string'),
             array($date, 'Jan 1, 2000, 12:00 AM', $date, 'Jan 1, 2000, 12:00 AM', 'DateTime'),
-            array($object, '2', $object, '2', __NAMESPACE__.'\ComparisonTest_Class'),
+            array($object, '2', $object, '2', ComparisonTest_Class::class),
         );
 
         return $comparisons;

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/StaticMethodLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/StaticMethodLoaderTest.php
@@ -32,7 +32,7 @@ class StaticMethodLoaderTest extends \PHPUnit_Framework_TestCase
     public function testLoadClassMetadataReturnsTrueIfSuccessful()
     {
         $loader = new StaticMethodLoader('loadMetadata');
-        $metadata = new ClassMetadata(__NAMESPACE__.'\StaticLoaderEntity');
+        $metadata = new ClassMetadata(StaticLoaderEntity::class);
 
         $this->assertTrue($loader->loadClassMetadata($metadata));
     }
@@ -48,7 +48,7 @@ class StaticMethodLoaderTest extends \PHPUnit_Framework_TestCase
     public function testLoadClassMetadata()
     {
         $loader = new StaticMethodLoader('loadMetadata');
-        $metadata = new ClassMetadata(__NAMESPACE__.'\StaticLoaderEntity');
+        $metadata = new ClassMetadata(StaticLoaderEntity::class);
 
         $loader->loadClassMetadata($metadata);
 
@@ -58,12 +58,12 @@ class StaticMethodLoaderTest extends \PHPUnit_Framework_TestCase
     public function testLoadClassMetadataDoesNotRepeatLoadWithParentClasses()
     {
         $loader = new StaticMethodLoader('loadMetadata');
-        $metadata = new ClassMetadata(__NAMESPACE__.'\StaticLoaderDocument');
+        $metadata = new ClassMetadata(StaticLoaderDocument::class);
         $loader->loadClassMetadata($metadata);
         $this->assertCount(0, $metadata->getConstraints());
 
         $loader = new StaticMethodLoader('loadMetadata');
-        $metadata = new ClassMetadata(__NAMESPACE__.'\BaseStaticLoaderDocument');
+        $metadata = new ClassMetadata(BaseStaticLoaderDocument::class);
         $loader->loadClassMetadata($metadata);
         $this->assertCount(1, $metadata->getConstraints());
     }
@@ -71,7 +71,7 @@ class StaticMethodLoaderTest extends \PHPUnit_Framework_TestCase
     public function testLoadClassMetadataIgnoresInterfaces()
     {
         $loader = new StaticMethodLoader('loadMetadata');
-        $metadata = new ClassMetadata(__NAMESPACE__.'\StaticLoaderInterface');
+        $metadata = new ClassMetadata(StaticLoaderInterface::class);
 
         $loader->loadClassMetadata($metadata);
 
@@ -81,7 +81,7 @@ class StaticMethodLoaderTest extends \PHPUnit_Framework_TestCase
     public function testLoadClassMetadataInAbstractClasses()
     {
         $loader = new StaticMethodLoader('loadMetadata');
-        $metadata = new ClassMetadata(__NAMESPACE__.'\AbstractStaticLoader');
+        $metadata = new ClassMetadata(AbstractStaticLoader::class);
 
         $loader->loadClassMetadata($metadata);
 
@@ -94,7 +94,7 @@ class StaticMethodLoaderTest extends \PHPUnit_Framework_TestCase
         // strict standards error
         error_reporting(0);
 
-        $metadata = new ClassMetadata(__NAMESPACE__.'\AbstractStaticMethodLoader');
+        $metadata = new ClassMetadata(AbstractStaticMethodLoader::class);
 
         $loader = new StaticMethodLoader('loadMetadata');
         $loader->loadClassMetadata($metadata);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master and 3.1 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

The obscurity of building full Constraint class names by concatenating strings is removed. This could make it easier for some IDEs or other static analysis tools to identify usages of that specific class.

More details about "::class": http://php.net/manual/en/language.oop5.basic.php#language.oop5.basic.class.class

PS: It could be a good idea to apply this throughout the code, not just in Validator Component.
