### PR TITLE
[Security] Fixed roles serialization on token from user object

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -150,7 +150,7 @@ abstract class AbstractToken implements TokenInterface
             array(
                 is_object($this->user) ? clone $this->user : $this->user,
                 $this->authenticated,
-                $this->roles,
+                array_map(function ($role) { return clone $role; }, $this->roles),
                 $this->attributes,
             )
         );

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/UserAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/UserAuthenticationProviderTest.php
@@ -220,7 +220,7 @@ class UserAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken', $authToken);
         $this->assertSame($user, $authToken->getUser());
         $this->assertContains(new Role('ROLE_FOO'), $authToken->getRoles(), '', false, false);
-        $this->assertContains($switchUserRole, $authToken->getRoles());
+        $this->assertContains($switchUserRole, $authToken->getRoles(), '', false, false);
         $this->assertEquals('foo', $authToken->getCredentials());
         $this->assertEquals(array('foo' => 'bar'), $authToken->getAttributes(), '->authenticate() copies token attributes');
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/AbstractTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/AbstractTokenTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Security\Core\Tests\Authentication\Token;
 use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
 use Symfony\Component\Security\Core\Role\Role;
 use Symfony\Component\Security\Core\Role\SwitchUserRole;
+use Symfony\Component\Security\Core\User\User;
 
 class TestUser
 {
@@ -87,13 +88,26 @@ class AbstractTokenTest extends \PHPUnit_Framework_TestCase
 
     public function testSerialize()
     {
-        $token = $this->getToken(array('ROLE_FOO'));
+        $token = $this->getToken(array('ROLE_FOO', new Role('ROLE_BAR')));
         $token->setAttributes(array('foo' => 'bar'));
 
         $uToken = unserialize(serialize($token));
 
         $this->assertEquals($token->getRoles(), $uToken->getRoles());
         $this->assertEquals($token->getAttributes(), $uToken->getAttributes());
+    }
+
+    public function testSerializeWithRoleObjects()
+    {
+        $user = new User('name', 'password', array(new Role('ROLE_FOO'), new Role('ROLE_BAR')));
+        $token = new ConcreteToken($user, $user->getRoles());
+
+        $serialized = serialize($token);
+        $unserialized = unserialize($serialized);
+
+        $roles = $unserialized->getRoles();
+
+        $this->assertEquals($roles, $user->getRoles());
     }
 
     public function testSerializeParent()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #14274 |
| License | MIT |
| Doc PR | - |

This PR fixes the serialization of tokens when using `Role` objects provided from the user. Indeed, there were actually a reference issue that can causes fatal errors like the following one:

```
FatalErrorException in RoleHierarchy.php line 43:
Error: Call to a member function getRole() on string
```

Here is a small code example to reproduce and its output:

``` php
$user = new Symfony\Component\Security\Core\User\User('name', 'password', [
    new Symfony\Component\Security\Core\Role\Role('name')
]);
$token = new Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken($user, 'password', 'providerKey', $user->getRoles());

$serialized = serialize($token);
$unserialized = unserialize($serialized);

var_dump($unserialized->getRoles());
```

Before:

```
array(1) { [0]=> bool(true) }
```

After:

```
array(1) { [0]=> object(Symfony\Component\Security\Core\Role\Role)#15 (1) {["role":"Symfony\Component\Security\Core\Role\Role":private]=> string(4) "name" } }
```

Thank you
