### PR TITLE
[WIP] [HttpKernel] added phpdoc information support for the argument resolver

### DIFF
--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadata.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadata.php
@@ -24,6 +24,7 @@ class ArgumentMetadata
     private $hasDefaultValue;
     private $defaultValue;
     private $isNullable;
+    private $isArray;
 
     /**
      * @param string $name
@@ -33,7 +34,7 @@ class ArgumentMetadata
      * @param mixed  $defaultValue
      * @param bool   $isNullable
      */
-    public function __construct($name, $type, $isVariadic, $hasDefaultValue, $defaultValue, $isNullable = false)
+    public function __construct($name, $type, $isVariadic, $hasDefaultValue, $defaultValue, $isNullable = false, $isArray = false)
     {
         $this->name = $name;
         $this->type = $type;
@@ -41,6 +42,7 @@ class ArgumentMetadata
         $this->hasDefaultValue = $hasDefaultValue;
         $this->defaultValue = $defaultValue;
         $this->isNullable = $isNullable || null === $type || ($hasDefaultValue && null === $defaultValue);
+        $this->isArray = (bool) $isArray;
     }
 
     /**
@@ -95,6 +97,16 @@ class ArgumentMetadata
     public function isNullable()
     {
         return $this->isNullable;
+    }
+
+    /**
+     * Returns whether the argument is an array.
+     *
+     * @return bool
+     */
+    public function isArray()
+    {
+        return $this->isArray;
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -38,6 +38,7 @@
         "symfony/templating": "~2.8|~3.0",
         "symfony/translation": "~2.8|~3.0",
         "symfony/var-dumper": "~3.3",
+        "phpdocumentor/reflection-docblock": "^3.0",
         "psr/cache": "~1.0"
     },
     "conflict": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | not yet |

The idea is to be able to write argument resolvers that needs more information that a type hint can provide today. Think an array of objects. PHPDocs can convey this information.

With the following method signature, we would have everything we need:

``` php
   /**
     * @param Post[] $posts
     */
    public function indexAction($posts, $page)
    {
    }
```

We would also need to take care of caching this information to avoid too much overhead. But first, I wanted to see if there is some interest.

With this support, I would then be able to support something along the lines of:

``` php
   /**
     * @Route("/page/{page}", requirements={"page": "[1-9]\d*"}, name="blog_index_paginated")
     * @param Post[] $posts
     * @Arg("posts", expr="repository.findLatest(page)")
     */
    public function indexAction($posts, $page)
    {
    }
```

ping @iltar, @weaverryan 
