### PR TITLE
[Serializer] Throw exception when extra attributes are used during an object denor…

### DIFF
--- a/src/Symfony/Component/Serializer/Exception/ExtraAttributesException.php
+++ b/src/Symfony/Component/Serializer/Exception/ExtraAttributesException.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Exception;
+
+/**
+ * ExtraAttributesException.
+ *
+ * @author Julien DIDIER <julien@didier.io>
+ */
+class ExtraAttributesException extends RuntimeException
+{
+    public function __construct(array $extraAttributes, \Exception $previous = null)
+    {
+        $msg = sprintf('Extra attributes are not allowed ("%s" are unknown).', implode('", "', $extraAttributes));
+
+        parent::__construct($msg, 0, $previous);
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -37,6 +37,21 @@ class AbstractObjectNormalizerTest extends \PHPUnit_Framework_TestCase
         $normalizer = new AbstractObjectNormalizerDummy();
         $normalizer->instantiateObject($data, $class, $context, new \ReflectionClass($class), array());
     }
+
+    /**
+     * @expectedException \Symfony\Component\Serializer\Exception\ExtraAttributesException
+     * @expectedExceptionMessage Extra attributes are not allowed ("fooFoo", "fooBar" are unknown).
+     */
+    public function testDenormalizeWithExtraAttributes()
+    {
+        $normalizer = new AbstractObjectNormalizerDummy();
+        $normalizer->denormalize(
+            array('fooFoo' => 'foo', 'fooBar' => 'bar'),
+            __NAMESPACE__.'\Dummy',
+            'any',
+            array('allow_extra_attributes' => false)
+        );
+    }
 }
 
 class AbstractObjectNormalizerDummy extends AbstractObjectNormalizer


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #19948 |
| License | MIT |
| Doc PR | [#6975](https://github.com/symfony/symfony-docs/pull/6975) |

I will update the doc if you're ok with this PR.
