### PR TITLE
[Workflow] Make PropertyAccess required dependency

### DIFF
--- a/src/Symfony/Component/Workflow/composer.json
+++ b/src/Symfony/Component/Workflow/composer.json
@@ -20,12 +20,12 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9"
+        "php": ">=5.5.9",
+        "symfony/property-access": "~2.3|~3.0"
     },
     "require-dev": {
         "psr/log": "~1.0",
         "symfony/event-dispatcher": "~2.1|~3.0",
-        "symfony/property-access": "~2.3|~3.0",
         "twig/twig": "~1.14"
     },
     "autoload": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master (3.2 is not yet released) |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | N/A |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

Hi, when using Workflow as a standalone component (and instantiating new `Workflow()` instance), I'm getting errors like:

```
PHP Fatal error:  Class 'Symfony\Component\PropertyAccess\PropertyAccess' not found in .../workflow-example/vendor/symfony/workflow/MarkingStore/PropertyAccessorMarkingStore.php on line 37
```

The reason is the PropertyAccessorMarkingStore (and the ScalarMarkingStore as well) [uses](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Workflow/MarkingStore/PropertyAccessorMarkingStore.php#L14) PropertyAccess class. So it is basically not possible to use the component without the symfony/property-access.

Is this correct @lyrixx?
