### PR TITLE
[symfony/symfony] fix typo in "provides" for psr/cache-implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,7 +94,7 @@
         "phpdocumentor/reflection-docblock": "<3.0",
         "phpdocumentor/type-resolver": "<0.2.0"
     },
-    "provides": {
+    "provide": {
         "psr/cache-implementation": "1.0"
     },
     "autoload": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #19742 |
| License | MIT |
