### PR TITLE
[DX] Changed visibility of findTemplatesInFolder to protected

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/TemplateFinder.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/TemplateFinder.php
@@ -71,7 +71,7 @@ class TemplateFinder implements TemplateFinderInterface
      *
      * @return TemplateReferenceInterface[]
      */
-    private function findTemplatesInFolder($dir)
+    protected function findTemplatesInFolder($dir)
     {
         $templates = array();
 

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/TemplateFinder.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/TemplateFinder.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Templating\TemplateNameParserInterface;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Symfony\Component\Templating\TemplateReferenceInterface;
 
 /**
  * Finds all the templates.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Changed visibility of `findTemplatesInFolder` to protected for better DX in other bundles (avoid copy-paste), like: LiipThemeBundle

Example: https://github.com/liip/LiipThemeBundle/pull/151/files#diff-c4dd8b4440b3cfe222e47a98ea403b13R121
