### PR TITLE
[SecurityBundle][2.8] Support autowiring for AccessDecisionManagerInterface

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -107,6 +107,8 @@
         <!-- Authorization related services -->
         <service id="security.access.decision_manager" class="%security.access.decision_manager.class%" public="false">
             <argument type="collection" />
+
+            <autowiring-type>Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface</autowiring-type>
         </service>
 
         <service id="security.role_hierarchy" class="%security.role_hierarchy.class%" public="false">

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AutowiringTypesTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AutowiringTypesTest.php
@@ -22,6 +22,15 @@ class AutowiringTypesTest extends WebTestCase
         $this->assertInstanceOf('Symfony\Component\Security\Core\Authorization\AccessDecisionManager', $accessDecisionManager);
     }
 
+    public function testDebugAccessDecisionManagerAutowiring()
+    {
+        static::bootKernel(array('debug' => true));
+        $container = static::$kernel->getContainer();
+
+        $accessDecisionManager = $container->get('test.autowiring_types.autowired_services')->getAccessDecisionManager();
+        $this->assertInstanceOf('Symfony\Component\Security\Core\Authorization\AccessDecisionManager', $accessDecisionManager);
+    }
+
     protected static function createKernel(array $options = array())
     {
         return parent::createKernel(array('test_case' => 'AutowiringTypes') + $options);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AutowiringTypesTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AutowiringTypesTest.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
-use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
-
 class AutowiringTypesTest extends WebTestCase
 {
     public function testAccessDecisionManagerAutowiring()
@@ -21,7 +19,7 @@ class AutowiringTypesTest extends WebTestCase
         $container = static::$kernel->getContainer();
 
         $accessDecisionManager = $container->get('test.autowiring_types.autowired_services')->getAccessDecisionManager();
-        $this->assertInstanceOf(AccessDecisionManager::class, $accessDecisionManager);
+        $this->assertInstanceOf('Symfony\Component\Security\Core\Authorization\AccessDecisionManager', $accessDecisionManager);
     }
 
     protected static function createKernel(array $options = array())

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AutowiringTypesTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AutowiringTypesTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
+
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
+
+class AutowiringTypesTest extends WebTestCase
+{
+    public function testAccessDecisionManagerAutowiring()
+    {
+        static::bootKernel(array('debug' => false));
+        $container = static::$kernel->getContainer();
+
+        $accessDecisionManager = $container->get('test.autowiring_types.autowired_services')->getAccessDecisionManager();
+        $this->assertInstanceOf(AccessDecisionManager::class, $accessDecisionManager);
+    }
+
+    protected static function createKernel(array $options = array())
+    {
+        return parent::createKernel(array('test_case' => 'AutowiringTypes') + $options);
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/TestBundle/AutowiringTypes/AutowiredServices.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/TestBundle/AutowiringTypes/AutowiredServices.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\TestBundle\AutowiringTypes;
+
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
+
+class AutowiredServices
+{
+    private $accessDecisionManager;
+
+    public function __construct(AccessDecisionManagerInterface $accessDecisionManager)
+    {
+        $this->accessDecisionManager = $accessDecisionManager;
+    }
+
+    public function getAccessDecisionManager()
+    {
+        return $this->accessDecisionManager;
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/TestBundle/TestBundle.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/TestBundle/TestBundle.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\TestBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class TestBundle extends Bundle
+{
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AutowiringTypes/bundles.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AutowiringTypes/bundles.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return array(
+    new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+    new Symfony\Bundle\SecurityBundle\SecurityBundle(),
+    new Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\TestBundle\TestBundle(),
+);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AutowiringTypes/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AutowiringTypes/config.yml
@@ -1,0 +1,18 @@
+imports:
+    - { resource: ../config/framework.yml }
+
+
+security:
+    providers:
+        in_memory:
+            memory: ~
+
+    firewalls:
+        test:
+            pattern:  ^/
+            security: false
+
+services:
+    test.autowiring_types.autowired_services:
+        class: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\TestBundle\AutowiringTypes\AutowiredServices
+        autowire: true


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

port of #19684 for 2.8
