### PR TITLE
[Form] Add support for DateTimeImmutable

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/BaseDateTimeTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/BaseDateTimeTransformer.php
@@ -29,16 +29,19 @@ abstract class BaseDateTimeTransformer implements DataTransformerInterface
 
     protected $outputTimezone;
 
+    protected $immutable;
+
     /**
      * Constructor.
      *
      * @param string $inputTimezone  The name of the input timezone
      * @param string $outputTimezone The name of the output timezone
+     * @param bool   $immutable      Whether to use \DateTimeImmutable instead of \DateTime
      *
      * @throws UnexpectedTypeException  if a timezone is not a string
      * @throws InvalidArgumentException if a timezone is not valid
      */
-    public function __construct($inputTimezone = null, $outputTimezone = null)
+    public function __construct($inputTimezone = null, $outputTimezone = null, $immutable = false)
     {
         if (null !== $inputTimezone && !is_string($inputTimezone)) {
             throw new UnexpectedTypeException($inputTimezone, 'string');
@@ -63,5 +66,12 @@ abstract class BaseDateTimeTransformer implements DataTransformerInterface
         } catch (\Exception $e) {
             throw new InvalidArgumentException(sprintf('Output timezone is invalid: %s.', $this->outputTimezone), $e->getCode(), $e);
         }
+
+        $this->immutable = $immutable;
+    }
+
+    protected function getDateTimeClass()
+    {
+        return true === $this->immutable ? \DateTimeImmutable::class : \DateTime::class;
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
@@ -33,12 +33,13 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
      * @param string $outputTimezone The output timezone
      * @param array  $fields         The date fields
      * @param bool   $pad            Whether to use padding
+     * @param bool   $immutable      Whether to use \DateTimeImmutable instead of \DateTime
      *
      * @throws UnexpectedTypeException if a timezone is not a string
      */
-    public function __construct($inputTimezone = null, $outputTimezone = null, array $fields = null, $pad = false)
+    public function __construct($inputTimezone = null, $outputTimezone = null, array $fields = null, $pad = false, $immutable = false)
     {
-        parent::__construct($inputTimezone, $outputTimezone);
+        parent::__construct($inputTimezone, $outputTimezone, $immutable);
 
         if (null === $fields) {
             $fields = array('year', 'month', 'day', 'hour', 'minute', 'second');
@@ -108,7 +109,7 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
      *
      * @param array $value Localized date
      *
-     * @return \DateTime Normalized date
+     * @return \DateTimeInterface Normalized date
      *
      * @throws TransformationFailedException If the given value is not an array,
      *                                       if the value could not be transformed
@@ -170,7 +171,8 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
         }
 
         try {
-            $dateTime = new \DateTime(sprintf(
+            $dateTimeClass = $this->getDateTimeClass();
+            $dateTime = new $dateTimeClass(sprintf(
                 '%s-%s-%s %s:%s:%s',
                 empty($value['year']) ? '1970' : $value['year'],
                 empty($value['month']) ? '1' : $value['month'],

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToRfc3339Transformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToRfc3339Transformer.php
@@ -53,7 +53,7 @@ class DateTimeToRfc3339Transformer extends BaseDateTimeTransformer
      *
      * @param string $rfc3339 Formatted string
      *
-     * @return \DateTime Normalized date
+     * @return \DateTimeInterface Normalized date
      *
      * @throws TransformationFailedException If the given value is not a string,
      *                                       if the value could not be transformed
@@ -68,8 +68,10 @@ class DateTimeToRfc3339Transformer extends BaseDateTimeTransformer
             return;
         }
 
+        $dateTimeClass = $this->getDateTimeClass();
+
         try {
-            $dateTime = new \DateTime($rfc3339);
+            $dateTime = new $dateTimeClass($rfc3339);
         } catch (\Exception $e) {
             throw new TransformationFailedException($e->getMessage(), $e->getCode(), $e);
         }

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -87,6 +87,7 @@ class DateTimeType extends AbstractType
         $timeFormat = self::DEFAULT_TIME_FORMAT;
         $calendar = \IntlDateFormatter::GREGORIAN;
         $pattern = is_string($options['format']) ? $options['format'] : null;
+        $immutable = 'datetimeimmutable' === $options['input'];
 
         if (!in_array($dateFormat, self::$acceptedFormats, true)) {
             throw new InvalidOptionsException('The "date_format" option must be one of the IntlDateFormatter constants (FULL, LONG, MEDIUM, SHORT) or a string representing a custom format.');
@@ -96,7 +97,8 @@ class DateTimeType extends AbstractType
             if (self::HTML5_FORMAT === $pattern) {
                 $builder->addViewTransformer(new DateTimeToRfc3339Transformer(
                     $options['model_timezone'],
-                    $options['view_timezone']
+                    $options['view_timezone'],
+                    $immutable
                 ));
             } else {
                 $builder->addViewTransformer(new DateTimeToLocalizedStringTransformer(
@@ -105,7 +107,8 @@ class DateTimeType extends AbstractType
                     $dateFormat,
                     $timeFormat,
                     $calendar,
-                    $pattern
+                    $pattern,
+                    $immutable
                 ));
             }
         } else {
@@ -155,7 +158,7 @@ class DateTimeType extends AbstractType
 
             $builder
                 ->addViewTransformer(new DataTransformerChain(array(
-                    new DateTimeToArrayTransformer($options['model_timezone'], $options['view_timezone'], $parts),
+                    new DateTimeToArrayTransformer($options['model_timezone'], $options['view_timezone'], $parts, false, $immutable),
                     new ArrayToPartsTransformer(array(
                         'date' => $dateParts,
                         'time' => $timeParts,
@@ -255,6 +258,7 @@ class DateTimeType extends AbstractType
 
         $resolver->setAllowedValues('input', array(
             'datetime',
+            'datetimeimmutable',
             'string',
             'timestamp',
             'array',

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -51,6 +51,7 @@ class DateType extends AbstractType
         $timeFormat = \IntlDateFormatter::NONE;
         $calendar = \IntlDateFormatter::GREGORIAN;
         $pattern = is_string($options['format']) ? $options['format'] : null;
+        $immutable = 'datetimeimmutable' === $options['input'];
 
         if (!in_array($dateFormat, self::$acceptedFormats, true)) {
             throw new InvalidOptionsException('The "format" option must be one of the IntlDateFormatter constants (FULL, LONG, MEDIUM, SHORT) or a string representing a custom format.');
@@ -67,7 +68,8 @@ class DateType extends AbstractType
                 $dateFormat,
                 $timeFormat,
                 $calendar,
-                $pattern
+                $pattern,
+                $immutable
             ));
         } else {
             $yearOptions = $monthOptions = $dayOptions = array(
@@ -113,7 +115,7 @@ class DateType extends AbstractType
                 ->add('month', self::$widgets[$options['widget']], $monthOptions)
                 ->add('day', self::$widgets[$options['widget']], $dayOptions)
                 ->addViewTransformer(new DateTimeToArrayTransformer(
-                    $options['model_timezone'], $options['view_timezone'], array('year', 'month', 'day')
+                    $options['model_timezone'], $options['view_timezone'], array('year', 'month', 'day'), false, $immutable
                 ))
                 ->setAttribute('formatter', $formatter)
             ;
@@ -254,6 +256,7 @@ class DateType extends AbstractType
 
         $resolver->setAllowedValues('input', array(
             'datetime',
+            'datetimeimmutable',
             'string',
             'timestamp',
             'array',

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -52,8 +52,10 @@ class TimeType extends AbstractType
             $parts[] = 'second';
         }
 
+        $immutable = 'datetimeimmutable' === $options['input'];
+
         if ('single_text' === $options['widget']) {
-            $builder->addViewTransformer(new DateTimeToStringTransformer($options['model_timezone'], $options['view_timezone'], $format));
+            $builder->addViewTransformer(new DateTimeToStringTransformer($options['model_timezone'], $options['view_timezone'], $format, true, $immutable));
         } else {
             $hourOptions = $minuteOptions = $secondOptions = array(
                 'error_bubbling' => true,
@@ -117,7 +119,7 @@ class TimeType extends AbstractType
                 $builder->add('second', self::$widgets[$options['widget']], $secondOptions);
             }
 
-            $builder->addViewTransformer(new DateTimeToArrayTransformer($options['model_timezone'], $options['view_timezone'], $parts, 'text' === $options['widget']));
+            $builder->addViewTransformer(new DateTimeToArrayTransformer($options['model_timezone'], $options['view_timezone'], $parts, 'text' === $options['widget'], $immutable));
         }
 
         if ('string' === $options['input']) {
@@ -239,6 +241,7 @@ class TimeType extends AbstractType
 
         $resolver->setAllowedValues('input', array(
             'datetime',
+            'datetimeimmutable',
             'string',
             'timestamp',
             'array',

--- a/src/Symfony/Component/Form/Test/TypeTestCase.php
+++ b/src/Symfony/Component/Form/Test/TypeTestCase.php
@@ -34,7 +34,7 @@ abstract class TypeTestCase extends FormIntegrationTestCase
         $this->builder = new FormBuilder(null, null, $this->dispatcher, $this->factory);
     }
 
-    public static function assertDateTimeEquals(\DateTime $expected, \DateTime $actual)
+    public static function assertDateTimeEquals(\DateTimeInterface $expected, \DateTimeInterface $actual)
     {
         self::assertEquals($expected->format('c'), $actual->format('c'));
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -52,22 +52,29 @@ class DateTypeTest extends TestCase
         ));
     }
 
-    public function testSubmitFromSingleTextDateTimeWithDefaultFormat()
+    /**
+     * @dataProvider provideDateTimeClasses
+     */
+    public function testSubmitFromSingleTextDateTimeWithDefaultFormat($dateTimeClass, $inputType)
     {
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'single_text',
-            'input' => 'datetime',
+            'input' => $inputType,
         ));
 
         $form->submit('2010-06-02');
 
-        $this->assertDateTimeEquals(new \DateTime('2010-06-02 UTC'), $form->getData());
+        $this->assertInstanceOf($dateTimeClass, $form->getData());
+        $this->assertDateTimeEquals(new $dateTimeClass('2010-06-02 UTC'), $form->getData());
         $this->assertEquals('2010-06-02', $form->getViewData());
     }
 
-    public function testSubmitFromSingleTextDateTime()
+    /**
+     * @dataProvider provideDateTimeClasses
+     */
+    public function testSubmitFromSingleTextDateTime($dateTimeClass, $inputType)
     {
         // we test against "de_AT", so we need the full implementation
         IntlTestHelper::requireFullIntl($this);
@@ -79,12 +86,13 @@ class DateTypeTest extends TestCase
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'single_text',
-            'input' => 'datetime',
+            'input' => $inputType,
         ));
 
         $form->submit('2.6.2010');
 
-        $this->assertDateTimeEquals(new \DateTime('2010-06-02 UTC'), $form->getData());
+        $this->assertInstanceOf($dateTimeClass, $form->getData());
+        $this->assertDateTimeEquals(new $dateTimeClass('2010-06-02 UTC'), $form->getData());
         $this->assertEquals('02.06.2010', $form->getViewData());
     }
 
@@ -159,12 +167,16 @@ class DateTypeTest extends TestCase
         $this->assertEquals('02.06.2010', $form->getViewData());
     }
 
-    public function testSubmitFromText()
+    /**
+     * @dataProvider provideDateTimeClasses
+     */
+    public function testSubmitFromText($dateTimeClass, $inputType)
     {
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'text',
+            'input' => $inputType,
         ));
 
         $text = array(
@@ -175,19 +187,22 @@ class DateTypeTest extends TestCase
 
         $form->submit($text);
 
-        $dateTime = new \DateTime('2010-06-02 UTC');
-
-        $this->assertDateTimeEquals($dateTime, $form->getData());
+        $this->assertInstanceOf($dateTimeClass, $form->getData());
+        $this->assertDateTimeEquals(new $dateTimeClass('2010-06-02 UTC'), $form->getData());
         $this->assertEquals($text, $form->getViewData());
     }
 
-    public function testSubmitFromChoice()
+    /**
+     * @dataProvider provideDateTimeClasses
+     */
+    public function testSubmitFromChoice($dateTimeClass, $inputType)
     {
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'choice',
             'years' => array(2010),
+            'input' => $inputType,
         ));
 
         $text = array(
@@ -198,9 +213,8 @@ class DateTypeTest extends TestCase
 
         $form->submit($text);
 
-        $dateTime = new \DateTime('2010-06-02 UTC');
-
-        $this->assertDateTimeEquals($dateTime, $form->getData());
+        $this->assertInstanceOf($dateTimeClass, $form->getData());
+        $this->assertDateTimeEquals(new $dateTimeClass('2010-06-02 UTC'), $form->getData());
         $this->assertEquals($text, $form->getViewData());
     }
 
@@ -225,19 +239,23 @@ class DateTypeTest extends TestCase
         $this->assertEquals($text, $form->getViewData());
     }
 
-    public function testSubmitFromInputDateTimeDifferentPattern()
+    /**
+     * @dataProvider provideDateTimeClasses
+     */
+    public function testSubmitFromInputDateTimeDifferentPattern($dateTimeClass, $inputType)
     {
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\DateType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'format' => 'MM*yyyy*dd',
             'widget' => 'single_text',
-            'input' => 'datetime',
+            'input' => $inputType,
         ));
 
         $form->submit('06*2010*02');
 
-        $this->assertDateTimeEquals(new \DateTime('2010-06-02 UTC'), $form->getData());
+        $this->assertInstanceOf($dateTimeClass, $form->getData());
+        $this->assertDateTimeEquals(new $dateTimeClass('2010-06-02 UTC'), $form->getData());
         $this->assertEquals('06*2010*02', $form->getViewData());
     }
 
@@ -418,7 +436,10 @@ class DateTypeTest extends TestCase
         $this->assertEquals('01.06.2010', $form->getViewData());
     }
 
-    public function testSetDataWithNegativeTimezoneOffsetDateTimeInput()
+    /**
+     * @dataProvider provideDateTimeClasses
+     */
+    public function testSetDataWithNegativeTimezoneOffsetDateTimeInput($dateTimeClass, $inputType)
     {
         // we test against "de_AT", so we need the full implementation
         IntlTestHelper::requireFullIntl($this);
@@ -429,18 +450,28 @@ class DateTypeTest extends TestCase
             'format' => \IntlDateFormatter::MEDIUM,
             'model_timezone' => 'UTC',
             'view_timezone' => 'America/New_York',
-            'input' => 'datetime',
+            'input' => $inputType,
             'widget' => 'single_text',
         ));
 
-        $dateTime = new \DateTime('2010-06-02 UTC');
+        $dateTime = new $dateTimeClass('2010-06-02 UTC');
 
         $form->setData($dateTime);
+
+        $this->assertInstanceOf($dateTimeClass, $form->getData());
 
         // 2010-06-02 00:00:00 UTC
         // 2010-06-01 20:00:00 UTC-4
         $this->assertDateTimeEquals($dateTime, $form->getData());
         $this->assertEquals('01.06.2010', $form->getViewData());
+    }
+
+    public function provideDateTimeClasses()
+    {
+        return array(
+            array(\DateTime::class, 'datetime'),
+            array(\DateTimeImmutable::class, 'datetimeimmutable'),
+        );
     }
 
     public function testYearsOption()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -17,12 +17,15 @@ use Symfony\Component\Form\Test\TypeTestCase as TestCase;
 
 class TimeTypeTest extends TestCase
 {
-    public function testSubmitDateTime()
+    /**
+     * @dataProvider provideDateTimeClasses
+     */
+    public function testSubmitDateTime($dateTimeClass, $inputType)
     {
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
-            'input' => 'datetime',
+            'input' => $inputType,
         ));
 
         $input = array(
@@ -32,9 +35,8 @@ class TimeTypeTest extends TestCase
 
         $form->submit($input);
 
-        $dateTime = new \DateTime('1970-01-01 03:04:00 UTC');
-
-        $this->assertEquals($dateTime, $form->getData());
+        $this->assertInstanceOf($dateTimeClass, $form->getData());
+        $this->assertEquals(new $dateTimeClass('1970-01-01 03:04:00 UTC'), $form->getData());
         $this->assertEquals($input, $form->getViewData());
     }
 
@@ -97,34 +99,42 @@ class TimeTypeTest extends TestCase
         $this->assertEquals($input, $form->getViewData());
     }
 
-    public function testSubmitDatetimeSingleText()
+    /**
+     * @dataProvider provideDateTimeClasses
+     */
+    public function testSubmitDatetimeSingleText($dateTimeClass, $inputType)
     {
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
-            'input' => 'datetime',
+            'input' => $inputType,
             'widget' => 'single_text',
         ));
 
         $form->submit('03:04');
 
-        $this->assertEquals(new \DateTime('1970-01-01 03:04:00 UTC'), $form->getData());
+        $this->assertInstanceOf($dateTimeClass, $form->getData());
+        $this->assertEquals(new $dateTimeClass('1970-01-01 03:04:00 UTC'), $form->getData());
         $this->assertEquals('03:04', $form->getViewData());
     }
 
-    public function testSubmitDatetimeSingleTextWithoutMinutes()
+    /**
+     * @dataProvider provideDateTimeClasses
+     */
+    public function testSubmitDatetimeSingleTextWithoutMinutes($dateTimeClass, $inputType)
     {
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
-            'input' => 'datetime',
+            'input' => $inputType,
             'widget' => 'single_text',
             'with_minutes' => false,
         ));
 
         $form->submit('03');
 
-        $this->assertEquals(new \DateTime('1970-01-01 03:00:00 UTC'), $form->getData());
+        $this->assertInstanceOf($dateTimeClass, $form->getData());
+        $this->assertEquals(new $dateTimeClass('1970-01-01 03:00:00 UTC'), $form->getData());
         $this->assertEquals('03', $form->getViewData());
     }
 
@@ -221,32 +231,46 @@ class TimeTypeTest extends TestCase
         $this->assertEquals('03', $form->getViewData());
     }
 
-    public function testSetDataWithoutMinutes()
+    /**
+     * @dataProvider provideDateTimeClasses
+     */
+    public function testSetDataWithoutMinutes($dateTimeClass, $inputType)
     {
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
-            'input' => 'datetime',
+            'input' => $inputType,
             'with_minutes' => false,
         ));
 
-        $form->setData(new \DateTime('03:04:05 UTC'));
+        $form->setData(new $dateTimeClass('03:04:05 UTC'));
 
         $this->assertEquals(array('hour' => 3), $form->getViewData());
     }
 
-    public function testSetDataWithSeconds()
+    /**
+     * @dataProvider provideDateTimeClasses
+     */
+    public function testSetDataWithSeconds($dateTimeClass, $inputType)
     {
         $form = $this->factory->create('Symfony\Component\Form\Extension\Core\Type\TimeType', null, array(
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
-            'input' => 'datetime',
+            'input' => $inputType,
             'with_seconds' => true,
         ));
 
-        $form->setData(new \DateTime('03:04:05 UTC'));
+        $form->setData(new $dateTimeClass('03:04:05 UTC'));
 
         $this->assertEquals(array('hour' => 3, 'minute' => 4, 'second' => 5), $form->getViewData());
+    }
+
+    public function provideDateTimeClasses()
+    {
+        return array(
+            array(\DateTime::class, 'datetime'),
+            array(\DateTimeImmutable::class, 'datetimeimmutable'),
+        );
     }
 
     public function testSetDataDifferentTimezones()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #9508 |
| License | MIT |
| Doc PR | TODO |

This PR is an initial concept for adding support for `\DateTimeImmutable` in the Form component. 

The `DateType`, `TimeType` and `DateTimeType` now support a new "input" option called "datetimeimmutable". When this is set the returned values from `$form->getData()` will be instances of `\DateTimeImmutable` instead of `\DateTime` (which is the case for an "input" value of "datetime" - the default).

The existing `DateTime` transformers now take an additional constructor argument indicating whether the `DateTime` object is immutable, affecting the reverse-transformed value

I'm looking for feedback on this approach before I finalise it.
