### PR TITLE
Fix BinaryFileResponse sending wrong Content-Length header for files modified by stream wrappers/filters

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -133,4 +133,18 @@ class File extends \SplFileInfo
 
         return $originalName;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSize()
+    {
+        // Since stream wrappers and stream filters can change the file contents as read, the only
+        // reliable way to get the effective size of the file is to actually read it.
+        ob_start();
+        $size = readfile($this->getPathname());
+        ob_end_clean();
+
+        return $size;
+    }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/File/FileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/FileTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\HttpFoundation\Tests\File;
 
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser;
+use Symfony\Component\HttpFoundation\File\Tests\Fixtures\PaddingStreamWrapper;
 
 class FileTest extends \PHPUnit_Framework_TestCase
 {
@@ -26,6 +27,21 @@ class FileTest extends \PHPUnit_Framework_TestCase
         MimeTypeGuesser::getInstance()->register($guesser);
 
         $this->assertEquals('image/gif', $file->getMimeType());
+    }
+
+    public function testGetSizeWithStreamFilter()
+    {
+        // @todo Where should these fixture classes go so this isn't necessary?
+        require_once 'Fixtures/PaddingStreamWrapper.php';
+        require_once 'Fixtures/PaddingStreamFilter.php';
+
+        stream_wrapper_register('pad', '\Symfony\Component\HttpFoundation\File\Tests\Fixtures\PaddingStreamWrapper');
+        $path = 'pad://test';
+
+        $filtered_contents = file_get_contents($path);
+        $file = new File($path);
+
+        $this->assertEquals(strlen($filtered_contents), $file->getSize());
     }
 
     public function testGuessExtensionWithoutGuesser()

--- a/src/Symfony/Component/HttpFoundation/Tests/File/Fixtures/PaddingStreamFilter.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/Fixtures/PaddingStreamFilter.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Component\HttpFoundation\File\Tests\Fixtures;
+
+class PaddingStreamFilter extends \php_user_filter
+{
+    const NAME = 'pad';
+
+    const PADDING = '     ';
+
+    public function filter($in, $out, &$consumed, $closing)
+    {
+        while ($bucket = stream_bucket_make_writeable($in)) {
+            $bucket->data .= self::PADDING;
+            $consumed += $bucket->datalen;
+            stream_bucket_append($out, $bucket);
+        }
+
+        return PSFS_PASS_ON;
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/File/Fixtures/PaddingStreamWrapper.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/Fixtures/PaddingStreamWrapper.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Symfony\Component\HttpFoundation\File\Tests\Fixtures;
+
+class PaddingStreamWrapper
+{
+    protected $file;
+
+    public function stream_open($path, $mode, $options, &$opened_path)
+    {
+        $this->file = fopen('php://temp', 'r+');
+
+        $path_parts = explode('://', $path);
+        $file_contents = end($path_parts);
+        fwrite($this->file, $file_contents);
+        fseek($this->file, 0);
+
+        stream_filter_register(PaddingStreamFilter::NAME, '\Symfony\Component\HttpFoundation\File\Tests\Fixtures\PaddingStreamFilter');
+        stream_filter_append($this->file, PaddingStreamFilter::NAME, STREAM_FILTER_READ);
+
+        return (bool) $this->file;
+    }
+
+    public function stream_read($count)
+    {
+        return fread($this->file, $count);
+    }
+
+    public function stream_write($data)
+    {
+        return fwrite($this->file, $data);
+    }
+
+    public function stream_tell()
+    {
+        return ftell($this->file);
+    }
+
+    public function stream_eof()
+    {
+        return feof($this->file);
+    }
+
+    public function stream_seek($offset, $whence)
+    {
+        return fseek($this->file, $offset, $whence);
+    }
+
+    public function stream_stat()
+    {
+        return fstat($this->file);
+    }
+
+    public function url_stat($path, $flags)
+    {
+        $file = fopen($path, 'r');
+        $stat = fstat($file);
+        fclose($file);
+
+        return $stat;
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes/no |
| Fixed tickets | #19738 |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

I have attempted to follow [the guidelines for submitting a patch](https://symfony.com/doc/current/contributing/code/patches.html), but this is my first attempt to the contribute to the Symfony community, so I welcome feedback. Thanks.
