### PR TITLE
[Config] Add ExprBuilder::ifEmpty()

### DIFF
--- a/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
@@ -98,6 +98,18 @@ class ExprBuilder
     }
 
     /**
+     * Tests if the value is empty.
+     *
+     * @return ExprBuilder
+     */
+    public function ifEmpty()
+    {
+        $this->ifPart = function ($v) { return empty($v); };
+
+        return $this;
+    }
+
+    /**
      * Tests if the value is an array.
      *
      * @return ExprBuilder

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/ExprBuilderTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/ExprBuilderTest.php
@@ -75,6 +75,21 @@ class ExprBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertFinalizedValueIs('value', $test);
     }
 
+    public function testIfEmptyExpression()
+    {
+        $test = $this->getTestBuilder()
+            ->ifEmpty()
+            ->then($this->returnClosure('new_value'))
+        ->end();
+        $this->assertFinalizedValueIs('new_value', $test, array('key' => array()));
+
+        $test = $this->getTestBuilder()
+            ->ifEmpty()
+            ->then($this->returnClosure('new_value'))
+        ->end();
+        $this->assertFinalizedValueIs('value', $test);
+    }
+
     public function testIfArrayExpression()
     {
         $test = $this->getTestBuilder()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/6922 |

Useful for instance when you don't expect to have a key set in the resolved config if its content is empty:

``` php
$builder = new TreeBuilder();
$tree = $builder
    ->root('matcher')
        ->children()
            ->arrayNode('references_to_exclude')
                ->validate()
                    ->ifEmpty()
                    ->thenUnset()
                ->end()
                ->prototype('scalar')->end()
            ->end()
        ->end()
    ->end()
    ->buildTree()
;

$tree->finalize(['references_to_exclude' => ['foo', 'bar']]);
>>> ['references_to_exclude' => ['foo', 'bar']]

$tree->finalize(['references_to_exclude' => []]);
>>> []
```
