### PR TITLE
[Yaml][TwigBridge] Use JSON_UNESCAPED_SLASHES for lint commands output

### DIFF
--- a/src/Symfony/Bridge/Twig/Command/LintCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/LintCommand.php
@@ -202,7 +202,7 @@ EOF
             }
         });
 
-        $output->writeln(json_encode($filesInfo, defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 0));
+        $output->writeln(json_encode($filesInfo, defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES : 0));
 
         return min($errors, 1);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/YamlLintCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/YamlLintCommand.php
@@ -156,7 +156,7 @@ EOF
             }
         });
 
-        $output->writeln(json_encode($filesInfo, defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 0));
+        $output->writeln(json_encode($filesInfo, defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES : 0));
 
         return min($errors, 1);
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Slashes are escaped when sing the `lint:twig` and `lint:yaml` commands with the `format` option set to `json`, giving such results:

``` json
[
    {
        "file": "yaml\/wrong\/1.yml",
        "valid": false,
        "message": "Unable to parse at line 1 (near \";:cc`\")."
    }
]
```

That's not convenient as file paths may be reused (e.g. copy-pasted).
Results stay fine as error messages are already escaped:

``` json
[
    {
        "file": "yaml/wrong/1.yml",
        "valid": false,
        "message": "Unable to parse at line 1 (near \";:cc`\")."
    }
]
```
