### PR TITLE
Release v2.7.18

### DIFF
--- a/CHANGELOG-2.7.md
+++ b/CHANGELOG-2.7.md
@@ -7,6 +7,16 @@ in 2.7 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.7.0...v2.7.1
 
+* 2.7.18 (2016-09-07)
+
+ * bug #19859 [ClassLoader] Fix ClassCollectionLoader inlining with declare(strict_types=1) (nicolas-grekas)
+ * bug #19780 [FrameworkBundle] Incorrect line break in exception message (500 debug page) (pedroresende)
+ * bug #19595 [form] lazy trans `post_max_size_message`. (aitboudad)
+ * bug #19870 [DI] Fix setting synthetic services on ContainerBuilder (nicolas-grekas)
+ * bug #19848 Revert "minor #19689 [DI] Cleanup array_key_exists (ro0NL)" (nicolas-grekas)
+ * bug #19842 [FrameworkBundle] Check for class existence before is_subclass_of (chalasr)
+ * bug #19827 [BrowserKit] Fix cookie expiration on 32 bit systems (jameshalsall)
+
 * 2.7.17 (2016-09-02)
 
  * bug #19794 [VarDumper] Various minor fixes & cleanups (nicolas-grekas)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,8 +16,8 @@ Symfony is the result of the work of many people who made the code better
  - Kris Wallsmith (kriswallsmith)
  - Jakub Zalas (jakubzalas)
  - Ryan Weaver (weaverryan)
- - Kévin Dunglas (dunglas)
  - Javier Eguiluz (javier.eguiluz)
+ - Kévin Dunglas (dunglas)
  - Hugo Hamon (hhamon)
  - Abdellatif Ait boudad (aitboudad)
  - Pascal Borreli (pborreli)
@@ -52,8 +52,8 @@ Symfony is the result of the work of many people who made the code better
  - Konstantin Kudryashov (everzet)
  - Bilal Amarni (bamarni)
  - Florin Patan (florinpatan)
- - Peter Rehm (rpet)
  - Ener-Getick (energetick)
+ - Peter Rehm (rpet)
  - Iltar van der Berg (kjarli)
  - Kevin Bond (kbond)
  - Andrej Hudec (pulzarraider)
@@ -315,6 +315,7 @@ Symfony is the result of the work of many people who made the code better
  - JhonnyL
  - hossein zolfi (ocean)
  - Clément Gautier (clementgautier)
+ - James Halsall (jaitsu)
  - Eduardo Gulias (egulias)
  - giulio de donato (liuggio)
  - Stéphane PY (steph_py)
@@ -396,7 +397,6 @@ Symfony is the result of the work of many people who made the code better
  - Christian Wahler
  - Mathieu Lemoine
  - Gintautas Miselis
- - James Halsall (jaitsu)
  - David Badura (davidbadura)
  - Zander Baldwin
  - Adam Harvey
@@ -1302,6 +1302,7 @@ Symfony is the result of the work of many people who made the code better
  - Muriel (metalmumu)
  - Michael Pohlers (mick_the_big)
  - Cayetano Soriano Gallego (neoshadybeat)
+ - Ondrej Machulda (ondram)
  - Patrick McDougle (patrick-mcdougle)
  - Pablo Monterde Perez (plebs)
  - Jimmy Leger (redpanda)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -58,12 +58,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '2.7.18-DEV';
+    const VERSION = '2.7.18';
     const VERSION_ID = 20718;
     const MAJOR_VERSION = 2;
     const MINOR_VERSION = 7;
     const RELEASE_VERSION = 18;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '05/2018';
     const END_OF_LIFE = '05/2019';


### PR DESCRIPTION
Changes since last release: https://github.com/symfony/symfony/compare/v2.7.17...5998561

**Changelog**
- bug #19859 [ClassLoader] Fix ClassCollectionLoader inlining with declare(strict_types=1) (@nicolas-grekas)
- bug #19780 [FrameworkBundle] Incorrect line break in exception message (500 debug page) (@pedroresende)
- bug #19595 [form] lazy trans `post_max_size_message`. (@aitboudad)
- bug #19870 [DI] Fix setting synthetic services on ContainerBuilder (@nicolas-grekas)
- bug #19848 Revert "minor #19689 [DI] Cleanup array_key_exists (ro0NL)" (@nicolas-grekas)
- bug #19842 [FrameworkBundle] Check for class existence before is_subclass_of (@chalasr)
- bug #19827 [BrowserKit] Fix cookie expiration on 32 bit systems (@jameshalsall)
