### PR TITLE
[Bridge/PhpUnit] Add bin/simple-phpunit wrapper (=phpunit - yaml - prophecy)

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/TextUI/Command.php
+++ b/src/Symfony/Bridge/PhpUnit/TextUI/Command.php
@@ -23,24 +23,4 @@ class Command extends \PHPUnit_TextUI_Command
     {
         return new TestRunner($this->arguments['loader']);
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function handleBootstrap($filename)
-    {
-        parent::handleBootstrap($filename);
-
-        // By default, we want PHPUnit's autoloader before Symfony's one
-        if (!getenv('SYMFONY_PHPUNIT_OVERLOAD')) {
-            $filename = realpath(stream_resolve_include_path($filename));
-            $symfonyLoader = realpath(dirname(PHPUNIT_COMPOSER_INSTALL).'/../../../vendor/autoload.php');
-
-            if ($filename === $symfonyLoader) {
-                $symfonyLoader = require $symfonyLoader;
-                $symfonyLoader->unregister();
-                $symfonyLoader->register(false);
-            }
-        }
-    }
 }

--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
@@ -11,30 +11,27 @@
  */
 
 // Please update when phpunit needs to be reinstalled with fresh deps:
-// Cache-Id-Version: 2016-06-29 13:45 UTC
-
-use Symfony\Component\Process\ProcessUtils;
+// Cache-Id-Version: 2016-09-12 09:00 UTC
 
 error_reporting(-1);
-require __DIR__.'/src/Symfony/Component/Process/ProcessUtils.php';
 
 // PHPUnit 4.8 does not support PHP 7, while 5.1 requires PHP 5.6+
 $PHPUNIT_VERSION = PHP_VERSION_ID >= 50600 ? '5.1' : '4.8';
-$PHPUNIT_DIR = __DIR__.'/.phpunit';
+$oldPwd = getcwd();
+$PHPUNIT_DIR = getenv('SYMFONY_PHPUNIT_DIR') ?: (__DIR__.'/.phpunit');
 $PHP = defined('PHP_BINARY') ? PHP_BINARY : 'php';
-$PHP = ProcessUtils::escapeArgument($PHP);
+$PHP = escapeshellarg($PHP);
 if ('phpdbg' === PHP_SAPI) {
     $PHP .= ' -qrr';
 }
 
-$COMPOSER = file_exists($COMPOSER = __DIR__.'/composer.phar') || ($COMPOSER = rtrim('\\' === DIRECTORY_SEPARATOR ? preg_replace('/[\r\n].*/', '', `where.exe composer.phar`) : `which composer.phar`))
-    ? $PHP.' '.ProcessUtils::escapeArgument($COMPOSER)
+$COMPOSER = file_exists($COMPOSER = $oldPwd.'/composer.phar') || ($COMPOSER = rtrim('\\' === DIRECTORY_SEPARATOR ? preg_replace('/[\r\n].*/', '', `where.exe composer.phar`) : `which composer.phar`))
+    ? $PHP.' '.escapeshellarg($COMPOSER)
     : 'composer';
 
 if (!file_exists("$PHPUNIT_DIR/phpunit-$PHPUNIT_VERSION/phpunit") || md5_file(__FILE__) !== @file_get_contents("$PHPUNIT_DIR/.$PHPUNIT_VERSION.md5")) {
-    // Build a standalone phpunit without symfony/yaml
+    // Build a standalone phpunit without symfony/yaml nor prophecy
 
-    $oldPwd = getcwd();
     @mkdir($PHPUNIT_DIR);
     chdir($PHPUNIT_DIR);
     if (file_exists("phpunit-$PHPUNIT_VERSION")) {
@@ -65,13 +62,7 @@ if (!file_exists("$PHPUNIT_DIR/phpunit-$PHPUNIT_VERSION/phpunit") || md5_file(__
 <?php
 
 define('PHPUNIT_COMPOSER_INSTALL', __DIR__.'/vendor/autoload.php');
-
-$loader = require PHPUNIT_COMPOSER_INSTALL;
-
-if (getenv('SYMFONY_PHPUNIT_OVERLOAD') && file_exists(__DIR__.'/../../src/Symfony/Bridge/PhpUnit')) {
-    $loader->addPsr4('Symfony\\Bridge\\PhpUnit\\', array('src/Symfony/Bridge/PhpUnit'), true);
-}
-unset($loader);
+require PHPUNIT_COMPOSER_INSTALL;
 Symfony\Bridge\PhpUnit\TextUI\Command::main();
 
 EOPHP
@@ -82,14 +73,17 @@ EOPHP
 
 }
 
-$cmd = array_map('Symfony\Component\Process\ProcessUtils::escapeArgument', $argv);
+$cmd = array_map('escapeshellarg', $argv);
 $exit = 0;
 
-if (isset($argv[1]) && 'symfony' === $argv[1]) {
+if (isset($argv[1]) && 'symfony' === $argv[1] && !file_exists('symfony') && file_exists('src/Symfony')) {
+    $argv[1] = 'src/Symfony';
+}
+if (isset($argv[1]) && is_dir($argv[1]) && !file_exists($argv[1].'/phpunit.xml.dist')) {
     array_shift($cmd);
 }
 
-$cmd[0] = sprintf('%s %s --colors=always', $PHP, ProcessUtils::escapeArgument("$PHPUNIT_DIR/phpunit-$PHPUNIT_VERSION/phpunit"));
+$cmd[0] = sprintf('%s %s --colors=always', $PHP, escapeshellarg("$PHPUNIT_DIR/phpunit-$PHPUNIT_VERSION/phpunit"));
 $cmd = str_replace('%', '%%', implode(' ', $cmd)).' %1$s';
 
 if ('\\' === DIRECTORY_SEPARATOR) {
@@ -98,14 +92,12 @@ if ('\\' === DIRECTORY_SEPARATOR) {
     $cmd .= '%2$s';
 }
 
-if (isset($argv[1]) && 'symfony' === $argv[1]) {
+if (isset($argv[1]) && is_dir($argv[1]) && !file_exists($argv[1].'/phpunit.xml.dist')) {
     // Find Symfony components in plain php for Windows portability
 
-    $oldPwd = getcwd();
-    chdir(__DIR__);
-    $finder = new RecursiveDirectoryIterator('src/Symfony', FilesystemIterator::KEY_AS_FILENAME | FilesystemIterator::UNIX_PATHS);
+    $finder = new RecursiveDirectoryIterator($argv[1], FilesystemIterator::KEY_AS_FILENAME | FilesystemIterator::UNIX_PATHS);
     $finder = new RecursiveIteratorIterator($finder);
-    $finder->setMaxDepth(3);
+    $finder->setMaxDepth(getenv('SYMFONY_PHPUNIT_MAX_DEPTH') ?: 3);
 
     $skippedTests = isset($_SERVER['SYMFONY_PHPUNIT_SKIPPED_TESTS']) ? $_SERVER['SYMFONY_PHPUNIT_SKIPPED_TESTS'] : false;
     $runningProcs = array();
@@ -120,7 +112,7 @@ if (isset($argv[1]) && 'symfony' === $argv[1]) {
                 putenv("SYMFONY_PHPUNIT_SKIPPED_TESTS=$component/$skippedTests");
             }
 
-            $c = ProcessUtils::escapeArgument($component);
+            $c = escapeshellarg($component);
 
             if ($proc = proc_open(sprintf($cmd, $c, " > $c/phpunit.stdout 2> $c/phpunit.stderr"), array(), $pipes)) {
                 $runningProcs[$component] = $proc;
@@ -130,7 +122,6 @@ if (isset($argv[1]) && 'symfony' === $argv[1]) {
             }
         }
     }
-    chdir($oldPwd);
 
     // Fixes for colors support on appveyor
     // See https://github.com/appveyor/ci/issues/373
@@ -185,11 +176,11 @@ if (isset($argv[1]) && 'symfony' === $argv[1]) {
             }
         }
     }
-} elseif (!isset($argv[1]) || 'install' !== $argv[1]) {
+} elseif (!isset($argv[1]) || 'install' !== $argv[1] || file_exists('install')) {
     // Run regular phpunit in a subprocess
 
     $errFile = tempnam(sys_get_temp_dir(), 'phpunit.stderr.');
-    if ($proc = proc_open(sprintf($cmd, '', ' 2> '.ProcessUtils::escapeArgument($errFile)), array(1 => array('pipe', 'w')), $pipes)) {
+    if ($proc = proc_open(sprintf($cmd, '', ' 2> '.escapeshellarg($errFile)), array(1 => array('pipe', 'w')), $pipes)) {
         stream_copy_to_stream($pipes[1], STDOUT);
         fclose($pipes[1]);
         $exit = proc_close($proc);
@@ -199,7 +190,7 @@ if (isset($argv[1]) && 'symfony' === $argv[1]) {
     }
 
     if (!file_exists($component = array_pop($argv))) {
-        $component = basename(getcwd());
+        $component = basename($oldcwd);
     }
 
     if ($exit) {

--- a/src/Symfony/Bridge/PhpUnit/composer.json
+++ b/src/Symfony/Bridge/PhpUnit/composer.json
@@ -30,6 +30,9 @@
             "/Tests/"
         ]
     },
+    "bin": [
+        "bin/simple-phpunit"
+    ],
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| New feature? | yes |
| Tests pass? | not yet |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/6962 |

So that e.g. [Sami](https://github.com/FriendsOfPHP/Sami/blob/master/phpunit) & [SensioFranmeworkExtraBundle](https://github.com/sensiolabs/SensioFrameworkExtraBundle/blob/master/phpunit) can stop copy/pasting our phpunit wrapper and get it from phpunit-bridge instead.

2 commits to keep the "rename" semantic in the git history.
Diff best viewed by looking directly at each commit.
