### PR TITLE
Make redis host configurable in tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,6 +15,7 @@
         <env name="DUMP_STRING_LENGTH" value="" />
         <env name="LDAP_HOST" value="127.0.0.1" />
         <env name="LDAP_PORT" value="3389" />
+        <env name="REDIS_HOST" value="localhost" />
     </php>
 
     <testsuites>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
@@ -17,6 +17,16 @@ use Symfony\Component\Cache\Exception\InvalidArgumentException;
 
 class CachePoolsTest extends WebTestCase
 {
+    protected function setUp()
+    {
+        $_SERVER['SYMFONY__REDIS_HOST'] = getenv('REDIS_HOST');
+    }
+
+    protected function tearDown()
+    {
+        unset($_SERVER['SYMFONY__REDIS_HOST']);
+    }
+
     public function testCachePools()
     {
         $this->doTestCachePools(array(), FilesystemAdapter::class);
@@ -30,7 +40,7 @@ class CachePoolsTest extends WebTestCase
         try {
             $this->doTestCachePools(array('root_config' => 'redis_config.yml', 'environment' => 'redis_cache'), RedisAdapter::class);
         } catch (\PHPUnit_Framework_Error_Warning $e) {
-            if (0 !== strpos($e->getMessage(), 'unable to connect to 127.0.0.1')) {
+            if (0 !== strpos($e->getMessage(), 'unable to connect to')) {
                 throw $e;
             }
             $this->markTestSkipped($e->getMessage());
@@ -50,7 +60,7 @@ class CachePoolsTest extends WebTestCase
         try {
             $this->doTestCachePools(array('root_config' => 'redis_custom_config.yml', 'environment' => 'custom_redis_cache'), RedisAdapter::class);
         } catch (\PHPUnit_Framework_Error_Warning $e) {
-            if (0 !== strpos($e->getMessage(), 'unable to connect to 127.0.0.1')) {
+            if (0 !== strpos($e->getMessage(), 'unable to connect to')) {
                 throw $e;
             }
             $this->markTestSkipped($e->getMessage());

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/CachePools/redis_config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/CachePools/redis_config.yml
@@ -4,6 +4,7 @@ imports:
 framework:
     cache:
         app: cache.adapter.redis
+        default_redis_provider: "redis://%redis_host%"
         pools:
             cache.test:
                 public: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/CachePools/redis_custom_config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/CachePools/redis_custom_config.yml
@@ -6,7 +6,7 @@ services:
         public: false
         class: Redis
         calls:
-            - [connect, [127.0.0.1]]
+            - [connect, ['%redis_host%']]
 
     cache.app:
         parent: cache.adapter.redis

--- a/src/Symfony/Bundle/FrameworkBundle/phpunit.xml.dist
+++ b/src/Symfony/Bundle/FrameworkBundle/phpunit.xml.dist
@@ -8,6 +8,7 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
+        <env name="REDIS_HOST" value="localhost" />
     </php>
 
     <testsuites>

--- a/src/Symfony/Component/Cache/Tests/Adapter/AbstractRedisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AbstractRedisAdapterTest.php
@@ -33,7 +33,7 @@ abstract class AbstractRedisAdapterTest extends AdapterTestCase
         if (!extension_loaded('redis')) {
             self::markTestSkipped('Extension redis required.');
         }
-        if (!@((new \Redis())->connect('127.0.0.1'))) {
+        if (!@((new \Redis())->connect(getenv('REDIS_HOST')))) {
             $e = error_get_last();
             self::markTestSkipped($e['message']);
         }

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterTest.php
@@ -19,12 +19,14 @@ class PredisAdapterTest extends AbstractRedisAdapterTest
     public static function setupBeforeClass()
     {
         parent::setupBeforeClass();
-        self::$redis = new \Predis\Client();
+        self::$redis = new \Predis\Client(array('host' => getenv('REDIS_HOST')));
     }
 
     public function testCreateConnection()
     {
-        $redis = RedisAdapter::createConnection('redis://localhost/1', array('class' => \Predis\Client::class, 'timeout' => 3));
+        $redisHost = getenv('REDIS_HOST');
+
+        $redis = RedisAdapter::createConnection('redis://'.$redisHost.'/1', array('class' => \Predis\Client::class, 'timeout' => 3));
         $this->assertInstanceOf(\Predis\Client::class, $redis);
 
         $connection = $redis->getConnection();
@@ -32,7 +34,7 @@ class PredisAdapterTest extends AbstractRedisAdapterTest
 
         $params = array(
             'scheme' => 'tcp',
-            'host' => 'localhost',
+            'host' => $redisHost,
             'path' => '',
             'dbindex' => '1',
             'port' => 6379,

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterTest.php
@@ -19,26 +19,28 @@ class RedisAdapterTest extends AbstractRedisAdapterTest
     {
         parent::setupBeforeClass();
         self::$redis = new \Redis();
-        self::$redis->connect('127.0.0.1');
+        self::$redis->connect(getenv('REDIS_HOST'));
     }
 
     public function testCreateConnection()
     {
-        $redis = RedisAdapter::createConnection('redis://localhost');
+        $redisHost = getenv('REDIS_HOST');
+
+        $redis = RedisAdapter::createConnection('redis://'.$redisHost);
         $this->assertInstanceOf(\Redis::class, $redis);
         $this->assertTrue($redis->isConnected());
         $this->assertSame(0, $redis->getDbNum());
 
-        $redis = RedisAdapter::createConnection('redis://localhost/2');
+        $redis = RedisAdapter::createConnection('redis://'.$redisHost.'/2');
         $this->assertSame(2, $redis->getDbNum());
 
-        $redis = RedisAdapter::createConnection('redis://localhost', array('timeout' => 3));
+        $redis = RedisAdapter::createConnection('redis://'.$redisHost, array('timeout' => 3));
         $this->assertEquals(3, $redis->getTimeout());
 
-        $redis = RedisAdapter::createConnection('redis://localhost?timeout=4');
+        $redis = RedisAdapter::createConnection('redis://'.$redisHost.'?timeout=4');
         $this->assertEquals(4, $redis->getTimeout());
 
-        $redis = RedisAdapter::createConnection('redis://localhost', array('read_timeout' => 5));
+        $redis = RedisAdapter::createConnection('redis://'.$redisHost, array('read_timeout' => 5));
         $this->assertEquals(5, $redis->getReadTimeout());
     }
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisArrayAdapterTest.php
@@ -19,6 +19,6 @@ class RedisArrayAdapterTest extends AbstractRedisAdapterTest
         if (!class_exists('RedisArray')) {
             self::markTestSkipped('The RedisArray class is required.');
         }
-        self::$redis = new \RedisArray(array('localhost'), array('lazy_connect' => true));
+        self::$redis = new \RedisArray(array(getenv('REDIS_HOST')), array('lazy_connect' => true));
     }
 }

--- a/src/Symfony/Component/Cache/phpunit.xml.dist
+++ b/src/Symfony/Component/Cache/phpunit.xml.dist
@@ -8,6 +8,7 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
+        <env name="REDIS_HOST" value="localhost" />
     </php>
 
     <testsuites>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Makes running tests on dockerized environments possible, since we can now export the `REDIS_HOST` environment variable:

```
REDIS_HOST=redis ./phpunit src/Symfony/Component/Cache
```

If this gets merged, in master we can later replace the `SYMFONY__REDIS_HOST` usage in the FrameworkBundle with the new `env(REDIS_HOST)`.
