### PR TITLE
[VarDumper] Add LinkStub to create links in HTML dumps

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -912,11 +912,6 @@ table.logs .sf-call-stack abbr {
 #collector-content .sf-dump .trace li.selected {
     background: rgba(255, 255, 153, 0.5);
 }
-#collector-content .sf-dump-expanded code { color: #222; }
-#collector-content .sf-dump-expanded code .sf-dump-const {
-    background: rgba(255, 255, 153, 0.5);
-    font-weight: normal;
-}
 
 {# Search Results page
    ========================================================================= #}

--- a/src/Symfony/Component/VarDumper/Caster/DOMCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/DOMCaster.php
@@ -107,7 +107,7 @@ class DOMCaster
             'namespaceURI' => $dom->namespaceURI,
             'prefix' => $dom->prefix,
             'localName' => $dom->localName,
-            'baseURI' => $dom->baseURI,
+            'baseURI' => $dom->baseURI ? new LinkStub($dom->baseURI) : $dom->baseURI,
             'textContent' => new CutStub($dom->textContent),
         );
 
@@ -144,7 +144,7 @@ class DOMCaster
             'version' => $dom->version,
             'xmlVersion' => $dom->xmlVersion,
             'strictErrorChecking' => $dom->strictErrorChecking,
-            'documentURI' => $dom->documentURI,
+            'documentURI' => $dom->documentURI ? new LinkStub($dom->documentURI) : $dom->documentURI,
             'config' => $dom->config,
             'formatOutput' => $dom->formatOutput,
             'validateOnParse' => $dom->validateOnParse,
@@ -237,7 +237,7 @@ class DOMCaster
             'columnNumber' => $dom->columnNumber,
             'offset' => $dom->offset,
             'relatedNode' => $dom->relatedNode,
-            'uri' => $dom->uri,
+            'uri' => $dom->uri ? new LinkStub($dom->uri, $dom->lineNumber) : $dom->uri,
         );
 
         return $a;

--- a/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
@@ -221,6 +221,8 @@ class ExceptionCaster
         }
         unset($a[$xPrefix.'string'], $a[Caster::PREFIX_DYNAMIC.'xdebug_message'], $a[Caster::PREFIX_DYNAMIC.'__destructorException']);
 
+        $a[Caster::PREFIX_PROTECTED.'file'] = new LinkStub($a[Caster::PREFIX_PROTECTED.'file'], $a[Caster::PREFIX_PROTECTED.'line']);
+
         return $a;
     }
 

--- a/src/Symfony/Component/VarDumper/Caster/LinkStub.php
+++ b/src/Symfony/Component/VarDumper/Caster/LinkStub.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Caster;
+
+/**
+ * Represents a file or a URL.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class LinkStub extends ConstStub
+{
+    public function __construct($file, $line = 0)
+    {
+        $this->value = $file;
+
+        if (is_string($file)) {
+            $this->type = self::TYPE_STRING;
+            $this->class = preg_match('//u', $file) ? self::STRING_UTF8 : self::STRING_BINARY;
+
+            if (0 === strpos($file, 'file://')) {
+                $file = substr($file, 7);
+            } elseif (false !== strpos($file, '://')) {
+                $this->attr['href'] = $file;
+
+                return;
+            }
+            if (file_exists($file)) {
+                if ($line) {
+                    $this->attr['line'] = $line;
+                }
+                $this->attr['file'] = realpath($file);
+
+                if ($this->attr['file'] === $file) {
+                    $ellipsis = explode(DIRECTORY_SEPARATOR, $file);
+                    $this->attr['ellipsis'] = 3 < count($ellipsis) ? 2 + strlen(implode(array_slice($ellipsis, -2))) : 0;
+                }
+            }
+        }
+    }
+}

--- a/src/Symfony/Component/VarDumper/Caster/ReflectionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ReflectionCaster.php
@@ -53,7 +53,7 @@ class ReflectionCaster
         }
 
         if ($f = $c->getFileName()) {
-            $a[$prefix.'file'] = $f;
+            $a[$prefix.'file'] = new LinkStub($f, $c->getStartLine());
             $a[$prefix.'line'] = $c->getStartLine().' to '.$c->getEndLine();
         }
 
@@ -287,7 +287,7 @@ class ReflectionCaster
         $x = isset($a[Caster::PREFIX_VIRTUAL.'extra']) ? $a[Caster::PREFIX_VIRTUAL.'extra']->value : array();
 
         if (method_exists($c, 'getFileName') && $m = $c->getFileName()) {
-            $x['file'] = $m;
+            $x['file'] = new LinkStub($m, $c->getStartLine());
             $x['line'] = $c->getStartLine().' to '.$c->getEndLine();
         }
 

--- a/src/Symfony/Component/VarDumper/Caster/ResourceCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ResourceCaster.php
@@ -40,7 +40,10 @@ class ResourceCaster
 
     public static function castStream($stream, array $a, Stub $stub, $isNested)
     {
-        return stream_get_meta_data($stream) + static::castStreamContext($stream, $a, $stub, $isNested);
+        $a = stream_get_meta_data($stream) + static::castStreamContext($stream, $a, $stub, $isNested);
+        $a['uri'] = new LinkStub($a['uri']);
+
+        return $a;
     }
 
     public static function castStreamContext($stream, array $a, Stub $stub, $isNested)

--- a/src/Symfony/Component/VarDumper/Caster/SplCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/SplCaster.php
@@ -115,6 +115,10 @@ class SplCaster
             }
         }
 
+        if (isset($a[$prefix.'realPath'])) {
+            $a[$prefix.'realPath'] = new LinkStub($a[$prefix.'realPath']);
+        }
+
         if (isset($a[$prefix.'perms'])) {
             $a[$prefix.'perms'] = new ConstStub(sprintf('0%o', $a[$prefix.'perms']), $a[$prefix.'perms']);
         }

--- a/src/Symfony/Component/VarDumper/Caster/XmlReaderCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/XmlReaderCaster.php
@@ -54,7 +54,7 @@ class XmlReaderCaster
             'attributeCount' => $reader->attributeCount,
             'value' => $reader->value,
             'namespaceURI' => $reader->namespaceURI,
-            'baseURI' => $reader->baseURI,
+            'baseURI' => $reader->baseURI ? new LinkStub($reader->baseURI) : $reader->baseURI,
             $props => array(
                 'LOADDTD' => $reader->getParserProperty(\XmlReader::LOADDTD),
                 'DEFAULTATTRS' => $reader->getParserProperty(\XmlReader::DEFAULTATTRS),

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php
@@ -153,7 +153,7 @@ EODUMP;
 <foo></foo><bar><span class=sf-dump-note>Exception</span> {<samp>
   #<span class=sf-dump-protected title="Protected property">message</span>: "<span class=sf-dump-str title="3 characters">foo</span>"
   #<span class=sf-dump-protected title="Protected property">code</span>: <span class=sf-dump-num>0</span>
-  #<span class=sf-dump-protected title="Protected property">file</span>: "<span class=sf-dump-str title="%d characters">%sExceptionCasterTest.php</span>"
+  #<span class=sf-dump-protected title="Protected property">file</span>: "<a data-file="%sExceptionCasterTest.php" data-line="25"><span class=sf-dump-str title="%d characters"><abbr title="%sTests" class=sf-dump-ellipsis>%sTests</abbr>%eCaster%eExceptionCasterTest.php</span></a>"
   #<span class=sf-dump-protected title="Protected property">line</span>: <span class=sf-dump-num>25</span>
   -<span class=sf-dump-private title="Private property defined in class:&#10;`Exception`">trace</span>: {<samp>
     <span class=sf-dump-meta title="Stack level %d."><abbr title="%sVarDumper%eTests" class=sf-dump-ellipsis>%sVarDumper%eTests</abbr>%eCaster%eExceptionCasterTest.php</span>: <span class=sf-dump-num>25</span>

--- a/src/Symfony/Component/VarDumper/Tests/HtmlDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/HtmlDumperTest.php
@@ -84,7 +84,7 @@ class HtmlDumperTest extends \PHPUnit_Framework_TestCase
         <span class=sf-dump-meta>default</span>: <span class=sf-dump-const>null</span>
       </samp>}
     </samp>}
-    <span class=sf-dump-meta>file</span>: "<span class=sf-dump-str title="%d characters">{$var['file']}</span>"
+    <span class=sf-dump-meta>file</span>: "<a data-file="{$var['file']}" data-line="24"><span class=sf-dump-str title="%d characters"><abbr title="%sTests" class=sf-dump-ellipsis>%sTests</abbr>%eFixtures%edumb-var.php</span></a>"
     <span class=sf-dump-meta>line</span>: "<span class=sf-dump-str title="%d characters">{$var['line']} to {$var['line']}</span>"
   </samp>}
   "<span class=sf-dump-key>line</span>" => <span class=sf-dump-num>{$var['line']}</span>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| New feature? | yes |
| Tests pass? | yes |
| License | MIT |

This builds on top of #19797 & adds a new `LinkStub` to inform HtmlDumper about values that can be dumped as html links.

![capture du 2016-09-01 16-37-56](https://cloud.githubusercontent.com/assets/243674/18171810/8a786518-7063-11e6-9719-1eca295087e7.png)

Note in the screenshot:
- the "file" item has ellipsis,
- the browser displays the target at the bottom
