### PR TITLE
[Console] added ability to add custom colors

### DIFF
--- a/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
@@ -75,6 +75,66 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
     }
 
     /**
+     * Add additional foreground color option.
+     *
+     * @param string     $name  The color name
+     * @param string|int $color The color code
+     * @param string|int $unset The unset color code
+     *
+     * @throws InvalidArgumentException When the color name is already defined
+     */
+    public static function addForegroundColor($name, $value, $unset = 0)
+    {
+        static::addColor('foreground', $name, (int) $value, (int) $unset);
+    }
+
+    /**
+     * Add additional background color option.
+     *
+     * @param string     $name  The color name
+     * @param string|int $color The color code
+     * @param string|int $unset The unset color code
+     *
+     * @throws InvalidArgumentException When the color name is already defined
+     */
+    public static function addBackgroundColor($name, $value, $unset = 0)
+    {
+        static::addColor('background', $name, (int) $value, (int) $unset);
+    }
+
+    /**
+     * Add additional color option.
+     *
+     * @param string $color The color type
+     * @param int    $color The color code
+     * @param int    $unset The unset color code
+     *
+     * @throws InvalidArgumentException When the color name is already defined
+     */
+    private static function addColor($type, $name, $value, $unset)
+    {
+        $property = 'available'.ucfirst($type).'Colors';
+
+        if (isset(static::${$property}[$name])) {
+            throw new InvalidArgumentException(sprintf(
+                'The specified %s color "%s" is already defined. Expected a different name than (%s)',
+                $type,
+                $name,
+                implode(', ', array_keys(static::${$property}))
+            ));
+        }
+
+        if ($unset === 0) {
+            $unset = static::${$property}['default']['set'];
+        }
+
+        static::${$property}[$name] = array(
+            'set' => $value,
+            'unset' => $unset,
+        );
+    }
+
+    /**
      * Sets style foreground color.
      *
      * @param string|null $color The color name

--- a/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterStyleTest.php
@@ -96,4 +96,51 @@ class OutputFormatterStyleTest extends \PHPUnit_Framework_TestCase
             $this->assertContains('Invalid option specified: "foo"', $e->getMessage(), '->unsetOption() throws an \InvalidArgumentException when the option does not exist in the available options');
         }
     }
+
+    public function testAddColorForeground()
+    {
+        OutputFormatterStyle::addForegroundColor('light_gray', 37);
+        OutputFormatterStyle::addForegroundColor('dark_gray', 90, 91);
+        $style = new OutputFormatterStyle();
+
+        $style->setForeground('black');
+        $this->assertEquals("\033[30mfoo\033[39m", $style->apply('foo'));
+
+        $style->setForeground('light_gray');
+        $this->assertEquals("\033[37mfoo\033[39m", $style->apply('foo'));
+
+        $style->setForeground('dark_gray');
+        $this->assertEquals("\033[90mfoo\033[91m", $style->apply('foo'));
+
+        $this->setExpectedException('InvalidArgumentException');
+        $style->setBackground('undefined-color');
+    }
+
+    public function testAddColorBackground()
+    {
+        OutputFormatterStyle::addBackgroundColor('light_gray', 47);
+        OutputFormatterStyle::addBackgroundColor('dark_gray', 100, 101);
+        $style = new OutputFormatterStyle();
+
+        $style->setBackground('black');
+        $this->assertEquals("\033[40mfoo\033[49m", $style->apply('foo'));
+
+        $style->setBackground('light_gray');
+        $this->assertEquals("\033[47mfoo\033[49m", $style->apply('foo'));
+
+        $style->setBackground('dark_gray');
+        $this->assertEquals("\033[100mfoo\033[101m", $style->apply('foo'));
+
+        $this->setExpectedException('InvalidArgumentException');
+        $style->setBackground('undefined-color');
+    }
+
+    public function testAddColorExisting()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        OutputFormatterStyle::addForegroundColor('cyan', 60);
+
+        $this->setExpectedException('InvalidArgumentException');
+        OutputFormatterStyle::addBackgroundColor('cyan', 70);
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

It's currently quite tedious to add additional colors to the console components as it does require a custom implementation of `OutputFormatterInterface` as well as `OutputFormatterStyleInterface` just to add some color codes.
