### PR TITLE
[Twig] Fix tests failing with the most recent (dev) twig versions

### DIFF
--- a/src/Symfony/Bridge/Twig/Node/TransNode.php
+++ b/src/Symfony/Bridge/Twig/Node/TransNode.php
@@ -97,6 +97,10 @@ class TransNode extends \Twig_Node
 
         foreach ($matches[1] as $var) {
             $key = new \Twig_Node_Expression_Constant('%'.$var.'%', $body->getLine());
+            // @todo condition to be removed the minimum twig/twig version is raised to ^1.25||^2.0 (getFilename will always exist)
+            if (method_exists($key, 'getFilename')) {
+                $key->setAttribute('module_filename', $vars->getFilename());
+            }
             if (!$vars->hasElement($key)) {
                 if ('count' === $var && null !== $this->getNode('count')) {
                     $vars->addElement($this->getNode('count'), $key);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Twig bridge tests were broken by https://github.com/twigphp/Twig/pull/2118.

The [filename is now registered as a node attribute](https://github.com/twigphp/Twig/commit/1f41e9f9e1d3d62ad2578fba1ad0b934e01e10da#diff-aa24cf31f5a686107ff664817c8559a7R88). Since attributes take part in node comparison, the TransNode compilation is now broken. Each var is included twice:

```
protected function doDisplay(array $context, array $blocks = array())
{
    // line 1
    echo $this->env->getExtension('translator')->getTranslator()->trans("Hello %name%", array("%name%" => "Symfony", "%name%" => (isset($context["name"]) ? $context["name"] : null)), "messages");
}
```

The second time comes from the context and it effectively removes the variable
(since the var is not set on the context, null is used).

The TransNode duplicates each var as [the node created for comparison purposes](https://github.com/symfony/symfony/blob/a5c7a85b7889bd1e9c6cf419bc19827240ff34e8/src/Symfony/Bridge/Twig/Node/TransNode.php#L99)
does not include the filename attribute.
