### PR TITLE
Fix for broken timezone after creating DateTime with timestamp and timezone

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
@@ -138,7 +138,7 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
             throw new TransformationFailedException($e->getMessage(), $e->getCode(), $e);
         }
 
-        if ($this->outputTimezone !== $this->inputTimezone) {
+        if ($this->outputTimezone !== $this->inputTimezone || 'UTC' !== $this->inputTimezone) {
             $dateTime->setTimezone(new \DateTimeZone($this->inputTimezone));
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" for new features / 2.7, 2.8 or 3.1 for fixes |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

When creating \DateTime with '@timestamp' and \DateTImeZone, the result object has broken timezone.

DateTimeToLocalizedStringTransformer.php line 136
$dateTime = new \DateTime(sprintf('@%s', $timestamp), new \DateTimeZone($this->outputTimezone));
