### PR TITLE
[DependencyInjection] Introduce interface attribute for services

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckDefinitionValidityPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckDefinitionValidityPass.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 
 /**
  * This pass validates each definition individually only taking the information
@@ -56,6 +57,14 @@ class CheckDefinitionValidityPass implements CompilerPassInterface
                    .'please add abstract=true, otherwise specify a class to get rid of this error.',
                    $id
                 ));
+            }
+
+            if (($class = $definition->getClass()) && ($interface = $definition->getInterface()) && !is_subclass_of($class, $interface)) {
+                if (!class_exists($class, false)) {
+                    throw new InvalidArgumentException(sprintf('The class "%s" used for service "%s" doesn\'t exist.', $class, $id));
+                }
+
+                throw new RuntimeException(sprintf('The class "%s" used for service "%s" must implement interface "%s".', $class, $id, $interface));
             }
 
             // tag attribute values must be scalars

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
@@ -128,6 +128,7 @@ class ResolveDefinitionTemplatesPass implements CompilerPassInterface
         $def->setPublic($parentDef->isPublic());
         $def->setLazy($parentDef->isLazy());
         $def->setAutowired($parentDef->isAutowired());
+        $def->setInterface($parentDef->getInterface());
 
         // overwrite with values specified in the decorator
         $changes = $definition->getChanges();

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -38,6 +38,7 @@ class Definition
     private $decoratedService;
     private $autowired = false;
     private $autowiringTypes = array();
+    private $interface;
 
     protected $arguments;
 
@@ -727,5 +728,27 @@ class Definition
     public function hasAutowiringType($type)
     {
         return isset($this->autowiringTypes[$type]);
+    }
+
+    /**
+     * Gets the interface that must be implemented by services definitions extending this one.
+     *
+     * @return string|null
+     */
+    public function getInterface()
+    {
+        return $this->interface;
+    }
+
+    /**
+     * Sets the interface that must be implemented by services definitions extending this one.
+     *
+     * @return string|null
+     */
+    public function setInterface($interface)
+    {
+        $this->interface = $interface;
+
+        return $this;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -150,7 +150,7 @@ class XmlFileLoader extends FileLoader
             $definition = new Definition();
         }
 
-        foreach (array('class', 'shared', 'public', 'synthetic', 'lazy', 'abstract') as $key) {
+        foreach (array('class', 'interface', 'shared', 'public', 'synthetic', 'lazy', 'abstract') as $key) {
             if ($value = $service->getAttribute($key)) {
                 $method = 'set'.str_replace('-', '', $key);
                 $definition->$method(XmlUtils::phpize($value));

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -35,6 +35,7 @@ class YamlFileLoader extends FileLoader
 {
     private static $keywords = array(
         'alias' => 'alias',
+        'interface' => 'interface',
         'parent' => 'parent',
         'class' => 'class',
         'shared' => 'shared',
@@ -196,6 +197,10 @@ class YamlFileLoader extends FileLoader
 
         if (isset($service['class'])) {
             $definition->setClass($service['class']);
+        }
+
+        if (isset($service['interface'])) {
+            $definition->setInterface($service['interface']);
         }
 
         if (isset($service['shared'])) {

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -103,6 +103,7 @@
     </xsd:choice>
     <xsd:attribute name="id" type="xsd:string" />
     <xsd:attribute name="class" type="xsd:string" />
+    <xsd:attribute name="interface" type="xsd:string" />
     <xsd:attribute name="shared" type="boolean" />
     <xsd:attribute name="public" type="boolean" />
     <xsd:attribute name="synthetic" type="boolean" />

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckDefinitionValidityPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckDefinitionValidityPassTest.php
@@ -62,6 +62,18 @@ class CheckDefinitionValidityPassTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
+     * @expectedExceptionMessage The class "stdClass" used for service "interfaced" must implement interface "Serializable".
+     */
+    public function testProcesDefinitionNotImplementingInterfaceThrowsException()
+    {
+        $container = new ContainerBuilder();
+        $container->register('interfaced', 'stdClass')->setInterface('Serializable');
+
+        $this->process($container);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
      */
     public function testInvalidTags()
     {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveDefinitionTemplatesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveDefinitionTemplatesPassTest.php
@@ -240,6 +240,38 @@ class ResolveDefinitionTemplatesPassTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($container->getDefinition('child1')->isAutowired());
     }
 
+    public function testServiceOverrideParentInterfaceHasNoEffect()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('parent')
+            ->setInterface('Serializable')
+        ;
+
+        $container->setDefinition('child1', new DefinitionDecorator('parent'))
+            ->setInterface('ArrayAccess')
+        ;
+
+        $this->process($container);
+
+        $this->assertSame('Serializable', $container->getDefinition('child1')->getInterface());
+    }
+
+    public function testSetInterfaceOnServiceIsParent()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('parent', 'ArrayObject')
+            ->setInterface('Serializable')
+        ;
+
+        $container->setDefinition('child1', new DefinitionDecorator('parent'));
+
+        $this->process($container);
+
+        $this->assertSame('Serializable', $container->getDefinition('child1')->getInterface());
+    }
+
     public function testDeepDefinitionsResolving()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services25.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services25.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="bar" abstract="true" interface="BarInterface" />
+    </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services25.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services25.yml
@@ -1,0 +1,4 @@
+services:
+    bar:
+        interface: BarInterface
+        abstract: true

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -556,6 +556,15 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($container->getDefinition('bar')->isAutowired());
     }
 
+    public function testGetInterface()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader->load('services25.xml');
+
+        $this->assertSame('BarInterface', $container->getDefinition('bar')->getInterface());
+    }
+
     /**
      * @group legacy
      * @requires function Symfony\Bridge\PhpUnit\ErrorAssert::assertDeprecationsAreTriggered

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -325,6 +325,15 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($container->getDefinition('bar_service')->isAutowired());
     }
 
+    public function testGetInterface()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('services25.yml');
+
+        $this->assertSame('BarInterface', $container->getDefinition('bar')->getInterface());
+    }
+
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
      * @expectedExceptionMessage The value of the "decorates" option for the "bar" service must be the id of the service without the "@" prefix (replace "@foo" with "foo").


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | todo |

Here is a proposal for introducing a new `interface` attribute usable in ~~abstract~~ service definitions. Setting this attribute to an abstract service involves that all services that will use it as parent must have a `class` implementing this interface.

This is mainly useful for third party bundles and libraries with services for which an interface must be implemented in order to work properly, without needing of use a factory or a compiler pass for doing this check manually (that is a bit too much for such need IMHO).

I will not describe it as an RFC but please give me your opinion about this feature sort as I can look if there is places in the core where this could be useful and see if other things need to be updated, or simply abandon the idea.

---
- An interface can be set on both normal and abstract services
- If set on an abstract service, the child definitions inherit the interface but cannot override its value (not stored in `DefinitionDecorator::$changes`)
