### PR TITLE
[HttpFoundation] Add support for DateTimeImmutable in setters

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -626,12 +626,13 @@ class Response
     /**
      * Sets the Date header.
      *
-     * @param \DateTime $date A \DateTime instance
+     * @param \DateTimeInterface $date A \DateTimeInterface instance
      *
      * @return Response
      */
-    public function setDate(\DateTime $date)
+    public function setDate(\DateTimeInterface $date)
     {
+        $date = \DateTime::createFromFormat(\DateTime::ISO8601, $date->format(\DateTime::ISO8601));
         $date->setTimezone(new \DateTimeZone('UTC'));
         $this->headers->set('Date', $date->format('D, d M Y H:i:s').' GMT');
 
@@ -686,16 +687,16 @@ class Response
      *
      * Passing null as value will remove the header.
      *
-     * @param \DateTime|null $date A \DateTime instance or null to remove the header
+     * @param \DateTimeInterface|null $date A \DateTimeInterface instance or null to remove the header
      *
      * @return Response
      */
-    public function setExpires(\DateTime $date = null)
+    public function setExpires(\DateTimeInterface $date = null)
     {
         if (null === $date) {
             $this->headers->remove('Expires');
         } else {
-            $date = clone $date;
+            $date = \DateTime::createFromFormat(\DateTime::ISO8601, $date->format(\DateTime::ISO8601));
             $date->setTimezone(new \DateTimeZone('UTC'));
             $this->headers->set('Expires', $date->format('D, d M Y H:i:s').' GMT');
         }
@@ -826,16 +827,16 @@ class Response
      *
      * Passing null as value will remove the header.
      *
-     * @param \DateTime|null $date A \DateTime instance or null to remove the header
+     * @param \DateTimeInterface|null $date A \DateTimeInterface instance or null to remove the header
      *
      * @return Response
      */
-    public function setLastModified(\DateTime $date = null)
+    public function setLastModified(\DateTimeInterface $date = null)
     {
         if (null === $date) {
             $this->headers->remove('Last-Modified');
         } else {
-            $date = clone $date;
+            $date = \DateTime::createFromFormat(\DateTime::ISO8601, $date->format(\DateTime::ISO8601));
             $date->setTimezone(new \DateTimeZone('UTC'));
             $this->headers->set('Last-Modified', $date->format('D, d M Y H:i:s').' GMT');
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

Backwards compatibility is assured by typehinting for DateTimeInterface, and converting to \DateTime for onward use

This is my first PR for Symfony, so please let me know if I've done something not quite right.
