### PR TITLE
[WebProfilerBundle] Fix margin on toolbar route panel when no route is found in the request

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -461,8 +461,11 @@
         padding-left: 0;
         padding-right: 0;
     }
-    .sf-toolbar-block-request .sf-toolbar-status {
-        margin-right: 5px;
+    .sf-toolbar-block-request .sf-toolbar-label {
+        margin-left: 5px;
+    }
+    .sf-toolbar-block-request .sf-toolbar-status + svg {
+        margin-left: 5px;
     }
     .sf-toolbar-block-request .sf-toolbar-icon svg + .sf-toolbar-label {
         margin-left: 0;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #19805 |
| License | MIT |

Just to clarify, this bug was introduced in the 3.1 release when some of the toolbar was re-structured
