### PR TITLE
[FrameworkBundle] Check for class existence before is_subclass_of

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddConsoleCommandPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddConsoleCommandPass.php
@@ -38,6 +38,10 @@ class AddConsoleCommandPass implements CompilerPassInterface
 
             $class = $container->getParameterBag()->resolveValue($definition->getClass());
             if (!is_subclass_of($class, 'Symfony\\Component\\Console\\Command\\Command')) {
+                if (!class_exists($class, false)) {
+                    throw new \InvalidArgumentException(sprintf('Class "%s" used for service "%s" cannot be found.', $class, $id));
+                }
+
                 throw new \InvalidArgumentException(sprintf('The service "%s" tagged "console.command" must be a subclass of "Symfony\\Component\\Console\\Command\\Command".', $id));
             }
             $container->setAlias('console.command.'.strtolower(str_replace('\\', '_', $class)), $id);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Same as #19342 
