### PR TITLE
Use UUID for error codes for Form validator.

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/Form.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/Form.php
@@ -18,14 +18,14 @@ use Symfony\Component\Validator\Constraint;
  */
 class Form extends Constraint
 {
-    const NOT_SYNCHRONIZED_ERROR = 1;
-    const NO_SUCH_FIELD_ERROR = 2;
+    const NOT_SYNCHRONIZED_ERROR = '1dafa156-89e1-4736-b832-419c2e501fca';
+    const NO_SUCH_FIELD_ERROR = '6e5212ed-a197-4339-99aa-5654798a4854';
 
     /**
      * @deprecated since version 2.6, to be removed in 3.0.
      *             Use {@self NOT_SYNCHRONIZED_ERROR} instead.
      */
-    const ERR_INVALID = 1;
+    const ERR_INVALID = self::NOT_SYNCHRONIZED_ERROR;
 
     protected static $errorNames = array(
         self::NOT_SYNCHRONIZED_ERROR => 'NOT_SYNCHRONIZED_ERROR',


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | tiny, but it allowed http://symfony.com/doc/current/contributing/code/bc.html#changing-classes |
| Deprecations? | no |
| Tests pass? | I hope so :) |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
