### PR TITLE
[Console] Fix Application::setDefaultCommand() missing return in docblock

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -1002,6 +1002,8 @@ class Application
      *
      * @param string $commandName     The Command name
      * @param bool   $isSingleCommand Set to true if there is only one command in this application
+     *
+     * @return self
      */
     public function setDefaultCommand($commandName, $isSingleCommand = false)
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| License | MIT |

Despite the fact IDEs are clever enough to make this useless, I think it's clearly part of the contract of this public method anyway 😄 
