### PR TITLE
[HttpFoundation] Enable memcached tests with the latest memcached extension

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcachedSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcachedSessionHandlerTest.php
@@ -37,8 +37,8 @@ class MemcachedSessionHandlerTest extends \PHPUnit_Framework_TestCase
 
         parent::setUp();
 
-        if (version_compare(phpversion('memcached'), '2.2.0', '>=')) {
-            $this->markTestSkipped('Tests can only be run with memcached extension 2.1.0 or lower');
+        if (version_compare(phpversion('memcached'), '2.2.0', '>=') && version_compare(phpversion('memcached'), '3.0.0b1', '<')) {
+            $this->markTestSkipped('Tests can only be run with memcached extension 2.1.0 or lower, or 3.0.0b1 or higher');
         }
 
         $this->memcached = $this->getMock('Memcached');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The check was introduced because of #9797. The issue is now fixed in the memcached extension, but only for the upcoming 3.0 release (for PHP7). 

I've tested it with the latest memcached extension built from source and PHP 7.0.8.
