### PR TITLE
[DoctrineBridge] Enhance exception message in EntityUserProvider

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
@@ -51,7 +51,7 @@ class EntityUserProvider implements UserProviderInterface
             $user = $repository->findOneBy(array($this->property => $username));
         } else {
             if (!$repository instanceof UserProviderInterface) {
-                throw new \InvalidArgumentException(sprintf('The Doctrine repository "%s" must implement UserProviderInterface.', get_class($repository)));
+                throw new \InvalidArgumentException(sprintf('You must either make the "%s" entity Doctrine Repository ("%s") implement "Symfony\Component\Security\Core\User\UserProviderInterface" or set the "property" option in the corresponding entity provider configuration.', $this->classOrAlias, get_class($repository)));
             }
 
             $user = $repository->loadUserByUsername($username);

--- a/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
@@ -38,6 +38,65 @@ class EntityUserProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($user1, $provider->refreshUser($user1));
     }
 
+    public function testLoadUserByUsername()
+    {
+        $em = DoctrineTestHelper::createTestEntityManager();
+        $this->createSchema($em);
+
+        $user = new User(1, 1, 'user1');
+
+        $em->persist($user);
+        $em->flush();
+
+        $provider = new EntityUserProvider($this->getManager($em), 'Symfony\Bridge\Doctrine\Tests\Fixtures\User', 'name');
+
+        $this->assertSame($user, $provider->loadUserByUsername('user1'));
+    }
+
+    public function testLoadUserByUsernameWithUserProviderRepositoryAndWithoutProperty()
+    {
+        $user = new User(1, 1, 'user1');
+
+        $repository = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserProviderInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $repository
+            ->expects($this->once())
+            ->method('loadUserByUsername')
+            ->with('user1')
+            ->willReturn($user);
+
+        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $em
+            ->expects($this->once())
+            ->method('getRepository')
+            ->with('Symfony\Bridge\Doctrine\Tests\Fixtures\User')
+            ->willReturn($repository);
+
+        $provider = new EntityUserProvider($this->getManager($em), 'Symfony\Bridge\Doctrine\Tests\Fixtures\User');
+        $this->assertSame($user, $provider->loadUserByUsername('user1'));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage You must either make the "Symfony\Bridge\Doctrine\Tests\Fixtures\User" entity Doctrine Repository ("Doctrine\ORM\EntityRepository") implement "Symfony\Component\Security\Core\User\UserProviderInterface" or set the "property" option in the corresponding entity provider configuration.
+     */
+    public function testLoadUserByUsernameWithNonUserProviderRepositoryAndWithoutProperty()
+    {
+        $em = DoctrineTestHelper::createTestEntityManager();
+        $this->createSchema($em);
+
+        $user = new User(1, 1, 'user1');
+
+        $em->persist($user);
+        $em->flush();
+
+        $provider = new EntityUserProvider($this->getManager($em), 'Symfony\Bridge\Doctrine\Tests\Fixtures\User');
+        $provider->loadUserByUsername('user1');
+    }
+
     public function testRefreshUserRequiresId()
     {
         $em = DoctrineTestHelper::createTestEntityManager();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Lots of people use the `UserEntityProvider` without having a custom Repository for the user entity configured on the entity provider and in this case, if the `property` key of the provider isn't set, the exception thrown says:

> The Doctrine repository "Doctrine\ORM\EntityRepository" must implement Symfony\Bridge\Doctrine\Security\User\UserLoaderInterface

"Doctrine\ORM\EntityRepository" doesn't feel relevant. 
Plus, we can't guess that the exception is thrown first because there is no `property` configured on the corresponding provider, that is useful to have in the trace IMHO.

If accepted, `"Symfony\Component\Security\Core\User\UserProviderInterface"` will need to be replaced by `"Symfony\Bridge\Doctrine\Security\User\UserLoaderInterface"` when merging in newer branches.
