### PR TITLE
Fix translation:update command count

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -160,11 +160,8 @@ EOF
             foreach ($operation->getDomains() as $domain) {
                 $newKeys = array_keys($operation->getNewMessages($domain));
                 $allKeys = array_keys($operation->getMessages($domain));
-                $domainMessagesCount = count($newKeys) + count($allKeys);
 
-                $io->section(sprintf('Messages extracted for domain "<info>%s</info>" (%d messages)', $domain, $domainMessagesCount));
-
-                $io->listing(array_merge(
+                $list = array_merge(
                     array_diff($allKeys, $newKeys),
                     array_map(function ($id) {
                         return sprintf('<fg=green>%s</>', $id);
@@ -172,7 +169,12 @@ EOF
                     array_map(function ($id) {
                         return sprintf('<fg=red>%s</>', $id);
                     }, array_keys($operation->getObsoleteMessages($domain)))
-                ));
+                );
+
+                $domainMessagesCount = count($list);
+
+                $io->section(sprintf('Messages extracted for domain "<info>%s</info>" (%d message%s)', $domain, $domainMessagesCount, $domainMessagesCount > 1 ? 's' : ''));
+                $io->listing($list);
 
                 $extractedMessagesCount += $domainMessagesCount;
             }
@@ -181,7 +183,7 @@ EOF
                 $io->comment('Xliff output version is <info>1.2</info>');
             }
 
-            $resultMessage = sprintf('%d messages were successfully extracted', $extractedMessagesCount);
+            $resultMessage = sprintf('%d message%s successfully extracted', $extractedMessagesCount, $extractedMessagesCount > 1 ? 's were' : ' was');
         }
 
         if ($input->getOption('no-backup') === true) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/TranslationUpdateCommandTest.php
@@ -28,6 +28,15 @@ class TranslationUpdateCommandTest extends \PHPUnit_Framework_TestCase
         $tester = $this->createCommandTester($this->getContainer(array('foo' => 'foo')));
         $tester->execute(array('command' => 'translation:update', 'locale' => 'en', 'bundle' => 'foo', '--dump-messages' => true, '--clean' => true));
         $this->assertRegExp('/foo/', $tester->getDisplay());
+        $this->assertRegExp('/1 message was successfully extracted/', $tester->getDisplay());
+    }
+
+    public function testDumpTwoMessagesAndClean()
+    {
+        $tester = $this->createCommandTester($this->getContainer(array('foo' => 'foo', 'bar' => 'bar')));
+        $tester->execute(array('command' => 'translation:update', 'locale' => 'en', 'bundle' => 'foo', '--dump-messages' => true, '--clean' => true));
+        $this->assertRegExp('/foo/', $tester->getDisplay());
+        $this->assertRegExp('/bar/', $tester->getDisplay());
         $this->assertRegExp('/2 messages were successfully extracted/', $tester->getDisplay());
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This issue fixes a bad count in the `translation:update` command. Previously, the number was badly calculated and doubled if the translation file didn't exists.

Before:

```
Messages extracted for domain "messages" (2 messages)
-----------------------------------------------------

 * hello.world


 [OK] 2 messages were successfully extracted.
```

After:

```
Messages extracted for domain "messages" (1 message)
-----------------------------------------------------

 * hello.world


 [OK] 1 message was successfully extracted.
```
