### PR TITLE
[DX] Fixed regression when exception message swallowed when logging it.

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
@@ -147,6 +147,10 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
         }
 
         if (is_object($context)) {
+            if ($context instanceof \Exception) {
+                return sprintf('Exception(%s): %s', get_class($context), $context->getMessage());
+            }
+
             return sprintf('Object(%s)', get_class($context));
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | maybe, wait for Travis |
| Fixed tickets | fixed regression introduced in #13418 |
| License | MIT |
| Doc PR | - |

The problem is: after merging referenced PR we cann't understand what error occured and why authentication request failed (see attached screenshot). Previously it displays exception message, but now it only displays class of the exception.

![9003644109](https://cloud.githubusercontent.com/assets/191082/18717550/f0df61c4-8028-11e6-8dbb-684e4928e913.jpg)
