### PR TITLE
Fixed the nullable support for php 7.1 and below (2.7, 2.8, 3.0)

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\HttpKernel\Tests\Controller;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Controller\ControllerResolver;
+use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\NullableController;
 use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\VariadicController;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -220,6 +221,34 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
         $request = Request::create('/');
         $request->attributes->set('_controller', 'foobar');
         $mock->getController($request);
+    }
+
+    /**
+     * @requires PHP 7.1
+     */
+    public function testGetNullableArguments()
+    {
+        $resolver = new ControllerResolver();
+
+        $request = Request::create('/');
+        $request->attributes->set('foo', 'foo');
+        $request->attributes->set('bar', new \stdClass());
+        $request->attributes->set('mandatory', 'mandatory');
+        $controller = array(new NullableController(), 'action');
+        $this->assertEquals(array('foo', new \stdClass(), 'value', 'mandatory'), $resolver->getArguments($request, $controller));
+    }
+
+    /**
+     * @requires PHP 7.1
+     */
+    public function testGetNullableArgumentsWithDefaults()
+    {
+        $resolver = new ControllerResolver();
+
+        $request = Request::create('/');
+        $request->attributes->set('mandatory', 'mandatory');
+        $controller = array(new NullableController(), 'action');
+        $this->assertEquals(array(null, null, 'value', 'mandatory'), $resolver->getArguments($request, $controller));
     }
 
     protected function createControllerResolver(LoggerInterface $logger = null)

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/Controller/NullableController.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/Controller/NullableController.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures\Controller;
+
+class NullableController
+{
+    public function action(?string $foo, ?\stdClass $bar, ?string $baz = 'value', $mandatory)
+    {
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7, 2.8, 3.0 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/pull/19784#issuecomment-243852825 |
| License | MIT |
| Doc PR | ~ |

Fixes the nullable support for 2.7, 2.8 and 3.0, can probably be partially merged into 3.1 but not 100% sure.

/ping @fabpot 
