### PR TITLE
[Expression Language] Added anonymous function support

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Lexer.php
+++ b/src/Symfony/Component/ExpressionLanguage/Lexer.php
@@ -73,7 +73,7 @@ class Lexer
                 // strings
                 $tokens[] = new Token(Token::STRING_TYPE, stripcslashes(substr($match[0], 1, -1)), $cursor + 1);
                 $cursor += strlen($match[0]);
-            } elseif (preg_match('/not in(?=[\s(])|\!\=\=|not(?=[\s(])|and(?=[\s(])|\=\=\=|\>\=|or(?=[\s(])|\<\=|\*\*|\.\.|in(?=[\s(])|&&|\|\||matches|\=\=|\!\=|\*|~|%|\/|\>|\||\!|\^|&|\+|\<|\-/A', $expression, $match, null, $cursor)) {
+            } elseif (preg_match('/\->|not in(?=[\s(])|\!\=\=|not(?=[\s(])|and(?=[\s(])|\=\=\=|\>\=|or(?=[\s(])|\<\=|\*\*|\.\.|in(?=[\s(])|&&|\|\||matches|\=\=|\!\=|\*|~|%|\/|\>|\||\!|\^|&|\+|\<|\-/A', $expression, $match, null, $cursor)) {
                 // operators
                 $tokens[] = new Token(Token::OPERATOR_TYPE, $match[0], $cursor + 1);
                 $cursor += strlen($match[0]);

--- a/src/Symfony/Component/ExpressionLanguage/Node/AnonFuncNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/AnonFuncNode.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ExpressionLanguage\Node;
+
+use Symfony\Component\ExpressionLanguage\Compiler;
+
+/**
+ * @author Christian Sciberras <christian@sciberras.me>
+ *
+ * @internal
+ */
+class AnonFuncNode extends Node
+{
+    /**
+     * 
+     * @param NameNode[] $parameters
+     * @param Node|null $body
+     */
+    public function __construct(array $parameters, Node $body = null)
+    {
+        parent::__construct(
+            array(
+                'parameters' => $parameters,
+                'body' => $body,
+            )
+        );
+    }
+
+    public function compile(Compiler $compiler)
+    {
+        $arguments = [];
+        
+        foreach ($this->nodes['parameters'] as $parameterNode) {
+            $arguments[] = $compiler->subcompile($parameterNode);
+        }
+        
+        $compiler->raw(
+            sprintf(
+                'function (%s) { return %s; }',
+                implode(', ', $arguments),
+                $this->nodes['body'] ? $compiler->subcompile($this->nodes['body']) : 'null'
+            )
+        );
+    }
+
+    public function evaluate($functions, $values)
+    {
+        if (!$this->nodes['body']) {
+            return function () {};
+        }
+        
+        $paramNames = array();
+        
+        foreach ($this->nodes['parameters'] as $parameterNode) {
+            $nodeData = $parameterNode->toArray();
+            $paramNames[] = $nodeData[0];
+        }
+        
+        return function () use($functions, $paramNames) {
+            $passedValues = array_combine($paramNames, func_get_args());
+            return $this->nodes['body']->evaluate($functions, $passedValues);
+        };
+    }
+
+    public function toArray()
+    {
+        $array = array();
+
+        foreach ($this->nodes['parameters'] as $node) {
+            $array[] = ', ';
+            $array[] = $node;
+        }
+        $array[0] = '(';
+        $array[] = ') -> {';
+        if ($this->nodes['body']) {
+            $array[] = $this->nodes['body'];
+        }
+        $array[] = '}';
+
+        return $array;
+    }
+}

--- a/src/Symfony/Component/ExpressionLanguage/Node/AnonFuncNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/AnonFuncNode.php
@@ -25,11 +25,10 @@ class AnonFuncNode extends Node
      * @var SafeCallable
      */
     private static $noopSafeCallable;
-    
+
     /**
-     * 
      * @param NameNode[] $parameters
-     * @param Node|null $body
+     * @param Node|null  $body
      */
     public function __construct(array $parameters, Node $body = null)
     {
@@ -39,7 +38,7 @@ class AnonFuncNode extends Node
                 'body' => $body,
             )
         );
-        
+
         if (!self::$noopSafeCallable) {
             self::$noopSafeCallable = new SafeCallable(function () {});
         }
@@ -47,12 +46,12 @@ class AnonFuncNode extends Node
 
     public function compile(Compiler $compiler)
     {
-        $arguments = [];
-        
+        $arguments = array();
+
         foreach ($this->nodes['parameters'] as $parameterNode) {
             $arguments[] = $compiler->subcompile($parameterNode);
         }
-        
+
         $compiler->raw(
             sprintf(
                 'function (%s) { return %s; }',
@@ -67,17 +66,18 @@ class AnonFuncNode extends Node
         if (!$this->nodes['body']) {
             return self::$noopSafeCallable;
         }
-        
+
         $paramNames = array();
-        
+
         foreach ($this->nodes['parameters'] as $parameterNode) {
             $nodeData = $parameterNode->toArray();
             $paramNames[] = $nodeData[0];
         }
-        
+
         return new SafeCallable(
-            function () use($functions, $paramNames) {
+            function () use ($functions, $paramNames) {
                 $passedValues = array_combine($paramNames, func_get_args());
+
                 return $this->nodes['body']->evaluate($functions, $passedValues);
             }
         );

--- a/src/Symfony/Component/ExpressionLanguage/Node/AnonFuncNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/AnonFuncNode.php
@@ -63,22 +63,26 @@ class AnonFuncNode extends Node
 
     public function evaluate($functions, $values)
     {
-        if (!$this->nodes['body']) {
+        /** @var Node|null $bodyNode */
+        $bodyNode = $this->nodes['body'];
+
+        if (!$bodyNode) {
             return self::$noopSafeCallable;
         }
 
         $paramNames = array();
 
         foreach ($this->nodes['parameters'] as $parameterNode) {
+            /** @var NameNode $parameterNode */
             $nodeData = $parameterNode->toArray();
             $paramNames[] = $nodeData[0];
         }
 
         return new SafeCallable(
-            function () use ($functions, $paramNames) {
+            function () use ($functions, $paramNames, $bodyNode) {
                 $passedValues = array_combine($paramNames, func_get_args());
 
-                return $this->nodes['body']->evaluate($functions, $passedValues);
+                return $bodyNode->evaluate($functions, $passedValues);
             }
         );
     }

--- a/src/Symfony/Component/ExpressionLanguage/Parser.php
+++ b/src/Symfony/Component/ExpressionLanguage/Parser.php
@@ -134,6 +134,7 @@ class Parser
      * Replaces all anonymous functions with placeholder tokens.
      *
      * @param TokenStream $stream
+     *
      * @return TokenStream
      */
     protected function preParseAnonFuncs(TokenStream $stream)
@@ -172,11 +173,11 @@ class Parser
                 $openingBracketCount = 1;
                 while ($openingBracketCount != 0) {
                     if ($stream->current->test(Token::PUNCTUATION_TYPE, '{')) {
-                        $openingBracketCount++;
+                        ++$openingBracketCount;
                     }
 
                     if ($stream->current->test(Token::PUNCTUATION_TYPE, '}')) {
-                        $openingBracketCount--;
+                        --$openingBracketCount;
                     }
 
                     if (!$openingBracketCount) {

--- a/src/Symfony/Component/ExpressionLanguage/Resources/bin/generate_operator_regex.php
+++ b/src/Symfony/Component/ExpressionLanguage/Resources/bin/generate_operator_regex.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-$operators = array('not', '!', 'or', '||', '&&', 'and', '|', '^', '&', '==', '===', '!=', '!==', '<', '>', '>=', '<=', 'not in', 'in', '..', '+', '-', '~', '*', '/', '%', 'matches', '**');
+$operators = array('->', 'not', '!', 'or', '||', '&&', 'and', '|', '^', '&', '==', '===', '!=', '!==', '<', '>', '>=', '<=', 'not in', 'in', '..', '+', '-', '~', '*', '/', '%', 'matches', '**');
 $operators = array_combine($operators, array_map('strlen', $operators));
 arsort($operators);
 

--- a/src/Symfony/Component/ExpressionLanguage/SafeCallable.php
+++ b/src/Symfony/Component/ExpressionLanguage/SafeCallable.php
@@ -27,43 +27,47 @@ class SafeCallable
     /**
      * Constructor.
      *
-     * @param Callable $callback The target callback.
+     * @param callable $callback The target callback.
      */
-    public function __construct(Callable $callback)
+    public function __construct(callable $callback)
     {
         $this->callback = $callback;
     }
 
     /**
-     * @return Callable
+     * @return callable
      */
     public function getCallback()
     {
         return $this->callback;
     }
-    
+
     /**
      * Call the callback with the provided arguments and returns result.
+     *
      * @return mixed
      */
     public function call()
     {
         return $this->callArray(func_get_args());
     }
-    
+
     /**
      * Call the callback with the provided arguments and returns result.
+     *
      * @param array $arguments
+     *
      * @return mixed
      */
     public function callArray(array $arguments)
     {
         $callback = $this->getCallback();
+
         return count($arguments)
             ? call_user_func_array($callback, $arguments)
             : $callback();
     }
-    
+
     public function __invoke()
     {
         throw new Exception('Callback wrapper cannot be invoked, use $wrapper->getCallback() instead.');

--- a/src/Symfony/Component/ExpressionLanguage/SafeCallable.php
+++ b/src/Symfony/Component/ExpressionLanguage/SafeCallable.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ExpressionLanguage;
+
+/**
+ * A wrapper for an anonymous function.
+ * We do not return anonymous functions directly for security reason, to avoid
+ * calling arbitrary functions by returning arrays containing class/method or
+ * string function names. From the userland, one can still get access to the
+ * anonymous function using the various public methods.
+ *
+ * @author Christian Sciberras <christian@sciberras.me>
+ */
+class SafeCallable
+{
+    protected $callback;
+
+    /**
+     * Constructor.
+     *
+     * @param Callable $callback The target callback.
+     */
+    public function __construct(Callable $callback)
+    {
+        $this->callback = $callback;
+    }
+
+    /**
+     * @return Callable
+     */
+    public function getCallback()
+    {
+        return $this->callback;
+    }
+    
+    /**
+     * Call the callback with the provided arguments and returns result.
+     * @return mixed
+     */
+    public function call()
+    {
+        return $this->callArray(func_get_args());
+    }
+    
+    /**
+     * Call the callback with the provided arguments and returns result.
+     * @param array $arguments
+     * @return mixed
+     */
+    public function callArray(array $arguments)
+    {
+        $callback = $this->getCallback();
+        return count($arguments)
+            ? call_user_func_array($callback, $arguments)
+            : $callback();
+    }
+    
+    public function __invoke()
+    {
+        throw new Exception('Callback wrapper cannot be invoked, use $wrapper->getCallback() instead.');
+    }
+}

--- a/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/LexerTest.php
@@ -86,6 +86,23 @@ class LexerTest extends \PHPUnit_Framework_TestCase
                 array(new Token('string', '#foo', 1)),
                 '"#foo"',
             ),
+            array(
+                array(
+                    new Token('name', 'foo', 1),
+                    new Token('punctuation', '(', 4),
+                    new Token('punctuation', '(', 5),
+                    new Token('name', 'bar', 6),
+                    new Token('punctuation', ',', 9),
+                    new Token('name', 'baz', 11),
+                    new Token('punctuation', ')', 14),
+                    new Token('operator', '->', 16),
+                    new Token('punctuation', '{', 19),
+                    new Token('name', 'baz', 21),
+                    new Token('punctuation', '}', 25),
+                    new Token('punctuation', ')', 26),
+                ),
+                'foo((bar, baz) -> { baz })',
+            ),
         );
     }
 }

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/AnonFuncNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/AnonFuncNodeTest.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ExpressionLanguage\Tests\Node;
+
+use Symfony\Component\ExpressionLanguage\Node\AnonFuncNode;
+use Symfony\Component\ExpressionLanguage\Node\BinaryNode;
+use Symfony\Component\ExpressionLanguage\Node\NameNode;
+use Symfony\Component\ExpressionLanguage\Node\ConstantNode;
+
+class AnonFuncNodeTest extends AbstractNodeTest
+{
+    /**
+     * @dataProvider getEvaluateData
+     */
+    public function testEvaluate($expectedResult, $node, $variables = array(), $functions = array())
+    {
+        $callback = $node->evaluate($functions, $variables);
+        $this->assertTrue(is_callable($callback));
+        
+        $actualResult = call_user_func_array($callback, $variables);
+        $this->assertSame($expectedResult, $actualResult);
+    }
+    
+    public function getEvaluateData()
+    {
+        return array(
+            'parameterless call, null result' => array(
+                null,
+                new AnonFuncNode(
+                    array(),
+                    null
+                )
+            ),
+            'one parameter, returned' => array(
+                123,
+                new AnonFuncNode(
+                    array(new NameNode('foo')),
+                    new NameNode('foo')
+                ),
+                array('foovalue' => 123)
+            ),
+            'two parameters, multiplied and result returned' => array(
+                246,
+                new AnonFuncNode(
+                    array(new NameNode('foo'), new NameNode('bar')),
+                    new BinaryNode('*', new NameNode('foo'), new NameNode('bar'))
+                ),
+                array('foovalue' => 123, 'barvalue' => 2)
+            ),
+            'one unused parameter, returns literal' => array(
+                890,
+                new AnonFuncNode(
+                    array(new NameNode('foo')),
+                    new ConstantNode(890)
+                ),
+                array('foovalue' => 123)
+            ),
+        );
+    }
+
+    public function getCompileData()
+    {
+        return array(
+            array(
+                'function () { return null; }',
+                new AnonFuncNode(
+                    array(),
+                    null
+                )
+            ),
+            array(
+                'function ($foo) { return $foo; }',
+                new AnonFuncNode(
+                    array(new NameNode('foo')),
+                    new NameNode('foo')
+                )
+            ),
+            array(
+                'function ($foo, $bar) { return ($foo * $bar); }',
+                new AnonFuncNode(
+                    array(new NameNode('foo'), new NameNode('bar')),
+                    new BinaryNode('*', new NameNode('foo'), new NameNode('bar'))
+                )
+            ),
+        );
+    }
+
+    public function getDumpData()
+    {
+        return array(
+            array(
+                '() -> {}',
+                new AnonFuncNode(
+                    array(),
+                    null
+                )
+            ),
+            array(
+                '(foo) -> {foo}',
+                new AnonFuncNode(
+                    array(new NameNode('foo')),
+                    new NameNode('foo')
+                )
+            ),
+            array(
+                '(foo) -> {"bar"}',
+                new AnonFuncNode(
+                    array(new NameNode('foo')),
+                    new ConstantNode('bar')
+                )
+            ),
+            array(
+                '(foo, bar) -> {(foo * bar)}',
+                new AnonFuncNode(
+                    array(new NameNode('foo'), new NameNode('bar')),
+                    new BinaryNode('*', new NameNode('foo'), new NameNode('bar'))
+                )
+            ),
+        );
+    }
+}

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/AnonFuncNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/AnonFuncNodeTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\ExpressionLanguage\Node\AnonFuncNode;
 use Symfony\Component\ExpressionLanguage\Node\BinaryNode;
 use Symfony\Component\ExpressionLanguage\Node\NameNode;
 use Symfony\Component\ExpressionLanguage\Node\ConstantNode;
+use Symfony\Component\ExpressionLanguage\SafeCallable;
 
 class AnonFuncNodeTest extends AbstractNodeTest
 {
@@ -23,10 +24,11 @@ class AnonFuncNodeTest extends AbstractNodeTest
      */
     public function testEvaluate($expectedResult, $node, $variables = array(), $functions = array())
     {
-        $callback = $node->evaluate($functions, $variables);
-        $this->assertTrue(is_callable($callback));
+        $safeCallback = $node->evaluate($functions, $variables);
+        $this->assertInstanceOf(SafeCallable::class, $safeCallback);
+        $this->assertTrue(is_callable($safeCallback->getCallback()));
         
-        $actualResult = call_user_func_array($callback, $variables);
+        $actualResult = $safeCallback->callArray($variables);
         $this->assertSame($expectedResult, $actualResult);
     }
     

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/AnonFuncNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/AnonFuncNodeTest.php
@@ -27,11 +27,11 @@ class AnonFuncNodeTest extends AbstractNodeTest
         $safeCallback = $node->evaluate($functions, $variables);
         $this->assertInstanceOf(SafeCallable::class, $safeCallback);
         $this->assertTrue(is_callable($safeCallback->getCallback()));
-        
+
         $actualResult = $safeCallback->callArray($variables);
         $this->assertSame($expectedResult, $actualResult);
     }
-    
+
     public function getEvaluateData()
     {
         return array(
@@ -40,7 +40,7 @@ class AnonFuncNodeTest extends AbstractNodeTest
                 new AnonFuncNode(
                     array(),
                     null
-                )
+                ),
             ),
             'one parameter, returned' => array(
                 123,
@@ -48,7 +48,7 @@ class AnonFuncNodeTest extends AbstractNodeTest
                     array(new NameNode('foo')),
                     new NameNode('foo')
                 ),
-                array('foovalue' => 123)
+                array('foovalue' => 123),
             ),
             'two parameters, multiplied and result returned' => array(
                 246,
@@ -56,7 +56,7 @@ class AnonFuncNodeTest extends AbstractNodeTest
                     array(new NameNode('foo'), new NameNode('bar')),
                     new BinaryNode('*', new NameNode('foo'), new NameNode('bar'))
                 ),
-                array('foovalue' => 123, 'barvalue' => 2)
+                array('foovalue' => 123, 'barvalue' => 2),
             ),
             'one unused parameter, returns literal' => array(
                 890,
@@ -64,7 +64,7 @@ class AnonFuncNodeTest extends AbstractNodeTest
                     array(new NameNode('foo')),
                     new ConstantNode(890)
                 ),
-                array('foovalue' => 123)
+                array('foovalue' => 123),
             ),
         );
     }
@@ -77,21 +77,21 @@ class AnonFuncNodeTest extends AbstractNodeTest
                 new AnonFuncNode(
                     array(),
                     null
-                )
+                ),
             ),
             array(
                 'function ($foo) { return $foo; }',
                 new AnonFuncNode(
                     array(new NameNode('foo')),
                     new NameNode('foo')
-                )
+                ),
             ),
             array(
                 'function ($foo, $bar) { return ($foo * $bar); }',
                 new AnonFuncNode(
                     array(new NameNode('foo'), new NameNode('bar')),
                     new BinaryNode('*', new NameNode('foo'), new NameNode('bar'))
-                )
+                ),
             ),
         );
     }
@@ -104,28 +104,28 @@ class AnonFuncNodeTest extends AbstractNodeTest
                 new AnonFuncNode(
                     array(),
                     null
-                )
+                ),
             ),
             array(
                 '(foo) -> {foo}',
                 new AnonFuncNode(
                     array(new NameNode('foo')),
                     new NameNode('foo')
-                )
+                ),
             ),
             array(
                 '(foo) -> {"bar"}',
                 new AnonFuncNode(
                     array(new NameNode('foo')),
                     new ConstantNode('bar')
-                )
+                ),
             ),
             array(
                 '(foo, bar) -> {(foo * bar)}',
                 new AnonFuncNode(
                     array(new NameNode('foo'), new NameNode('bar')),
                     new BinaryNode('*', new NameNode('foo'), new NameNode('bar'))
-                )
+                ),
             ),
         );
     }

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
@@ -154,6 +154,21 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                 'bar',
                 array('foo' => 'bar'),
             ),
+            
+            array(
+                new Node\AnonFuncNode(
+                    array(
+                        new Node\NameNode('foo'),
+                        new Node\NameNode('bar'),
+                    ),
+                    new Node\BinaryNode(
+                        '*',
+                        new Node\NameNode('foo'),
+                        new Node\NameNode('bar')
+                    )
+                ),
+                '(foo, bar) -> { foo * bar }',
+            ),
         );
     }
 

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
@@ -42,10 +42,10 @@ class ParserTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider getParseData
      */
-    public function testParse($node, $expression, $names = array())
+    public function testParse($node, $expression, $names = array(), $funcs = array())
     {
         $lexer = new Lexer();
-        $parser = new Parser(array());
+        $parser = new Parser($funcs);
         $this->assertEquals($node, $parser->parse($lexer->tokenize($expression), $names));
     }
 
@@ -168,6 +168,40 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                     )
                 ),
                 '(foo, bar) -> { foo * bar }',
+            ),
+
+            array(
+                new Node\AnonFuncNode(
+                    array(
+                        new Node\NameNode('foo'),
+                        new Node\NameNode('bars'),
+                    ),
+                    new Node\BinaryNode(
+                        '*',
+                        new Node\NameNode('foo'),
+                        new Node\FunctionNode(
+                            'map',
+                            new Node\Node(
+                                array(
+                                    new Node\NameNode('bars'),
+                                    new Node\AnonFuncNode(
+                                        array(
+                                            new Node\NameNode('bar'),
+                                        ),
+                                        new Node\BinaryNode(
+                                            '*',
+                                            new Node\NameNode('bar'),
+                                            new Node\NameNode('baz')
+                                        )
+                                    ),
+                                )
+                            )
+                        )
+                    )
+                ),
+                '(foo, bars) -> { foo * map(bars, (bar) -> { bar * baz }) }',
+                array('baz'),
+                array('map' => 'array_map')
             ),
         );
     }

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
@@ -154,7 +154,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                 'bar',
                 array('foo' => 'bar'),
             ),
-            
+
             array(
                 new Node\AnonFuncNode(
                     array(
@@ -201,7 +201,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                 ),
                 '(foo, bars) -> { foo * map(bars, (bar) -> { bar * baz }) }',
                 array('baz'),
-                array('map' => 'array_map')
+                array('map' => 'array_map'),
             ),
         );
     }

--- a/src/Symfony/Component/ExpressionLanguage/Tests/TokenStreamTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/TokenStreamTest.php
@@ -18,7 +18,7 @@ class TokenStreamTest extends \PHPUnit_Framework_TestCase
 {
     /** @var Token[] */
     protected $tokens;
-    
+
     protected function setUp()
     {
         $this->tokens = array(
@@ -43,14 +43,14 @@ class TokenStreamTest extends \PHPUnit_Framework_TestCase
     {
         $tokens = $this->tokens;
         $stream = $this->getStream();
-        
+
         $this->assertEquals($tokens[0], $stream->current);
         $this->assertSame(0, $stream->position());
-        
+
         $stream->next();
         $this->assertEquals($tokens[1], $stream->current);
         $this->assertSame(1, $stream->position());
-        
+
         $stream->next();
         $stream->expect(Token::OPERATOR_TYPE, '*');
         $this->assertEquals($tokens[3], $stream->current);
@@ -61,17 +61,17 @@ class TokenStreamTest extends \PHPUnit_Framework_TestCase
     {
         $tokens = $this->tokens;
         $stream = $this->getStream();
-        
+
         $stream->next();
         $stream->next();
-        
+
         $this->assertEquals($tokens[2], $stream->current);
         $this->assertSame(2, $stream->position());
-        
+
         $stream->prev();
         $this->assertEquals($tokens[1], $stream->current);
         $this->assertSame(1, $stream->position());
-        
+
         $stream->expectPrev(Token::NAME_TYPE, 'foo');
         $this->assertEquals($tokens[0], $stream->current);
         $this->assertSame(0, $stream->position());
@@ -81,24 +81,24 @@ class TokenStreamTest extends \PHPUnit_Framework_TestCase
     {
         $tokens = $this->tokens;
         $stream = $this->getStream();
-        
+
         $stream->seek(3, SEEK_SET);
         $this->assertEquals($tokens[3], $stream->current);
         $this->assertSame(3, $stream->position());
-        
+
         $stream->seek(-1, SEEK_CUR);
         $this->assertEquals($tokens[2], $stream->current);
         $this->assertSame(2, $stream->position());
-        
+
         $stream->seek(2, SEEK_CUR);
         $this->assertEquals($tokens[4], $stream->current);
         $this->assertSame(4, $stream->position());
-        
+
         $stream->seek(0, SEEK_END);
         $this->assertEquals($tokens[5], $stream->current);
         $this->assertSame(5, $stream->position());
         $this->assertTrue($stream->isEOF());
-        
+
         $stream->seek(-2, SEEK_END);
         $this->assertEquals($tokens[3], $stream->current);
         $this->assertSame(3, $stream->position());
@@ -111,20 +111,20 @@ class TokenStreamTest extends \PHPUnit_Framework_TestCase
         $replacement2 = new Token(Token::NUMBER_TYPE, 64, 0);
         $original = $this->getStream();
         $spliced = $original->splice(2, 3, array($replacement1, $replacement2));
-        
+
         $spliced->expect($tokens[0]->type, $tokens[0]->value);
         $spliced->expect($tokens[1]->type, $tokens[1]->value);
-        
+
         $spliced->expect($replacement1->type, $replacement1->value);
         $spliced->expect($replacement2->type, $replacement2->value);
-        
+
         $this->assertTrue($spliced->isEOF());
-        
+
         $original->expect($tokens[0]->type, $tokens[0]->value);
         $original->expect($tokens[1]->type, $tokens[1]->value);
         $original->expect($tokens[2]->type, $tokens[2]->value);
         $original->expect($tokens[3]->type, $tokens[3]->value);
-        
+
         $this->assertTrue($spliced->isEOF());
     }
 }

--- a/src/Symfony/Component/ExpressionLanguage/Tests/TokenStreamTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/TokenStreamTest.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ExpressionLanguage\Tests;
+
+use Symfony\Component\ExpressionLanguage\Token;
+use Symfony\Component\ExpressionLanguage\TokenStream;
+
+class TokenStreamTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var Token[] */
+    protected $tokens;
+    
+    protected function setUp()
+    {
+        $this->tokens = array(
+            new Token(Token::PUNCTUATION_TYPE, '(', 1),
+            new Token(Token::NAME_TYPE, 'foo', 2),
+            new Token(Token::OPERATOR_TYPE, '*', 6),
+            new Token(Token::NAME_TYPE, 'bar', 8),
+            new Token(Token::PUNCTUATION_TYPE, ')', 11),
+            new Token(Token::EOF_TYPE, null, 12),
+        );
+    }
+
+    /**
+     * @return TokenStream
+     */
+    protected function getStream()
+    {
+        return new TokenStream($this->tokens);
+    }
+
+    public function testMovingForward()
+    {
+        $tokens = $this->tokens;
+        $stream = $this->getStream();
+        
+        $this->assertEquals($tokens[0], $stream->current);
+        $this->assertSame(0, $stream->position());
+        
+        $stream->next();
+        $this->assertEquals($tokens[1], $stream->current);
+        $this->assertSame(1, $stream->position());
+        
+        $stream->next();
+        $stream->expect(Token::OPERATOR_TYPE, '*');
+        $this->assertEquals($tokens[3], $stream->current);
+        $this->assertSame(3, $stream->position());
+    }
+
+    public function testMovingBackward()
+    {
+        $tokens = $this->tokens;
+        $stream = $this->getStream();
+        
+        $stream->next();
+        $stream->next();
+        
+        $this->assertEquals($tokens[2], $stream->current);
+        $this->assertSame(2, $stream->position());
+        
+        $stream->prev();
+        $this->assertEquals($tokens[1], $stream->current);
+        $this->assertSame(1, $stream->position());
+        
+        $stream->expectPrev(Token::NAME_TYPE, 'foo');
+        $this->assertEquals($tokens[0], $stream->current);
+        $this->assertSame(0, $stream->position());
+    }
+
+    public function testSeeking()
+    {
+        $tokens = $this->tokens;
+        $stream = $this->getStream();
+        
+        $stream->seek(3, SEEK_SET);
+        $this->assertEquals($tokens[3], $stream->current);
+        $this->assertSame(3, $stream->position());
+        
+        $stream->seek(-1, SEEK_CUR);
+        $this->assertEquals($tokens[2], $stream->current);
+        $this->assertSame(2, $stream->position());
+        
+        $stream->seek(2, SEEK_CUR);
+        $this->assertEquals($tokens[4], $stream->current);
+        $this->assertSame(4, $stream->position());
+        
+        $stream->seek(0, SEEK_END);
+        $this->assertEquals($tokens[5], $stream->current);
+        $this->assertSame(5, $stream->position());
+        $this->assertTrue($stream->isEOF());
+        
+        $stream->seek(-2, SEEK_END);
+        $this->assertEquals($tokens[3], $stream->current);
+        $this->assertSame(3, $stream->position());
+    }
+
+    public function testSplicing()
+    {
+        $tokens = $this->tokens;
+        $replacement1 = new Token(Token::NUMBER_TYPE, 42, 0);
+        $replacement2 = new Token(Token::NUMBER_TYPE, 64, 0);
+        $original = $this->getStream();
+        $spliced = $original->splice(2, 3, array($replacement1, $replacement2));
+        
+        $spliced->expect($tokens[0]->type, $tokens[0]->value);
+        $spliced->expect($tokens[1]->type, $tokens[1]->value);
+        
+        $spliced->expect($replacement1->type, $replacement1->value);
+        $spliced->expect($replacement2->type, $replacement2->value);
+        
+        $this->assertTrue($spliced->isEOF());
+        
+        $original->expect($tokens[0]->type, $tokens[0]->value);
+        $original->expect($tokens[1]->type, $tokens[1]->value);
+        $original->expect($tokens[2]->type, $tokens[2]->value);
+        $original->expect($tokens[3]->type, $tokens[3]->value);
+        
+        $this->assertTrue($spliced->isEOF());
+    }
+}

--- a/src/Symfony/Component/ExpressionLanguage/Token.php
+++ b/src/Symfony/Component/ExpressionLanguage/Token.php
@@ -28,6 +28,7 @@ class Token
     const STRING_TYPE = 'string';
     const OPERATOR_TYPE = 'operator';
     const PUNCTUATION_TYPE = 'punctuation';
+    const REPLACEMENT_TYPE = 'replacement';
 
     /**
      * Constructor.

--- a/src/Symfony/Component/ExpressionLanguage/TokenStream.php
+++ b/src/Symfony/Component/ExpressionLanguage/TokenStream.php
@@ -18,20 +18,24 @@ namespace Symfony\Component\ExpressionLanguage;
  */
 class TokenStream
 {
+    /** @var Token */
     public $current;
 
+    /** @var Token[] */
     private $tokens;
+
+    /** @var int */
     private $position = 0;
 
     /**
      * Constructor.
      *
-     * @param array $tokens An array of tokens
+     * @param Token[] $tokens An array of tokens
      */
     public function __construct(array $tokens)
     {
         $this->tokens = $tokens;
-        $this->current = $tokens[0];
+        $this->rewind();
     }
 
     /**
@@ -45,7 +49,7 @@ class TokenStream
     }
 
     /**
-     * Sets the pointer to the next token and returns the old one.
+     * Sets the pointer to the next token.
      */
     public function next()
     {
@@ -59,7 +63,7 @@ class TokenStream
     }
 
     /**
-     * Tests a token.
+     * Tests a token and moves to next one.
      *
      * @param array|int   $type    The type to test
      * @param string|null $value   The token value
@@ -69,7 +73,17 @@ class TokenStream
     {
         $token = $this->current;
         if (!$token->test($type, $value)) {
-            throw new SyntaxError(sprintf('%sUnexpected token "%s" of value "%s" ("%s" expected%s)', $message ? $message.'. ' : '', $token->type, $token->value, $type, $value ? sprintf(' with value "%s"', $value) : ''), $token->cursor);
+            throw new SyntaxError(
+                sprintf(
+                    '%sUnexpected token "%s" of value "%s" ("%s" expected%s)',
+                    $message ? $message.'. ' : '',
+                    $token->type,
+                    $token->value,
+                    $type,
+                    $value ? sprintf(' with value "%s"', $value) : ''
+                ),
+                $token->cursor
+            );
         }
         $this->next();
     }
@@ -82,5 +96,115 @@ class TokenStream
     public function isEOF()
     {
         return $this->current->type === Token::EOF_TYPE;
+    }
+
+    /**
+     * Move stream pointer to the beginning.
+     */
+    public function rewind()
+    {
+        $this->position = 0;
+        $this->current = $this->tokens[0];
+    }
+
+    /**
+     * Move to a particular position in the stream.
+     *
+     * @param int $offset The offset relative to $whence.
+     * @param int $whence One of SEEK_SET, SEEK_CUR or SEEK_END constants.
+     */
+    public function seek($offset, $whence)
+    {
+        switch($whence){
+            case SEEK_CUR:
+                $this->position += $offset;
+                break;
+
+            case SEEK_END:
+                $this->position = count($this->tokens) - 1 + $offset;
+                break;
+
+            case SEEK_SET:
+                $this->position = $offset;
+                break;
+
+            default:
+                throw new \InvalidArgumentException('Value of argument $whence is not valid.');
+        }
+
+        if (!isset($this->tokens[$this->position])) {
+            throw new SyntaxError(
+                sprintf('Cannot seek to %s of expression', $this->position > 0 ? 'beyond end' : 'before start'),
+                $this->position
+            );
+        }
+
+        $this->current = $this->tokens[$this->position];
+    }
+
+    /**
+     * Sets the pointer to the previous token.
+     */
+    public function prev()
+    {
+        if (!isset($this->tokens[$this->position])) {
+            throw new SyntaxError('Unexpected start of expression', $this->current->cursor);
+        }
+
+        --$this->position;
+
+        $this->current = $this->tokens[$this->position];
+    }
+
+    /**
+     * Tests a token and moves to previous one.
+     *
+     * @param array|int   $type    The type to test
+     * @param string|null $value   The token value
+     * @param string|null $message The syntax error message
+     */
+    public function expectPrev($type, $value = null, $message = null)
+    {
+        $token = $this->current;
+        if (!$token->test($type, $value)) {
+            throw new SyntaxError(
+                sprintf(
+                    '%sUnexpected token "%s" of value "%s" ("%s" expected%s)',
+                    $message ? $message.'. ' : '',
+                    $token->type,
+                    $token->value,
+                    $type,
+                    $value ? sprintf(' with value "%s"', $value) : ''
+                ),
+                $token->cursor
+            );
+        }
+        $this->prev();
+    }
+
+    /**
+     * Returns new TokenStream with tokens replaced by some others.
+     *
+     * @param int $offset
+     * @param int $length
+     * @param array $replacements
+     * @return \static
+     */
+    public function splice($offset, $length, $replacements)
+    {
+        $tokens = $this->tokens;
+        array_splice($tokens, $offset, $length, $replacements);
+
+        return new static($tokens);
+    }
+
+    /**
+     * Returns the current position.
+     *
+     * @return int
+     */
+    public function position()
+    {
+        return $this->position;
     }
 }

--- a/src/Symfony/Component/ExpressionLanguage/TokenStream.php
+++ b/src/Symfony/Component/ExpressionLanguage/TokenStream.php
@@ -115,7 +115,7 @@ class TokenStream
      */
     public function seek($offset, $whence)
     {
-        switch($whence){
+        switch ($whence) {
             case SEEK_CUR:
                 $this->position += $offset;
                 break;
@@ -185,9 +185,10 @@ class TokenStream
     /**
      * Returns new TokenStream with tokens replaced by some others.
      *
-     * @param int $offset
-     * @param int $length
+     * @param int   $offset
+     * @param int   $length
      * @param array $replacements
+     *
      * @return \static
      */
     public function splice($offset, $length, $replacements)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
## A few notes
### New Syntax
- `() -> { expr }` - Function without arguments and an expression.
- `(arg1, arg2) -> { arg1 + arg2 }` - Function with two arguments that returns their sum.
- `(arg1) -> {}` - Function that always returns null. Due to a small optimisation, the same function is always reused and the number of arguments are actually irrelevant.
### Safety

If the new syntax simply generated an anonymous function, user-land code can easily be susceptible to security issues (for example, one can return an arbitrary string or array instead of a callable).

To counter this, the anonymous function node generates a callback contained within a non-invokeable object (see `ExpressionLanguage/SafeCallable.php`). User-land code needs to be aware of this and use any of the available methods to actually call the anonymous function.
### Syntax Parsing

I've found it difficult to integrate the new syntax parsing within the existing mechanism. One reason for this is that it follows a familiar (but still different) syntax that causes the parser to stop because of variables not found (function parameters) or unexpected punctuation between parameters (comma).

So what I did is to introduce a middle step between tokens and the final node tree - a partial tree structure where all the tokens related to an anonymous function are replaced with a "replacement token", (`Token::REPLACEMENT_TYPE`), that is finally replaced with the anonymous function node.
### Increased `TokenStream` Functionality

Due to the new syntax and parsing mechanism, I had to add a couple of new methods to the token stream in order to:
- move backward
- expect a token backward
- jump to any position in the stream, most useful with:
- get the current stream position
- slice tokens in the stream (replace one or more tokens with others, returning new stream)

I've added various tests for these new methods.
## Remaining Tasks
- [x] Ensure CI tests are ok
- [x] Fix any code style / code review issues
- [ ] Performance checkup?
- [ ] Decide whether generated PHP should also use SafeCallable, not a plain callable
- [ ] variables passed to the engine are available inside anon funcs during execution, but the generated PHP code actually does not `use()` those arguments, nor does it declare them as global.
