### PR TITLE
[HttpFoundation] Deprecate extending some methods

### DIFF
--- a/UPGRADE-3.2.md
+++ b/UPGRADE-3.2.md
@@ -41,6 +41,29 @@ FrameworkBundle
   * The service `serializer.mapping.cache.doctrine.apc` is deprecated. APCu should now
     be automatically used when available.
 
+HttpFoundation
+---------------
+
+  * Extending the following methods of `Response`
+    is deprecated (these methods will be `final` in 4.0):
+
+     - `setDate`/`getDate`
+     - `setExpires`/`getExpires`
+     - `setLastModified`/`getLastModified`
+     - `setProtocolVersion`/`getProtocolVersion`
+     - `setStatusCode`/`getStatusCode`
+     - `setCharset`/`getCharset`
+     - `setPrivate`/`setPublic`
+     - `getAge`
+     - `getMaxAge`/`setMaxAge`
+     - `setSharedMaxAge`
+     - `getTtl`/`setTtl`
+     - `setClientTtl`
+     - `getEtag`/`setEtag`
+     - `hasVary`/`getVary`/`setVary`
+     - `isInvalid`/`isSuccessful`/`isRedirection`/`isClientError`/`isServerError`
+     - `isOk`/`isForbidden`/`isNotFound`/`isRedirect`/`isEmpty`
+
 Validator
 ---------
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -121,6 +121,29 @@ FrameworkBundle
  * The `Controller::getUser()` method has been removed in favor of the ability
    to typehint the security user object in the action.
 
+HttpFoundation
+---------------
+
+ * Extending the following methods of `Response`
+   is no longer possible (these methods are now `final`):
+
+    - `setDate`/`getDate`
+    - `setExpires`/`getExpires`
+    - `setLastModified`/`getLastModified`
+    - `setProtocolVersion`/`getProtocolVersion`
+    - `setStatusCode`/`getStatusCode`
+    - `setCharset`/`getCharset`
+    - `setPrivate`/`setPublic`
+    - `getAge`
+    - `getMaxAge`/`setMaxAge`
+    - `setSharedMaxAge`
+    - `getTtl`/`setTtl`
+    - `setClientTtl`
+    - `getEtag`/`setEtag`
+    - `hasVary`/`getVary`/`setVary`
+    - `isInvalid`/`isSuccessful`/`isRedirection`/`isClientError`/`isServerError`
+    - `isOk`/`isForbidden`/`isNotFound`/`isRedirect`/`isEmpty`
+
 HttpKernel
 ----------
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/pull/19727 |
| License | MIT |
| Doc PR |  |

It's really hard to change methods signature because of bc. I'm proposing to deprecate extending some getters/setters of `Response` because of this (and because extending them is not really useful).
If you like this approach it could be used in other places to simplify bc in 4.0.

Edit: This causes issues (warnings always triggered) when mocking `Response` entirely but does it matter as people should only mock needed methods?
