### PR TITLE
[Console] Exclude empty namespaces in text descriptor

### DIFF
--- a/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
@@ -191,7 +191,20 @@ class TextDescriptor extends Descriptor
             $this->writeText("\n");
             $this->writeText("\n");
 
-            $width = $this->getColumnWidth($description->getCommands());
+            $commands = $description->getCommands();
+            $namespaces = $description->getNamespaces();
+            if ($describedNamespace && $namespaces) {
+                // make sure all alias commands are included when describing a specific namespace
+                $describedNamespaceInfo = reset($namespaces);
+                foreach ($describedNamespaceInfo['commands'] as $name) {
+                    $commands[$name] = $description->getCommand($name);
+                }
+            }
+
+            // calculate max. width based on available commands per namespace
+            $width = $this->getColumnWidth(call_user_func_array('array_merge', array_map(function ($namespace) use ($commands) {
+                return array_intersect($namespace['commands'], array_keys($commands));
+            }, $namespaces)));
 
             if ($describedNamespace) {
                 $this->writeText(sprintf('<comment>Available commands for the "%s" namespace:</comment>', $describedNamespace), $options);
@@ -199,23 +212,26 @@ class TextDescriptor extends Descriptor
                 $this->writeText('<comment>Available commands:</comment>', $options);
             }
 
-            // add commands by namespace
-            $commands = $description->getCommands();
+            foreach ($namespaces as $namespace) {
+                $namespace['commands'] = array_filter($namespace['commands'], function ($name) use ($commands) {
+                    return isset($commands[$name]);
+                });
 
-            foreach ($description->getNamespaces() as $namespace) {
+                if (!$namespace['commands']) {
+                    continue;
+                }
+
                 if (!$describedNamespace && ApplicationDescription::GLOBAL_NAMESPACE !== $namespace['id']) {
                     $this->writeText("\n");
                     $this->writeText(' <comment>'.$namespace['id'].'</comment>', $options);
                 }
 
                 foreach ($namespace['commands'] as $name) {
-                    if (isset($commands[$name])) {
-                        $this->writeText("\n");
-                        $spacingWidth = $width - Helper::strlen($name);
-                        $command = $commands[$name];
-                        $commandAliases = $this->getCommandAliasesText($command);
-                        $this->writeText(sprintf('  <info>%s</info>%s%s', $name, str_repeat(' ', $spacingWidth), $commandAliases.$command->getDescription()), $options);
-                    }
+                    $this->writeText("\n");
+                    $spacingWidth = $width - Helper::strlen($name);
+                    $command = $commands[$name];
+                    $commandAliases = $name === $command->getName() ? $this->getCommandAliasesText($command) : '';
+                    $this->writeText(sprintf('  <info>%s</info>%s%s', $name, str_repeat(' ', $spacingWidth), $commandAliases.$command->getDescription()), $options);
                 }
             }
 
@@ -276,7 +292,7 @@ class TextDescriptor extends Descriptor
     }
 
     /**
-     * @param Command[] $commands
+     * @param (Command|string)[] $commands
      *
      * @return int
      */
@@ -285,13 +301,17 @@ class TextDescriptor extends Descriptor
         $widths = array();
 
         foreach ($commands as $command) {
-            $widths[] = Helper::strlen($command->getName());
-            foreach ($command->getAliases() as $alias) {
-                $widths[] = Helper::strlen($alias);
+            if ($command instanceof Command) {
+                $widths[] = Helper::strlen($command->getName());
+                foreach ($command->getAliases() as $alias) {
+                    $widths[] = Helper::strlen($alias);
+                }
+            } else {
+                $widths[] = Helper::strlen($command);
             }
         }
 
-        return max($widths) + 2;
+        return $widths ? max($widths) + 2 : 0;
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Descriptor/AbstractDescriptorTest.php
+++ b/src/Symfony/Component/Console/Tests/Descriptor/AbstractDescriptorTest.php
@@ -98,10 +98,10 @@ abstract class AbstractDescriptorTest extends TestCase
         return $data;
     }
 
-    protected function assertDescription($expectedDescription, $describedObject)
+    protected function assertDescription($expectedDescription, $describedObject, array $options = array())
     {
         $output = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, true);
-        $this->getDescriptor()->describe($output, $describedObject, array('raw_output' => true));
+        $this->getDescriptor()->describe($output, $describedObject, $options + array('raw_output' => true));
         $this->assertEquals(trim($expectedDescription), trim(str_replace(PHP_EOL, "\n", $output->fetch())));
     }
 }

--- a/src/Symfony/Component/Console/Tests/Descriptor/JsonDescriptorTest.php
+++ b/src/Symfony/Component/Console/Tests/Descriptor/JsonDescriptorTest.php
@@ -26,10 +26,10 @@ class JsonDescriptorTest extends AbstractDescriptorTest
         return 'json';
     }
 
-    protected function assertDescription($expectedDescription, $describedObject)
+    protected function assertDescription($expectedDescription, $describedObject, array $options = array())
     {
         $output = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, true);
-        $this->getDescriptor()->describe($output, $describedObject, array('raw_output' => true));
+        $this->getDescriptor()->describe($output, $describedObject, $options + array('raw_output' => true));
         $this->assertEquals(json_decode(trim($expectedDescription), true), json_decode(trim(str_replace(PHP_EOL, "\n", $output->fetch())), true));
     }
 }

--- a/src/Symfony/Component/Console/Tests/Descriptor/TextDescriptorTest.php
+++ b/src/Symfony/Component/Console/Tests/Descriptor/TextDescriptorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Console\Tests\Descriptor;
 
 use Symfony\Component\Console\Descriptor\TextDescriptor;
+use Symfony\Component\Console\Tests\Fixtures\DescriptorApplication2;
 use Symfony\Component\Console\Tests\Fixtures\DescriptorApplicationMbString;
 use Symfony\Component\Console\Tests\Fixtures\DescriptorCommandMbString;
 
@@ -31,6 +32,13 @@ class TextDescriptorTest extends AbstractDescriptorTest
             ObjectsProvider::getApplications(),
             array('application_mbstring' => new DescriptorApplicationMbString())
         ));
+    }
+
+    public function testDescribeApplicationWithFilteredNamespace()
+    {
+        $application = new DescriptorApplication2();
+
+        $this->assertDescription(file_get_contents(__DIR__.'/../Fixtures/application_filtered_namespace.txt'), $application, array('namespace' => 'command4'));
     }
 
     protected function getDescriptor()

--- a/src/Symfony/Component/Console/Tests/Fixtures/DescriptorApplication2.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/DescriptorApplication2.php
@@ -21,5 +21,6 @@ class DescriptorApplication2 extends Application
         $this->add(new DescriptorCommand1());
         $this->add(new DescriptorCommand2());
         $this->add(new DescriptorCommand3());
+        $this->add(new DescriptorCommand4());
     }
 }

--- a/src/Symfony/Component/Console/Tests/Fixtures/DescriptorCommand4.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/DescriptorCommand4.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Fixtures;
+
+use Symfony\Component\Console\Command\Command;
+
+class DescriptorCommand4 extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('descriptor:command4')
+            ->setAliases(array('descriptor:alias_command4', 'command4:descriptor'))
+        ;
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.json
@@ -398,6 +398,85 @@
                     }
                 }
             }
+        },
+        {
+            "name": "descriptor:command4",
+            "hidden": false,
+            "usage": [
+                "descriptor:command4",
+                "descriptor:alias_command4",
+                "command4:descriptor"
+            ],
+            "description": null,
+            "help": "",
+            "definition": {
+                "arguments": {},
+                "options": {
+                    "help": {
+                        "name": "--help",
+                        "shortcut": "-h",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Display this help message",
+                        "default": false
+                    },
+                    "quiet": {
+                        "name": "--quiet",
+                        "shortcut": "-q",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Do not output any message",
+                        "default": false
+                    },
+                    "verbose": {
+                        "name": "--verbose",
+                        "shortcut": "-v|-vv|-vvv",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug",
+                        "default": false
+                    },
+                    "version": {
+                        "name": "--version",
+                        "shortcut": "-V",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Display this application version",
+                        "default": false
+                    },
+                    "ansi": {
+                        "name": "--ansi",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Force ANSI output",
+                        "default": false
+                    },
+                    "no-ansi": {
+                        "name": "--no-ansi",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Disable ANSI output",
+                        "default": false
+                    },
+                    "no-interaction": {
+                        "name": "--no-interaction",
+                        "shortcut": "-n",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Do not ask any interactive question",
+                        "default": false
+                    }
+                }
+            }
         }
     ],
     "namespaces": [
@@ -411,11 +490,19 @@
             ]
         },
         {
+            "id": "command4",
+            "commands": [
+                "command4:descriptor"
+            ]
+        },
+        {
             "id": "descriptor",
             "commands": [
+                "descriptor:alias_command4",
                 "descriptor:command1",
                 "descriptor:command2",
-                "descriptor:command3"
+                "descriptor:command3",
+                "descriptor:command4"
             ]
         }
     ]

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.md
@@ -6,10 +6,16 @@ My Symfony application v1.0
 * [`help`](#help)
 * [`list`](#list)
 
+**command4:**
+
+* [`command4:descriptor`](#descriptorcommand4)
+
 **descriptor:**
 
+* [`descriptor:alias_command4`](#descriptorcommand4)
 * [`descriptor:command1`](#descriptorcommand1)
 * [`descriptor:command2`](#descriptorcommand2)
+* [`descriptor:command4`](#descriptorcommand4)
 
 `help`
 ------
@@ -285,6 +291,81 @@ command 2 help
 * Is value required: no
 * Is multiple: no
 * Default: `false`
+
+#### `--help|-h`
+
+Display this help message
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+#### `--quiet|-q`
+
+Do not output any message
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+#### `--verbose|-v|-vv|-vvv`
+
+Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+#### `--version|-V`
+
+Display this application version
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+#### `--ansi`
+
+Force ANSI output
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+#### `--no-ansi`
+
+Disable ANSI output
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+#### `--no-interaction|-n`
+
+Do not ask any interactive question
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Default: `false`
+
+`descriptor:command4`
+---------------------
+
+### Usage
+
+* `descriptor:command4`
+* `descriptor:alias_command4`
+* `command4:descriptor`
+
+
+### Options
 
 #### `--help|-h`
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.xml
@@ -199,6 +199,39 @@
         </option>
       </options>
     </command>
+    <command id="descriptor:command4" name="descriptor:command4" hidden="0">
+      <usages>
+        <usage>descriptor:command4</usage>
+        <usage>descriptor:alias_command4</usage>
+        <usage>command4:descriptor</usage>
+      </usages>
+      <description></description>
+      <help></help>
+      <arguments/>
+      <options>
+        <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Display this help message</description>
+        </option>
+        <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Do not output any message</description>
+        </option>
+        <option name="--verbose" shortcut="-v" shortcuts="-v|-vv|-vvv" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug</description>
+        </option>
+        <option name="--version" shortcut="-V" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Display this application version</description>
+        </option>
+        <option name="--ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Force ANSI output</description>
+        </option>
+        <option name="--no-ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Disable ANSI output</description>
+        </option>
+        <option name="--no-interaction" shortcut="-n" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Do not ask any interactive question</description>
+        </option>
+      </options>
+    </command>
   </commands>
   <namespaces>
     <namespace id="_global">
@@ -207,10 +240,15 @@
       <command>help</command>
       <command>list</command>
     </namespace>
+    <namespace id="command4">
+      <command>command4:descriptor</command>
+    </namespace>
     <namespace id="descriptor">
+      <command>descriptor:alias_command4</command>
       <command>descriptor:command1</command>
       <command>descriptor:command2</command>
       <command>descriptor:command3</command>
+      <command>descriptor:command4</command>
     </namespace>
   </namespaces>
 </symfony>

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_filtered_namespace.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_filtered_namespace.txt
@@ -12,10 +12,5 @@ My Symfony application <info>v1.0</info>
   <info>-n, --no-interaction</info>  Do not ask any interactive question
   <info>-v|vv|vvv, --verbose</info>  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 
-<comment>Available commands:</comment>
-  <info>help</info>                 Displays help for a command
-  <info>list</info>                 Lists commands
- <comment>descriptor</comment>
-  <info>descriptor:command1</info>  [alias1|alias2] command 1 description
-  <info>descriptor:command2</info>  command 2 description
-  <info>descriptor:command4</info>  [descriptor:alias_command4|command4:descriptor]
+<comment>Available commands for the "command4" namespace:</comment>
+  <info>command4:descriptor</info>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

Before:

```
$ bin/console

 doctrine
  doctrine:mapping:convert                [orm:convert:mapping] Convert mapping information between supported formats.
 orm <----
 router
  router:match                            Helps debug routes by simulating a path info match

$ bin/console list orm

  [Symfony\Component\Debug\Exception\ContextErrorException]  
  Warning: max(): Array must contain at least one element  

$ bin/console list generate

Available commands for the "generate" namespace:
  generate:bundle      Generates a bundle
  generate:command     Generates a console command
  generate:controller  Generates a controller
```

After:

```
$ bin/console

 doctrine
  doctrine:mapping:convert                [orm:convert:mapping] Convert mapping information between supported formats.
 router
  router:match                            Helps debug routes by simulating a path info match

$ bin/console list orm

Available commands for the "orm" namespace:
  orm:convert:mapping  Convert mapping information between supported formats.

$ bin/console list generate

Available commands for the "generate" namespace:
  generate:bundle             Generates a bundle
  generate:command            Generates a console command
  generate:controller         Generates a controller
  generate:doctrine:crud      Generates a CRUD based on a Doctrine entity
  generate:doctrine:entities  Generates entity classes and method stubs from your mapping information
  generate:doctrine:entity    Generates a new Doctrine entity inside a bundle
  generate:doctrine:form      Generates a form type class based on a Doctrine entity
```

Overrules #19776 but also includes other fixes related to aliases that popped up when writing tests :+1:  
