### PR TITLE
[Security] $attributes can be anything, but RoleVoter assumes strings

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/Voter/RoleVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/RoleVoter.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Core\Authorization\Voter;
 
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Role\RoleInterface;
 
 /**
  * RoleVoter votes if any attribute starts with a given prefix.
@@ -37,7 +38,7 @@ class RoleVoter implements VoterInterface
      */
     public function supportsAttribute($attribute)
     {
-        return 0 === strpos($attribute, $this->prefix);
+        return is_string($attribute) && 0 === strpos($attribute, $this->prefix);
     }
 
     /**
@@ -57,6 +58,10 @@ class RoleVoter implements VoterInterface
         $roles = $this->extractRoles($token);
 
         foreach ($attributes as $attribute) {
+            if ($attribute instanceof RoleInterface) {
+                $attribute = $attribute->getRole();
+            }
+
             if (!$this->supportsAttribute($attribute)) {
                 continue;
             }

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/RoleVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/RoleVoterTest.php
@@ -43,6 +43,12 @@ class RoleVoterTest extends \PHPUnit_Framework_TestCase
             array(array('ROLE_FOO'), array('ROLE_FOO'), VoterInterface::ACCESS_GRANTED),
             array(array('ROLE_FOO'), array('FOO', 'ROLE_FOO'), VoterInterface::ACCESS_GRANTED),
             array(array('ROLE_BAR', 'ROLE_FOO'), array('ROLE_FOO'), VoterInterface::ACCESS_GRANTED),
+
+            // Test mixed Types
+            array(array(), array(array()), VoterInterface::ACCESS_ABSTAIN),
+            array(array(), array(new \stdClass()), VoterInterface::ACCESS_ABSTAIN),
+            array(array('ROLE_BAR'), array(new Role('ROLE_BAR')), VoterInterface::ACCESS_GRANTED),
+            array(array('ROLE_BAR'), array(new Role('ROLE_FOO')), VoterInterface::ACCESS_DENIED),
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18042 |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |
