### PR TITLE
[DX] made deleteFileAfterSend() behavior explicit

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -350,7 +350,7 @@ class BinaryFileResponse extends Response
      *
      * @return BinaryFileResponse
      */
-    public function deleteFileAfterSend($shouldDelete)
+    public function deleteFileAfterSend($shouldDelete = true)
     {
         $this->deleteFileAfterSend = $shouldDelete;
 

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -280,7 +280,7 @@ class BinaryFileResponseTest extends ResponseTestCase
         $this->assertFileExists($realPath);
 
         $response = new BinaryFileResponse($realPath, 200, array('Content-Type' => 'application/octet-stream'));
-        $response->deleteFileAfterSend(true);
+        $response->deleteFileAfterSend();
 
         $response->prepare($request);
         $response->sendContent();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | **yes** |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
| Doc PR | No need, the docs already say [it's possible](http://symfony.com/doc/current/components/http_foundation.html#serving-files). |
