### PR TITLE
[Security] Make sure RoleVoter only votes for RoleInterface objects and strings

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/Voter/RoleVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/RoleVoter.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Core\Authorization\Voter;
 
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Role\RoleInterface;
 
 /**
  * RoleVoter votes if any attribute starts with a given prefix.
@@ -41,7 +42,9 @@ class RoleVoter implements VoterInterface
         $roles = $this->extractRoles($token);
 
         foreach ($attributes as $attribute) {
-            if (0 !== strpos($attribute, $this->prefix)) {
+            if ($attribute instanceof RoleInterface) {
+                $attribute = $attribute->getRole();
+            } elseif (!is_string($attribute) || 0 !== strpos($attribute, $this->prefix)) {
                 continue;
             }
 

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/RoleVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/RoleVoterTest.php
@@ -36,6 +36,12 @@ class RoleVoterTest extends \PHPUnit_Framework_TestCase
             array(array('ROLE_FOO'), array('ROLE_FOO'), VoterInterface::ACCESS_GRANTED),
             array(array('ROLE_FOO'), array('FOO', 'ROLE_FOO'), VoterInterface::ACCESS_GRANTED),
             array(array('ROLE_BAR', 'ROLE_FOO'), array('ROLE_FOO'), VoterInterface::ACCESS_GRANTED),
+
+            array(array('ROLE_FOO'), array('some'), VoterInterface::ACCESS_ABSTAIN),
+            array(array('ROLE_FOO'), array( new Role('ROLE_FOO')), VoterInterface::ACCESS_GRANTED),
+            array(array('ROLE_FOO'), array( new \StdClass() ), VoterInterface::ACCESS_ABSTAIN),
+            array(array('ROLE_FOO'), array( new \StdClass(),'some', 'ROLE_FOO' ), VoterInterface::ACCESS_GRANTED),
+            array(array('ROLE_FOO'), array( new \StdClass(),'some', 'ROLE_NON_FOO' ), VoterInterface::ACCESS_DENIED),
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18042 |
| License | MIT |
| Doc PR |  |

make sure RoleVoter only vote for roles and don't produce fatal error on non-strings.
The BC-Break happen, if someone use a Object as Role by not implementing the RoleInterface but adding a toString method which gives "ROLE_SOMETHING" back. This "feature" breaks.
