### PR TITLE
[HttpKernel] Fix assertion of deprecation in surrogate fragment renderer

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/EsiFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/EsiFragmentRendererTest.php
@@ -32,7 +32,7 @@ class EsiFragmentRendererTest extends \PHPUnit_Framework_TestCase
      */
     public function testRenderFallbackWithObjectAttributesIsDeprecated()
     {
-        ErrorAssert::assertDeprecationsAreTriggered('Passing objects as part of URI attributes to the ESI and SSI rendering strategies is deprecated', function () {
+        ErrorAssert::assertDeprecationsAreTriggered('Passing non-scalar values as part of URI attributes to the ESI and SSI rendering strategies is deprecated', function () {
             $strategy = new EsiFragmentRenderer(new Esi(), $this->getInlineStrategy(true), new UriSigner('foo'));
             $request = Request::create('/');
             $reference = new ControllerReference('main_controller', array('foo' => array('a' => array(), 'b' => new \stdClass())), array());


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

The message has been changed in #19281 but not the corresponding assertion
