### PR TITLE
Revert "minor #19689 [DI] Cleanup array_key_exists (ro0NL)"

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -223,6 +223,7 @@ class Container implements IntrospectableContainerInterface
             if ('service_container' === $id
                 || isset($this->aliases[$id])
                 || isset($this->services[$id])
+                || array_key_exists($id, $this->services)
             ) {
                 return true;
             }
@@ -265,7 +266,7 @@ class Container implements IntrospectableContainerInterface
                 $id = $this->aliases[$id];
             }
             // Re-use shared service instance if it exists.
-            if (isset($this->services[$id])) {
+            if (isset($this->services[$id]) || array_key_exists($id, $this->services)) {
                 return $this->services[$id];
             }
 
@@ -347,7 +348,7 @@ class Container implements IntrospectableContainerInterface
             $id = $this->aliases[$id];
         }
 
-        return isset($this->services[$id]);
+        return isset($this->services[$id]) || array_key_exists($id, $this->services);
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -436,7 +436,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             return $service;
         }
 
-        if (!isset($this->definitions[$id]) && isset($this->aliasDefinitions[$id])) {
+        if (!array_key_exists($id, $this->definitions) && isset($this->aliasDefinitions[$id])) {
             return $this->get($this->aliasDefinitions[$id]);
         }
 
@@ -784,7 +784,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      */
     public function hasDefinition($id)
     {
-        return isset($this->definitions[strtolower($id)]);
+        return array_key_exists(strtolower($id), $this->definitions);
     }
 
     /**
@@ -800,7 +800,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     {
         $id = strtolower($id);
 
-        if (!isset($this->definitions[$id])) {
+        if (!array_key_exists($id, $this->definitions)) {
             throw new ServiceNotFoundException($id);
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| Tests pass? | yes |
| Fixed tickets | #19689 #19840 #19825 #19857 |
| License | MIT |
| Doc PR | - |

This reverts commit c89f80a9cd3f291159ba5e466c7c968cf15d476a, reversing
changes made to 386e5e78b4ad8356fe01ac5406872a56b5177134.

See discussion in #19847

I'll try adding test cases soon that ensure that:
- [x] _when not leaving scope_ synthetic services always throw and ignore the `ContainerInterface::NULL_ON_INVALID_REFERENCE` flag (on 3.x also)
- [x] _when leaving scope_ synthetic services always return null and ignore the `ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE`  (until 2.8 since scopes are gone in 3.x)
