### PR TITLE
[WIP] Adding hook point to override the resource

### DIFF
--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -116,7 +116,7 @@ abstract class AnnotationClassLoader implements LoaderInterface
         $globals = $this->getGlobals($class);
 
         $collection = new RouteCollection();
-        $collection->addResource(new FileResource($class->getFileName()));
+        $collection->addResource($this->createConfigResource($class));
 
         foreach ($class->getMethods() as $method) {
             $this->defaultRouteIndex = 0;
@@ -259,6 +259,11 @@ abstract class AnnotationClassLoader implements LoaderInterface
     protected function createRoute($path, $defaults, $requirements, $options, $host, $schemes, $methods, $condition)
     {
         return new Route($path, $defaults, $requirements, $options, $host, $schemes, $methods, $condition);
+    }
+
+    protected function createConfigResource(\ReflectionClass $class)
+    {
+        return new FileResource($class->getFileName());
     }
 
     abstract protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, $annot);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | n/a |

This introduces a hook point, which I need in sensiolabs/SensioFrameworkExtraBundle#422

Basically, I want to allow specific implementations of this class to add a "smarter" resource. The `FileResource` simply checks if the file was modified. In SensioFWExtraBundle, I want to go further: only mark the cache as stale if some annotations have changed. To do that, I need a way to override the resource for a class.

Pending Issue:
- The `DirectoryResource` is being too smart :). If it detects that any files have been changed, it marks the direction as stale, preventing a smarter file resource.
