### PR TITLE
[Ldap] [Tests] Fixed issue with PHPUnit warnings

### DIFF
--- a/src/Symfony/Component/Ldap/Tests/LdapClientTest.php
+++ b/src/Symfony/Component/Ldap/Tests/LdapClientTest.php
@@ -29,7 +29,7 @@ class LdapClientTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->ldap = $this->getMock(LdapInterface::class);
+        $this->ldap = $this->getMockBuilder(LdapInterface::class)->getMock();
 
         $this->client = new LdapClient(null, 389, 3, false, false, false, $this->ldap);
     }
@@ -66,7 +66,7 @@ class LdapClientTest extends \PHPUnit_Framework_TestCase
 
     public function testLdapFind()
     {
-        $collection = $this->getMock(CollectionInterface::class);
+        $collection = $this->getMockBuilder(CollectionInterface::class)->getMock();
         $collection
             ->expects($this->once())
             ->method('getIterator')
@@ -85,7 +85,7 @@ class LdapClientTest extends \PHPUnit_Framework_TestCase
                 )),
             ))))
         ;
-        $query = $this->getMock(QueryInterface::class);
+        $query = $this->getMockBuilder(QueryInterface::class)->getMock();
         $query
             ->expects($this->once())
             ->method('execute')

--- a/src/Symfony/Component/Ldap/Tests/LdapTest.php
+++ b/src/Symfony/Component/Ldap/Tests/LdapTest.php
@@ -26,13 +26,13 @@ class LdapTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->adapter = $this->getMock(AdapterInterface::class);
+        $this->adapter = $this->getMockBuilder(AdapterInterface::class)->getMock();
         $this->ldap = new Ldap($this->adapter);
     }
 
     public function testLdapBind()
     {
-        $connection = $this->getMock(ConnectionInterface::class);
+        $connection = $this->getMockBuilder(ConnectionInterface::class)->getMock();
         $connection
             ->expects($this->once())
             ->method('bind')


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Removed PHPUnit warnings due to the PHPUnit_Framework_TestCase::getMock() method being deprecated. This was done only for the Ldap component. These happen when using PHPUnit v5.5+:

```
Testing src/Symfony/Component/Ldap
......WWWWWWWWWWWWWW...........................................  63 / 158 ( 39%)
............................................................... 126 / 158 ( 79%)
................................                                158 / 158 (100%)

Time: 197 ms, Memory: 6.75MB

There were 14 warnings:

1) Symfony\Component\Ldap\Tests\LdapClientTest::testLdapBind
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

2) Symfony\Component\Ldap\Tests\LdapClientTest::testLdapEscape
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

3) Symfony\Component\Ldap\Tests\LdapClientTest::testLdapQuery
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

4) Symfony\Component\Ldap\Tests\LdapClientTest::testLdapFind
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

5) Symfony\Component\Ldap\Tests\LdapClientTest::testLdapClientConfig with data set #0 (array('localhost', 389, 3, true, false, false), array('localhost', 389, 'ssl', array(3, false)))
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

6) Symfony\Component\Ldap\Tests\LdapClientTest::testLdapClientConfig with data set #1 (array('localhost', 389, 3, false, true, false), array('localhost', 389, 'tls', array(3, false)))
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

7) Symfony\Component\Ldap\Tests\LdapClientTest::testLdapClientConfig with data set #2 (array('localhost', 389, 3, false, false, false), array('localhost', 389, 'none', array(3, false)))
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

8) Symfony\Component\Ldap\Tests\LdapClientTest::testLdapClientConfig with data set #3 (array('localhost', 389, 3, false, false, false), array('localhost', 389, 'none', array(3, false)))
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

9) Symfony\Component\Ldap\Tests\LdapClientTest::testLdapClientFunctional
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

10) Symfony\Component\Ldap\Tests\LdapTest::testLdapBind
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

11) Symfony\Component\Ldap\Tests\LdapTest::testLdapEscape
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

12) Symfony\Component\Ldap\Tests\LdapTest::testLdapQuery
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

13) Symfony\Component\Ldap\Tests\LdapTest::testLdapCreate
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

14) Symfony\Component\Ldap\Tests\LdapTest::testCreateWithInvalidAdapterName
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

WARNINGS!
Tests: 158, Assertions: 226, Warnings: 14.

Legacy deprecation notices (3)
```
