### PR TITLE
[Cache] Fixed password used to make the redis connection.

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/RedisAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/RedisAdapter.php
@@ -69,7 +69,7 @@ class RedisAdapter extends AbstractAdapter
         if (0 !== strpos($dsn, 'redis://')) {
             throw new InvalidArgumentException(sprintf('Invalid Redis DSN: %s does not start with "redis://"', $dsn));
         }
-        $params = preg_replace_callback('#^redis://(?:([^@]*)@)?#', function ($m) use (&$auth) {
+        $params = preg_replace_callback('#^redis://(?:(?:[^:@]*+:)?([^@]*+)@)?#', function ($m) use (&$auth) {
             if (isset($m[1])) {
                 $auth = $m[1];
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/issues/20025 |
| License | MIT |
| Doc PR | http://symfony.com/blog/new-in-symfony-3-1-cache-component |

I do not know if it's possible to provide a test as `REDIS_HOST` is provided by Travis in [RedisAdapterTest.php](https://github.com/symfony/symfony/blob/3.1/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterTest.php).
