### PR TITLE
[FrameworkBundle] Remove TranslatorBagInterface check

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/LoggingTranslatorPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/LoggingTranslatorPass.php
@@ -26,11 +26,6 @@ class LoggingTranslatorPass implements CompilerPassInterface
             return;
         }
 
-        // skip if the symfony/translation version is lower than 2.6
-        if (!interface_exists('Symfony\Component\Translation\TranslatorBagInterface')) {
-            return;
-        }
-
         if ($container->hasParameter('translator.logging') && $container->getParameter('translator.logging')) {
             $translatorAlias = $container->getAlias('translator');
             $definition = $container->getDefinition((string) $translatorAlias);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This check is not needed anymore since the existence of TranslatorBagInterface should be guaranteed now.
