### PR TITLE
[Debug][HttpKernel][VarDumper] Prepare for committed 7.2 changes (aka "small-bc-breaks")

### DIFF
--- a/src/Symfony/Component/Debug/Exception/FlattenException.php
+++ b/src/Symfony/Component/Debug/Exception/FlattenException.php
@@ -263,7 +263,10 @@ class FlattenException extends LegacyFlattenException
             if (++$count > 1e4) {
                 return array('array', '*SKIPPED over 10000 entries*');
             }
-            if (is_object($value)) {
+            if ($value instanceof \__PHP_Incomplete_Class) {
+                // is_object() returns false on PHP<=7.1
+                $result[$key] = array('incomplete-object', $this->getClassNameFromIncomplete($value));
+            } elseif (is_object($value)) {
                 $result[$key] = array('object', get_class($value));
             } elseif (is_array($value)) {
                 if ($level > 10) {
@@ -277,9 +280,6 @@ class FlattenException extends LegacyFlattenException
                 $result[$key] = array('boolean', $value);
             } elseif (is_resource($value)) {
                 $result[$key] = array('resource', get_resource_type($value));
-            } elseif ($value instanceof \__PHP_Incomplete_Class) {
-                // Special case of object, is_object will return false
-                $result[$key] = array('incomplete-object', $this->getClassNameFromIncomplete($value));
             } else {
                 $result[$key] = array('string', (string) $value);
             }

--- a/src/Symfony/Component/HttpKernel/DataCollector/Util/ValueExporter.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/Util/ValueExporter.php
@@ -27,16 +27,16 @@ class ValueExporter
      */
     public function exportValue($value, $depth = 1, $deep = false)
     {
+        if ($value instanceof \__PHP_Incomplete_Class) {
+            return sprintf('__PHP_Incomplete_Class(%s)', $this->getClassNameFromIncomplete($value));
+        }
+
         if (is_object($value)) {
             if ($value instanceof \DateTime || $value instanceof \DateTimeInterface) {
                 return sprintf('Object(%s) - %s', get_class($value), $value->format(\DateTime::ISO8601));
             }
 
             return sprintf('Object(%s)', get_class($value));
-        }
-
-        if ($value instanceof \__PHP_Incomplete_Class) {
-            return sprintf('__PHP_Incomplete_Class(%s)', $this->getClassNameFromIncomplete($value));
         }
 
         if (is_array($value)) {

--- a/src/Symfony/Component/VarDumper/Caster/CutStub.php
+++ b/src/Symfony/Component/VarDumper/Caster/CutStub.php
@@ -39,9 +39,12 @@ class CutStub extends Stub
 
             case 'resource':
             case 'unknown type':
+            case 'resource (closed)':
                 $this->type = self::TYPE_RESOURCE;
                 $this->handle = (int) $value;
-                $this->class = @get_resource_type($value);
+                if ('Unknown' === $this->class = @get_resource_type($value)) {
+                    $this->class = 'Closed';
+                }
                 $this->cut = -1;
                 break;
 

--- a/src/Symfony/Component/VarDumper/Cloner/VarCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/VarCloner.php
@@ -183,10 +183,13 @@ class VarCloner extends AbstractCloner
 
                     case 'resource':
                     case 'unknown type':
+                    case 'resource (closed)':
                         if (empty($resRefs[$h = (int) $v])) {
                             $stub = new Stub();
                             $stub->type = Stub::TYPE_RESOURCE;
-                            $stub->class = $zval['resource_type'] ?: get_resource_type($v);
+                            if ('Unknown' === $stub->class = $zval['resource_type'] ?: @get_resource_type($v)) {
+                                $stub->class = 'Closed';
+                            }
                             $stub->value = $v;
                             $stub->handle = $h;
                             $a = $this->castResource($stub, 0 < $i);

--- a/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
@@ -193,7 +193,7 @@ EOTXT
 
         $this->assertStringMatchesFormat(
             <<<EOTXT
-Unknown resource @{$res}
+Closed resource @{$res}
 
 EOTXT
             ,


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| Tests pass? | yes |
| License | MIT |

On PHP 7.2:
- `is_object()` is going to return `true` for `__PHP_Incomplete_Class` instances
- `gettype($closed_resource);` returns "resource (closed)"

ping @nikic FYI
see https://travis-ci.org/symfony/symfony/jobs/154114269 for fixed tests (except the one on ClassLoader which is a BC break on 7.1 that should be fixed there IMHO).
