### PR TITLE
[SecurityBundle] Allow accessing remember_me services via FirewallMap

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
@@ -43,11 +43,11 @@ class RememberMeFactory implements SecurityFactoryInterface
         // remember me services
         if (isset($config['token_provider'])) {
             $templateId = 'security.authentication.rememberme.services.persistent';
-            $rememberMeServicesId = $templateId.'.'.$id;
         } else {
             $templateId = 'security.authentication.rememberme.services.simplehash';
-            $rememberMeServicesId = $templateId.'.'.$id;
         }
+
+        $rememberMeServicesId = $templateId.'.'.$id;
 
         if ($container->hasDefinition('security.logout_listener.'.$id)) {
             $container

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -249,6 +249,12 @@ class SecurityExtension extends Extension
                 ->replaceArgument(2, new Reference($configId))
             ;
 
+            if ($container->hasDefinition('security.authentication.rememberme.services.persistent.'.$name)) {
+                $context->replaceArgument(3, new Reference('security.authentication.rememberme.services.persistent.'.$name));
+            } elseif ($container->hasDefinition('security.authentication.rememberme.services.simplehash.'.$name)) {
+                $context->replaceArgument(3, new Reference('security.authentication.rememberme.services.simplehash.'.$name));
+            }
+
             $map[$contextId] = $matcher;
         }
         $mapDef->replaceArgument(1, $map);

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -112,6 +112,7 @@
             <argument type="collection" />
             <argument type="service" id="security.exception_listener" />
             <argument />  <!-- FirewallConfig -->
+            <argument type="service" on-invalid="null" />
         </service>
 
         <service id="security.firewall.config" class="Symfony\Bundle\SecurityBundle\Security\FirewallConfig" abstract="true" public="false">

--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallContext.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallContext.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\SecurityBundle\Security;
 
 use Symfony\Component\Security\Http\Firewall\ExceptionListener;
+use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
 
 /**
  * This is a wrapper around the actual firewall configuration which allows us
@@ -24,8 +25,9 @@ class FirewallContext
     private $listeners;
     private $exceptionListener;
     private $config;
+    private $rememberMeServices;
 
-    public function __construct(array $listeners, ExceptionListener $exceptionListener = null, FirewallConfig $config = null)
+    public function __construct(array $listeners, ExceptionListener $exceptionListener = null, FirewallConfig $config = null, RememberMeServicesInterface $rememberMeServices = null)
     {
         if (null === $config) {
             @trigger_error(sprintf('"%s()" expects an instance of "%s" as third argument since version 3.2 and will trigger an error in 4.0 if not provided.', __METHOD__, FirewallConfig::class), E_USER_DEPRECATED);
@@ -34,6 +36,7 @@ class FirewallContext
         $this->listeners = $listeners;
         $this->exceptionListener = $exceptionListener;
         $this->config = $config;
+        $this->rememberMeServices = $rememberMeServices;
     }
 
     public function getConfig()
@@ -44,5 +47,10 @@ class FirewallContext
     public function getContext()
     {
         return array($this->listeners, $this->exceptionListener);
+    }
+
+    public function getRememberMeServices()
+    {
+        return $this->rememberMeServices;
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\SecurityBundle\Security;
 
 use Symfony\Component\Security\Http\FirewallMapInterface;
+use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -61,6 +62,24 @@ class FirewallMap implements FirewallMapInterface
         }
 
         return $context->getConfig();
+    }
+
+    /**
+     * Gets the remember me services for the given Request.
+     *
+     * @param Request $request
+     *
+     * @return RememberMeServicesInterface|null
+     */
+    public function getRememberMeServices(Request $request)
+    {
+        $context = $this->getFirewallContext($request);
+
+        if (null === $context) {
+            return;
+        }
+
+        return $context->getRememberMeServices();
     }
 
     private function getFirewallContext(Request $request)

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallContextTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallContextTest.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\SecurityBundle\Security\FirewallConfig;
 use Symfony\Bundle\SecurityBundle\Security\FirewallContext;
 use Symfony\Component\Security\Http\Firewall\ExceptionListener;
 use Symfony\Component\Security\Http\Firewall\ListenerInterface;
+use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
 
 class FirewallContextTest extends \PHPUnit_Framework_TestCase
 {
@@ -22,6 +23,10 @@ class FirewallContextTest extends \PHPUnit_Framework_TestCase
     {
         $config = new FirewallConfig('main', 'request_matcher', 'user_checker');
 
+        $rememberMeServices = $this
+            ->getMockBuilder(RememberMeServicesInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
         $exceptionListener = $this
             ->getMockBuilder(ExceptionListener::class)
             ->disableOriginalConstructor()
@@ -34,9 +39,10 @@ class FirewallContextTest extends \PHPUnit_Framework_TestCase
                 ->getMock(),
         );
 
-        $context = new FirewallContext($listeners, $exceptionListener, $config);
+        $context = new FirewallContext($listeners, $exceptionListener, $config, $rememberMeServices);
 
-        $this->assertEquals(array($listeners, $exceptionListener), $context->getContext());
-        $this->assertEquals($config, $context->getConfig());
+        $this->assertSame(array($listeners, $exceptionListener), $context->getContext());
+        $this->assertSame($config, $context->getConfig());
+        $this->assertSame($rememberMeServices, $context->getRememberMeServices());
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #3137, #11158 (not sure) |
| License | MIT |
| Doc PR | todo |

This allows to retrieve the `RememberMeServices` service of the current firewall using:

``` php
FirwallMap::getRememberMeServices(Request $request) : RememberMeServicesInterface
```

An alternative could be to create a public alias of the service.
It seems there are use cases, see the ticket and the ones mentioning it (some from FOSUserBundle).
