### PR TITLE
Allow disabling redirection in logout

### DIFF
--- a/src/Symfony/Component/Security/Http/Logout/DefaultLogoutSuccessHandler.php
+++ b/src/Symfony/Component/Security/Http/Logout/DefaultLogoutSuccessHandler.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Logout;
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Http\HttpUtils;
 
 /**
@@ -41,6 +42,10 @@ class DefaultLogoutSuccessHandler implements LogoutSuccessHandlerInterface
      */
     public function onLogoutSuccess(Request $request)
     {
-        return $this->httpUtils->createRedirectResponse($request, $this->targetUrl);
+        if (! empty($this->targetUrl)) {
+            return $this->httpUtils->createRedirectResponse($request, $this->targetUrl);
+        } else {
+            return new Response();
+        }
     }
 }

--- a/src/Symfony/Component/Security/Http/Logout/DefaultLogoutSuccessHandler.php
+++ b/src/Symfony/Component/Security/Http/Logout/DefaultLogoutSuccessHandler.php
@@ -44,8 +44,8 @@ class DefaultLogoutSuccessHandler implements LogoutSuccessHandlerInterface
     {
         if (!empty($this->targetUrl)) {
             return $this->httpUtils->createRedirectResponse($request, $this->targetUrl);
-        } 
-        
+        }
+
         return new Response();
     }
 }

--- a/src/Symfony/Component/Security/Http/Logout/DefaultLogoutSuccessHandler.php
+++ b/src/Symfony/Component/Security/Http/Logout/DefaultLogoutSuccessHandler.php
@@ -44,8 +44,8 @@ class DefaultLogoutSuccessHandler implements LogoutSuccessHandlerInterface
     {
         if (!empty($this->targetUrl)) {
             return $this->httpUtils->createRedirectResponse($request, $this->targetUrl);
-        } else {
-            return new Response();
-        }
+        } 
+        
+        return new Response();
     }
 }

--- a/src/Symfony/Component/Security/Http/Logout/DefaultLogoutSuccessHandler.php
+++ b/src/Symfony/Component/Security/Http/Logout/DefaultLogoutSuccessHandler.php
@@ -42,7 +42,7 @@ class DefaultLogoutSuccessHandler implements LogoutSuccessHandlerInterface
      */
     public function onLogoutSuccess(Request $request)
     {
-        if (! empty($this->targetUrl)) {
+        if (!empty($this->targetUrl)) {
             return $this->httpUtils->createRedirectResponse($request, $this->targetUrl);
         } else {
             return new Response();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master", although as it's a simple option could be ported back to 2.7, 2.8 or 3.1 |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? |  |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

With this change, the redirection after the default logout action can be disabled if target is established to an empty string or to null
