### PR TITLE
Fixed expectedException annotations

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerNameParserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerNameParserTest.php
@@ -108,7 +108,6 @@ class ControllerNameParserTest extends TestCase
     }
 
     /**
-     * @expectedException
      * @dataProvider getInvalidBundleNameTests
      */
     public function testInvalidBundleName($bundleName, $suggestedBundleName)
@@ -117,6 +116,7 @@ class ControllerNameParserTest extends TestCase
 
         try {
             $parser->parse($bundleName);
+            $this->fail();
         } catch (\Exception $e) {
             $this->assertInstanceOf('\InvalidArgumentException', $e, '->parse() throws a \InvalidArgumentException if the bundle does not exist');
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerNameParserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerNameParserTest.php
@@ -93,7 +93,7 @@ class ControllerNameParserTest extends TestCase
 
         try {
             $parser->parse($name);
-            $this->fail('->parse() throws a \InvalidArgumentException if the string is in the valid format, but not matching class can be found');
+            $this->fail('->parse() throws a \InvalidArgumentException if the class is found but does not exist');
         } catch (\Exception $e) {
             $this->assertInstanceOf('\InvalidArgumentException', $e, '->parse() throws a \InvalidArgumentException if the class is found but does not exist');
         }
@@ -116,7 +116,7 @@ class ControllerNameParserTest extends TestCase
 
         try {
             $parser->parse($bundleName);
-            $this->fail();
+            $this->fail('->parse() throws a \InvalidArgumentException if the bundle does not exist');
         } catch (\Exception $e) {
             $this->assertInstanceOf('\InvalidArgumentException', $e, '->parse() throws a \InvalidArgumentException if the bundle does not exist');
 

--- a/src/Symfony/Component/Asset/Tests/UrlPackageTest.php
+++ b/src/Symfony/Component/Asset/Tests/UrlPackageTest.php
@@ -14,8 +14,6 @@ namespace Symfony\Component\Asset\Tests;
 use Symfony\Component\Asset\UrlPackage;
 use Symfony\Component\Asset\VersionStrategy\StaticVersionStrategy;
 use Symfony\Component\Asset\VersionStrategy\EmptyVersionStrategy;
-use Symfony\Component\Asset\Exception\InvalidArgumentException;
-use Symfony\Component\Asset\Exception\LogicException;
 
 class UrlPackageTest extends \PHPUnit_Framework_TestCase
 {
@@ -79,7 +77,7 @@ class UrlPackageTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException LogicException
+     * @expectedException \Symfony\Component\Asset\Exception\LogicException
      */
     public function testNoBaseUrls()
     {
@@ -87,7 +85,7 @@ class UrlPackageTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \Symfony\Component\Asset\Exception\InvalidArgumentException
      */
     public function testWrongBaseUrl()
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

See #19237... as this is not going to be fixed in phpunit nor php-cs-fixer and i believe by now these are the last 2 false positives.

Found with `@expectedException\s+[^\s\\]`

In master there are still +-25 consistency issues, ie. FQCN but without a root namespace. Shall we fix this?
