### PR TITLE
[HttpKernel] enabled cache-reloading when cache file is rebuilt

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -479,15 +479,21 @@ abstract class Kernel implements KernelInterface, TerminableInterface
         $class = $this->getContainerClass();
         $cache = new ConfigCache($this->getCacheDir().'/'.$class.'.php', $this->debug);
         $fresh = true;
+        for ($classVersion = 0; class_exists($class . ($classVersion ?: '')); $classVersion++);
         if (!$cache->isFresh()) {
             $container = $this->buildContainer();
             $container->compile();
+            $class .= $classVersion ?: '';
             $this->dumpContainer($cache, $container, $class, $this->getContainerBaseClass());
 
             $fresh = false;
+        } else {
+            $class .= $classVersion ? $classVersion - 1 : '';
         }
 
-        require_once $cache->getPath();
+        if(!in_array($class, get_declared_classes())) {
+            require $cache->getPath();
+        }
 
         $this->container = new $class();
         $this->container->set('kernel', $this);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no, because of #20032 |
| Fixed tickets | #19681 |
| License | MIT |
| Doc PR | none |

Allows the cache file to be deleted, rebuilt & reloaded between Container builds in WebTestCase scenario, to enable testing of multiple configurations of the same application through WebTestCase.

Will only reload the cache file when in debug mode and the cache class file is deleted.
