### PR TITLE
[Validator] Allow Choice Constraint Callback to be non-static

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
@@ -47,7 +47,8 @@ class ChoiceValidator extends ConstraintValidator
         }
 
         if ($constraint->callback) {
-            if (!is_callable($choices = array($this->context->getClassName(), $constraint->callback))
+            if (!is_callable($choices = array($this->context->getObject(), $constraint->callback))
+                && !is_callable($choices = array($this->context->getClassName(), $constraint->callback))
                 && !is_callable($choices = $constraint->callback)
             ) {
                 throw new ConstraintDefinitionException('The Choice constraint expects a valid callback');

--- a/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
@@ -32,6 +32,11 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
         return array('foo', 'bar');
     }
 
+    public function nonStaticCallback()
+    {
+        return array('foo', 'bar');
+    }
+
     /**
      * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
      */
@@ -120,12 +125,24 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    public function testValidChoiceCallbackContextMethod()
+    public function testValidStaticChoiceCallbackContextMethod()
     {
         // search $this for "staticCallback"
         $this->setObject($this);
 
         $constraint = new Choice(array('callback' => 'staticCallback', 'strict' => true));
+
+        $this->validator->validate('bar', $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testValidChoiceCallbackContextMethod()
+    {
+        // search $this for "nonStaticCallback"
+        $this->setObject($this);
+
+        $constraint = new Choice(array('callback' => 'nonStaticCallback', 'strict' => true));
 
         $this->validator->validate('bar', $constraint);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | will write if community wants this feature |

Now that as of 3.0 the ExecutionContextInterface has a getObject method, the callback doesn't need to be static anymore, it can actually be on the object that's being validated. This is great because you can actually have dynamic choices and this validator will actually work. Maintainers are free to add commits to this branch.
