### PR TITLE
Fix EntityType->empty_data=null

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/DoctrineChoiceLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/DoctrineChoiceLoader.php
@@ -146,7 +146,7 @@ class DoctrineChoiceLoader implements ChoiceLoaderInterface
         // this was tested on, no exception was thrown for such invalid
         // statements, consequently no test fails when this code is removed.
         // https://github.com/symfony/symfony/pull/8981#issuecomment-24230557
-        if (empty($values)) {
+        if (empty($values) || $values === array('')) {
             return array();
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| License | MIT |

Symfony 3.1, Doctine 2.5, PHP 7, SQL Server

With :

```
$builder
            ->add('users', EntityType::class, array(
                'label' => 'Users',
                'class' => 'AppBundle\Entity\Users',
                'choice_label' => 'name',
                'query_builder' => function (EntityRepository $er) {
                    return $er->createQueryBuilder('u')
                        ->orderBy('u.name', 'ASC');
                },
                'empty_data'  => null,
                'required' => false
            ))
```

I got an error : 
SQLSTATE [42000, 8114]: [Microsoft][ODBC Driver 13 for SQL Server][SQL Server]Eror converting nvarchar datatype to numeric.
