### PR TITLE
[travis] Test on PHP 7.1 again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
         - php: 5.6
         - php: 7.0
           env: deps=high
-        - php: 7.0
+        - php: 7.1
           env: deps=low
     fast_finish: true
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Tests pass? | let's see |
| License | MIT |

PHP 7.1 RC1 has been released today.
