### PR TITLE
[Finder] Trim trailing directory slash in ExcludeDirectoryFilterIterator

### DIFF
--- a/src/Symfony/Component/Finder/Iterator/ExcludeDirectoryFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/ExcludeDirectoryFilterIterator.php
@@ -35,6 +35,7 @@ class ExcludeDirectoryFilterIterator extends FilterIterator implements \Recursiv
         $this->isRecursive = $iterator instanceof \RecursiveIterator;
         $patterns = array();
         foreach ($directories as $directory) {
+            $directory = rtrim($directory, '/');
             if (!$this->isRecursive || false !== strpos($directory, '/')) {
                 $patterns[] = preg_quote($directory, '#');
             } else {
@@ -51,7 +52,7 @@ class ExcludeDirectoryFilterIterator extends FilterIterator implements \Recursiv
     /**
      * Filters the iterator values.
      *
-     * @return bool true if the value should be kept, false otherwise
+     * @return bool True if the value should be kept, false otherwise
      */
     public function accept()
     {

--- a/src/Symfony/Component/Finder/Tests/Iterator/ExcludeDirectoryFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/ExcludeDirectoryFilterIteratorTest.php
@@ -58,9 +58,23 @@ class ExcludeDirectoryFilterIteratorTest extends RealIteratorTestCase
             'foo bar',
         );
 
+        $toto = array(
+            '.bar',
+            '.foo',
+            '.foo/.bar',
+            '.foo/bar',
+            '.git',
+            'test.py',
+            'foo',
+            'foo/bar.tmp',
+            'test.php',
+            'foo bar',
+        );
+
         return array(
             array(array('foo'), $this->toAbsolute($foo)),
             array(array('fo'), $this->toAbsolute($fo)),
+            array(array('toto/'), $this->toAbsolute($toto)),
         );
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #19599 |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

In this context `path` equals `path/`
