### PR TITLE
[FrameworkBundle] Parse source link maps using json_decode() instead of parse_str()

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
@@ -34,9 +34,9 @@ class CodeExtension extends \Twig_Extension
         $fileLinkFormat = $fileLinkFormat ?: ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format');
         if ($fileLinkFormat && !is_array($fileLinkFormat)) {
             $i = max(strpos($fileLinkFormat, '%f'), strpos($fileLinkFormat, '%l'));
-            $i = strpos($fileLinkFormat, '#', $i) ?: strlen($fileLinkFormat);
+            $i = strpos($fileLinkFormat, '#"', $i) ?: strlen($fileLinkFormat);
             $fileLinkFormat = array(substr($fileLinkFormat, 0, $i), substr($fileLinkFormat, $i + 1));
-            parse_str($fileLinkFormat[1], $fileLinkFormat[1]);
+            $fileLinkFormat[1] = @json_decode('{'.$fileLinkFormat[1].'}', true) ?: array();
         }
         $this->fileLinkFormat = $fileLinkFormat;
         $this->rootDir = str_replace('/', DIRECTORY_SEPARATOR, dirname($rootDir)).DIRECTORY_SEPARATOR;

--- a/src/Symfony/Bridge/Twig/Tests/Extension/CodeExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/CodeExtensionTest.php
@@ -64,6 +64,6 @@ class CodeExtensionTest extends \PHPUnit_Framework_TestCase
 
     protected function getExtension()
     {
-        return new CodeExtension('proto://%f#&line=%l#'.substr(__FILE__, 0, 5).'=foobar', '/root', 'UTF-8');
+        return new CodeExtension('proto://%f#&line=%l#'.json_encode(substr(__FILE__, 0, 5)).':"foobar"', '/root', 'UTF-8');
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
@@ -36,9 +36,9 @@ class CodeHelper extends Helper
         $fileLinkFormat = $fileLinkFormat ?: ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format');
         if ($fileLinkFormat && !is_array($fileLinkFormat)) {
             $i = max(strpos($fileLinkFormat, '%f'), strpos($fileLinkFormat, '%l'));
-            $i = strpos($fileLinkFormat, '#', $i) ?: strlen($fileLinkFormat);
+            $i = strpos($fileLinkFormat, '#"', $i) ?: strlen($fileLinkFormat);
             $fileLinkFormat = array(substr($fileLinkFormat, 0, $i), substr($fileLinkFormat, $i + 1));
-            parse_str($fileLinkFormat[1], $fileLinkFormat[1]);
+            $fileLinkFormat[1] = @json_decode('{'.$fileLinkFormat[1].'}', true) ?: array();
         }
         $this->fileLinkFormat = $fileLinkFormat;
         $this->rootDir = str_replace('\\', '/', $rootDir).'/';

--- a/src/Symfony/Component/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/Debug/ExceptionHandler.php
@@ -40,9 +40,9 @@ class ExceptionHandler
         $fileLinkFormat = $fileLinkFormat ?: ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format');
         if ($fileLinkFormat && !is_array($fileLinkFormat)) {
             $i = max(strpos($fileLinkFormat, '%f'), strpos($fileLinkFormat, '%l'));
-            $i = strpos($fileLinkFormat, '#', $i) ?: strlen($fileLinkFormat);
+            $i = strpos($fileLinkFormat, '#"', $i) ?: strlen($fileLinkFormat);
             $fileLinkFormat = array(substr($fileLinkFormat, 0, $i), substr($fileLinkFormat, $i + 1));
-            parse_str($fileLinkFormat[1], $fileLinkFormat[1]);
+            $fileLinkFormat[1] = @json_decode('{'.$fileLinkFormat[1].'}', true) ?: array();
         }
         $this->debug = $debug;
         $this->charset = $charset ?: ini_get('default_charset') ?: 'UTF-8';
@@ -97,9 +97,9 @@ class ExceptionHandler
     {
         $old = $this->fileLinkFormat;
         if ($fileLinkFormat && !is_array($fileLinkFormat)) {
-            $i = strpos($fileLinkFormat, '#') ?: strlen($fileLinkFormat);
+            $i = strpos($fileLinkFormat, '#"') ?: strlen($fileLinkFormat);
             $fileLinkFormat = array(substr($fileLinkFormat, 0, $i), substr($fileLinkFormat, $i + 1));
-            parse_str($fileLinkFormat[1], $fileLinkFormat[1]);
+            $fileLinkFormat[1] = @json_decode('{'.$fileLinkFormat[1].'}', true) ?: array();
         }
         $this->fileLinkFormat = $fileLinkFormat;
         if ($old) {

--- a/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
@@ -43,9 +43,9 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
         $fileLinkFormat = $fileLinkFormat ?: ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format');
         if ($fileLinkFormat && !is_array($fileLinkFormat)) {
             $i = max(strpos($fileLinkFormat, '%f'), strpos($fileLinkFormat, '%l'));
-            $i = strpos($fileLinkFormat, '#', $i) ?: strlen($fileLinkFormat);
+            $i = strpos($fileLinkFormat, '#"', $i) ?: strlen($fileLinkFormat);
             $fileLinkFormat = array(substr($fileLinkFormat, 0, $i), substr($fileLinkFormat, $i + 1));
-            parse_str($fileLinkFormat[1], $fileLinkFormat[1]);
+            $fileLinkFormat[1] = @json_decode('{'.$fileLinkFormat[1].'}', true) ?: array();
         }
         $this->stopwatch = $stopwatch;
         $this->fileLinkFormat = $fileLinkFormat;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | updated code exists only on master |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #19807 |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/6944 |

Because `parse_str()` turns some characters into underscores in keys (e.g. `.`).
