### PR TITLE
[PropertyInfo] Make ReflectionExtractor compatible with ReflectionType changes in PHP 7.1

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -231,7 +231,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
      */
     private function extractFromReflectionType(\ReflectionType $reflectionType)
     {
-        $phpTypeOrClass = (string) $reflectionType;
+        $phpTypeOrClass = method_exists($reflectionType, 'getName') ? $reflectionType->getName() : (string) $reflectionType;
         $nullable = $reflectionType->allowsNull();
 
         if ($reflectionType->isBuiltin()) {

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractors/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractors/ReflectionExtractorTest.php
@@ -94,6 +94,25 @@ class ReflectionExtractorTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @dataProvider php71TypesProvider
+     * @requires PHP 7.1
+     */
+    public function testExtractPhp71Type($property, array $type = null)
+    {
+        $this->assertEquals($type, $this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\Php71Dummy', $property, array()));
+    }
+
+    public function php71TypesProvider()
+    {
+        return array(
+            array('foo', array(new Type(Type::BUILTIN_TYPE_ARRAY, true, null, true))),
+            array('bar', array(new Type(Type::BUILTIN_TYPE_INT, true))),
+            array('baz', array(new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_STRING)))),
+            array('donotexist', null),
+        );
+    }
+
     public function testIsReadable()
     {
         $this->assertFalse($this->extractor->isReadable('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', 'bar', array()));

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php71Dummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php71Dummy.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+/**
+ * @author Teoh Han Hui <teohhanhui@gmail.com>
+ */
+class Php71Dummy
+{
+    public function getFoo(): ?array
+    {
+    }
+
+    public function setBar(?int $bar)
+    {
+    }
+
+    public function addBaz(string $baz)
+    {
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/issues/19677#issuecomment-244671828 |
| License | MIT |
| Doc PR | N/A |
