### PR TITLE
Implemented getReachableRoleNames method, since I saw a lot of calls …

### DIFF
--- a/src/Symfony/Component/Security/Core/Role/RoleHierarchy.php
+++ b/src/Symfony/Component/Security/Core/Role/RoleHierarchy.php
@@ -52,6 +52,29 @@ class RoleHierarchy implements RoleHierarchyInterface
         return $reachableRoles;
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function getReachableRoleNames(array $roles)
+    {
+        $reachableRoleNames = array();
+        foreach ($roles as $role) {
+            $reachableRoleNames[] = $role->getRole();
+        }
+
+        foreach ($reachableRoleNames as $roleName) {
+            if (isset($this->map[$roleName]) === false) {
+                continue;
+            }
+
+            foreach ($this->map[$roleName] as $subRoleName) {
+                $reachableRoleNames[] = $subRoleName;
+            }
+        }
+
+        return $reachableRoleNames;
+    }
+
     protected function buildRoleMap()
     {
         $this->map = array();

--- a/src/Symfony/Component/Security/Core/Role/RoleHierarchyInterface.php
+++ b/src/Symfony/Component/Security/Core/Role/RoleHierarchyInterface.php
@@ -29,4 +29,16 @@ interface RoleHierarchyInterface
      * @return RoleInterface[] An array of all reachable roles
      */
     public function getReachableRoles(array $roles);
+
+
+    /**
+     * Returns an array of all reachable role names by the given ones.
+     * Reachable roles are the roles directly assigned but also all roles that
+     * are transitively reachable from them in the role hierarchy.
+     *
+     * @param RoleInterface[] $roles An array of directly assigned roles
+     *
+     * @return string[] An array of all reachable role names
+     */
+    public function getReachableRoleNames(array $roles);
 }

--- a/src/Symfony/Component/Security/Core/Tests/Role/RoleHierarchyTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Role/RoleHierarchyTest.php
@@ -29,4 +29,18 @@ class RoleHierarchyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(new Role('ROLE_FOO'), new Role('ROLE_ADMIN'), new Role('ROLE_USER')), $role->getReachableRoles(array(new Role('ROLE_FOO'), new Role('ROLE_ADMIN'))));
         $this->assertEquals(array(new Role('ROLE_SUPER_ADMIN'), new Role('ROLE_ADMIN'), new Role('ROLE_FOO'), new Role('ROLE_USER')), $role->getReachableRoles(array(new Role('ROLE_SUPER_ADMIN'))));
     }
+
+    public function testGetReachableRoleNames()
+    {
+        $role = new RoleHierarchy(array(
+            'ROLE_ADMIN' => array('ROLE_USER'),
+            'ROLE_SUPER_ADMIN' => array ('ROLE_ADMIN', 'ROLE_FOO'),
+        ));
+
+        $this->assertEquals(array('ROLE_USER'), $role->getReachableRoleNames(array(new Role('ROLE_USER'))));
+        $this->assertEquals(array('ROLE_FOO'), $role->getReachableRoleNames(array(new Role('ROLE_FOO'))));
+        $this->assertEquals(array('ROLE_ADMIN', 'ROLE_USER'), $role->getReachableRoleNames(array(new Role('ROLE_ADMIN'))));
+        $this->assertEquals(array('ROLE_FOO', 'ROLE_ADMIN', 'ROLE_USER'), $role->getReachableRoleNames(array(new Role('ROLE_FOO'), new Role('ROLE_ADMIN'))));
+        $this->assertEquals(array('ROLE_SUPER_ADMIN', 'ROLE_ADMIN', 'ROLE_FOO', 'ROLE_USER'), $role->getReachableRoleNames(array(new Role('ROLE_SUPER_ADMIN'))));
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

…to getReachableRoles, followed by an array map to get the role names
