### PR TITLE
[FrameworkBundle] Fix test scanning the full tmp directory

### DIFF
--- a/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
@@ -67,7 +67,7 @@ bar';
      */
     private function createFile($content)
     {
-        $filename = tempnam(sys_get_temp_dir(), 'sf-');
+        $filename = tempnam(sys_get_temp_dir().'/framework-yml-lint-test', 'sf-');
         file_put_contents($filename, $content);
 
         $this->files[] = $filename;
@@ -90,6 +90,7 @@ bar';
     protected function setUp()
     {
         $this->files = array();
+        @mkdir(sys_get_temp_dir().'/framework-yml-lint-test');
     }
 
     protected function tearDown()
@@ -99,5 +100,7 @@ bar';
                 unlink($file);
             }
         }
+
+        rmdir(sys_get_temp_dir().'/framework-yml-lint-test');
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Tests pass? | yes/no |
| Fixed tickets | n/a |
| License | MIT |

Next to #19777 (my bad for both ☺️ ).

@nicolas-grekas It seems there are [some similar ones](https://github.com/search?utf8=%E2%9C%93&q=tempnam%28sys_get_temp_dir%28%29%2C+repo%3Asymfony%2Fsymfony&type=Code&ref=searchresults) that need to be fixed
