### PR TITLE
[Yaml] Add bin/lint for using the LintCommand

### DIFF
--- a/src/Symfony/Component/Yaml/bin/lint
+++ b/src/Symfony/Component/Yaml/bin/lint
@@ -1,0 +1,28 @@
+#!/usr/bin/env php
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+require_once __DIR__.'/vendor/autoload.php';
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Yaml\Command\LintCommand;
+
+if (!class_exists(Application::class)) {
+    fwrite(STDERR, 'The "symfony/console" package must be installed.'.PHP_EOL);
+
+    exit(1);
+}
+
+(new Application('symfony/yaml'))
+    ->add(new LintCommand())
+    ->getApplication()
+    ->setDefaultCommand('lint:yaml', true)
+    ->run();

--- a/src/Symfony/Component/Yaml/composer.json
+++ b/src/Symfony/Component/Yaml/composer.json
@@ -24,12 +24,18 @@
     "suggest": {
         "symfony/console": "For validating YAML files using the lint command"
     },
+    "conflict": {
+        "symfony/console": "<3.2"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Yaml\\": "" },
         "exclude-from-classmap": [
             "/Tests/"
         ]
     },
+    "bin": [
+        "bin/lint"
+    ],
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

In #19139 we moved the `lint:yaml` command from the FrameworkBundle to the Yaml component.
The usage did not change in the framework, the old command became a child of the Yaml one.

But now, using this command in the standalone Yaml requires to create an application. Here I propose to provide the application as an executable, so that the command is really usable directly when installing the yaml+console components as dependencies.

I may be wrong when I think it's worth it but to me, moving the command to the yaml component doesn't fully make sense if it cannot be used directly outside of the full stack framework.
