### PR TITLE
Release v2.8.11

### DIFF
--- a/CHANGELOG-2.8.md
+++ b/CHANGELOG-2.8.md
@@ -7,6 +7,16 @@ in 2.8 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.8.0...v2.8.1
 
+* 2.8.11 (2016-09-07)
+
+ * bug #19859 [ClassLoader] Fix ClassCollectionLoader inlining with declare(strict_types=1) (nicolas-grekas)
+ * bug #19780 [FrameworkBundle] Incorrect line break in exception message (500 debug page) (pedroresende)
+ * bug #19595 [form] lazy trans `post_max_size_message`. (aitboudad)
+ * bug #19870 [DI] Fix setting synthetic services on ContainerBuilder (nicolas-grekas)
+ * bug #19848 Revert "minor #19689 [DI] Cleanup array_key_exists (ro0NL)" (nicolas-grekas)
+ * bug #19842 [FrameworkBundle] Check for class existence before is_subclass_of (chalasr)
+ * bug #19827 [BrowserKit] Fix cookie expiration on 32 bit systems (jameshalsall)
+
 * 2.8.10 (2016-09-02)
 
  * bug #19786 Update profiler's layout to use flexbox (javiereguiluz)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -59,12 +59,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '2.8.11-DEV';
+    const VERSION = '2.8.11';
     const VERSION_ID = 20811;
     const MAJOR_VERSION = 2;
     const MINOR_VERSION = 8;
     const RELEASE_VERSION = 11;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '11/2018';
     const END_OF_LIFE = '11/2019';


### PR DESCRIPTION
Changes since last release: https://github.com/symfony/symfony/compare/v2.8.10...af440e3

**Changelog**
- bug #19859 [ClassLoader] Fix ClassCollectionLoader inlining with declare(strict_types=1) (@nicolas-grekas)
- bug #19780 [FrameworkBundle] Incorrect line break in exception message (500 debug page) (@pedroresende)
- bug #19595 [form] lazy trans `post_max_size_message`. (@aitboudad)
- bug #19870 [DI] Fix setting synthetic services on ContainerBuilder (@nicolas-grekas)
- bug #19848 Revert "minor #19689 [DI] Cleanup array_key_exists (ro0NL)" (@nicolas-grekas)
- bug #19842 [FrameworkBundle] Check for class existence before is_subclass_of (@chalasr)
- bug #19827 [BrowserKit] Fix cookie expiration on 32 bit systems (@jameshalsall)
