### PR TITLE
[VarDumper] Handle "title" attribute on virtual properties

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
@@ -89,6 +89,7 @@ class ExceptionCaster
         $stub->handle = 0;
         $frames = $trace->value;
         $prefix = Caster::PREFIX_VIRTUAL;
+        $format = "\0~Stack level %s.\0%s";
 
         $a = array();
         $j = count($frames);
@@ -124,7 +125,7 @@ class ExceptionCaster
                     $frame->value['args'] = $f[$prefix.'args'];
                 }
             }
-            $a[$prefix.$j.'. '.$label] = $frame;
+            $a[sprintf($format, $j, $label)] = $frame;
 
             $lastCall = ' ==> '.$call;
         }

--- a/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
@@ -342,13 +342,16 @@ class CliDumper extends AbstractDumper
                     } elseif (0 < strpos($key, "\0", 1)) {
                         $key = explode("\0", substr($key, 1), 2);
 
-                        switch ($key[0]) {
+                        switch ($key[0][0]) {
                             case '+': // User inserted keys
                                 $attr['dynamic'] = true;
                                 $this->line .= '+'.$bin.'"'.$this->style('public', $key[1], $attr).'": ';
                                 break 2;
                             case '~':
                                 $style = 'meta';
+                                if (isset($key[0][1])) {
+                                    $attr['title'] = substr($key[0], 1);
+                                }
                                 break;
                             case '*':
                                 $style = 'protected';

--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -445,6 +445,8 @@ EOHTML
             return sprintf('<abbr title="%s" class=sf-dump-%s>%s</abbr>', $v, $style, substr($v, $c + 1));
         } elseif ('protected' === $style) {
             $style .= ' title="Protected property"';
+        } elseif ('meta' === $style && isset($attr['title'])) {
+            $style .= sprintf(' title="%s"', htmlspecialchars($attr['title'], ENT_QUOTES, 'UTF-8'));
         } elseif ('private' === $style) {
             $style .= sprintf(' title="Private property defined in class:&#10;`%s`"', $attr['class']);
         }

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
@@ -177,17 +177,17 @@ array:2 [
   0 => ReflectionGenerator {
     this: Symfony\Component\VarDumper\Tests\Fixtures\GeneratorDemo { …}
     trace: {
-      3. %sGeneratorDemo.php:9: {
+      %sGeneratorDemo.php:9: {
          8: {
          9:     yield 1;
         10: }
       }
-      2. %sGeneratorDemo.php:20: {
+      %sGeneratorDemo.php:20: {
         19: {
         20:     yield from GeneratorDemo::foo();
         21: }
       }
-      1. %sGeneratorDemo.php:14: {
+      %sGeneratorDemo.php:14: {
         13: {
         14:     yield from bar();
         15: }

--- a/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
@@ -288,23 +288,23 @@ stream resource {@{$ref}
   ⚠: Symfony\Component\VarDumper\Exception\ThrowingCasterException {{$r}
     #message: "Unexpected Exception thrown from a caster: Foobar"
     -trace: {
-      %d. {$twig}
-      %d. %sTemplate.php:%d: {
+      {$twig}
+      %sTemplate.php:%d: {
         %d: try {
         %d:     \$this->doDisplay(\$context, \$blocks);
         %d: } catch (Twig_Error \$e) {
       }
-      %d. %sTemplate.php:%d: {
+      %sTemplate.php:%d: {
         %d: {
         %d:     \$this->displayWithErrorHandling(\$this->env->mergeGlobals(\$context), array_merge(\$this->blocks, \$blocks));
         %d: }
       }
-      %d. %sTemplate.php:%d: {
+      %sTemplate.php:%d: {
         %d: try {
         %d:     \$this->display(\$context);
         %d: } catch (Exception \$e) {
       }
-      %d. %sCliDumperTest.php:{$line}: {
+      %sCliDumperTest.php:{$line}: {
         %d:         }
         {$line}:     };'),
         %d: ));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| New feature? | yes |
| Tests pass? | yes |
| License | MIT |

As seen with @wouterj , it would be better to _not_ display the stack level in front of each stack line.
This PR does just that, and moves the stack level to a title attribute in HtmlDumper.

![capture du 2016-08-23 14-09-43](https://cloud.githubusercontent.com/assets/243674/17891395/cc40b088-693b-11e6-8523-89ff51be929a.png)
