### PR TITLE
Added a default ide file link web view

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Extension/CodeExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/CodeExtensionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Twig\Tests\Extension;
 
 use Symfony\Bridge\Twig\Extension\CodeExtension;
+use Symfony\Component\HttpKernel\Debug\FileLinkFormatter;
 
 class CodeExtensionTest extends \PHPUnit_Framework_TestCase
 {
@@ -64,6 +65,6 @@ class CodeExtensionTest extends \PHPUnit_Framework_TestCase
 
     protected function getExtension()
     {
-        return new CodeExtension('proto://%f#&line=%l&'.substr(__FILE__, 0, 5).'>foobar', '/root', 'UTF-8');
+        return new CodeExtension(new FileLinkFormatter('proto://%f#&line=%l&'.substr(__FILE__, 0, 5).'>foobar'), '/root', 'UTF-8');
     }
 }

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -23,7 +23,7 @@
         "symfony/asset": "~2.8|~3.0",
         "symfony/finder": "~2.8|~3.0",
         "symfony/form": "~3.0.4",
-        "symfony/http-kernel": "~2.8|~3.0",
+        "symfony/http-kernel": "~3.2",
         "symfony/polyfill-intl-icu": "~1.0",
         "symfony/routing": "~2.8|~3.0",
         "symfony/templating": "~2.8|~3.0",

--- a/src/Symfony/Bundle/DebugBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/DebugBundle/Resources/config/services.xml
@@ -14,7 +14,7 @@
         <service id="data_collector.dump" class="Symfony\Component\HttpKernel\DataCollector\DumpDataCollector">
             <tag name="data_collector" id="dump" template="@Debug/Profiler/dump.html.twig" priority="240" />
             <argument type="service" id="debug.stopwatch" on-invalid="ignore" />
-            <argument>%debug.file_link_format%</argument>
+            <argument type="service" id="debug.file_link_formatter"></argument>
             <argument>%kernel.charset%</argument>
             <argument type="service" id="request_stack" />
             <argument>null</argument><!-- var_dumper.cli_dumper when debug.dump_destination is set -->
@@ -38,7 +38,7 @@
             <argument>0</argument> <!-- flags -->
             <call method="setDisplayOptions">
                 <argument type="collection">
-                    <argument key="fileLinkFormat">%debug.file_link_format%</argument>
+                    <argument key="fileLinkFormat" type="service" id="debug.file_link_formatter"></argument>
                 </argument>
             </call>
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug_prod.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug_prod.xml
@@ -17,10 +17,14 @@
             <argument>-1</argument><!-- Log levels map for enabled error levels -->
             <argument>%debug.error_handler.throw_at%</argument>
             <argument>true</argument>
-            <argument>%debug.file_link_format%</argument>
+            <argument type="service" id="debug.file_link_formatter"></argument>
             <argument>true</argument>
         </service>
 
         <service id="debug.stopwatch" class="Symfony\Component\Stopwatch\Stopwatch" />
+
+        <service id="debug.file_link_formatter" class="Symfony\Component\HttpKernel\Debug\FileLinkFormatter" public="false">
+            <argument>%debug.file_link_format%</argument>
+        </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
@@ -44,7 +44,7 @@
 
         <service id="templating.helper.code" class="Symfony\Bundle\FrameworkBundle\Templating\Helper\CodeHelper">
             <tag name="templating.helper" alias="code" />
-            <argument>%debug.file_link_format%</argument>
+            <argument type="service" id="debug.file_link_formatter"></argument>
             <argument>%kernel.root_dir%</argument>
             <argument>%kernel.charset%</argument>
         </service>

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -86,7 +86,7 @@
 
         <service id="twig.extension.code" class="Symfony\Bridge\Twig\Extension\CodeExtension" public="false">
             <tag name="twig.extension" />
-            <argument>%debug.file_link_format%</argument>
+            <argument type="service" id="debug.file_link_formatter"></argument>
             <argument>%kernel.root_dir%</argument>
             <argument>%kernel.charset%</argument>
         </service>

--- a/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/WebProfilerExtension.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/WebProfilerExtension.php
@@ -52,6 +52,24 @@ class WebProfilerExtension extends Extension
             $container->setParameter('web_profiler.debug_toolbar.intercept_redirects', $config['intercept_redirects']);
             $container->setParameter('web_profiler.debug_toolbar.mode', $config['toolbar'] ? WebDebugToolbarListener::ENABLED : WebDebugToolbarListener::DISABLED);
         }
+
+        $baseDir = array();
+        $rootDir = $container->getParameter('kernel.root_dir');
+        $rootDir = explode(DIRECTORY_SEPARATOR, realpath($rootDir) ?: $rootDir);
+        $bundleDir = explode(DIRECTORY_SEPARATOR, __DIR__);
+        for ($i = 0; isset($rootDir[$i], $bundleDir[$i]); ++$i) {
+            if ($rootDir[$i] !== $bundleDir[$i]) {
+                break;
+            }
+            $baseDir[] = $rootDir[$i];
+        }
+        $baseDir = implode(DIRECTORY_SEPARATOR, $baseDir);
+
+        $profilerController = $container->getDefinition('web_profiler.controller.profiler');
+        $profilerController->replaceArgument(6, $baseDir);
+
+        $fileLinkFormatter = $container->getDefinition('debug.file_link_formatter');
+        $fileLinkFormatter->replaceArgument(2, $baseDir);
     }
 
     /**

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/profiler.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/profiler.xml
@@ -12,6 +12,7 @@
             <argument>%data_collector.templates%</argument>
             <argument>%web_profiler.debug_toolbar.position%</argument>
             <argument type="service" id="web_profiler.csp.handler" />
+            <argument>null</argument>
         </service>
 
         <service id="web_profiler.controller.router" class="Symfony\Bundle\WebProfilerBundle\Controller\RouterController">
@@ -41,11 +42,18 @@
                     <argument type="constant">Symfony\Component\VarDumper\Dumper\HtmlDumper::DUMP_LIGHT_ARRAY</argument>
                     <call method="setDisplayOptions">
                         <argument type="collection">
-                            <argument key="fileLinkFormat">%debug.file_link_format%</argument>
+                            <argument key="fileLinkFormat" type="service" id="debug.file_link_formatter"></argument>
                         </argument>
                     </call>
                 </service>
             </argument>
+        </service>
+
+        <service id="debug.file_link_formatter" class="Symfony\Component\HttpKernel\Debug\FileLinkFormatter" public="false">
+            <argument>%debug.file_link_format%</argument>
+            <argument type="service" id="request_stack" on-invalid="ignore" />
+            <argument>null</argument>
+            <argument>/_profiler/open?file=%%f&amp;line=%%l#line%%l</argument>
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/profiler.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/profiler.xml
@@ -28,6 +28,10 @@
         <default key="_controller">web_profiler.controller.profiler:searchResultsAction</default>
     </route>
 
+    <route id="_profiler_open_file" path="/open">
+        <default key="_controller">web_profiler.controller.profiler:openAction</default>
+    </route>
+
     <route id="_profiler" path="/{token}">
         <default key="_controller">web_profiler.controller.profiler:panelAction</default>
     </route>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/open.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/open.css.twig
@@ -1,0 +1,67 @@
+{# Mixins
+   ========================================================================= #}
+{% set mixins = {
+    'break_long_words': '-ms-word-break: break-all; word-break: break-all; word-break: break-word; -webkit-hyphens: auto; -moz-hyphens: auto; hyphens: auto;',
+    'monospace_font': 'font-family: monospace; font-size: 13px; font-size-adjust: 0.5;',
+    'sans_serif_font': 'font-family: Helvetica, Arial, sans-serif;',
+    'subtle_border_and_shadow': 'background: #FFF; border: 1px solid #E0E0E0; box-shadow: 0px 0px 1px rgba(128, 128, 128, .2);'
+} %}
+
+{# Normalization
+   (normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css)
+   ========================================================================= #}
+html{font-family:sans-serif;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%}body{margin:0}article,aside,details,figcaption,figure,footer,header,hgroup,main,menu,nav,section,summary{display:block}audio,canvas,progress,video{display:inline-block;vertical-align:baseline}audio:not([controls]){display:none;height:0}[hidden],template{display:none}a{background-color:transparent}a:active,a:hover{outline:0}abbr[title]{border-bottom:1px dotted}b,strong{font-weight:700}dfn{font-style:italic}h1{margin:.67em 0;font-size:2em}mark{color:#000;background:#ff0}small{font-size:80%}sub,sup{position:relative;font-size:75%;line-height:0;vertical-align:baseline}sup{top:-.5em}sub{bottom:-.25em}img{border:0}svg:not(:root){overflow:hidden}figure{margin:1em 40px}hr{height:0;-webkit-box-sizing:content-box;-moz-box-sizing:content-box;box-sizing:content-box}pre{overflow:auto}code,kbd,pre,samp{font-family:monospace,monospace;font-size:1em}button,input,optgroup,select,textarea{margin:0;font:inherit;color:inherit}button{overflow:visible}button,select{text-transform:none}button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}button[disabled],html input[disabled]{cursor:default}button::-moz-focus-inner,input::-moz-focus-inner{padding:0;border:0}input{line-height:normal}input[type="checkbox"],input[type="radio"]{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;padding:0}input[type="number"]::-webkit-inner-spin-button,input[type="number"]::-webkit-outer-spin-button{height:auto}input[type="search"]{-webkit-box-sizing:content-box;-moz-box-sizing:content-box;box-sizing:content-box;-webkit-appearance:textfield}input[type="search"]::-webkit-search-cancel-button,input[type="search"]::-webkit-search-decoration{-webkit-appearance:none}fieldset{padding:.35em .625em .75em;margin:0 2px;border:1px solid silver}legend{padding:0;border:0}textarea{overflow:auto}optgroup{font-weight:700}table{border-spacing:0;border-collapse:collapse}td,th{padding:0}
+
+{# Basic styles
+   ========================================================================= #}
+html, body  {
+    height: 100%;
+    width: 100%;
+}
+body {
+    background-color: #F9F9F9;
+    color: #aaa;
+    display: flex;
+    flex-direction: column;
+    {{ mixins.sans_serif_font|raw }}
+    font-size: 14px;
+    line-height: 1.4;
+}
+.header {
+    background-color: #222;
+    position: fixed;
+    top: 0;
+    width: 100%;
+}
+.header h1 {
+    float: left;
+    color: #FFF;
+    font-weight: normal;
+    font-size: 21px;
+    margin: 0;
+    padding: 10px 10px 8px;
+}
+
+a.doc {
+    float: right;
+    color: #FFF;
+    text-decoration: none;
+}
+
+a.doc:hover {
+    text-decoration: underline;
+}
+
+.source {
+    margin-top: 41px;
+}
+
+.source li.selected {
+    background: rgba(255, 255, 153, 0.5);
+}
+
+.anchor {
+    position: relative;
+    top: -7em;
+    visibility: hidden;
+}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/open.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/open.html.twig
@@ -1,0 +1,17 @@
+{% extends '@WebProfiler/Profiler/base.html.twig' %}
+
+{% block head %}
+    <style>
+        {{ include('@WebProfiler/Profiler/open.css.twig') }}
+    </style>
+{% endblock %}
+
+{% block body %}
+<div class="header">
+    <a class="doc" href="https://symfony.com/doc/{{ constant('Symfony\\Component\\HttpKernel\\Kernel::VERSION') }}/reference/configuration/framework.html#ide" rel="help">Open in your IDE?</a>
+    <h1>{{ file }} <small>line {{ line }}</small></h1>
+</div>
+<div class="source">
+    {{ filename|file_excerpt(line, -1) }}
+</div>
+{% endblock %}

--- a/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
+++ b/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Debug;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Formats debug file links.
+ *
+ * @author Jérémy Romey <jeremy@free-agent.fr>
+ */
+class FileLinkFormatter implements \Serializable
+{
+    private $fileLinkFormat;
+    private $requestStack;
+    private $baseDir;
+    private $urlFormat;
+
+    public function __construct($fileLinkFormat = null, RequestStack $requestStack = null, $baseDir = null, $urlFormat = null)
+    {
+        $fileLinkFormat = $fileLinkFormat ?: ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format');
+        if ($fileLinkFormat && !is_array($fileLinkFormat)) {
+            $i = strpos($f = $fileLinkFormat, '&', max(strrpos($f, '%f'), strrpos($f, '%l'))) ?: strlen($f);
+            $fileLinkFormat = array(substr($f, 0, $i)) + preg_split('/&([^>]++)>/', substr($f, $i), -1, PREG_SPLIT_DELIM_CAPTURE);
+        }
+
+        $this->fileLinkFormat = $fileLinkFormat;
+        $this->requestStack = $requestStack;
+        $this->baseDir = $baseDir;
+        $this->urlFormat = $urlFormat;
+    }
+
+    public function format($file, $line)
+    {
+        if ($fmt = $this->getFileLinkFormat()) {
+            for ($i = 1; isset($fmt[$i]); ++$i) {
+                if (0 === strpos($file, $k = $fmt[$i++])) {
+                    $file = substr_replace($file, $fmt[$i], 0, strlen($k));
+                    break;
+                }
+            }
+
+            return strtr($fmt[0], array('%f' => $file, '%l' => $line));
+        }
+
+        return false;
+    }
+
+    public function serialize()
+    {
+        return serialize($this->getFileLinkFormat());
+    }
+
+    public function unserialize($serialized)
+    {
+        $this->fileLinkFormat = unserialize($serialized);
+    }
+
+    private function getFileLinkFormat()
+    {
+        if ($this->fileLinkFormat) {
+            return $this->fileLinkFormat;
+        }
+        if ($this->requestStack && $this->baseDir && $this->urlFormat) {
+            $request = $this->requestStack->getMasterRequest();
+            if ($request instanceof Request) {
+                return array(
+                    $request->getSchemeAndHttpHost().$request->getBaseUrl().$this->urlFormat,
+                    $this->baseDir.DIRECTORY_SEPARATOR, '',
+                );
+            }
+        }
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Debug/FileLinkFormatterTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Debug/FileLinkFormatterTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Debug;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Debug\FileLinkFormatter;
+
+class FileLinkFormatterTest extends \PHPUnit_Framework_TestCase
+{
+    public function testWhenNoFileLinkFormatAndNoRequest()
+    {
+        $sut = new FileLinkFormatter();
+
+        $this->assertFalse($sut->format('/kernel/root/src/my/very/best/file.php', 3));
+    }
+
+    public function testWhenFileLinkFormatAndNoRequest()
+    {
+        $file = __DIR__.DIRECTORY_SEPARATOR.'file.php';
+
+        $sut = new FileLinkFormatter('debug://open?url=file://%f&line=%l', new RequestStack());
+
+        $this->assertSame("debug://open?url=file://$file&line=3", $sut->format($file, 3));
+    }
+
+    public function testWhenFileLinkFormatAndRequest()
+    {
+        $file = __DIR__.DIRECTORY_SEPARATOR.'file.php';
+        $baseDir = __DIR__;
+        $requestStack = new RequestStack();
+        $request = new Request();
+        $requestStack->push($request);
+
+        $sut = new FileLinkFormatter('debug://open?url=file://%f&line=%l', $requestStack, __DIR__, '/_profiler/open?file=%f&line=%l#line%l');
+
+        $this->assertSame("debug://open?url=file://$file&line=3", $sut->format($file, 3));
+    }
+
+    public function testWhenNoFileLinkFormatAndRequest()
+    {
+        $file = __DIR__.DIRECTORY_SEPARATOR.'file.php';
+        $requestStack = new RequestStack();
+        $request = new Request();
+        $requestStack->push($request);
+
+        $request->server->set('SERVER_NAME', 'www.example.org');
+        $request->server->set('SERVER_PORT', 80);
+        $request->server->set('SCRIPT_NAME', '/app.php');
+        $request->server->set('SCRIPT_FILENAME', '/web/app.php');
+        $request->server->set('REQUEST_URI', '/app.php/example');
+
+        $sut = new FileLinkFormatter(null, $requestStack, __DIR__, '/_profiler/open?file=%f&line=%l#line%l');
+
+        $this->assertSame('http://www.example.org/app.php/_profiler/open?file=file.php&line=3#line3', $sut->format($file, 3));
+    }
+}

--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -536,23 +536,13 @@ EOHTML
 
     private function getSourceLink($file, $line)
     {
-        $fileLinkFormat = $this->extraDisplayOptions + $this->displayOptions;
+        $options = $this->extraDisplayOptions + $this->displayOptions;
 
-        if (!$fileLinkFormat = $fileLinkFormat['fileLinkFormat']) {
-            return false;
-        }
-        if (!is_array($fileLinkFormat)) {
-            $i = strpos($f = $fileLinkFormat, '&', max(strrpos($f, '%f'), strrpos($f, '%l'))) ?: strlen($f);
-            $fileLinkFormat = array(substr($f, 0, $i)) + preg_split('/&([^>]++)>/', substr($f, $i), -1, PREG_SPLIT_DELIM_CAPTURE);
-        }
-        for ($i = 1; isset($fileLinkFormat[$i]); ++$i) {
-            if (0 === strpos($file, $k = $fileLinkFormat[$i++])) {
-                $file = substr_replace($file, $fileLinkFormat[$i], 0, strlen($k));
-                break;
-            }
+        if ($fmt = $options['fileLinkFormat']) {
+            return is_string($fmt) ? strtr($fmt, array('%f' => $file, '%l' => $line)) : $fmt->format($file, $line);
         }
 
-        return strtr($fileLinkFormat[0], array('%f' => $file, '%l' => $line));
+        return false;
     }
 }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

When having no `framework.ide` configured or `framework.ide = symfony` the file link open the source in a web view (eg `_profiler/open?file=/src/AppBundle/Controller/DefaultController.php&line=50#line50`).

![](https://cl.ly/2Z0W2J020p43/feature_ide.png)
