### PR TITLE
Fix indexBy type extraction

### DIFF
--- a/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
+++ b/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
@@ -88,7 +88,8 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
 
                 if (isset($associationMapping['indexBy'])) {
                     $indexProperty = $associationMapping['indexBy'];
-                    $typeOfField = $metadata->getTypeOfField($indexProperty);
+                    $subMetadata = $this->classMetadataFactory->getMetadataFor($associationMapping['targetEntity']);
+                    $typeOfField = $subMetadata->getTypeOfField($indexProperty);
 
                     $collectionKeyType = $this->getPhpType($typeOfField);
                 }

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineDummy.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineDummy.php
@@ -41,7 +41,7 @@ class DoctrineDummy
     public $bar;
 
     /**
-     * @ManyToMany(targetEntity="DoctrineRelation", indexBy="guid")
+     * @ManyToMany(targetEntity="DoctrineRelation", indexBy="rguid")
      */
     protected $indexedBar;
 

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineRelation.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineRelation.php
@@ -31,5 +31,5 @@ class DoctrineRelation
     /**
      * @Column(type="guid")
      */
-    protected $guid;
+    protected $rguid;
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8+ |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

Bug found and patched by @ksom

Since https://github.com/symfony/symfony/commit/3008228b48d6285dcfbd10422029c0c55a9e713e, the Doctrine Bridge's PropertyInfo Extractor tries to extract the type of the key in an indexed association. However, as you can see in https://github.com/symfony/symfony/commit/3008228b48d6285dcfbd10422029c0c55a9e713e#diff-7a8fb8072d57f95ea6e37898b05895bcR91, the extractor was using the metadata of the class containing the association instead of the target entity's metadata to retrieve the type of the index.

The tests were green because in https://github.com/symfony/symfony/commit/3008228b48d6285dcfbd10422029c0c55a9e713e#diff-c7e914ed89ceffd939733efe08c039c2R44, the property used to `indexBy` was present in the classes on both sides of the relation with the same type.

Once the test is fixed (by renaming the property in the targetEntity), the test provided at https://github.com/symfony/symfony/commit/3008228b48d6285dcfbd10422029c0c55a9e713e#diff-1b2e044d1df011c00caf802a07895bdbR88 gives the error

```
1) Symfony\Bridge\Doctrine\PropertyInfo\Tests\DoctrineExtractorTest::testExtract with data set #9 ('indexedBar', array(Symfony\Component\PropertyInfo\Type Object (...)))
InvalidArgumentException: "" is not a valid PHP type.
```

The fix is to fetch the metadata of the target entity and check there for the property type.
