### PR TITLE
[VarDumper] Handle attributes in Data clones for more semantic dumps

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -912,6 +912,11 @@ table.logs .sf-call-stack abbr {
 #collector-content .sf-dump .trace li.selected {
     background: rgba(255, 255, 153, 0.5);
 }
+#collector-content .sf-dump-expanded code { color: #222; }
+#collector-content .sf-dump-expanded code .sf-dump-const {
+    background: rgba(255, 255, 153, 0.5);
+    font-weight: normal;
+}
 
 {# Search Results page
    ========================================================================= #}

--- a/src/Symfony/Component/VarDumper/Caster/StubCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/StubCaster.php
@@ -28,6 +28,7 @@ class StubCaster
             $stub->value = $c->value;
             $stub->handle = $c->handle;
             $stub->cut = $c->cut;
+            $stub->attr = $c->attr;
 
             return array();
         }
@@ -56,6 +57,7 @@ class StubCaster
             $stub->handle = 0;
             $stub->value = null;
             $stub->cut = $c->cut;
+            $stub->attr = $c->attr;
 
             $a = array();
 

--- a/src/Symfony/Component/VarDumper/Cloner/Cursor.php
+++ b/src/Symfony/Component/VarDumper/Cloner/Cursor.php
@@ -38,4 +38,5 @@ class Cursor
     public $hashLength = 0;
     public $hashCut = 0;
     public $stop = false;
+    public $attr = array();
 }

--- a/src/Symfony/Component/VarDumper/Cloner/Data.php
+++ b/src/Symfony/Component/VarDumper/Cloner/Data.php
@@ -155,6 +155,7 @@ class Data
         $firstSeen = true;
 
         if (!$item instanceof Stub) {
+            $cursor->attr = array();
             $type = gettype($item);
         } elseif (Stub::TYPE_REF === $item->type) {
             if ($item->handle) {
@@ -167,6 +168,7 @@ class Data
                 $cursor->hardRefHandle = $this->useRefHandles & $item->handle;
                 $cursor->hardRefCount = $item->refCount;
             }
+            $cursor->attr = $item->attr;
             $type = $item->class ?: gettype($item->value);
             $item = $item->value;
         }
@@ -181,6 +183,7 @@ class Data
             }
             $cursor->softRefHandle = $this->useRefHandles & $item->handle;
             $cursor->softRefCount = $item->refCount;
+            $cursor->attr = $item->attr;
             $cut = $item->cut;
 
             if ($item->position && $firstSeen) {

--- a/src/Symfony/Component/VarDumper/Cloner/Stub.php
+++ b/src/Symfony/Component/VarDumper/Cloner/Stub.php
@@ -37,4 +37,5 @@ class Stub
     public $handle = 0;
     public $refCount = 0;
     public $position = 0;
+    public $attr = array();
 }

--- a/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
@@ -112,7 +112,7 @@ class CliDumper extends AbstractDumper
         $this->dumpKey($cursor);
 
         $style = 'const';
-        $attr = array();
+        $attr = $cursor->attr;
 
         switch ($type) {
             case 'default':
@@ -148,7 +148,7 @@ class CliDumper extends AbstractDumper
                 break;
 
             default:
-                $attr['value'] = isset($value[0]) && !preg_match('//u', $value) ? $this->utf8Encode($value) : $value;
+                $attr += array('value' => isset($value[0]) && !preg_match('//u', $value) ? $this->utf8Encode($value) : $value);
                 $value = isset($type[0]) && !preg_match('//u', $type) ? $this->utf8Encode($type) : $type;
                 break;
         }
@@ -164,6 +164,7 @@ class CliDumper extends AbstractDumper
     public function dumpString(Cursor $cursor, $str, $bin, $cut)
     {
         $this->dumpKey($cursor);
+        $attr = $cursor->attr;
 
         if ($bin) {
             $str = $this->utf8Encode($str);
@@ -172,7 +173,7 @@ class CliDumper extends AbstractDumper
             $this->line .= '""';
             $this->dumpLine($cursor->depth, true);
         } else {
-            $attr = array(
+            $attr += array(
                 'length' => 0 <= $cut ? mb_strlen($str, 'UTF-8') + $cut : 0,
                 'binary' => $bin,
             );
@@ -350,7 +351,8 @@ class CliDumper extends AbstractDumper
                             case '~':
                                 $style = 'meta';
                                 if (isset($key[0][1])) {
-                                    $attr['title'] = substr($key[0], 1);
+                                    parse_str(substr($key[0], 1), $attr);
+                                    $attr += array('binary' => $cursor->hashKeyIsBinary);
                                 }
                                 break;
                             case '*':

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php
@@ -43,14 +43,14 @@ Exception {
   #line: 25
   -trace: {
     %sExceptionCasterTest.php:25: {
-      24: {
-      25:     return new \Exception('foo');
-      26: }
+      : {
+      :     return new \Exception('foo');
+      : }
     }
     %sExceptionCasterTest.php:%d: {
-      %d: {
-      %d:     $e = $this->getTestException(1);
-      %d: 
+      : {
+      :     $e = $this->getTestException(1);
+      : 
       args: {
         1
       }
@@ -68,14 +68,14 @@ EODUMP;
         $expectedDump = <<<'EODUMP'
 {
   %sExceptionCasterTest.php:25: {
-    24: {
-    25:     return new \Exception('foo');
-    26: }
+    : {
+    :     return new \Exception('foo');
+    : }
   }
   %sExceptionCasterTest.php:%d: {
-    %d: {
-    %d:     $e = $this->getTestException(2);
-    %d: 
+    : {
+    :     $e = $this->getTestException(2);
+    : 
     args: {
       2
     }
@@ -99,14 +99,14 @@ Exception {
   #line: 25
   -trace: {
     %sExceptionCasterTest.php:25: {
-      24: {
-      25:     return new \Exception('foo');
-      26: }
+      : {
+      :     return new \Exception('foo');
+      : }
     }
     %sExceptionCasterTest.php:%d: {
-      %d: {
-      %d:     $e = $this->getTestException(1);
-      %d:     ExceptionCaster::$traceArgs = false;
+      : {
+      :     $e = $this->getTestException(1);
+      :     ExceptionCaster::$traceArgs = false;
     }
 %A
 EODUMP;
@@ -156,7 +156,7 @@ EODUMP;
   #<span class=sf-dump-protected title="Protected property">file</span>: "<span class=sf-dump-str title="%d characters">%sExceptionCasterTest.php</span>"
   #<span class=sf-dump-protected title="Protected property">line</span>: <span class=sf-dump-num>25</span>
   -<span class=sf-dump-private title="Private property defined in class:&#10;`Exception`">trace</span>: {<samp>
-    <span class=sf-dump-meta title="Stack level %d.">%sExceptionCasterTest.php</span>: <span class=sf-dump-num>25</span>
+    <span class=sf-dump-meta title="Stack level %d."><abbr title="%sVarDumper%eTests" class=sf-dump-ellipsis>%sVarDumper%eTests</abbr>%eCaster%eExceptionCasterTest.php</span>: <span class=sf-dump-num>25</span>
      &hellip;12
   </samp>}
 </samp>}

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
@@ -157,9 +157,9 @@ Generator {
   executing: {
     Symfony\Component\VarDumper\Tests\Fixtures\GeneratorDemo->baz(): {
       %sGeneratorDemo.php:14: {
-        13: {
-        14:     yield from bar();
-        15: }
+        : {
+        :     yield from bar();
+        : }
       }
     }
   }
@@ -178,19 +178,19 @@ array:2 [
     this: Symfony\Component\VarDumper\Tests\Fixtures\GeneratorDemo { …}
     trace: {
       %sGeneratorDemo.php:9: {
-         8: {
-         9:     yield 1;
-        10: }
+        : {
+        :     yield 1;
+        : }
       }
       %sGeneratorDemo.php:20: {
-        19: {
-        20:     yield from GeneratorDemo::foo();
-        21: }
+        : {
+        :     yield from GeneratorDemo::foo();
+        : }
       }
       %sGeneratorDemo.php:14: {
-        13: {
-        14:     yield from bar();
-        15: }
+        : {
+        :     yield from bar();
+        : }
       }
     }
   }
@@ -198,9 +198,9 @@ array:2 [
     executing: {
       Symfony\Component\VarDumper\Tests\Fixtures\GeneratorDemo::foo(): {
         %sGeneratorDemo.php:10: {
-           9:     yield 1;
-          10: }
-          11: 
+          :     yield 1;
+          : }
+          : 
         }
       }
     }

--- a/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
@@ -264,9 +264,9 @@ EOTXT
         if (method_exists($twig, 'getSource')) {
             $twig = <<<EOTXT
 foo.twig:%d: {
-        1: foo bar
-        2:   twig source
-        3: 
+        : foo bar
+        :   twig source
+        : 
       }
 EOTXT;
         } else {
@@ -289,24 +289,24 @@ stream resource {@{$ref}
     -trace: {
       {$twig}
       %sTemplate.php:%d: {
-        %d: try {
-        %d:     \$this->doDisplay(\$context, \$blocks);
-        %d: } catch (Twig_Error \$e) {
+        : try {
+        :     \$this->doDisplay(\$context, \$blocks);
+        : } catch (Twig_Error \$e) {
       }
       %sTemplate.php:%d: {
-        %d: {
-        %d:     \$this->displayWithErrorHandling(\$this->env->mergeGlobals(\$context), array_merge(\$this->blocks, \$blocks));
-        %d: }
+        : {
+        :     \$this->displayWithErrorHandling(\$this->env->mergeGlobals(\$context), array_merge(\$this->blocks, \$blocks));
+        : }
       }
       %sTemplate.php:%d: {
-        %d: try {
-        %d:     \$this->display(\$context);
-        %d: } catch (Exception \$e) {
+        : try {
+        :     \$this->display(\$context);
+        : } catch (Exception \$e) {
       }
       %sCliDumperTest.php:{$line}: {
-        %d:         }
-        {$line}:     };'),
-        %d: ));
+        :         }
+        :     };'),
+        : ));
       }
     }
   }

--- a/src/Symfony/Component/VarDumper/Tests/VarClonerTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/VarClonerTest.php
@@ -41,6 +41,10 @@ Symfony\Component\VarDumper\Cloner\Data Object
                             [handle] => 0
                             [refCount] => 0
                             [position] => 1
+                            [attr] => Array
+                                (
+                                )
+
                         )
 
                 )
@@ -86,6 +90,10 @@ Symfony\Component\VarDumper\Cloner\Data Object
                             [handle] => %i
                             [refCount] => 0
                             [position] => 1
+                            [attr] => Array
+                                (
+                                )
+
                         )
 
                 )
@@ -101,6 +109,10 @@ Symfony\Component\VarDumper\Cloner\Data Object
                             [handle] => %i
                             [refCount] => 0
                             [position] => 2
+                            [attr] => Array
+                                (
+                                )
+
                         )
 
                     [\000+\0002] => Symfony\Component\VarDumper\Cloner\Stub Object
@@ -112,6 +124,10 @@ Symfony\Component\VarDumper\Cloner\Data Object
                             [handle] => %i
                             [refCount] => 0
                             [position] => 3
+                            [attr] => Array
+                                (
+                                )
+
                         )
 
                 )
@@ -153,7 +169,7 @@ object(Symfony\Component\VarDumper\Cloner\Data)#%i (6) {
     [0]=>
     array(1) {
       [0]=>
-      object(Symfony\Component\VarDumper\Cloner\Stub)#%i (7) {
+      object(Symfony\Component\VarDumper\Cloner\Stub)#%i (8) {
         ["type"]=>
         string(5) "array"
         ["class"]=>
@@ -168,12 +184,15 @@ object(Symfony\Component\VarDumper\Cloner\Data)#%i (6) {
         int(0)
         ["position"]=>
         int(1)
+        ["attr"]=>
+        array(0) {
+        }
       }
     }
     [1]=>
     array(1) {
       ["1"]=>
-      object(Symfony\Component\VarDumper\Cloner\Stub)#%i (7) {
+      object(Symfony\Component\VarDumper\Cloner\Stub)#%i (8) {
         ["type"]=>
         string(6) "object"
         ["class"]=>
@@ -188,6 +207,9 @@ object(Symfony\Component\VarDumper\Cloner\Data)#%i (6) {
         int(0)
         ["position"]=>
         int(0)
+        ["attr"]=>
+        array(0) {
+        }
       }
     }
   }
@@ -239,6 +261,10 @@ Symfony\Component\VarDumper\Cloner\Data Object
                             [handle] => %i
                             [refCount] => 0
                             [position] => 1
+                            [attr] => Array
+                                (
+                                )
+
                         )
 
                 )


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| New feature? | yes |
| Tests pass? | yes |
| License | MIT |

Casters can now add attributes to the stub they create and to virtual propertie names so that e.g. the HtmlDumper knows more about the structure it is dumping. This allows for fine tuned HTML representations.

The ExceptionCaster uses this feature to make traces more useful, by telling the HtmlDumper which keys/values are files, lines or code excerpt (and which language). Thus, code excerpts can now be opened directly in the IDE.
