### PR TITLE
Hide commands from ApplicationDescriptor, but allow invoking

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -450,7 +450,7 @@ class Command
     /**
      * Sets if the command should be hidden from application inspection.
      *
-     * @param bool $hiddenBool To show this command or not
+     * @param bool $hidden To show this command or not
      * 
      * @return Command The current instance
      */

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -448,7 +448,7 @@ class Command
     }
 
     /**
-     * Sets if the command should be hidden from application inspection.
+     * To hide the command in application descriptions.
      *
      * @param bool $hidden To show this command or not
      * 
@@ -462,7 +462,7 @@ class Command
     }
 
     /**
-     * Returns if the command should be hidden from application inspection.
+     * Returns if the command should be hidden in application descriptions
      *
      * @return bool If the command is hidden or not
      */

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -34,6 +34,7 @@ class Command
     private $processTitle;
     private $aliases = array();
     private $definition;
+    private $hidden;
     private $help;
     private $description;
     private $ignoreValidationErrors = false;
@@ -444,6 +445,16 @@ class Command
     public function getName()
     {
         return $this->name;
+    }
+    
+    public function setHidden($hiddenBool)
+    {
+        return $this->hidden = $hiddenBool;
+    }
+
+    public function isHidden()
+    {
+        return $this->hidden;
     }
 
     /**

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -448,9 +448,7 @@ class Command
     }
 
     /**
-     * To hide the command in application descriptions.
-     *
-     * @param bool $public To show this command or not
+     * @param bool $public Whether the command should be publicly shown or not.
      * 
      * @return Command The current instance
      */
@@ -462,9 +460,7 @@ class Command
     }
 
     /**
-     * Returns if the command is public in application descriptions.
-     *
-     * @return bool If the command is public or not
+     * @return bool Whether the command should be publicly shown or not.
      */
     public function isPublic()
     {

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -34,7 +34,7 @@ class Command
     private $processTitle;
     private $aliases = array();
     private $definition;
-    private $hidden = false;
+    private $public = true;
     private $help;
     private $description;
     private $ignoreValidationErrors = false;
@@ -450,25 +450,25 @@ class Command
     /**
      * To hide the command in application descriptions.
      *
-     * @param bool $hidden To show this command or not
+     * @param bool $public To show this command or not
      * 
      * @return Command The current instance
      */
-    public function setHidden($hidden)
+    public function setPublic($public)
     {
-        $this->hidden = $hidden;
+        $this->public = $public;
 
         return $this;
     }
 
     /**
-     * Returns if the command is hidden in application descriptions.
+     * Returns if the command is public in application descriptions.
      *
-     * @return bool If the command is hidden or not
+     * @return bool If the command is public or not
      */
-    public function isHidden()
+    public function isPublic()
     {
-        return $this->hidden;
+        return $this->public;
     }
 
     /**

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -462,7 +462,7 @@ class Command
     }
 
     /**
-     * Returns if the command is hidden in application descriptions
+     * Returns if the command is hidden in application descriptions.
      *
      * @return bool If the command is hidden or not
      */

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -34,7 +34,7 @@ class Command
     private $processTitle;
     private $aliases = array();
     private $definition;
-    private $hidden;
+    private $hidden = false;
     private $help;
     private $description;
     private $ignoreValidationErrors = false;
@@ -454,9 +454,9 @@ class Command
      * 
      * @return Command The current instance
      */
-    public function setHidden($hiddenBool)
+    public function setHidden($hidden)
     {
-        $this->hidden = $hiddenBool;
+        $this->hidden = $hidden;
 
         return $this;
     }

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -447,11 +447,24 @@ class Command
         return $this->name;
     }
     
+     /**
+     * Sets if the command should be hidden from application inspection.
+     *
+     * @param bool $hiddenBool To show this command or not
+     * 
+     * @return Command The current instance
+     */
     public function setHidden($hiddenBool)
     {
-        return $this->hidden = $hiddenBool;
+        $this->hidden = $hiddenBool;
+        return $this;
     }
 
+    /**
+     * Returns if the command should be hidden from application inspection.
+     *
+     * @return boolean If the command is hidden or not
+     */
     public function isHidden()
     {
         return $this->hidden;

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -446,7 +446,7 @@ class Command
     {
         return $this->name;
     }
-    
+
     /**
      * Sets if the command should be hidden from application inspection.
      *
@@ -457,7 +457,7 @@ class Command
     public function setHidden($hiddenBool)
     {
         $this->hidden = $hiddenBool;
-        
+
         return $this;
     }
 

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -462,7 +462,7 @@ class Command
     }
 
     /**
-     * Returns if the command should be hidden in application descriptions
+     * Returns if the command is hidden in application descriptions
      *
      * @return bool If the command is hidden or not
      */

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -454,7 +454,7 @@ class Command
      */
     public function setPublic($public)
     {
-        $this->public = $public;
+        $this->public = (bool) $public;
 
         return $this;
     }

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -447,7 +447,7 @@ class Command
         return $this->name;
     }
     
-     /**
+    /**
      * Sets if the command should be hidden from application inspection.
      *
      * @param bool $hiddenBool To show this command or not
@@ -457,13 +457,14 @@ class Command
     public function setHidden($hiddenBool)
     {
         $this->hidden = $hiddenBool;
+        
         return $this;
     }
 
     /**
      * Returns if the command should be hidden from application inspection.
      *
-     * @return boolean If the command is hidden or not
+     * @return bool If the command is hidden or not
      */
     public function isHidden()
     {

--- a/src/Symfony/Component/Console/Descriptor/ApplicationDescription.php
+++ b/src/Symfony/Component/Console/Descriptor/ApplicationDescription.php
@@ -112,7 +112,7 @@ class ApplicationDescription
 
             /** @var Command $command */
             foreach ($commands as $name => $command) {
-                if (!$command->getName()) {
+                if (!$command->getName() || $command->isHidden()) {
                     continue;
                 }
 

--- a/src/Symfony/Component/Console/Descriptor/ApplicationDescription.php
+++ b/src/Symfony/Component/Console/Descriptor/ApplicationDescription.php
@@ -112,7 +112,7 @@ class ApplicationDescription
 
             /** @var Command $command */
             foreach ($commands as $name => $command) {
-                if (!$command->getName() || $command->isHidden()) {
+                if (!$command->getName() || !$command->isPublic()) {
                     continue;
                 }
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/DescriptorApplication2.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/DescriptorApplication2.php
@@ -20,5 +20,6 @@ class DescriptorApplication2 extends Application
         parent::__construct('My Symfony application', 'v1.0');
         $this->add(new DescriptorCommand1());
         $this->add(new DescriptorCommand2());
+        $this->add(new DescriptorCommand3());
     }
 }

--- a/src/Symfony/Component/Console/Tests/Fixtures/DescriptorCommand3.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/DescriptorCommand3.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Fixtures;
+
+use Symfony\Component\Console\Command\Command;
+
+class DescriptorCommand3 extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('descriptor:command3')
+            ->setDescription('command 3 description')
+            ->setHelp('command 3 help')
+            ->setPublic(false)
+        ;
+    }
+}


### PR DESCRIPTION
I would like to hide commands from cluttering the descriptors, but still allow their invocation from code or cron.

| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |
