### PR TITLE
[HttpKernel] Fix static code analysis warning

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -672,14 +672,14 @@ abstract class Kernel implements KernelInterface, TerminableInterface
      *
      * @param ContainerInterface $container The service container
      *
-     * @throws \DomainException If the container is not of type ContainerBuilder
+     * @throws \InvalidArgumentException When the container is not an instance of ContainerBuilder
      *
      * @return DelegatingLoader The loader
      */
     protected function getContainerLoader(ContainerInterface $container)
     {
         if (!$container instanceof ContainerBuilder) {
-            throw new \DomainException(sprintf('Container must be an instance of Symfony\Component\DependencyInjection\ContainerBuilder, got %s', get_class($container)));
+            throw new \InvalidArgumentException(sprintf('The container must be an instance of Symfony\Component\DependencyInjection\ContainerBuilder, got %s.', get_class($container)));
         }
 
         $locator = new FileLocator($this);

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -672,10 +672,16 @@ abstract class Kernel implements KernelInterface, TerminableInterface
      *
      * @param ContainerInterface $container The service container
      *
+     * @throws \DomainException If the container is not of type ContainerBuilder
+     *
      * @return DelegatingLoader The loader
      */
     protected function getContainerLoader(ContainerInterface $container)
     {
+        if (!$container instanceof ContainerBuilder) {
+            throw new \DomainException(sprintf('Container must be an instance of Symfony\Component\DependencyInjection\ContainerBuilder, got %s', get_class($container)));
+        }
+
         $locator = new FileLocator($this);
         $resolver = new LoaderResolver(array(
             new XmlFileLoader($container, $locator),

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -672,9 +672,9 @@ abstract class Kernel implements KernelInterface, TerminableInterface
      *
      * @param ContainerInterface $container The service container
      *
-     * @throws \InvalidArgumentException When the container is not an instance of ContainerBuilder
-     *
      * @return DelegatingLoader The loader
+     *
+     * @throws \InvalidArgumentException When the container is not an instance of ContainerBuilder
      */
     protected function getContainerLoader(ContainerInterface $container)
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #19867 |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

Before:

```
[Symfony\Component\Debug\Exception\ContextErrorException]                                                                                                                                                                                                                                                                                                
  Catchable Fatal Error: Argument 1 passed to Symfony\Component\DependencyInjection\Loader\FileLoader::__construct() must be an instance of Symfony\Component\DependencyInjection\ContainerBuilder, instance of Symfony\Component\DependencyInjection\Container given
```

After

```
[InvalidArgumentException]                                                                                                                      
  The container must be an instance of Symfony\Component\DependencyInjection\ContainerBuilder, got Symfony\Component\DependencyInjection\Container.
```

Cosmetic only (better error though), but fixes static code analysis warnings.

Ideally in 4.0 the signature is updated...
