### PR TITLE
[BrowserKit] Fix cookie expiration on 32 bit systems

### DIFF
--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -76,7 +76,7 @@ class Cookie
                 throw new \UnexpectedValueException(sprintf('The cookie expiration time "%s" is not valid.', $expires));
             }
 
-            $this->expires = $timestampAsDateTime->getTimestamp();
+            $this->expires = $timestampAsDateTime->format('U');
         }
     }
 
@@ -205,13 +205,13 @@ class Cookie
 
         foreach (self::$dateFormats as $dateFormat) {
             if (false !== $date = \DateTime::createFromFormat($dateFormat, $dateValue, new \DateTimeZone('GMT'))) {
-                return $date->getTimestamp();
+                return $date->format('U');
             }
         }
 
         // attempt a fallback for unusual formatting
         if (false !== $date = date_create($dateValue, new \DateTimeZone('GMT'))) {
-            return $date->getTimestamp();
+            return $date->format('U');
         }
 
         throw new \InvalidArgumentException(sprintf('Could not parse date "%s".', $dateValue));
@@ -304,6 +304,6 @@ class Cookie
      */
     public function isExpired()
     {
-        return null !== $this->expires && 0 !== $this->expires && $this->expires < time();
+        return null !== $this->expires && 0 != $this->expires && $this->expires < time();
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15739 |
| License | MIT |

On 32-bit systems the cookie expiration value was not being calculated
correctly as it was being fetched as an integer. When the timestamp exceeded
the PHP_INT_MAX size it would return an invalid value, breaking the cookie
construction.

The BrowserKit cookie has now been updated to get the timestamp as a string
which works around this platform limitation (similar to how it works in the Cookie 
from HttpFoundation).
