### PR TITLE
[ExpressionLanguage] Making cache PSR6 compliant

### DIFF
--- a/UPGRADE-3.2.md
+++ b/UPGRADE-3.2.md
@@ -37,6 +37,13 @@ DependencyInjection
  * Calling `get()` on a `ContainerBuilder` instance before compiling the
    container is deprecated and will throw an exception in Symfony 4.0.
 
+ExpressionLanguage
+-------------------
+
+* Passing a `ParserCacheInterface` instance to the `ExpressionLanguage` has been
+  deprecated and will not be supported in Symfony 4.0. You should use the
+  `CacheItemPoolInterface` interface instead.
+
 Form
 ----
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -33,6 +33,13 @@ DependencyInjection
  * Requesting a private service with the `Container::get()` method is no longer
    supported.
 
+ExpressionLanguage
+----------
+
+ * The ability to pass a `ParserCacheInterface` instance to the `ExpressionLanguage`
+   class has been removed. You should use the `CacheItemPoolInterface` interface
+   instead.
+
 Form
 ----
 

--- a/src/Symfony/Bridge/Doctrine/ExpressionLanguage/DoctrineParserCache.php
+++ b/src/Symfony/Bridge/Doctrine/ExpressionLanguage/DoctrineParserCache.php
@@ -11,12 +11,16 @@
 
 namespace Symfony\Bridge\Doctrine\ExpressionLanguage;
 
+@trigger_error('The '.__NAMESPACE__.'\DoctrineParserCache class is deprecated since version 3.2 and will be removed in 4.0. Use the Symfony\Component\Cache\Adapter\DoctrineAdapter class instead.', E_USER_DEPRECATED);
+
 use Doctrine\Common\Cache\Cache;
 use Symfony\Component\ExpressionLanguage\ParsedExpression;
 use Symfony\Component\ExpressionLanguage\ParserCache\ParserCacheInterface;
 
 /**
  * @author Adrien Brault <adrien.brault@gmail.com>
+ *
+ * @deprecated DoctrineParserCache class is deprecated since version 3.2 and will be removed in 4.0. Use the Symfony\Component\Cache\Adapter\DoctrineAdapter class instead.
  */
 class DoctrineParserCache implements ParserCacheInterface
 {

--- a/src/Symfony/Bridge/Doctrine/Tests/ExpressionLanguage/DoctrineParserCacheTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ExpressionLanguage/DoctrineParserCacheTest.php
@@ -13,6 +13,9 @@ namespace Symfony\Bridge\Doctrine\Tests\ExpressionLanguage;
 
 use Symfony\Bridge\Doctrine\ExpressionLanguage\DoctrineParserCache;
 
+/**
+ * @group legacy
+ */
 class DoctrineParserCacheTest extends \PHPUnit_Framework_TestCase
 {
     public function testFetch()

--- a/src/Symfony/Component/ExpressionLanguage/ParserCache/ArrayParserCache.php
+++ b/src/Symfony/Component/ExpressionLanguage/ParserCache/ArrayParserCache.php
@@ -11,10 +11,14 @@
 
 namespace Symfony\Component\ExpressionLanguage\ParserCache;
 
+@trigger_error('The '.__NAMESPACE__.'\ArrayParserCache class is deprecated since version 3.2 and will be removed in 4.0. Use the Symfony\Component\Cache\Adapter\ArrayAdapter class instead.', E_USER_DEPRECATED);
+
 use Symfony\Component\ExpressionLanguage\ParsedExpression;
 
 /**
  * @author Adrien Brault <adrien.brault@gmail.com>
+ *
+ * @deprecated ArrayParserCache class is deprecated since version 3.2 and will be removed in 4.0. Use the Symfony\Component\Cache\Adapter\ArrayAdapter class instead.
  */
 class ArrayParserCache implements ParserCacheInterface
 {

--- a/src/Symfony/Component/ExpressionLanguage/ParserCache/ParserCacheAdapter.php
+++ b/src/Symfony/Component/ExpressionLanguage/ParserCache/ParserCacheAdapter.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ExpressionLanguage\ParserCache;
+
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\CacheItem;
+
+/**
+ * @author Alexandre GESLIN <alexandre@gesl.in>
+ *
+ * @internal This class should be removed in Symfony 4.0.
+ */
+class ParserCacheAdapter implements CacheItemPoolInterface
+{
+    private $pool;
+    private $createCacheItem;
+
+    public function __construct(ParserCacheInterface $pool)
+    {
+        $this->pool = $pool;
+
+        $this->createCacheItem = \Closure::bind(
+            function ($key, $value, $isHit) {
+                $item = new CacheItem();
+                $item->key = $key;
+                $item->value = $value;
+                $item->isHit = $isHit;
+
+                return $item;
+            },
+            null,
+            CacheItem::class
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItem($key)
+    {
+        $value = $this->pool->fetch($key);
+        $f = $this->createCacheItem;
+
+        return $f($key, $value, null !== $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function save(CacheItemInterface $item)
+    {
+        $this->pool->save($item->getKey(), $item->get());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItems(array $keys = array())
+    {
+        throw new \BadMethodCallException('Not implemented');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasItem($key)
+    {
+        throw new \BadMethodCallException('Not implemented');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clear()
+    {
+        throw new \BadMethodCallException('Not implemented');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteItem($key)
+    {
+        throw new \BadMethodCallException('Not implemented');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteItems(array $keys)
+    {
+        throw new \BadMethodCallException('Not implemented');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function saveDeferred(CacheItemInterface $item)
+    {
+        throw new \BadMethodCallException('Not implemented');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function commit()
+    {
+        throw new \BadMethodCallException('Not implemented');
+    }
+}

--- a/src/Symfony/Component/ExpressionLanguage/ParserCache/ParserCacheInterface.php
+++ b/src/Symfony/Component/ExpressionLanguage/ParserCache/ParserCacheInterface.php
@@ -11,10 +11,14 @@
 
 namespace Symfony\Component\ExpressionLanguage\ParserCache;
 
+@trigger_error('The '.__NAMESPACE__.'\ParserCacheInterface interface is deprecated since version 3.2 and will be removed in 4.0. Use Psr\Cache\CacheItemPoolInterface instead.', E_USER_DEPRECATED);
+
 use Symfony\Component\ExpressionLanguage\ParsedExpression;
 
 /**
  * @author Adrien Brault <adrien.brault@gmail.com>
+ *
+ * @deprecated since version 3.2, to be removed in 4.0. Use Psr\Cache\CacheItemPoolInterface instead.
  */
 interface ParserCacheInterface
 {

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ParserCache/ParserCacheAdapterTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ParserCache/ParserCacheAdapterTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ExpressionLanguage\Tests;
+
+use Symfony\Component\ExpressionLanguage\ParsedExpression;
+use Symfony\Component\ExpressionLanguage\ParserCache\ParserCacheAdapter;
+use Symfony\Component\ExpressionLanguage\Node\Node;
+
+/**
+ * @group legacy
+ */
+class ParserCacheAdapterTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetItem()
+    {
+        $poolMock = $this->getMock('Symfony\Component\ExpressionLanguage\ParserCache\ParserCacheInterface');
+
+        $key = 'key';
+        $value = 'value';
+        $parserCacheAdapter = new ParserCacheAdapter($poolMock);
+
+        $poolMock
+            ->expects($this->once())
+            ->method('fetch')
+            ->with($key)
+            ->willReturn($value)
+        ;
+
+        $cacheItem = $parserCacheAdapter->getItem($key);
+
+        $this->assertEquals($cacheItem->get(), $value);
+        $this->assertEquals($cacheItem->isHit(), true);
+    }
+
+    public function testSave()
+    {
+        $poolMock = $this->getMock('Symfony\Component\ExpressionLanguage\ParserCache\ParserCacheInterface');
+        $cacheItemMock = $this->getMock('Psr\Cache\CacheItemInterface');
+        $key = 'key';
+        $value = new ParsedExpression('1 + 1', new Node(array(), array()));
+        $parserCacheAdapter = new ParserCacheAdapter($poolMock);
+
+        $poolMock
+            ->expects($this->once())
+            ->method('save')
+            ->with($key, $value)
+        ;
+
+        $cacheItemMock
+            ->expects($this->once())
+            ->method('getKey')
+            ->willReturn($key)
+        ;
+
+        $cacheItemMock
+            ->expects($this->once())
+            ->method('get')
+            ->willReturn($value)
+        ;
+
+        $cacheItem = $parserCacheAdapter->save($cacheItemMock);
+    }
+
+    public function testGetItems()
+    {
+        $poolMock = $this->getMock('Symfony\Component\ExpressionLanguage\ParserCache\ParserCacheInterface');
+        $parserCacheAdapter = new ParserCacheAdapter($poolMock);
+        $this->setExpectedException(\BadMethodCallException::class);
+
+        $parserCacheAdapter->getItems();
+    }
+
+    public function testHasItem()
+    {
+        $poolMock = $this->getMock('Symfony\Component\ExpressionLanguage\ParserCache\ParserCacheInterface');
+        $key = 'key';
+        $parserCacheAdapter = new ParserCacheAdapter($poolMock);
+        $this->setExpectedException(\BadMethodCallException::class);
+
+        $parserCacheAdapter->hasItem($key);
+    }
+
+    public function testClear()
+    {
+        $poolMock = $this->getMock('Symfony\Component\ExpressionLanguage\ParserCache\ParserCacheInterface');
+        $parserCacheAdapter = new ParserCacheAdapter($poolMock);
+        $this->setExpectedException(\BadMethodCallException::class);
+
+        $parserCacheAdapter->clear();
+    }
+
+    public function testDeleteItem()
+    {
+        $poolMock = $this->getMock('Symfony\Component\ExpressionLanguage\ParserCache\ParserCacheInterface');
+        $key = 'key';
+        $parserCacheAdapter = new ParserCacheAdapter($poolMock);
+        $this->setExpectedException(\BadMethodCallException::class);
+
+        $parserCacheAdapter->deleteItem($key);
+    }
+
+    public function testDeleteItems()
+    {
+        $poolMock = $this->getMock('Symfony\Component\ExpressionLanguage\ParserCache\ParserCacheInterface');
+        $keys = array('key');
+        $parserCacheAdapter = new ParserCacheAdapter($poolMock);
+        $this->setExpectedException(\BadMethodCallException::class);
+
+        $parserCacheAdapter->deleteItems($keys);
+    }
+
+    public function testSaveDeferred()
+    {
+        $poolMock = $this->getMock('Symfony\Component\ExpressionLanguage\ParserCache\ParserCacheInterface');
+        $parserCacheAdapter = new ParserCacheAdapter($poolMock);
+        $cacheItemMock = $this->getMock('Psr\Cache\CacheItemInterface');
+        $this->setExpectedException(\BadMethodCallException::class);
+
+        $parserCacheAdapter->saveDeferred($cacheItemMock);
+    }
+
+    public function testCommit()
+    {
+        $poolMock = $this->getMock('Symfony\Component\ExpressionLanguage\ParserCache\ParserCacheInterface');
+        $parserCacheAdapter = new ParserCacheAdapter($poolMock);
+        $this->setExpectedException(\BadMethodCallException::class);
+
+        $parserCacheAdapter->commit();
+    }
+}

--- a/src/Symfony/Component/ExpressionLanguage/composer.json
+++ b/src/Symfony/Component/ExpressionLanguage/composer.json
@@ -16,7 +16,8 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9"
+        "php": ">=5.5.9",
+        "symfony/cache": "~3.1"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\ExpressionLanguage\\": "" },


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | [#7064](https://github.com/symfony/symfony-docs/pull/7064) |

Adding Cache component compatible ParserCache in ExpressionLanguage component.
I hope you will find it useful :) I would like to make tests also
