### PR TITLE
[Ldap] Fixed issue with legacy find() method not working as expected

### DIFF
--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/AttributeCleaner.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/AttributeCleaner.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Ldap\Adapter\ExtLdap;
+
+/**
+ * Common trait used to filter LDAP attributes.
+ *
+ * @author Charles Sarrazin <charles@sarraz.in>
+ *
+ * @internal
+ */
+trait AttributeCleaner
+{
+    private function cleanupAttributes(array $entry)
+    {
+        $attributes = array_diff_key($entry, array_flip(range(0, $entry['count'] - 1)) + array(
+                'count' => null,
+                'dn' => null,
+            ));
+        array_walk($attributes, function (&$value) {
+            unset($value['count']);
+        });
+
+        return $attributes;
+    }
+}

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Collection.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Collection.php
@@ -20,6 +20,8 @@ use Symfony\Component\Ldap\Exception\LdapException;
  */
 class Collection implements CollectionInterface
 {
+    use AttributeCleaner;
+
     private $connection;
     private $search;
     private $entries;
@@ -105,18 +107,5 @@ class Collection implements CollectionInterface
 
             return new Entry($dn, $attributes);
         }, $entries);
-    }
-
-    private function cleanupAttributes(array $entry = array())
-    {
-        $attributes = array_diff_key($entry, array_flip(range(0, $entry['count'] - 1)) + array(
-                'count' => null,
-                'dn' => null,
-            ));
-        array_walk($attributes, function (&$value) {
-            unset($value['count']);
-        });
-
-        return $attributes;
     }
 }

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/ResultIterator.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/ResultIterator.php
@@ -21,6 +21,8 @@ use Symfony\Component\Ldap\Exception\LdapException;
  */
 class ResultIterator implements \Iterator
 {
+    use AttributeCleaner;
+
     private $connection;
     private $search;
     private $current;
@@ -44,6 +46,8 @@ class ResultIterator implements \Iterator
         if (false === $attributes) {
             throw new LdapException(sprintf('Could not fetch attributes: %s', ldap_error($this->connection)));
         }
+
+        $attributes = $this->cleanupAttributes($attributes);
 
         $dn = ldap_get_dn($this->connection, $this->current);
 

--- a/src/Symfony/Component/Ldap/LdapClient.php
+++ b/src/Symfony/Component/Ldap/LdapClient.php
@@ -64,24 +64,34 @@ final class LdapClient implements LdapClientInterface
 
         $query = $this->ldap->query($dn, $query, array('filter' => $filter));
         $entries = $query->execute();
-        $result = array();
+        $result = array(
+            'count' => 0,
+        );
 
         foreach ($entries as $entry) {
             $resultEntry = array();
 
             foreach ($entry->getAttributes() as $attribute => $values) {
-                $resultAttribute = $values;
+                $resultAttribute = array(
+                    'count' => count($values),
+                );
+
+                foreach ($values as $val) {
+                    $resultAttribute[] = $val;
+                }
+                $attributeName = strtolower($attribute);
 
                 $resultAttribute['count'] = count($values);
-                $resultEntry[] = $resultAttribute;
-                $resultEntry[$attribute] = $resultAttribute;
+                $resultEntry[$attributeName] = $resultAttribute;
+                $resultEntry[] = $attributeName;
             }
 
             $resultEntry['count'] = count($resultEntry) / 2;
+            $resultEntry['dn'] = $entry->getDn();
             $result[] = $resultEntry;
         }
 
-        $result['count'] = count($result);
+        $result['count'] = count($result) - 1;
 
         return $result;
     }

--- a/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
@@ -47,4 +47,22 @@ class AdapterTest extends LdapTestCase
         $this->assertEquals(array('Fabien Potencier'), $entry->getAttribute('cn'));
         $this->assertEquals(array('fabpot@symfony.com', 'fabien@potencier.com'), $entry->getAttribute('mail'));
     }
+
+    /**
+     * @group functional
+     */
+    public function testLdapQueryIterator()
+    {
+        $ldap = new Adapter($this->getLdapConfig());
+
+        $ldap->getConnection()->bind('cn=admin,dc=symfony,dc=com', 'symfony');
+        $query = $ldap->createQuery('dc=symfony,dc=com', '(&(objectclass=person)(ou=Maintainers))', array());
+        $result = $query->execute();
+        $iterator = $result->getIterator();
+        $iterator->rewind();
+        $entry = $iterator->current();
+        $this->assertInstanceOf(Entry::class, $entry);
+        $this->assertEquals(array('Fabien Potencier'), $entry->getAttribute('cn'));
+        $this->assertEquals(array('fabpot@symfony.com', 'fabien@potencier.com'), $entry->getAttribute('mail'));
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #19804 |
| License | MIT |
| Doc PR |  |

This PR fixes two bugs. The first, with the legacy `LdapClient` class' `find()` method not working as expected, sometimes throwing errors, which is an after-effect of missing Ldap attributes normalisation in the ResultIterator, and the second one being that the `find()` method does not return the expected output, which should be the same as PHP's `ldap_get_entries()` method.

As a reminder, this method should only be used by legacy software, which need to provide compatibility with Symfony 3.0 and Symfony 2.8.
