### PR TITLE
[Config] Fix DirectoryResourceTest for symlinks

### DIFF
--- a/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
@@ -53,7 +53,7 @@ class DirectoryResourceTest extends \PHPUnit_Framework_TestCase
     public function testGetResource()
     {
         $resource = new DirectoryResource($this->directory);
-        $this->assertSame($this->directory, $resource->getResource(), '->getResource() returns the path to the resource');
+        $this->assertSame(realpath($this->directory), $resource->getResource(), '->getResource() returns the path to the resource');
     }
 
     public function testGetPattern()
@@ -166,7 +166,7 @@ class DirectoryResourceTest extends \PHPUnit_Framework_TestCase
 
         $unserialized = unserialize(serialize($resource));
 
-        $this->assertSame($this->directory, $resource->getResource());
+        $this->assertSame(realpath($this->directory), $resource->getResource());
         $this->assertSame('/\.(foo|xml)$/', $resource->getPattern());
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | no (only tests, locally) |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Tests were failing locally (on my macbook), because the `DirectoryResource` implementation now uses `realpath`.
Which means the path returned by `->getResource()` may differ from the given one in case it is a symlink:

``` diff
There were 2 failures:

1) Symfony\Component\Config\Tests\Resource\DirectoryResourceTest::testGetResource 
->getResource() returns the path to the resource
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-/var/folders/j0/grc5nstx5b5f95cgg09_cy_h0000gn/T/symfonyDirectoryIterator
+/private/var/folders/j0/grc5nstx5b5f95cgg09_cy_h0000gn/T/symfonyDirectoryIterator

src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php:56

2) Symfony\Component\Config\Tests\Resource\DirectoryResourceTest::testSerializeUnserialize
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-/var/folders/j0/grc5nstx5b5f95cgg09_cy_h0000gn/T/symfonyDirectoryIterator
+/private/var/folders/j0/grc5nstx5b5f95cgg09_cy_h0000gn/T/symfonyDirectoryIterator

src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php:169
```
