### PR TITLE
[DoctrineBridge][PropertyInfo] Treat Doctrine decimal type as string

### DIFF
--- a/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
+++ b/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
@@ -178,12 +178,12 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
                 return Type::BUILTIN_TYPE_INT;
 
             case DBALType::FLOAT:
-            case DBALType::DECIMAL:
                 return Type::BUILTIN_TYPE_FLOAT;
 
             case DBALType::STRING:
             case DBALType::TEXT:
             case DBALType::GUID:
+            case DBALType::DECIMAL:
                 return Type::BUILTIN_TYPE_STRING;
 
             case DBALType::BOOLEAN:

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
@@ -49,6 +49,8 @@ class DoctrineExtractorTest extends \PHPUnit_Framework_TestCase
                 'time',
                 'json',
                 'simpleArray',
+                'float',
+                'decimal',
                 'bool',
                 'binary',
                 'customFoo',
@@ -73,6 +75,8 @@ class DoctrineExtractorTest extends \PHPUnit_Framework_TestCase
         return array(
             array('id', array(new Type(Type::BUILTIN_TYPE_INT))),
             array('guid', array(new Type(Type::BUILTIN_TYPE_STRING))),
+            array('float', array(new Type(Type::BUILTIN_TYPE_FLOAT))),
+            array('decimal', array(new Type(Type::BUILTIN_TYPE_STRING))),
             array('bool', array(new Type(Type::BUILTIN_TYPE_BOOL))),
             array('binary', array(new Type(Type::BUILTIN_TYPE_RESOURCE))),
             array('json', array(new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true))),

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineDummy.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineDummy.php
@@ -66,6 +66,16 @@ class DoctrineDummy
     private $simpleArray;
 
     /**
+     * @Column(type="float")
+     */
+    private $float;
+
+    /**
+     * @Column(type="decimal", precision=10, scale=2)
+     */
+    private $decimal;
+
+    /**
      * @Column(type="boolean")
      */
     private $bool;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

Using `float` for decimal type defeats the purpose of avoiding rounding errors / loss of precision.

See http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/types.html#decimal
