### PR TITLE
[Validator] Allow validating multiple groups in one GroupSequence step

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/GroupSequence.php
+++ b/src/Symfony/Component/Validator/Constraints/GroupSequence.php
@@ -57,7 +57,7 @@ class GroupSequence
     /**
      * The groups in the sequence.
      *
-     * @var string[]|GroupSequence[]
+     * @var string[]|array[]|GroupSequence[]
      */
     public $groups;
 

--- a/src/Symfony/Component/Validator/Tests/Validator/AbstractValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/AbstractValidatorTest.php
@@ -1212,6 +1212,20 @@ abstract class AbstractValidatorTest extends \PHPUnit_Framework_TestCase
                     'Violation in Group 2',
                 ),
             ),
+            array(
+                'sequence' => new GroupSequence(array('Group 1', array('Group 2', 'Group 3'), 'Entity')),
+                'assertViolations' => array(
+                    'Violation in Group 2',
+                    'Violation in Group 3',
+                ),
+            ),
+            array(
+                'sequence' => array('Group 1', array('Group 2', 'Group 3'), 'Entity'),
+                'assertViolations' => array(
+                    'Violation in Group 2',
+                    'Violation in Group 3',
+                ),
+            ),
         );
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Validator/AbstractValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/AbstractValidatorTest.php
@@ -1157,9 +1157,11 @@ abstract class AbstractValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('Violation in other group', $violations[0]->getMessage());
     }
 
-    public function testReplaceDefaultGroupWithObjectFromGroupSequenceProvider()
+    /**
+     * @dataProvider getTestReplaceDefaultGroup
+     */
+    public function testReplaceDefaultGroup($sequence, array $assertViolations)
     {
-        $sequence = new GroupSequence(array('Group 1', 'Group 2', 'Group 3', 'Entity'));
         $entity = new GroupSequenceProviderEntity($sequence);
 
         $callback1 = function ($value, ExecutionContextInterface $context) {
@@ -1189,43 +1191,27 @@ abstract class AbstractValidatorTest extends \PHPUnit_Framework_TestCase
         $violations = $this->validate($entity, null, 'Default');
 
         /* @var ConstraintViolationInterface[] $violations */
-        $this->assertCount(1, $violations);
-        $this->assertSame('Violation in Group 2', $violations[0]->getMessage());
+        $this->assertCount(count($assertViolations), $violations);
+        foreach ($assertViolations as $key => $message) {
+            $this->assertSame($message, $violations[$key]->getMessage());
+        }
     }
 
-    public function testReplaceDefaultGroupWithArrayFromGroupSequenceProvider()
+    public function getTestReplaceDefaultGroup()
     {
-        $sequence = array('Group 1', 'Group 2', 'Group 3', 'Entity');
-        $entity = new GroupSequenceProviderEntity($sequence);
-
-        $callback1 = function ($value, ExecutionContextInterface $context) {
-            $context->addViolation('Violation in Group 2');
-        };
-        $callback2 = function ($value, ExecutionContextInterface $context) {
-            $context->addViolation('Violation in Group 3');
-        };
-
-        $metadata = new ClassMetadata(get_class($entity));
-        $metadata->addConstraint(new Callback(array(
-            'callback' => function () {},
-            'groups' => 'Group 1',
-        )));
-        $metadata->addConstraint(new Callback(array(
-            'callback' => $callback1,
-            'groups' => 'Group 2',
-        )));
-        $metadata->addConstraint(new Callback(array(
-            'callback' => $callback2,
-            'groups' => 'Group 3',
-        )));
-        $metadata->setGroupSequenceProvider(true);
-
-        $this->metadataFactory->addMetadata($metadata);
-
-        $violations = $this->validate($entity, null, 'Default');
-
-        /* @var ConstraintViolationInterface[] $violations */
-        $this->assertCount(1, $violations);
-        $this->assertSame('Violation in Group 2', $violations[0]->getMessage());
+        return array(
+            array(
+                'sequence' => new GroupSequence(array('Group 1', 'Group 2', 'Group 3', 'Entity')),
+                'assertViolations' => array(
+                    'Violation in Group 2',
+                ),
+            ),
+            array(
+                'sequence' => array('Group 1', 'Group 2', 'Group 3', 'Entity'),
+                'assertViolations' => array(
+                    'Violation in Group 2',
+                ),
+            ),
+        );
     }
 }

--- a/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
@@ -761,7 +761,7 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
      * @param int                       $traversalStrategy The strategy used for
      *                                                     traversing the value
      * @param GroupSequence             $groupSequence     The group sequence
-     * @param string[]|null             $cascadedGroup     The group that should
+     * @param string|null               $cascadedGroup     The group that should
      *                                                     be passed to cascaded
      *                                                     objects instead of
      *                                                     the group sequence

--- a/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
@@ -773,7 +773,7 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
         $cascadedGroups = $cascadedGroup ? array($cascadedGroup) : null;
 
         foreach ($groupSequence->groups as $groupInSequence) {
-            $groups = array($groupInSequence);
+            $groups = (array) $groupInSequence;
 
             if ($metadata instanceof ClassMetadataInterface) {
                 $this->validateClassNode(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

To see what I've changed just look at the last commit. The other two are just refactoring without any effect.

GroupSequenceProviderInterface seems to be the recommended solution for conditional validators (like when some properties should be required only if other property has a certain value). And it's a good solution honestly. Except for the fact that it's completely useless when I want to get validation violations for all groups at once and not just violations for the first group that caused any violations.

``` php
// If the User validation group causes any violations the Premium group will not be
// validated at all even if the $this->isPremium() is true.
class User implements GroupSequenceProviderInterface {
    public function getGroupSequence() {
        $groups = array('User');
        if ($this->isPremium()) {
            $groups[] = 'Premium';
        }
        return $groups;
    }
}
```

To be honest I never found a use case for this step-by-step behavior. When user fills a form I want to show him all errors at once not just some subset.

It's surprisingly easy to fix this. With just one changed line in RecursiveContextualValidator it's perfectly solveable:

``` php
// With this PR it is possible to do this and get violations for both groups like this.
class User implements GroupSequenceProviderInterface {
    public function getGroupSequence() {
        $groups = array('User');
        if ($this->isPremium()) {
            $groups[] = 'Premium';
        }
        return [$groups]; // this line has changed
    }
}
```
