### PR TITLE
[HttpKernel] Deprecate X-Status-Code for better alternative

### DIFF
--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -76,6 +76,11 @@ HttpKernel
 
  * The `Psr6CacheClearer::addPool()` method has been deprecated. Pass an array of pools indexed
    by name to the constructor instead.
+   
+ * The `X-Status-Code` header method of setting a custom status code in the response
+   when handling exceptions has been removed. There is now a new
+   `GetResponseForExceptionEvent::allowCustomResponseCode()` method instead, which
+   will tell the Kernel to use the response code set on the event's response object.
 
 Process
 -------

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -236,6 +236,11 @@ HttpKernel
 
  * The `Psr6CacheClearer::addPool()` method has been removed. Pass an array of pools indexed
    by name to the constructor instead.
+   
+ * The `X-Status-Code` header method of setting a custom status code in the response
+   when handling exceptions has been removed. There is now a new
+   `GetResponseForExceptionEvent::allowCustomResponseCode()` method instead, which
+   will tell the Kernel to use the response code set on the event's response object.
 
 Process
 -------

--- a/src/Symfony/Component/HttpKernel/Event/GetResponseForExceptionEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/GetResponseForExceptionEvent.php
@@ -36,6 +36,11 @@ class GetResponseForExceptionEvent extends GetResponseEvent
      */
     private $exception;
 
+    /**
+     * @var bool
+     */
+    private $allowCustomResponseCode = false;
+
     public function __construct(HttpKernelInterface $kernel, Request $request, $requestType, \Exception $e)
     {
         parent::__construct($kernel, $request, $requestType);
@@ -63,5 +68,23 @@ class GetResponseForExceptionEvent extends GetResponseEvent
     public function setException(\Exception $exception)
     {
         $this->exception = $exception;
+    }
+
+    /**
+     * Mark the event as allowing a custom response code.
+     */
+    public function allowCustomResponseCode()
+    {
+        $this->allowCustomResponseCode = true;
+    }
+
+    /**
+     * Returns true if the event allows a custom response code.
+     *
+     * @return bool
+     */
+    public function isAllowingCustomResponseCode()
+    {
+        return $this->allowCustomResponseCode;
     }
 }

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -242,10 +242,12 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
 
         // the developer asked for a specific status code
         if ($response->headers->has('X-Status-Code')) {
+            @trigger_error(sprintf('Using the X-Status-Code header is deprecated since version 3.3 and will be removed in 4.0. Use %s::allowCustomResponseCode() instead.', GetResponseForExceptionEvent::class), E_USER_DEPRECATED);
+
             $response->setStatusCode($response->headers->get('X-Status-Code'));
 
             $response->headers->remove('X-Status-Code');
-        } elseif (!$response->isClientError() && !$response->isServerError() && !$response->isRedirect()) {
+        } elseif (!$event->isAllowingCustomResponseCode() && !$response->isClientError() && !$response->isServerError() && !$response->isRedirect()) {
             // ensure that we actually have an error response
             if ($e instanceof HttpExceptionInterface) {
                 // keep the HTTP status code and headers

--- a/src/Symfony/Component/HttpKernel/Tests/Event/GetResponseForExceptionEventTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Event/GetResponseForExceptionEventTest.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Event;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Tests\TestHttpKernel;
+
+class GetResponseForExceptionEventTest extends TestCase
+{
+    public function testAllowSuccessfulResponseIsFalseByDefault()
+    {
+        $event = new GetResponseForExceptionEvent(new TestHttpKernel(), new Request(), 1, new \Exception());
+
+        $this->assertFalse($event->isAllowingCustomResponseCode());
+    }
+}

--- a/src/Symfony/Component/Security/Http/EntryPoint/FormAuthenticationEntryPoint.php
+++ b/src/Symfony/Component/Security/Http/EntryPoint/FormAuthenticationEntryPoint.php
@@ -54,7 +54,7 @@ class FormAuthenticationEntryPoint implements AuthenticationEntryPointInterface
 
             $response = $this->httpKernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
             if (200 === $response->getStatusCode()) {
-                $response->headers->set('X-Status-Code', 401);
+                $response->setStatusCode(401);
             }
 
             return $response;

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -112,6 +112,7 @@ class ExceptionListener
 
         try {
             $event->setResponse($this->startAuthentication($event->getRequest(), $exception));
+            $event->allowCustomResponseCode();
         } catch (\Exception $e) {
             $event->setException($e);
         }
@@ -155,6 +156,7 @@ class ExceptionListener
                 $subRequest->attributes->set(Security::ACCESS_DENIED_ERROR, $exception);
 
                 $event->setResponse($event->getKernel()->handle($subRequest, HttpKernelInterface::SUB_REQUEST, true));
+                $event->allowCustomResponseCode();
             }
         } catch (\Exception $e) {
             if (null !== $this->logger) {

--- a/src/Symfony/Component/Security/Http/Tests/EntryPoint/FormAuthenticationEntryPointTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EntryPoint/FormAuthenticationEntryPointTest.php
@@ -64,6 +64,6 @@ class FormAuthenticationEntryPointTest extends TestCase
         $entryPointResponse = $entryPoint->start($request);
 
         $this->assertEquals($response, $entryPointResponse);
-        $this->assertEquals(401, $entryPointResponse->headers->get('X-Status-Code'));
+        $this->assertEquals(401, $entryPointResponse->getStatusCode());
     }
 }

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -20,7 +20,7 @@
         "symfony/security-core": "~3.2",
         "symfony/event-dispatcher": "~2.8|~3.0",
         "symfony/http-foundation": "~2.8|~3.0",
-        "symfony/http-kernel": "~2.8|~3.0",
+        "symfony/http-kernel": "~3.3",
         "symfony/polyfill-php56": "~1.0",
         "symfony/polyfill-php70": "~1.0",
         "symfony/property-access": "~2.8|~3.0"

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.5.9",
         "symfony/event-dispatcher": "~2.8|~3.0",
         "symfony/http-foundation": "~2.8|~3.0",
-        "symfony/http-kernel": "~2.8|~3.0",
+        "symfony/http-kernel": "~3.3",
         "symfony/polyfill-php56": "~1.0",
         "symfony/polyfill-php70": "~1.0",
         "symfony/polyfill-util": "~1.0",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #12343 |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/6948 |

This marks the X-Status-Code header method of setting a custom response status
code in exception listeners for a better alternative. There is now a new method
on the `GetResponseForExceptionEvent` that allows successful status codes in
the response sent to the client.

The old method of setting the X-Status-Code header will now throw a deprecation warning.

Instead, in your exception listener you simply call `GetResponseForExceptionEvent::allowCustomResponseCode()` which will tell the Kernel not to override the status code of the event's response object.

Currenty the `X-Status-Code` header will still be removed, so as not to change the existing behaviour, but this is something we can remove in 4.0.

TODO:
- [x] Replace usage of X-Status-Code in `FormAuthenticationEntryPoint`
- [x] Open Silex issue
- [x] Rename method on the response
- [x] Ensure correct response code is set in `AuthenticationEntryPointInterface` implementations
- [x] Ensure the exception listeners are marking `GetResponseForExceptionEvent` as allowing a custom response code
- [x] In the Security component we should only use the new method of setting a custom response code if it is available, and fall back to the `X-Status-Code` method