### PR TITLE
[FrameworkBundle] Remove cache clearer default value in config

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -585,7 +585,7 @@ class Configuration implements ConfigurationInterface
                                     ->scalarNode('provider')
                                         ->info('The service name to use as provider when the specified adapter needs one.')
                                     ->end()
-                                    ->scalarNode('clearer')->defaultValue('cache.default_clearer')->end()
+                                    ->scalarNode('clearer')->end()
                                 ->end()
                             ->end()
                             ->validate()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
@@ -62,22 +62,28 @@ class CachePoolsTest extends WebTestCase
         static::bootKernel($options);
         $container = static::$kernel->getContainer();
 
-        $pool = $container->get('cache.test');
-        $this->assertInstanceOf($adapterClass, $pool);
+        $pool1 = $container->get('cache.pool1');
+        $this->assertInstanceOf($adapterClass, $pool1);
 
         $key = 'foobar';
-        $pool->deleteItem($key);
-        $item = $pool->getItem($key);
+        $pool1->deleteItem($key);
+        $item = $pool1->getItem($key);
         $this->assertFalse($item->isHit());
 
         $item->set('baz');
-        $pool->save($item);
-        $item = $pool->getItem($key);
+        $pool1->save($item);
+        $item = $pool1->getItem($key);
         $this->assertTrue($item->isHit());
 
+        $pool2 = $container->get('cache.pool2');
+        $pool2->save($item);
+
         $container->get('cache_clearer')->clear($container->getParameter('kernel.cache_dir'));
-        $item = $pool->getItem($key);
+        $item = $pool1->getItem($key);
         $this->assertFalse($item->isHit());
+
+        $item = $pool2->getItem($key);
+        $this->assertTrue($item->isHit());
     }
 
     protected static function createKernel(array $options = array())

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/CachePools/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/CachePools/config.yml
@@ -4,5 +4,10 @@ imports:
 framework:
     cache:
         pools:
-            cache.test:
+            cache.pool1:
                 public: true
+            cache.pool2:
+                public: true
+                adapter: cache.pool3
+            cache.pool3:
+                clearer: ~

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/CachePools/redis_config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/CachePools/redis_config.yml
@@ -5,5 +5,8 @@ framework:
     cache:
         app: cache.adapter.redis
         pools:
-            cache.test:
+            cache.pool1:
                 public: true
+            cache.pool2:
+                public: true
+                clearer: ~

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/CachePools/redis_custom_config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/CachePools/redis_custom_config.yml
@@ -17,5 +17,8 @@ services:
 framework:
     cache:
         pools:
-            cache.test:
+            cache.pool1:
                 public: true
+            cache.pool2:
+                public: true
+                clearer: ~


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | yes |
| Tests pass? | yes |
| License | MIT |

`cache.default_clearer` is already the default behavior (tested), but duplicating this in the configuration prevents inheriting the `clearer` setting when configuring child pools.
