### PR TITLE
Allow defining a Name Converter by tag

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/SerializerPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/SerializerPass.php
@@ -46,5 +46,12 @@ class SerializerPass implements CompilerPassInterface
             throw new RuntimeException('You must tag at least one service as "serializer.encoder" to use the Serializer service');
         }
         $container->getDefinition('serializer')->replaceArgument(1, $encoders);
+
+        // Looks for all the services tagged "serializer.name-converter" and adds the highest priority one to the
+        // Object Normalizer
+        $nameConverters = $this->findAndSortTaggedServices('serializer.name-converter', $container);
+        if (!empty($nameConverters)) {
+            $container->getDefinition('serializer.normalizer.object')->replaceArgument(1, $nameConverters[0]);
+        }
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This allows the user to be able to configure a name converter for the
serializer to use. This is useful because it saves you writing a
normalizer for every single class you want to have underscores in the
name of the fields.

With this commit you can tag a service as "serializer.name-converter",
and it will be inserted into the "serializer.normalizer.object" service,
which is the primary service for normalizing general objects into
JSON or whatever. The highest priority name-converter is taken, allowing
the user to override what's been set in there.
