### PR TITLE
[ExpressionLanguage] Move the ::dump method to the Node classe to ease its usage

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Node/Node.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/Node.php
@@ -81,6 +81,17 @@ class Node
         throw new \BadMethodCallException(sprintf('Dumping a "%s" instance is not supported yet.', get_class($this)));
     }
 
+    public function dump()
+    {
+        $dump = '';
+
+        foreach ($this->toArray() as $v) {
+            $dump .= is_scalar($v) ? $v : $v->dump();
+        }
+
+        return $dump;
+    }
+
     protected function dumpString($value)
     {
         return sprintf('"%s"', addcslashes($value, "\0\t\"\\"));

--- a/src/Symfony/Component/ExpressionLanguage/ParsedExpression.php
+++ b/src/Symfony/Component/ExpressionLanguage/ParsedExpression.php
@@ -39,20 +39,4 @@ class ParsedExpression extends Expression
     {
         return $this->nodes;
     }
-
-    public function dump()
-    {
-        return $this->dumpNode($this->nodes);
-    }
-
-    private function dumpNode(Node $node)
-    {
-        $dump = '';
-
-        foreach ($node->toArray() as $v) {
-            $dump .= is_scalar($v) ? $v : $this->dumpNode($v);
-        }
-
-        return $dump;
-    }
 }

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/AbstractNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/AbstractNodeTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\ExpressionLanguage\Tests\Node;
 
 use Symfony\Component\ExpressionLanguage\Compiler;
-use Symfony\Component\ExpressionLanguage\ParsedExpression;
 
 abstract class AbstractNodeTest extends \PHPUnit_Framework_TestCase
 {
@@ -43,8 +42,7 @@ abstract class AbstractNodeTest extends \PHPUnit_Framework_TestCase
      */
     public function testDump($expected, $node)
     {
-        $expr = new ParsedExpression($expected, $node);
-        $this->assertSame($expected, $expr->dump());
+        $this->assertSame($expected, $node->dump());
     }
 
     abstract public function getDumpData();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Example (for @nicolas-grekas :trollface: )

``` php
<?php

require __DIR__.'/vendor/autoload.php';

use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
use Symfony\Component\ExpressionLanguage\Node\NameNode;

$el = new ExpressionLanguage();

$expression = $el->parse('a + b + 12', ['a','b']);

function dump_with_highlight($node)
{
    $dump = '';

    foreach ($node->toArray() as $v) {
        if (is_scalar($v)) {
            $dump .= $v;
        } elseif ($v instanceof NameNode) {
            $dump .= sprintf('`%s`', dump_with_highlight($v));
        } else {
            $dump .= dump_with_highlight($v);
        }
    }

    return $dump;
}

echo dump_with_highlight($expression->getNodes());
```

Result:

```
((<strong>a</strong> + <strong>b</strong>) + 12)
```
