### PR TITLE
[Security] AccessDeniedException: rename object to subject

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -194,7 +194,7 @@ abstract class Controller implements ContainerAwareInterface
         if (!$this->isGranted($attributes, $object)) {
             $exception = $this->createAccessDeniedException($message);
             $exception->setAttributes($attributes);
-            $exception->setObject($object);
+            $exception->setSubject($object);
 
             throw $exception;
         }

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 3.2.0
 -----
 
- * added `attributes` and `object` with getters/setters to `Symfony\Component\Security\Core\Exception\AccessDeniedException`
+ * added `$attributes` and `$subject` with getters/setters to `Symfony\Component\Security\Core\Exception\AccessDeniedException`
 
 3.0.0
 -----

--- a/src/Symfony/Component/Security/Core/Exception/AccessDeniedException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AccessDeniedException.php
@@ -19,7 +19,7 @@ namespace Symfony\Component\Security\Core\Exception;
 class AccessDeniedException extends \RuntimeException
 {
     private $attributes = array();
-    private $object;
+    private $subject;
 
     public function __construct($message = 'Access Denied.', \Exception $previous = null)
     {
@@ -45,16 +45,16 @@ class AccessDeniedException extends \RuntimeException
     /**
      * @return mixed
      */
-    public function getObject()
+    public function getSubject()
     {
-        return $this->object;
+        return $this->subject;
     }
 
     /**
-     * @param mixed $object
+     * @param mixed $subject
      */
-    public function setObject($object)
+    public function setSubject($subject)
     {
-        $this->object = $object;
+        $this->subject = $subject;
     }
 }

--- a/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
@@ -69,7 +69,7 @@ class AccessListener implements ListenerInterface
         if (!$this->accessDecisionManager->decide($token, $attributes, $request)) {
             $exception = new AccessDeniedException();
             $exception->setAttributes($attributes);
-            $exception->setObject($request);
+            $exception->setSubject($request);
 
             throw $exception;
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/pull/19473#r72766336 |
| License | MIT |
| Doc PR |  |

With this change the name is inline with what we use in the base voter
interface.
