### PR TITLE
[VarDumper] Get dump as string with `$dumper->dump(..., true);`

### DIFF
--- a/src/Symfony/Component/VarDumper/Dumper/AbstractDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/AbstractDumper.php
@@ -114,17 +114,29 @@ abstract class AbstractDumper implements DataDumperInterface, DumperInterface
     /**
      * Dumps a Data object.
      *
-     * @param Data                          $data   A Data object
-     * @param callable|resource|string|null $output A line dumper callable, an opened stream or an output path
+     * @param Data                               $data   A Data object
+     * @param callable|resource|string|true|null $output A line dumper callable, an opened stream, an output path or true to return the dump
+     *
+     * @return string|null The dump as string when $output is true
      */
     public function dump(Data $data, $output = null)
     {
+        if ($returnDump = true === $output) {
+            $output = fopen('php://memory', 'r+b');
+        }
         if ($output) {
             $prevOutput = $this->setOutput($output);
         }
         try {
             $data->dump($this);
             $this->dumpLine(-1);
+
+            if ($returnDump) {
+                $result = stream_get_contents($output, -1, 0);
+                fclose($output);
+
+                return $result;
+            }
         } finally {
             if ($output) {
                 $this->setOutput($prevOutput);

--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -108,8 +108,10 @@ class HtmlDumper extends CliDumper
     public function dump(Data $data, $output = null, array $extraDisplayOptions = array())
     {
         $this->extraDisplayOptions = $extraDisplayOptions;
-        parent::dump($data, $output);
+        $result = parent::dump($data, $output);
         $this->dumpId = 'sf-dump-'.mt_rand();
+
+        return $result;
     }
 
     /**

--- a/src/Symfony/Component/VarDumper/Test/VarDumperTestTrait.php
+++ b/src/Symfony/Component/VarDumper/Test/VarDumperTestTrait.php
@@ -34,19 +34,15 @@ trait VarDumperTestTrait
         $flags = getenv('DUMP_LIGHT_ARRAY') ? CliDumper::DUMP_LIGHT_ARRAY : 0;
         $flags |= getenv('DUMP_STRING_LENGTH') ? CliDumper::DUMP_STRING_LENGTH : 0;
 
-        $h = fopen('php://memory', 'r+b');
         $cloner = new VarCloner();
         $cloner->setMaxItems(-1);
-        $dumper = new CliDumper($h, null, $flags);
+        $dumper = new CliDumper(null, null, $flags);
         $dumper->setColors(false);
         $data = $cloner->cloneVar($data)->withRefHandles(false);
         if (null !== $key && null === $data = $data->seek($key)) {
             return;
         }
-        $dumper->dump($data);
-        $data = stream_get_contents($h, -1, 0);
-        fclose($h);
 
-        return rtrim($data);
+        return rtrim($dumper->dump($data, true));
     }
 }

--- a/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
@@ -259,8 +259,7 @@ EOTXT
 
         $data = $cloner->cloneVar($out);
         $dumper->dump($data, $out);
-        rewind($out);
-        $out = stream_get_contents($out);
+        $out = stream_get_contents($out, -1, 0);
 
         if (method_exists($twig, 'getSource')) {
             $twig = <<<EOTXT
@@ -328,11 +327,8 @@ EOTXT
         $dumper->setColors(false);
         $cloner = new VarCloner();
 
-        $out = fopen('php://memory', 'r+b');
         $data = $cloner->cloneVar($var);
-        $dumper->dump($data, $out);
-        rewind($out);
-        $out = stream_get_contents($out);
+        $out = $dumper->dump($data, true);
 
         $r = defined('HHVM_VERSION') ? '' : '#%d';
         $this->assertStringMatchesFormat(

--- a/src/Symfony/Component/VarDumper/Tests/HtmlDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/HtmlDumperTest.php
@@ -120,9 +120,7 @@ EOTXT
         $cloner = new VarCloner();
 
         $data = $cloner->cloneVar($var);
-        $out = fopen('php://memory', 'r+b');
-        $dumper->dump($data, $out);
-        $out = stream_get_contents($out, -1, 0);
+        $out = $dumper->dump($data, true);
 
         $this->assertStringMatchesFormat(
             <<<EOTXT


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| New feature? | yes |
| Tests pass? | yes |
| License | MIT |

ping @lyrixx @wouterj since you expressed interest in boilerplate reduction around this in the past :)
