### PR TITLE
[FrameworkBundle] Add %debug.file_link_format% with remapping for IDE links

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
@@ -25,13 +25,20 @@ class CodeExtension extends \Twig_Extension
     /**
      * Constructor.
      *
-     * @param string $fileLinkFormat The format for links to source files
-     * @param string $rootDir        The project root directory
-     * @param string $charset        The charset
+     * @param string|array $fileLinkFormat The format for links to source files
+     * @param string       $rootDir        The project root directory
+     * @param string       $charset        The charset
      */
     public function __construct($fileLinkFormat, $rootDir, $charset)
     {
-        $this->fileLinkFormat = $fileLinkFormat ?: ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format');
+        $fileLinkFormat = $fileLinkFormat ?: ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format');
+        if ($fileLinkFormat && !is_array($fileLinkFormat)) {
+            $i = max(strpos($fileLinkFormat, '%f'), strpos($fileLinkFormat, '%l'));
+            $i = strpos($fileLinkFormat, '#', $i) ?: strlen($fileLinkFormat);
+            $fileLinkFormat = array(substr($fileLinkFormat, 0, $i), substr($fileLinkFormat, $i + 1));
+            parse_str($fileLinkFormat[1], $fileLinkFormat[1]);
+        }
+        $this->fileLinkFormat = $fileLinkFormat;
         $this->rootDir = str_replace('/', DIRECTORY_SEPARATOR, dirname($rootDir)).DIRECTORY_SEPARATOR;
         $this->charset = $charset;
     }
@@ -190,8 +197,15 @@ class CodeExtension extends \Twig_Extension
      */
     public function getFileLink($file, $line)
     {
-        if ($this->fileLinkFormat && is_file($file)) {
-            return strtr($this->fileLinkFormat, array('%f' => $file, '%l' => $line));
+        if ($this->fileLinkFormat && file_exists($file)) {
+            foreach ($this->fileLinkFormat[1] as $k => $v) {
+                if (0 === strpos($file, $k)) {
+                    $file = substr_replace($file, $v, 0, strlen($k));
+                    break;
+                }
+            }
+
+            return strtr($this->fileLinkFormat[0], array('%f' => $file, '%l' => $line));
         }
 
         return false;

--- a/src/Symfony/Bridge/Twig/Tests/Extension/CodeExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/CodeExtensionTest.php
@@ -19,7 +19,7 @@ class CodeExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testFormatFile()
     {
-        $expected = sprintf('<a href="txmt://open?url=file://%s&amp;line=25" title="Click to open this file" class="file_link">%s at line 25</a>', __FILE__, __FILE__);
+        $expected = sprintf('<a href="proto://foobar%s#&amp;line=25" title="Click to open this file" class="file_link">%s at line 25</a>', substr(__FILE__, 5), __FILE__);
         $this->assertEquals($expected, $this->getExtension()->formatFile(__FILE__, 25));
     }
 
@@ -64,6 +64,6 @@ class CodeExtensionTest extends \PHPUnit_Framework_TestCase
 
     protected function getExtension()
     {
-        return new CodeExtension('txmt://open?url=file://%f&line=%l', '/root', 'UTF-8');
+        return new CodeExtension('proto://%f#&line=%l#'.substr(__FILE__, 0, 5).'=foobar', '/root', 'UTF-8');
     }
 }

--- a/src/Symfony/Bundle/DebugBundle/DependencyInjection/Compiler/DumpDataCollectorPass.php
+++ b/src/Symfony/Bundle/DebugBundle/DependencyInjection/Compiler/DumpDataCollectorPass.php
@@ -33,10 +33,6 @@ class DumpDataCollectorPass implements CompilerPassInterface
 
         $definition = $container->getDefinition('data_collector.dump');
 
-        if ($container->hasParameter('templating.helper.code.file_link_format')) {
-            $definition->replaceArgument(1, $container->getParameter('templating.helper.code.file_link_format'));
-        }
-
         if (!$container->hasParameter('web_profiler.debug_toolbar.mode') || WebDebugToolbarListener::DISABLED === $container->getParameter('web_profiler.debug_toolbar.mode')) {
             $definition->replaceArgument(3, null);
         }

--- a/src/Symfony/Bundle/DebugBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/DebugBundle/Resources/config/services.xml
@@ -8,12 +8,13 @@
         <service id="twig.extension.dump" class="Symfony\Bridge\Twig\Extension\DumpExtension" public="false">
             <tag name="twig.extension" />
             <argument type="service" id="var_dumper.cloner" />
+            <argument type="service" id="var_dumper.html_dumper" />
         </service>
 
         <service id="data_collector.dump" class="Symfony\Component\HttpKernel\DataCollector\DumpDataCollector">
             <tag name="data_collector" id="dump" template="@Debug/Profiler/dump.html.twig" priority="240" />
             <argument type="service" id="debug.stopwatch" on-invalid="ignore" />
-            <argument>null</argument><!-- %templating.helper.code.file_link_format% -->
+            <argument>%debug.file_link_format%</argument>
             <argument>%kernel.charset%</argument>
             <argument type="service" id="request_stack" />
             <argument>null</argument><!-- var_dumper.cli_dumper when debug.dump_destination is set -->
@@ -29,6 +30,17 @@
         <service id="var_dumper.cli_dumper" class="Symfony\Component\VarDumper\Dumper\CliDumper">
             <argument>null</argument><!-- debug.dump_destination -->
             <argument>%kernel.charset%</argument>
+            <argument>0</argument> <!-- flags -->
+        </service>
+        <service id="var_dumper.html_dumper" class="Symfony\Component\VarDumper\Dumper\HtmlDumper" public="false">
+            <argument>null</argument>
+            <argument>%kernel.charset%</argument>
+            <argument>0</argument> <!-- flags -->
+            <call method="setDisplayOptions">
+                <argument type="collection">
+                    <argument key="fileLinkFormat">%debug.file_link_format%</argument>
+                </argument>
+            </call>
         </service>
     </services>
 

--- a/src/Symfony/Bundle/DebugBundle/Tests/DependencyInjection/Compiler/DumpDataCollectorPassTest.php
+++ b/src/Symfony/Bundle/DebugBundle/Tests/DependencyInjection/Compiler/DumpDataCollectorPassTest.php
@@ -19,20 +19,6 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 class DumpDataCollectorPassTest extends \PHPUnit_Framework_TestCase
 {
-    public function testProcessWithFileLinkFormatParameter()
-    {
-        $container = new ContainerBuilder();
-        $container->addCompilerPass(new DumpDataCollectorPass());
-        $container->setParameter('templating.helper.code.file_link_format', 'file-link-format');
-
-        $definition = new Definition('Symfony\Component\HttpKernel\DataCollector\DumpDataCollector', array(null, null, null, null));
-        $container->setDefinition('data_collector.dump', $definition);
-
-        $container->compile();
-
-        $this->assertSame('file-link-format', $definition->getArgument(1));
-    }
-
     public function testProcessWithoutFileLinkFormatParameter()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug_prod.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug_prod.xml
@@ -17,7 +17,7 @@
             <argument>-1</argument><!-- Log levels map for enabled error levels -->
             <argument>%debug.error_handler.throw_at%</argument>
             <argument>true</argument>
-            <argument>null</argument><!-- %templating.helper.code.file_link_format% -->
+            <argument>%debug.file_link_format%</argument>
             <argument>true</argument>
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
@@ -44,7 +44,7 @@
 
         <service id="templating.helper.code" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\CodeHelper">
             <tag name="templating.helper" alias="code" />
-            <argument>%templating.helper.code.file_link_format%</argument>
+            <argument>%debug.file_link_format%</argument>
             <argument>%kernel.root_dir%</argument>
             <argument>%kernel.charset%</argument>
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -359,7 +359,7 @@ abstract class FrameworkExtensionTest extends TestCase
     {
         $container = $this->createContainerFromFile('full');
 
-        $this->assertEquals('file%link%format', $container->getParameter('templating.helper.code.file_link_format'));
+        $this->assertEquals('file%link%format', $container->getParameter('debug.file_link_format'));
     }
 
     public function testValidationAnnotations()

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
@@ -55,10 +55,6 @@ class ExtensionPass implements CompilerPassInterface
             $container->getDefinition('twig.extension.httpfoundation')->addTag('twig.extension');
         }
 
-        if ($container->hasParameter('templating.helper.code.file_link_format')) {
-            $container->getDefinition('twig.extension.code')->replaceArgument(0, $container->getParameter('templating.helper.code.file_link_format'));
-        }
-
         if ($container->getParameter('kernel.debug')) {
             $container->getDefinition('twig.extension.profiler')->addTag('twig.extension');
             $container->getDefinition('twig.extension.debug')->addTag('twig.extension');

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -83,7 +83,7 @@
 
         <service id="twig.extension.code" class="Symfony\Bridge\Twig\Extension\CodeExtension" public="false">
             <tag name="twig.extension" />
-            <argument /> <!-- %templating.helper.code.file_link_format% -->
+            <argument>%debug.file_link_format%</argument>
             <argument>%kernel.root_dir%</argument>
             <argument>%kernel.charset%</argument>
         </service>

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -31,7 +31,7 @@
         "symfony/routing": "~2.8|~3.0",
         "symfony/templating": "~2.8|~3.0",
         "symfony/yaml": "~2.8|~3.0",
-        "symfony/framework-bundle": "~2.8|~3.0"
+        "symfony/framework-bundle": "~3.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bundle\\TwigBundle\\": "" },

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/profiler.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/profiler.xml
@@ -34,6 +34,18 @@
 
         <service id="twig.extension.webprofiler" class="Symfony\Bundle\WebProfilerBundle\Twig\WebProfilerExtension" public="false">
             <tag name="twig.extension" />
+            <argument type="service">
+                <service class="Symfony\Component\VarDumper\Dumper\HtmlDumper">
+                    <argument>null</argument>
+                    <argument>%kernel.charset%</argument>
+                    <argument type="constant">Symfony\Component\VarDumper\Dumper\HtmlDumper::DUMP_LIGHT_ARRAY</argument>
+                    <call method="setDisplayOptions">
+                        <argument type="collection">
+                            <argument key="fileLinkFormat">%debug.file_link_format%</argument>
+                        </argument>
+                    </call>
+                </service>
+            </argument>
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
@@ -56,6 +56,8 @@ class WebProfilerExtensionTest extends TestCase
         $this->container->setParameter('kernel.cache_dir', __DIR__);
         $this->container->setParameter('kernel.debug', false);
         $this->container->setParameter('kernel.root_dir', __DIR__);
+        $this->container->setParameter('kernel.charset', 'UTF-8');
+        $this->container->setParameter('debug.file_link_format', null);
         $this->container->setParameter('profiler.class', array('Symfony\\Component\\HttpKernel\\Profiler\\Profiler'));
         $this->container->register('profiler', $this->getMockClass('Symfony\\Component\\HttpKernel\\Profiler\\Profiler'))
             ->addArgument(new Definition($this->getMockClass('Symfony\\Component\\HttpKernel\\Profiler\\ProfilerStorageInterface')));

--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -20,7 +20,8 @@
         "symfony/http-kernel": "~3.1",
         "symfony/polyfill-php70": "~1.0",
         "symfony/routing": "~2.8|~3.0",
-        "symfony/twig-bridge": "~2.8|~3.0"
+        "symfony/twig-bridge": "~2.8|~3.0",
+        "symfony/var-dumper": "~3.2"
     },
     "require-dev": {
         "symfony/config": "~2.8|~3.0",

--- a/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/DebugHandlersListener.php
@@ -44,7 +44,7 @@ class DebugHandlersListener implements EventSubscriberInterface
      * @param array|int            $levels           An array map of E_* to LogLevel::* or an integer bit field of E_* constants
      * @param int|null             $throwAt          Thrown errors in a bit field of E_* constants, or null to keep the current value
      * @param bool                 $scream           Enables/disables screaming mode, where even silenced errors are logged
-     * @param string               $fileLinkFormat   The format for links to source files
+     * @param string|array         $fileLinkFormat   The format for links to source files
      * @param bool                 $scope            Enables/disables scoping mode
      */
     public function __construct(callable $exceptionHandler = null, LoggerInterface $logger = null, $levels = E_ALL, $throwAt = E_ALL, $scream = true, $fileLinkFormat = null, $scope = true)
@@ -54,7 +54,7 @@ class DebugHandlersListener implements EventSubscriberInterface
         $this->levels = null === $levels ? E_ALL : $levels;
         $this->throwAt = is_numeric($throwAt) ? (int) $throwAt : (null === $throwAt ? null : ($throwAt ? E_ALL : null));
         $this->scream = (bool) $scream;
-        $this->fileLinkFormat = $fileLinkFormat ?: ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format');
+        $this->fileLinkFormat = $fileLinkFormat;
         $this->scope = (bool) $scope;
     }
 

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -37,7 +37,7 @@
         "symfony/stopwatch": "~2.8|~3.0",
         "symfony/templating": "~2.8|~3.0",
         "symfony/translation": "~2.8|~3.0",
-        "symfony/var-dumper": "~2.8|~3.0"
+        "symfony/var-dumper": "~3.2"
     },
     "conflict": {
         "symfony/config": "<2.8"


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| New feature? | yes |
| Tests pass? | yes |
| Fixed tickets | #14340 |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/6944 |

`templating.helper.code.file_link_format` is a parameter that requires templating to be defined, but holds a concept that is used beyond templating borders.
Let's make it a general parameter that can be injected easily when required.
