### PR TITLE
add specialised EguliasEmailValidator

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/EguliasEmail.php
+++ b/src/Symfony/Component/Validator/Constraints/EguliasEmail.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Egulias\EmailValidator\Validation\EmailValidation;
+use Egulias\EmailValidator\Validation\MultipleValidationWithAnd;
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @author Toni Uebernickel <tuebernickel@gmail.com>
+ */
+class EguliasEmail extends Constraint
+{
+    const INVALID_EMAIL = 'C3219C70-49CB-459E-89C3-D4057F1164FF';
+
+    /**
+     * The violation message to use.
+     *
+     * The '{{ value }}' placeholder is provided containing the invalid value.
+     *
+     * @var string
+     */
+    public $message = 'This value is not a valid email address.';
+
+    /**
+     * Whether to ignore warnings provided by the RFC validation.
+     *
+     * @var bool
+     */
+    public $suppressRFCWarnings = false;
+
+    /**
+     * Whether to apply DNS check validation.
+     *
+     * @var bool
+     */
+    public $checkDNS = true;
+
+    /**
+     * Whether to apply literal spoof checking.
+     *
+     * @var bool
+     */
+    public $checkSpoof = false;
+
+    /**
+     * Configure a concrete list of validations to apply on the evaluated value.
+     *
+     * Providing a non-empty list will ignore any validation options.
+     *
+     * @var EmailValidation[]
+     */
+    public $validations = [];
+
+    /**
+     * Validation mode to apply.
+     *
+     * @var int
+     */
+    public $validationMode = MultipleValidationWithAnd::STOP_ON_ERROR;
+}

--- a/src/Symfony/Component/Validator/Constraints/EguliasEmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EguliasEmailValidator.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Egulias\EmailValidator\EmailValidator as Validator;
+use Egulias\EmailValidator\Validation\DNSCheckValidation;
+use Egulias\EmailValidator\Validation\EmailValidation;
+use Egulias\EmailValidator\Validation\MultipleValidationWithAnd;
+use Egulias\EmailValidator\Validation\NoRFCWarningsValidation;
+use Egulias\EmailValidator\Validation\RFCValidation;
+use Egulias\EmailValidator\Validation\SpoofCheckValidation;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+/**
+ * @author Toni Uebernickel <tuebernickel@gmail.com>
+ */
+class EguliasEmailValidator extends ConstraintValidator
+{
+    /**
+     * @var Validator
+     */
+    private $validator;
+
+    /**
+     * Constructor.
+     *
+     * @param Validator|null $validator
+     */
+    public function __construct(Validator $validator = null)
+    {
+        if (null == $validator) {
+            $validator = new EmailValidator();
+        }
+
+        $this->validator = $validator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof EguliasEmail) {
+            throw new UnexpectedTypeException($constraint, EguliasEmail::class);
+        }
+
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString'))) {
+            throw new UnexpectedTypeException($value, 'string');
+        }
+
+        if (!$this->validator->isValid($value, $this->createValidation($constraint))) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setInvalidValue($value)
+                ->setCode(EguliasEmail::INVALID_EMAIL)
+                ->addViolation()
+            ;
+        }
+    }
+
+    /**
+     * Provides the validation represented by the given constraint and its configuration or contract.
+     *
+     * @param EguliasEmail $constraint
+     *
+     * @return EmailValidation
+     */
+    protected function createValidation(EguliasEmail $constraint)
+    {
+        if (count($constraint->validations)) {
+            return new MultipleValidationWithAnd($constraint->validations, $constraint->validationMode);
+        }
+
+        $validations = [];
+        if ($constraint->suppressRFCWarnings) {
+            $validations[] = new RFCValidation();
+        } else {
+            $validations[] = new NoRFCWarningsValidation();
+        }
+
+        if ($constraint->checkDNS) {
+            $validations[] = new DNSCheckValidation();
+        }
+
+        if ($constraint->checkSpoof) {
+            $validations[] = new SpoofCheckValidation();
+        }
+
+        return new MultipleValidationWithAnd($validations, $constraint->validationMode);
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/EguliasEmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EguliasEmailValidatorTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare (strict_types = 1);
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Egulias\EmailValidator\EmailValidator;
+use Egulias\EmailValidator\Validation\DNSCheckValidation;
+use Egulias\EmailValidator\Validation\EmailValidation;
+use Egulias\EmailValidator\Validation\MultipleValidationWithAnd;
+use Egulias\EmailValidator\Validation\NoRFCWarningsValidation;
+use Egulias\EmailValidator\Validation\RFCValidation;
+use Egulias\EmailValidator\Validation\SpoofCheckValidation;
+use Symfony\Component\Validator\Constraints\EguliasEmail;
+use Symfony\Component\Validator\Constraints\EguliasEmailValidator;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+class EguliasEmailValidatorTest extends ConstraintValidatorTestCase
+{
+    /**
+     * @var EmailValidator|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $egulias;
+
+    public static function setUpBeforeClass()
+    {
+        if (!interface_exists(EmailValidation::class)) {
+            self::markTestSkipped('Package egulias/email-validator ^2.0 is not installed.');
+        }
+    }
+
+    protected function createValidator()
+    {
+        $this->egulias = $this->createMock(EmailValidator::class);
+
+        return new EguliasEmailValidator($this->egulias);
+    }
+
+    public function testNullIsValid()
+    {
+        $this->validator->validate(null, new EguliasEmail());
+
+        $this->assertNoViolation();
+    }
+
+    public function testEmptyStringIsValid()
+    {
+        $this->validator->validate('', new EguliasEmail());
+
+        $this->assertNoViolation();
+    }
+
+    public function testValidEvaluation()
+    {
+        $email = 'foo@example.com';
+
+        $this->egulias
+            ->expects($this->once())
+            ->method('isValid')
+            ->with(self::equalTo($email), self::isInstanceOf(MultipleValidationWithAnd::class))
+            ->willReturn(true)
+        ;
+
+        $this->validator->validate($email, new EguliasEmail());
+
+        $this->assertNoViolation();
+    }
+
+    public function testInvalidEvaluation()
+    {
+        $email = 'foo@example';
+
+        $this->egulias
+            ->expects($this->once())
+            ->method('isValid')
+            ->with(self::equalTo($email), self::isInstanceOf(MultipleValidationWithAnd::class))
+            ->willReturn(false)
+        ;
+
+        $this->validator->validate($email, new EguliasEmail(['message' => 'error-message']));
+
+        $this->buildViolation('error-message')
+            ->setParameter('{{ value }}', '"'.$email.'"')
+            ->setInvalidValue($email)
+            ->setCode(EguliasEmail::INVALID_EMAIL)
+            ->assertRaised()
+        ;
+    }
+
+    public function constraintsOptionsProvider()
+    {
+        return [
+            'default_options' => [[], [NoRFCWarningsValidation::class, DNSCheckValidation::class]],
+            'suppress_rfc_warnings' => [['suppressRFCWarnings' => true], [RFCValidation::class, DNSCheckValidation::class]],
+            'check_literal_spoof' => [['checkSpoof' => true], [NoRFCWarningsValidation::class, DNSCheckValidation::class, SpoofCheckValidation::class]],
+            'concrete_validations' => [['validations' => [new DNSCheckValidation()]], [DNSCheckValidation::class]],
+        ];
+    }
+
+    /**
+     * @depends testValidEvaluation
+     * @dataProvider constraintsOptionsProvider
+     */
+    public function testOptionsForValidations($options, $expected)
+    {
+        $email = 'foo@example.com';
+
+        $reflection = new \ReflectionProperty(MultipleValidationWithAnd::class, 'validations');
+        $reflection->setAccessible(true);
+
+        $this->egulias
+            ->expects($this->once())
+            ->method('isValid')
+            ->with(self::equalTo($email), self::callback(function (MultipleValidationWithAnd $value) use ($reflection, $expected) {
+                $validations = array_map(function ($validation) {
+                    return get_class($validation);
+                }, $reflection->getValue($value));
+
+                return 0 === count(array_diff($validations, $expected));
+            }))
+            ->willReturn(true)
+        ;
+
+        $this->validator->validate($email, new EguliasEmail($options));
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @depends testValidEvaluation
+     */
+    public function testDefaultValidationMode()
+    {
+        $email = 'foo@example.com';
+
+        $reflection = new \ReflectionProperty(MultipleValidationWithAnd::class, 'mode');
+        $reflection->setAccessible(true);
+
+        $this->egulias
+            ->expects($this->once())
+            ->method('isValid')
+            ->with(self::equalTo($email), self::callback(function (MultipleValidationWithAnd $value) use ($reflection) {
+                $mode = $reflection->getValue($value);
+
+                return MultipleValidationWithAnd::STOP_ON_ERROR === $mode;
+            }))
+            ->willReturn(true)
+        ;
+
+        $this->validator->validate($email, new EguliasEmail());
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @depends testValidEvaluation
+     */
+    public function testAlteringValidationMode()
+    {
+        $email = 'foo@example.com';
+
+        $reflection = new \ReflectionProperty(MultipleValidationWithAnd::class, 'mode');
+        $reflection->setAccessible(true);
+
+        $this->egulias
+            ->expects($this->once())
+            ->method('isValid')
+            ->with(self::equalTo($email), self::callback(function (MultipleValidationWithAnd $value) use ($reflection) {
+                $mode = $reflection->getValue($value);
+
+                return MultipleValidationWithAnd::ALLOW_ALL_ERRORS === $mode;
+            }))
+            ->willReturn(true)
+        ;
+
+        $this->validator->validate($email, new EguliasEmail([
+            'validationMode' => MultipleValidationWithAnd::ALLOW_ALL_ERRORS,
+        ]));
+
+        $this->assertNoViolation();
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
| Doc PR | **TBD** |

Based on the feedback at #19989.

This validator opts for full feature support of the egulias/email-validator package.
I didn't touch the original `EmailValidator` in favor of BC.
