### PR TITLE
[Yaml] Remove escaping regex

### DIFF
--- a/src/Symfony/Component/Yaml/Escaper.php
+++ b/src/Symfony/Component/Yaml/Escaper.php
@@ -21,25 +21,33 @@ namespace Symfony\Component\Yaml;
  */
 class Escaper
 {
-    // Characters that would cause a dumped string to require double quoting.
-    const REGEX_CHARACTER_TO_ESCAPE = "[\\x00-\\x1f]|\xc2\x85|\xc2\xa0|\xe2\x80\xa8|\xe2\x80\xa9";
+    /**
+     * Characters that would cause a dumped string to require double quoting.
+     *
+     * @internal
+     */
+    const CHARACTER_TO_ESCAPE_MASK = "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f\xc2\xe2";
 
     // Mapping arrays for escaping a double quoted string. The backslash is
     // first to ensure proper escaping because str_replace operates iteratively
     // on the input arrays. This ordering of the characters avoids the use of strtr,
     // which performs more slowly.
-    private static $escapees = array('\\', '\\\\', '\\"', '"',
-                                     "\x00",  "\x01",  "\x02",  "\x03",  "\x04",  "\x05",  "\x06",  "\x07",
-                                     "\x08",  "\x09",  "\x0a",  "\x0b",  "\x0c",  "\x0d",  "\x0e",  "\x0f",
-                                     "\x10",  "\x11",  "\x12",  "\x13",  "\x14",  "\x15",  "\x16",  "\x17",
-                                     "\x18",  "\x19",  "\x1a",  "\x1b",  "\x1c",  "\x1d",  "\x1e",  "\x1f",
-                                     "\xc2\x85", "\xc2\xa0", "\xe2\x80\xa8", "\xe2\x80\xa9");
-    private static $escaped = array('\\\\', '\\"', '\\\\', '\\"',
-                                     '\\0',   '\\x01', '\\x02', '\\x03', '\\x04', '\\x05', '\\x06', '\\a',
-                                     '\\b',   '\\t',   '\\n',   '\\v',   '\\f',   '\\r',   '\\x0e', '\\x0f',
-                                     '\\x10', '\\x11', '\\x12', '\\x13', '\\x14', '\\x15', '\\x16', '\\x17',
-                                     '\\x18', '\\x19', '\\x1a', '\\e',   '\\x1c', '\\x1d', '\\x1e', '\\x1f',
-                                     '\\N', '\\_', '\\L', '\\P');
+    private static $escapees = array(
+        '\\', '\\\\', '\\"', '"', '/',
+        "\x00",  "\x01",  "\x02",  "\x03",  "\x04",  "\x05",  "\x06",  "\x07",
+        "\x08",  "\x09",  "\x0a",  "\x0b",  "\x0c",  "\x0d",  "\x0e",  "\x0f",
+        "\x10",  "\x11",  "\x12",  "\x13",  "\x14",  "\x15",  "\x16",  "\x17",
+        "\x18",  "\x19",  "\x1a",  "\x1b",  "\x1c",  "\x1d",  "\x1e",  "\x1f",
+        "\xc2\x85", "\xc2\xa0", "\xe2\x80\xa8", "\xe2\x80\xa9",
+    );
+    private static $escaped = array(
+        '\\\\', '\\"', '\\\\', '\\"', '\\/',
+        '\\0',   '\\x01', '\\x02', '\\x03', '\\x04', '\\x05', '\\x06', '\\a',
+        '\\b',   '\\t',   '\\n',   '\\v',   '\\f',   '\\r',   '\\x0e', '\\x0f',
+        '\\x10', '\\x11', '\\x12', '\\x13', '\\x14', '\\x15', '\\x16', '\\x17',
+        '\\x18', '\\x19', '\\x1a', '\\e',   '\\x1c', '\\x1d', '\\x1e', '\\x1f',
+        '\\N', '\\_', '\\L', '\\P',
+    );
 
     /**
      * Determines if a PHP value would require double quoting in YAML.
@@ -50,7 +58,7 @@ class Escaper
      */
     public static function requiresDoubleQuoting($value)
     {
-        return preg_match('/'.self::REGEX_CHARACTER_TO_ESCAPE.'/u', $value);
+        return strlen($value) !== strcspn($value, self::CHARACTER_TO_ESCAPE_MASK);
     }
 
     /**
@@ -80,9 +88,14 @@ class Escaper
             return true;
         }
 
-        // Determines if the PHP value contains any single characters that would
-        // cause it to require single quoting in YAML.
-        return preg_match('/[ \s \' " \: \{ \} \[ \] , & \* \# \?] | \A[ \- ? | < > = ! % @ ` ]/x', $value);
+        // First character is an indicator
+        // @see http://yaml.org/spec/1.2/spec.html#c-indicator
+        if ($value && 1 === strspn($value[0], '-?&*!|<>\'"=%@`')) {
+            return true;
+        }
+
+        // Contains spaces or ambigous characters
+        return strlen($value) !== strcspn($value, "\011\n\013\014\r :{}[],#");
     }
 
     /**

--- a/src/Symfony/Component/Yaml/Escaper.php
+++ b/src/Symfony/Component/Yaml/Escaper.php
@@ -84,13 +84,13 @@ class Escaper
     {
         // Determines if a PHP value is entirely composed of a value that would
         // require single quoting in YAML.
-        if (in_array(strtolower($value), array('null', '~', 'true', 'false', 'y', 'n', 'yes', 'no', 'on', 'off'))) {
+        if (in_array(strtolower($value), array('', 'null', '~', 'true', 'false', 'y', 'n', 'yes', 'no', 'on', 'off'))) {
             return true;
         }
 
         // First character is an indicator
         // @see http://yaml.org/spec/1.2/spec.html#c-indicator
-        if ($value && 1 === strspn($value[0], '-?&*!|<>\'"=%@`')) {
+        if (1 === strspn($value[0], '-?&*!|<>\'"=%@`')) {
             return true;
         }
 

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -684,7 +684,7 @@ class Inline
 
     private static function isBinaryString($value)
     {
-        return !preg_match('//u', $value) || preg_match('/[^\x09-\x0d\x20-\xff]/', $value);
+        return !preg_match('//u', $value) || preg_match('/[^\x00-\x1f\x20-\xff]/', $value);
     }
 
     /**

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -257,6 +257,7 @@ EOF;
     public function getEscapeSequences()
     {
         return array(
+            'empty string' => array('', "''"),
             'null' => array("\x0", '"\\0"'),
             'bell' => array("\x7", '"\\a"'),
             'backspace' => array("\x8", '"\\b"'),
@@ -271,7 +272,7 @@ EOF;
             'slash' => array('/', '/'),
             'backslash' => array('\\', '\\'),
             'next-line' => array("\xC2\x85", '"\\N"'),
-            'non-breaking-space' => array('�', '�'),
+            'non-breaking-space' => array("\xc2\xa0", '"\\_"'),
             'line-separator' => array("\xE2\x80\xA8", '"\\L"'),
             'paragraph-separator' => array("\xE2\x80\xA9", '"\\P"'),
             'colon' => array(':', "':'"),

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -57,7 +57,7 @@ class DumperTest extends \PHPUnit_Framework_TestCase
         $expected = <<<'EOF'
 '': bar
 foo: '#bar'
-'foo''bar': {  }
+foo'bar: {  }
 bar:
        - 1
        - foo
@@ -86,7 +86,7 @@ EOF;
         $expected = <<<'EOF'
 '': bar
 foo: '#bar'
-'foo''bar': {  }
+foo'bar: {  }
 bar:
        - 1
        - foo
@@ -133,7 +133,7 @@ EOF;
     public function testInlineLevel()
     {
         $expected = <<<'EOF'
-{ '': bar, foo: '#bar', 'foo''bar': {  }, bar: [1, foo], foobar: { foo: bar, bar: [1, foo], foobar: { foo: bar, bar: [1, foo] } } }
+{ '': bar, foo: '#bar', foo'bar: {  }, bar: [1, foo], foobar: { foo: bar, bar: [1, foo], foobar: { foo: bar, bar: [1, foo] } } }
 EOF;
         $this->assertEquals($expected, $this->dumper->dump($this->array, -10), '->dump() takes an inline level argument');
         $this->assertEquals($expected, $this->dumper->dump($this->array, 0), '->dump() takes an inline level argument');
@@ -141,7 +141,7 @@ EOF;
         $expected = <<<'EOF'
 '': bar
 foo: '#bar'
-'foo''bar': {  }
+foo'bar: {  }
 bar: [1, foo]
 foobar: { foo: bar, bar: [1, foo], foobar: { foo: bar, bar: [1, foo] } }
 
@@ -151,7 +151,7 @@ EOF;
         $expected = <<<'EOF'
 '': bar
 foo: '#bar'
-'foo''bar': {  }
+foo'bar: {  }
 bar:
     - 1
     - foo
@@ -166,7 +166,7 @@ EOF;
         $expected = <<<'EOF'
 '': bar
 foo: '#bar'
-'foo''bar': {  }
+foo'bar: {  }
 bar:
     - 1
     - foo
@@ -185,7 +185,7 @@ EOF;
         $expected = <<<'EOF'
 '': bar
 foo: '#bar'
-'foo''bar': {  }
+foo'bar: {  }
 bar:
     - 1
     - foo
@@ -257,23 +257,24 @@ EOF;
     public function getEscapeSequences()
     {
         return array(
-            'null' => array("\t\\0", '"\t\\\\0"'),
-            'bell' => array("\t\\a", '"\t\\\\a"'),
-            'backspace' => array("\t\\b", '"\t\\\\b"'),
-            'horizontal-tab' => array("\t\\t", '"\t\\\\t"'),
-            'line-feed' => array("\t\\n", '"\t\\\\n"'),
-            'vertical-tab' => array("\t\\v", '"\t\\\\v"'),
-            'form-feed' => array("\t\\f", '"\t\\\\f"'),
-            'carriage-return' => array("\t\\r", '"\t\\\\r"'),
-            'escape' => array("\t\\e", '"\t\\\\e"'),
-            'space' => array("\t\\ ", '"\t\\\\ "'),
-            'double-quote' => array("\t\\\"", '"\t\\\\\\""'),
-            'slash' => array("\t\\/", '"\t\\\\/"'),
-            'backslash' => array("\t\\\\", '"\t\\\\\\\\"'),
-            'next-line' => array("\t\\N", '"\t\\\\N"'),
-            'non-breaking-space' => array("\t\\�", '"\t\\\\�"'),
-            'line-separator' => array("\t\\L", '"\t\\\\L"'),
-            'paragraph-separator' => array("\t\\P", '"\t\\\\P"'),
+            'null' => array("\x0", '"\\0"'),
+            'bell' => array("\x7", '"\\a"'),
+            'backspace' => array("\x8", '"\\b"'),
+            'horizontal-tab' => array("\t", '"\\t"'),
+            'line-feed' => array("\n", '"\\n"'),
+            'vertical-tab' => array("\v", '"\\v"'),
+            'form-feed' => array("\xC", '"\\f"'),
+            'carriage-return' => array("\r", '"\\r"'),
+            'escape' => array("\x1B", '"\\e"'),
+            'space' => array(' ', "' '"),
+            'double-quote' => array('"', "'\"'"),
+            'slash' => array('/', '/'),
+            'backslash' => array('\\', '\\'),
+            'next-line' => array("\xC2\x85", '"\\N"'),
+            'non-breaking-space' => array('�', '�'),
+            'line-separator' => array("\xE2\x80\xA8", '"\\L"'),
+            'paragraph-separator' => array("\xE2\x80\xA9", '"\\P"'),
+            'colon' => array(':', "':'"),
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This PR replaces regexs in `Escaper` by call to `strcspn`. It is much easier to read imo and performance aren't degraded.
I also updated the data provider of a test because it was in practice testing nothing (it is checking if values are quoted as expected but as they always began with `\t` it was always quoted anyway).

Edit: quotes are moved to indicators as they are supported inside plain scalars as said by @stefk:

> It seems those characters are perfectly valid in unquoted strings:
> 
> http://yaml.org/spec/1.2/spec.html#id2788859
> http://yaml-online-parser.appspot.com/?yaml=foo%3A+ba%22r%0Abaz%3A+q%27u%27x%27%0A&type=canonical_yaml
