### PR TITLE
[Routing] Fixed route generation with fragment defined as defaults

### DIFF
--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -263,8 +263,15 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
         });
 
         // extract fragment
-        $fragment = isset($extra['_fragment']) ? $extra['_fragment'] : '';
-        unset($extra['_fragment']);
+        $fragment = '';
+        if (isset($defaults['_fragment'])) {
+            $fragment = $defaults['_fragment'];
+        }
+
+        if (isset($extra['_fragment'])) {
+            $fragment = $extra['_fragment'];
+            unset($extra['_fragment']);
+        }
 
         if ($extra && $query = http_build_query($extra, '', '&', PHP_QUERY_RFC3986)) {
             // "/" and "?" can be left decoded for better user experience, see

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -662,6 +662,14 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/app.php/testing#?/', $url);
     }
 
+    public function testFragmentsCanBeDefinedAsDefaults()
+    {
+        $routes = $this->getRoutes('test', new Route('/testing', array('_fragment' => 'fragment')));
+        $url = $this->getGenerator($routes)->generate('test', array(), UrlGeneratorInterface::ABSOLUTE_PATH);
+
+        $this->assertEquals('/app.php/testing#fragment', $url);
+    }
+
     protected function getGenerator(RouteCollection $routes, array $parameters = array(), $logger = null)
     {
         $context = new RequestContext('/app.php');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

As stated in https://symfony.com/blog/new-in-symfony-3-2-routing-improvements, it should support `_fragment` option as part of `_defaults` of route definition.
