### PR TITLE
normalize "SYMFONY__" environment variables

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -537,6 +537,18 @@ abstract class Kernel implements KernelInterface, TerminableInterface
         $parameters = array();
         foreach ($_SERVER as $key => $value) {
             if (0 === strpos($key, 'SYMFONY__')) {
+                if (is_numeric($value)) {
+                    $value = is_float($value + 0) ? (float) $value : (int) $value;
+                } elseif ('true' === strtolower($value)) {
+                    $value = true;
+                } elseif ('false' === strtolower($value)) {
+                    $value = false;
+                } elseif ('null' === strtolower($value)) {
+                    $value = null;
+                } elseif (($json = json_decode($value, true)) && json_last_error() === JSON_ERROR_NONE) {
+                    $value = $json;
+                }
+
                 $parameters[strtolower(str_replace('__', '.', substr($key, 9)))] = $value;
             }
         }

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -149,6 +149,45 @@ class KernelTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($found);
     }
 
+    public function testEnvParameters()
+    {
+        $method = new \ReflectionMethod(Kernel::class, 'getEnvParameters');
+        $method->setAccessible(true);
+
+        $_SERVER = array(
+            'SYMFONY__PARAMETER_TRUE_1' => 'TRUE',
+            'SYMFONY__PARAMETER_TRUE_2' => 'true',
+            'SYMFONY__PARAMETER_FALSE_1' => 'FALSE',
+            'SYMFONY__PARAMETER_FALSE_2'=> 'false',
+            'SYMFONY__PARAMETER_NULL_1' => 'null',
+            'SYMFONY__PARAMETER_NULL_2' => 'NULL',
+            'SYMFONY__PARAMETER_INT_1' => '314',
+            'SYMFONY__PARAMETER_INT_2' => '2e5',
+            'SYMFONY__PARAMETER_FLOAT_1' => '3.14',
+            'SYMFONY__PARAMETER_STRING_1'  => 'Some string',
+            'SYMFONY__PARAMETER_JSON_1' => '[1, 2, 3]',
+            'SYMFONY__PARAMETER_JSON_2' => '{"int": [1,2,3], "bool": [false, true, null], "assoc":{"a": 1, "b": 2, "c": "some string"}}'
+        );
+        $this->assertSame($method->invoke($this->getKernel()), array(
+            'parameter_true_1' => true,
+            'parameter_true_2' => true,
+            'parameter_false_1' => false,
+            'parameter_false_2' => false,
+            'parameter_null_1' => null,
+            'parameter_null_2' => null,
+            'parameter_int_1' => 314,
+            'parameter_int_2' => 2e5,
+            'parameter_float_1' => 3.14,
+            'parameter_string_1' => 'Some string',
+            'parameter_json_1' => array(1, 2, 3),
+            'parameter_json_2' => array(
+                'int' => array(1, 2, 3),
+                'bool' => array(false, true, null),
+                'assoc' => array('a' => 1, 'b' => 2, 'c' => 'some string')
+            )
+        ));
+    }
+
     public function testBootKernelSeveralTimesOnlyInitializesBundlesOnce()
     {
         $kernel = $this->getKernel(array('initializeBundles', 'initializeContainer'));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18905 |
| License | MIT |
| Doc PR | symfony/symfony-docs#6978 |

Environment variables are automatically normalize with casts type `int`, `float`, `bool`, `null`, `JSON` otherwise it will be a string

``` bash
$ export SYMFONY__SOME_ENV_VARIABLE_1=1024
$ export SYMFONY__SOME_ENV_VARIABLE_2=3.14
$ export SYMFONY__SOME_ENV_VARIABLE_3=true
$ export SYMFONY__SOME_ENV_VARIABLE_4=null
$ export SYMFONY__SOME_ENV_VARIABLE_5="[1, 2, 3]"
$ export SYMFONY__SOME_ENV_VARIABLE_6="some string"
```
## Before:

``` php
$container->getParameter('some_env_variable_1') // string: '1024'
$container->getParameter('some_env_variable_2') // string: '3.14'
$container->getParameter('some_env_variable_3') // string: 'true'
$container->getParameter('some_env_variable_4') // string: 'null'
$container->getParameter('some_env_variable_5') // string: '[1,2,3]'
$container->getParameter('some_env_variable_6') // string: 'some string'
```
## After:

``` php
$container->getParameter('some_env_variable_1') // int: 1024
$container->getParameter('some_env_variable_2') // float: 3.14
$container->getParameter('some_env_variable_3') // bool: true
$container->getParameter('some_env_variable_4') // null
$container->getParameter('some_env_variable_5') // array: [1,2,3]
$container->getParameter('some_env_variable_6') // string: 'some string'
```
