### PR TITLE
Set CloudFlare's connecting IP to remote address

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -793,7 +793,13 @@ class Request
     public function getClientIps()
     {
         $clientIps = array();
-        $ip = $this->server->get('REMOTE_ADDR');
+        
+        if (isset($_SERVER['HTTP_CF_CONNECTING_IP'])) {
+            $this->server->set('REMOTE_ADDR', $_SERVER['HTTP_CF_CONNECTING_IP']);
+            $ip = $this->server->get('REMOTE_ADDR');
+        } else {
+            $ip = $this->server->get('REMOTE_ADDR');
+        }
 
         if (!$this->isFromTrustedProxy()) {
             return array($ip);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" for new features / 2.7, 2.8 or 3.1 for fixes |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes/no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

When servers traffic are routed via CloudFlare, $this->server-get('REMOTE_ADDR'); would not return the real connection ip of the client. $_SERVER['HTTP_CF_CONNECTING_IP']; would return the original ip. 

PS: This might be not useful to merge to master, but all users out there using CloudFlare might face this issue. 

Cheers!
