### PR TITLE
[Console] Add a RepeatedQuestion

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -40,7 +40,7 @@ class QuestionHelper extends Helper
      * @param OutputInterface $output   An OutputInterface instance
      * @param Question        $question The question to ask
      *
-     * @return string|array|mixed The user answer
+     * @return mixed A string, the default answer or an array for {@link RepeatedQuestion}
      *
      * @throws RuntimeException If there is no data to read in the input stream
      */
@@ -134,7 +134,7 @@ class QuestionHelper extends Helper
      * @param OutputInterface $output
      * @param Question        $question
      *
-     * @return bool|mixed|null|string|array
+     * @return mixed
      *
      * @throws \Exception
      * @throws \RuntimeException
@@ -156,14 +156,6 @@ class QuestionHelper extends Helper
         return $responses;
     }
 
-    /**
-     * Gets the user answer to a question.
-     *
-     * @return bool|mixed|null|string
-     *
-     * @throws \Exception
-     * @throws \RuntimeException
-     */
     private function getResponse(OutputInterface $output, Question $question)
     {
         $this->prependResponse($output, $question);

--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -57,6 +57,8 @@ class QuestionHelper extends Helper
 
             $responses = array();
             $generator = $question->getGenerator();
+            // Will throw an exception if already used
+            $generator->rewind();
             while ($generator->valid()) {
                 $generator->send($question->getDefault());
                 $responses[] = $question->getDefault();
@@ -149,6 +151,8 @@ class QuestionHelper extends Helper
 
         $responses = array();
         $generator = $question->getGenerator();
+        // Will throw an exception if already used
+        $generator->rewind();
         while ($generator->valid()) {
             $generator->send($responses[] = $this->getResponse($output, $question));
         }
@@ -200,9 +204,6 @@ class QuestionHelper extends Helper
      */
     protected function prependResponse(OutputInterface $output, Question $question)
     {
-        if ($question instanceof RepeatedQuestion) {
-            $output->writeLn('');
-        }
     }
 
     /**

--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -56,8 +56,9 @@ class QuestionHelper extends Helper
             }
 
             $responses = array();
-            while ($question->shouldContinue()) {
-                $question->addAnswer($question->getDefault());
+            $generator = $question->getGenerator();
+            while ($generator->valid()) {
+                $generator->send($question->getDefault());
                 $responses[] = $question->getDefault();
             }
 
@@ -147,9 +148,9 @@ class QuestionHelper extends Helper
         }
 
         $responses = array();
-        while ($question->shouldContinue()) {
-            $responses[] = $response = $this->getResponse($output, $question);
-            $question->addAnswer($response);
+        $generator = $question->getGenerator();
+        while ($generator->valid()) {
+            $generator->send($responses[] = $this->getResponse($output, $question));
         }
 
         return $responses;

--- a/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Question\RepeatedQuestion;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
@@ -31,6 +32,12 @@ class SymfonyQuestionHelper extends QuestionHelper
      */
     public function ask(InputInterface $input, OutputInterface $output, Question $question)
     {
+        // The RepeatedQuestion should be stoppable
+        // by sending an empty value
+        if ($question instanceof RepeatedQuestion) {
+            return parent::ask($input, $output, $question);
+        }
+
         $validator = $question->getValidator();
         $question->setValidator(function ($value) use ($validator) {
             if (null !== $validator) {
@@ -57,7 +64,8 @@ class SymfonyQuestionHelper extends QuestionHelper
         $default = $question->getDefault();
 
         switch (true) {
-            case null === $default:
+            // RepeatedQuestion is managed in prependResponse
+            case null === $default || $question instanceof RepeatedQuestion:
                 $text = sprintf(' <info>%s</info>:', $text);
 
                 break;
@@ -89,16 +97,27 @@ class SymfonyQuestionHelper extends QuestionHelper
                 $text = sprintf(' <info>%s</info> [<comment>%s</comment>]:', $text, $default);
         }
 
-        $output->writeln($text);
+        $output->write($text);
 
         if ($question instanceof ChoiceQuestion) {
             $width = max(array_map('strlen', array_keys($question->getChoices())));
 
             foreach ($question->getChoices() as $key => $value) {
-                $output->writeln(sprintf("  [<comment>%-${width}s</comment>] %s", $key, $value));
+                $output->writeLn('');
+                $output->write(sprintf("  [<comment>%-${width}s</comment>] %s", $key, $value));
             }
         }
+    }
 
+    /**
+     * Prepends the user response.
+     */
+    protected function prependResponse(OutputInterface $output, Question $question)
+    {
+        $output->writeLn('');
+        if ($question instanceof RepeatedQuestion && null !== $question->getDefault()) {
+            $output->write(sprintf(' [<comment>%s</comment>]', $question->getDefault()));
+        }
         $output->write(' > ');
     }
 

--- a/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
@@ -110,7 +110,7 @@ class SymfonyQuestionHelper extends QuestionHelper
     }
 
     /**
-     * Prepends the user response.
+     * {@inheritdoc}
      */
     protected function prependResponse(OutputInterface $output, Question $question)
     {

--- a/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
@@ -97,14 +97,13 @@ class SymfonyQuestionHelper extends QuestionHelper
                 $text = sprintf(' <info>%s</info> [<comment>%s</comment>]:', $text, $default);
         }
 
-        $output->write($text);
+        $output->writeLn($text);
 
         if ($question instanceof ChoiceQuestion) {
             $width = max(array_map('strlen', array_keys($question->getChoices())));
 
             foreach ($question->getChoices() as $key => $value) {
-                $output->writeLn('');
-                $output->write(sprintf("  [<comment>%-${width}s</comment>] %s", $key, $value));
+                $output->writeLn(sprintf("  [<comment>%-${width}s</comment>] %s", $key, $value));
             }
         }
     }
@@ -114,7 +113,6 @@ class SymfonyQuestionHelper extends QuestionHelper
      */
     protected function prependResponse(OutputInterface $output, Question $question)
     {
-        $output->writeLn('');
         if ($question instanceof RepeatedQuestion && null !== $question->getDefault()) {
             $output->write(sprintf(' [<comment>%s</comment>]', $question->getDefault()));
         }

--- a/src/Symfony/Component/Console/Question/RepeatedQuestion.php
+++ b/src/Symfony/Component/Console/Question/RepeatedQuestion.php
@@ -34,22 +34,13 @@ final class RepeatedQuestion extends Question
     }
 
     /**
-     * Pass the last answer to the generator and set the
-     * generator pointer on the next question.
-     */
-    public function addAnswer($answer)
-    {
-        $this->generator->send($answer);
-    }
-
-    /**
-     * Checks whether the generator contains other questions.
+     * Returns the question generator.
      *
-     * @return bool
+     * @return \Generator
      */
-    public function shouldContinue()
+    public function getGenerator()
     {
-        return $this->generator->valid();
+        return $this->generator;
     }
 
     /**

--- a/src/Symfony/Component/Console/Question/RepeatedQuestion.php
+++ b/src/Symfony/Component/Console/Question/RepeatedQuestion.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Question;
+
+/**
+ * Represents a repeated Question.
+ *
+ * @author Guilhem N. <egetick@gmail.com>
+ */
+final class RepeatedQuestion extends Question
+{
+    private $generator;
+
+    public function __construct($question, \Generator $generator = null)
+    {
+        parent::__construct($question);
+        if (null === $generator) {
+            $generator = call_user_func(function () {
+                do {
+                    $answer = yield;
+                } while (null !== $answer);
+            });
+        }
+        $this->generator = $generator;
+    }
+
+    /**
+     * Pass the last answer to the generator and set the
+     * generator pointer on the next question.
+     */
+    public function addAnswer($answer)
+    {
+        $this->generator->send($answer);
+    }
+
+    /**
+     * Checks whether the generator contains other questions.
+     *
+     * @return bool
+     */
+    public function shouldContinue()
+    {
+        return $this->generator->valid();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefault()
+    {
+        return $this->generator->current();
+    }
+}

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -288,7 +288,7 @@ class SymfonyStyle extends OutputStyle
     /**
      * @param Question $question
      *
-     * @return string|array|mixed
+     * @return mixed see {@link SymfonyQuestionHelper::ask()}
      */
     public function askQuestion(Question $question)
     {

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -288,7 +288,7 @@ class SymfonyStyle extends OutputStyle
     /**
      * @param Question $question
      *
-     * @return string
+     * @return string|array|mixed
      */
     public function askQuestion(Question $question)
     {

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/interactive_command_1.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/interactive_command_1.php
@@ -3,17 +3,25 @@
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Question\RepeatedQuestion;
 
 //Ensure that questions have the expected outputs
 return function (InputInterface $input, OutputInterface $output) {
     $output = new SymfonyStyle($input, $output);
     $stream = fopen('php://memory', 'r+', false);
 
-    fputs($stream, "Foo\nBar\nBaz");
+    fputs($stream, "Foo\nBar\nBaz\nAwesome!\nThat's a nice place\n\n");
     rewind($stream);
     $input->setStream($stream);
 
     $output->ask('What\'s your name?');
     $output->ask('How are you?');
     $output->ask('Where do you come from?');
+
+    $question = new RepeatedQuestion('Do you have any comment?', call_user_func(function () {
+        do {
+            $answer = (yield 'default');
+        } while ('default' !== $answer);
+    }));
+    $output->askQuestion($question);
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/interactive_output_1.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/interactive_output_1.txt
@@ -6,6 +6,4 @@
  Where do you come from?:
  > 
  Do you have any comment?:
- [default] > 
- [default] > 
- [default] > 
+ [default] >  [default] >  [default] > 

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/interactive_output_1.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/interactive_output_1.txt
@@ -5,3 +5,7 @@
  > 
  Where do you come from?:
  > 
+ Do you have any comment?:
+ [default] > 
+ [default] > 
+ [default] > 

--- a/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
@@ -31,7 +31,8 @@ class SymfonyQuestionHelperTest extends AbstractQuestionHelperTest
         $inputStream = $this->getInputStream("\nSwimming\n\nClimbing\n\n");
         $this->assertEquals(array('Badminton', 'Swimming', 'Football', 'Climbing', null), $questionHelper->ask($this->createStreamableInputInterfaceMock($inputStream), $output = $this->createOutputInterface(), $question));
 
-        $this->assertOutputContains(str_replace("\n", PHP_EOL, " What are your hobbies?:\n [Badminton] > \n [Basket] > \n [Football] > \n > \n > "), $output);
+        $this->assertOutputContains(' What are your hobbies?:', $output);
+        $this->assertOutputContains(' [Badminton] >  [Basket] >  [Football] >  >  > ', $output);
     }
 
     public function testAskChoice()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/issues/19678 |
| License | MIT |
| Doc PR |  |

> Actually when I want to ask several times the same question with `SymfonyStyle` i have a very verbose output:
> 
> ``` console
> What do you want? [default]:
> > foo
> 
> What do you want? [default]:
> > bar
> 
> What do you want? [default]:
> >
> 
> ```
> 
> I propose to introduce a `RepeatedQuestion`. It could be implemented like that:
> 
> ``` php
> class RepeatedQuestion extends Question
> {
>     private $generator;
> 
>     public function __construct($question, \Generator $generator)
>     {
>         parent::__construct($question);
>         $this->generator = $generator;
>     }
> 
>     public function addAnswer($answer)
>     {
>          $this->generator->send($answer);
>     }
> 
>     public function shouldContinue(): bool
>     {
>         return $this->generator->valid();
>     }
> 
>     public function getDefault()
>     {
>         return $this->generator->current();
>     }
> }
> ```
> 
> It would be used like that:
> 
> ``` php
> $question = new RepeatedQuestion(call_user_func(function() use ($default) {
>     do {
>         $answer = yield $default;
>     } while ($answer !== $default);
> }));
> foreach ($helper->askQuestion($question) as $answer) {
>     // do what you want
> }
> ```
> 
> And the command output would be:
> 
> ``` console
> What do you want?
> [default] > foo
> [default] > bar
> [default] >
> ```
> 
> WDYT?
