### PR TITLE
[TwigBridge] Added access to token from twig AppVariable

### DIFF
--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 /**
  * Exposes some Symfony parameters and services as an "app" global variable.
@@ -49,6 +50,22 @@ class AppVariable
     }
 
     /**
+     * Returns the current token.
+     *
+     * @return TokenInterface|null
+     *
+     * @throws \RuntimeException When the TokenStorage is not available
+     */
+    public function getToken()
+    {
+        if (null === $tokenStorage = $this->tokenStorage) {
+            throw new \RuntimeException('The "app.token" variable is not available.');
+        }
+
+        return $tokenStorage->getToken();
+    }
+
+    /**
      * Returns the current user.
      *
      * @return mixed
@@ -57,9 +74,7 @@ class AppVariable
      */
     public function getUser()
     {
-        if (null !== $this->tokenStorage) {
-            $tokenStorage = $this->tokenStorage;
-        } else {
+        if (null === $tokenStorage = $this->tokenStorage) {
             throw new \RuntimeException('The "app.user" variable is not available.');
         }
 

--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.2.0
+-----
+
+ * added `AppVariable::getToken()`
+
 2.7.0
 -----
 

--- a/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
@@ -67,6 +67,17 @@ class AppVariableTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($request, $this->appVariable->getRequest());
     }
 
+    public function testGetToken()
+    {
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $this->appVariable->setTokenStorage($tokenStorage);
+
+        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $tokenStorage->method('getToken')->willReturn($token);
+
+        $this->assertEquals($token, $this->appVariable->getToken());
+    }
+
     public function testGetUser()
     {
         $this->setTokenStorage($user = $this->getMock('Symfony\Component\Security\Core\User\UserInterface'));
@@ -79,6 +90,14 @@ class AppVariableTest extends \PHPUnit_Framework_TestCase
         $this->setTokenStorage($user = 'username');
 
         $this->assertNull($this->appVariable->getUser());
+    }
+
+    public function testGetTokenWithNoToken()
+    {
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $this->appVariable->setTokenStorage($tokenStorage);
+
+        $this->assertNull($this->appVariable->getToken());
     }
 
     public function testGetUserWithNoToken()
@@ -103,6 +122,14 @@ class AppVariableTest extends \PHPUnit_Framework_TestCase
     public function testDebugNotSet()
     {
         $this->appVariable->getDebug();
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testGetTokenWithTokenStorageNotSet()
+    {
+        $this->appVariable->getToken();
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | TODO |

In Symfony 2.x we could access the token from `app.security` but now we can only get the user even if it comes from the token storage.

This makes mandatory to create a custom twig extension to access it and thus harder to update to symfony 3.x when you need this simple getter in a template where custom tokens are involved (e.g using a ConnectToken from SensioLabs Connect API).

I hope this little feature will be part of 3.2 :)
