### PR TITLE
[Console] Register terminal env variables

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -104,6 +104,9 @@ class Application
      */
     public function run(InputInterface $input = null, OutputInterface $output = null)
     {
+        putenv('LINES='.$this->terminal->getHeight());
+        putenv('COLUMNS='.$this->terminal->getWidth());
+
         if (null === $input) {
             $input = new ArgvInput();
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #19719 |
| License | MIT |
| Doc PR | - |

Solves #19719 by setting `COLUMNS` & `LINES` env vars when running an Application.
Those env vars are then meant to be reused when using the Process component.

~~It creates a new `Terminal::registerEnv()` method allowing to register terminal related informations into environment variables.~~ ~~It allows getting "consistent terminal informations" across processes.~~

Unless the env vars handling is backported from the 3.2 `Terminal` class to older branches in the `Application` class, the mentioned issue can't be solved this way.
