### PR TITLE
[Form] EntityType - Query Builder with closure that returns null

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
@@ -133,7 +133,7 @@ abstract class DoctrineType extends AbstractType
     {
         $choiceLoader = function (Options $options) {
             // Unless the choices are given explicitly, load them on demand
-            if (null === $options['choices']) {
+            if (null === $options['choices'] && false !== $options['query_builder']) {
                 $hash = null;
                 $qbParts = null;
 

--- a/src/Symfony/Bridge/Doctrine/Form/Type/EntityType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/EntityType.php
@@ -34,6 +34,10 @@ class EntityType extends DoctrineType
                 if (null !== $queryBuilder && !$queryBuilder instanceof QueryBuilder) {
                     throw new UnexpectedTypeException($queryBuilder, 'Doctrine\ORM\QueryBuilder');
                 }
+                
+                if ($queryBuilder === null) {
+                    return false;
+                }
             }
 
             return $queryBuilder;

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -224,7 +224,7 @@ class EntityTypeTest extends TypeTestCase
             },
         ));
 
-        $this->assertEquals(array(1 => new ChoiceView($entity1, '1', 'Foo'), 2 => new ChoiceView($entity2, '2', 'Bar')), $field->createView()->vars['choices']);
+        $this->assertEquals(array(), $field->createView()->vars['choices']);
     }
 
     public function testSetDataSingleNull()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" - I don't know if it must be pushed in other branches |
| Bug fix? | yes - Fix regression see https://github.com/symfony/symfony/issues/17352 |
| New feature? | no - Reintroduced a lost feature |
| BC breaks? | yes - For releases after commit eb08baa (2 Aug 2015) see https://github.com/symfony/symfony/issues/17352#issuecomment-244333823 |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17352 |
| License | MIT |
| Doc PR | Blog Post http://symfony.com/blog/new-in-symfony-2-8-form-improvements#allowed-to-return-null-for-query-builder |
