### PR TITLE
[minor] Use delimiter argument for `ucwords()`, removing old extra calls (since php >= 5.5.16)

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -358,7 +358,7 @@ class Container implements ResettableContainerInterface
      */
     public static function camelize($id)
     {
-        if (!defined('HHVM_VERSION') && PHP_VERSION_ID >= 50516) {
+        if (PHP_VERSION_ID >= 50516 || (defined('HHVM_VERSION') && HHVM_VERSION_ID >= 31200)) {
             return str_replace(array('_', '.', '\\', ' '), array('', '_ ', '_ ', ''), ucwords($id, ' _.\\'));
         }
 

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -358,6 +358,10 @@ class Container implements ResettableContainerInterface
      */
     public static function camelize($id)
     {
+        if (!defined('HHVM_VERSION') && PHP_VERSION_ID >= 50516) {
+            return str_replace(array('_', '.', '\\', ' '), array('', '_ ', '_ ', ''), ucwords($id, ' _.\\'));
+        }
+
         return strtr(ucwords(strtr($id, array('_' => ' ', '.' => '_ ', '\\' => '_ '))), array(' ' => ''));
     }
 

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -816,6 +816,10 @@ class PropertyAccessor implements PropertyAccessorInterface
      */
     private function camelize($string)
     {
+        if (!defined('HHVM_VERSION') && PHP_VERSION_ID >= 50516) {
+            return str_replace(array(' ', '_'), '', ucwords($string, ' _'));
+        }
+
         return str_replace(' ', '', ucwords(str_replace('_', ' ', $string)));
     }
 

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -816,7 +816,7 @@ class PropertyAccessor implements PropertyAccessorInterface
      */
     private function camelize($string)
     {
-        if (!defined('HHVM_VERSION') && PHP_VERSION_ID >= 50516) {
+        if (PHP_VERSION_ID >= 50516 || (defined('HHVM_VERSION') && HHVM_VERSION_ID >= 31200)) {
             return str_replace(array(' ', '_'), '', ucwords($string, ' _'));
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |
