### PR TITLE
[Form] FormView->isRendered() remove dead code and simplify the flow

### DIFF
--- a/src/Symfony/Component/Form/FormView.php
+++ b/src/Symfony/Component/Form/FormView.php
@@ -65,23 +65,17 @@ class FormView implements \ArrayAccess, \IteratorAggregate, \Countable
      */
     public function isRendered()
     {
-        $hasChildren = 0 < count($this->children);
-
-        if (true === $this->rendered || !$hasChildren) {
+        if (true === $this->rendered || 0 === count($this->children)) {
             return $this->rendered;
         }
 
-        if ($hasChildren) {
-            foreach ($this->children as $child) {
-                if (!$child->isRendered()) {
-                    return false;
-                }
+        foreach ($this->children as $child) {
+            if (!$child->isRendered()) {
+                return false;
             }
-
-            return $this->rendered = true;
         }
 
-        return false;
+        return $this->rendered = true;
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The method `FormView->isRendered()` can be easily simplified by removing useless conditions and statements.
The condition at line 74 is useless because of the composite condition at line 70.
Removed dead code statement at line 84.
