### PR TITLE
[Console] Format JSON fixtures

### DIFF
--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.json
@@ -1,1 +1,172 @@
-{"commands":[{"name":"help","usage":["help [--xml] [--format FORMAT] [--raw] [--] [<command_name>]"],"description":"Displays help for a command","help":"The <info>help<\/info> command displays help for a given command:\n\n  <info>php app\/console help list<\/info>\n\nYou can also output the help in other formats by using the <comment>--format<\/comment> option:\n\n  <info>php app\/console help --format=xml list<\/info>\n\nTo display the list of available commands, please use the <info>list<\/info> command.","definition":{"arguments":{"command_name":{"name":"command_name","is_required":false,"is_array":false,"description":"The command name","default":"help"}},"options":{"xml":{"name":"--xml","shortcut":"","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"To output help as XML","default":false},"format":{"name":"--format","shortcut":"","accept_value":true,"is_value_required":true,"is_multiple":false,"description":"The output format (txt, xml, json, or md)","default":"txt"},"raw":{"name":"--raw","shortcut":"","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"To output raw command help","default":false},"help":{"name":"--help","shortcut":"-h","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"Display this help message","default":false},"quiet":{"name":"--quiet","shortcut":"-q","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"Do not output any message","default":false},"verbose":{"name":"--verbose","shortcut":"-v|-vv|-vvv","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug","default":false},"version":{"name":"--version","shortcut":"-V","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"Display this application version","default":false},"ansi":{"name":"--ansi","shortcut":"","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"Force ANSI output","default":false},"no-ansi":{"name":"--no-ansi","shortcut":"","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"Disable ANSI output","default":false},"no-interaction":{"name":"--no-interaction","shortcut":"-n","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"Do not ask any interactive question","default":false}}}},{"name":"list","usage":["list [--xml] [--raw] [--format FORMAT] [--] [<namespace>]"],"description":"Lists commands","help":"The <info>list<\/info> command lists all commands:\n\n  <info>php app\/console list<\/info>\n\nYou can also display the commands for a specific namespace:\n\n  <info>php app\/console list test<\/info>\n\nYou can also output the information in other formats by using the <comment>--format<\/comment> option:\n\n  <info>php app\/console list --format=xml<\/info>\n\nIt's also possible to get raw list of commands (useful for embedding command runner):\n\n  <info>php app\/console list --raw<\/info>","definition":{"arguments":{"namespace":{"name":"namespace","is_required":false,"is_array":false,"description":"The namespace name","default":null}},"options":{"xml":{"name":"--xml","shortcut":"","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"To output list as XML","default":false},"raw":{"name":"--raw","shortcut":"","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"To output raw command list","default":false},"format":{"name":"--format","shortcut":"","accept_value":true,"is_value_required":true,"is_multiple":false,"description":"The output format (txt, xml, json, or md)","default":"txt"}}}}],"namespaces":[{"id":"_global","commands":["help","list"]}]}
+{
+    "commands": [
+        {
+            "name": "help",
+            "usage": [
+                "help [--xml] [--format FORMAT] [--raw] [--] [<command_name>]"
+            ],
+            "description": "Displays help for a command",
+            "help": "The <info>help<\/info> command displays help for a given command:\n\n  <info>php app\/console help list<\/info>\n\nYou can also output the help in other formats by using the <comment>--format<\/comment> option:\n\n  <info>php app\/console help --format=xml list<\/info>\n\nTo display the list of available commands, please use the <info>list<\/info> command.",
+            "definition": {
+                "arguments": {
+                    "command_name": {
+                        "name": "command_name",
+                        "is_required": false,
+                        "is_array": false,
+                        "description": "The command name",
+                        "default": "help"
+                    }
+                },
+                "options": {
+                    "xml": {
+                        "name": "--xml",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "To output help as XML",
+                        "default": false
+                    },
+                    "format": {
+                        "name": "--format",
+                        "shortcut": "",
+                        "accept_value": true,
+                        "is_value_required": true,
+                        "is_multiple": false,
+                        "description": "The output format (txt, xml, json, or md)",
+                        "default": "txt"
+                    },
+                    "raw": {
+                        "name": "--raw",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "To output raw command help",
+                        "default": false
+                    },
+                    "help": {
+                        "name": "--help",
+                        "shortcut": "-h",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Display this help message",
+                        "default": false
+                    },
+                    "quiet": {
+                        "name": "--quiet",
+                        "shortcut": "-q",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Do not output any message",
+                        "default": false
+                    },
+                    "verbose": {
+                        "name": "--verbose",
+                        "shortcut": "-v|-vv|-vvv",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug",
+                        "default": false
+                    },
+                    "version": {
+                        "name": "--version",
+                        "shortcut": "-V",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Display this application version",
+                        "default": false
+                    },
+                    "ansi": {
+                        "name": "--ansi",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Force ANSI output",
+                        "default": false
+                    },
+                    "no-ansi": {
+                        "name": "--no-ansi",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Disable ANSI output",
+                        "default": false
+                    },
+                    "no-interaction": {
+                        "name": "--no-interaction",
+                        "shortcut": "-n",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Do not ask any interactive question",
+                        "default": false
+                    }
+                }
+            }
+        },
+        {
+            "name": "list",
+            "usage": [
+                "list [--xml] [--raw] [--format FORMAT] [--] [<namespace>]"
+            ],
+            "description": "Lists commands",
+            "help": "The <info>list<\/info> command lists all commands:\n\n  <info>php app\/console list<\/info>\n\nYou can also display the commands for a specific namespace:\n\n  <info>php app\/console list test<\/info>\n\nYou can also output the information in other formats by using the <comment>--format<\/comment> option:\n\n  <info>php app\/console list --format=xml<\/info>\n\nIt's also possible to get raw list of commands (useful for embedding command runner):\n\n  <info>php app\/console list --raw<\/info>",
+            "definition": {
+                "arguments": {
+                    "namespace": {
+                        "name": "namespace",
+                        "is_required": false,
+                        "is_array": false,
+                        "description": "The namespace name",
+                        "default": null
+                    }
+                },
+                "options": {
+                    "xml": {
+                        "name": "--xml",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "To output list as XML",
+                        "default": false
+                    },
+                    "raw": {
+                        "name": "--raw",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "To output raw command list",
+                        "default": false
+                    },
+                    "format": {
+                        "name": "--format",
+                        "shortcut": "",
+                        "accept_value": true,
+                        "is_value_required": true,
+                        "is_multiple": false,
+                        "description": "The output format (txt, xml, json, or md)",
+                        "default": "txt"
+                    }
+                }
+            }
+        }
+    ],
+    "namespaces": [
+        {
+            "id": "_global",
+            "commands": [
+                "help",
+                "list"
+            ]
+        }
+    ]
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.json
@@ -1,1 +1,354 @@
-{"commands":[{"name":"help","usage":["help [--xml] [--format FORMAT] [--raw] [--] [<command_name>]"],"description":"Displays help for a command","help":"The <info>help<\/info> command displays help for a given command:\n\n  <info>php app\/console help list<\/info>\n\nYou can also output the help in other formats by using the <comment>--format<\/comment> option:\n\n  <info>php app\/console help --format=xml list<\/info>\n\nTo display the list of available commands, please use the <info>list<\/info> command.","definition":{"arguments":{"command_name":{"name":"command_name","is_required":false,"is_array":false,"description":"The command name","default":"help"}},"options":{"xml":{"name":"--xml","shortcut":"","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"To output help as XML","default":false},"format":{"name":"--format","shortcut":"","accept_value":true,"is_value_required":true,"is_multiple":false,"description":"The output format (txt, xml, json, or md)","default":"txt"},"raw":{"name":"--raw","shortcut":"","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"To output raw command help","default":false},"help":{"name":"--help","shortcut":"-h","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"Display this help message","default":false},"quiet":{"name":"--quiet","shortcut":"-q","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"Do not output any message","default":false},"verbose":{"name":"--verbose","shortcut":"-v|-vv|-vvv","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug","default":false},"version":{"name":"--version","shortcut":"-V","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"Display this application version","default":false},"ansi":{"name":"--ansi","shortcut":"","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"Force ANSI output","default":false},"no-ansi":{"name":"--no-ansi","shortcut":"","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"Disable ANSI output","default":false},"no-interaction":{"name":"--no-interaction","shortcut":"-n","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"Do not ask any interactive question","default":false}}}},{"name":"list","usage":["list [--xml] [--raw] [--format FORMAT] [--] [<namespace>]"],"description":"Lists commands","help":"The <info>list<\/info> command lists all commands:\n\n  <info>php app\/console list<\/info>\n\nYou can also display the commands for a specific namespace:\n\n  <info>php app\/console list test<\/info>\n\nYou can also output the information in other formats by using the <comment>--format<\/comment> option:\n\n  <info>php app\/console list --format=xml<\/info>\n\nIt's also possible to get raw list of commands (useful for embedding command runner):\n\n  <info>php app\/console list --raw<\/info>","definition":{"arguments":{"namespace":{"name":"namespace","is_required":false,"is_array":false,"description":"The namespace name","default":null}},"options":{"xml":{"name":"--xml","shortcut":"","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"To output list as XML","default":false},"raw":{"name":"--raw","shortcut":"","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"To output raw command list","default":false},"format":{"name":"--format","shortcut":"","accept_value":true,"is_value_required":true,"is_multiple":false,"description":"The output format (txt, xml, json, or md)","default":"txt"}}}},{"name":"descriptor:command1","usage":["descriptor:command1", "alias1", "alias2"],"description":"command 1 description","help":"command 1 help","definition":{"arguments":[],"options":{"help":{"name":"--help","shortcut":"-h","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"Display this help message","default":false},"quiet":{"name":"--quiet","shortcut":"-q","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"Do not output any message","default":false},"verbose":{"name":"--verbose","shortcut":"-v|-vv|-vvv","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug","default":false},"version":{"name":"--version","shortcut":"-V","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"Display this application version","default":false},"ansi":{"name":"--ansi","shortcut":"","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"Force ANSI output","default":false},"no-ansi":{"name":"--no-ansi","shortcut":"","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"Disable ANSI output","default":false},"no-interaction":{"name":"--no-interaction","shortcut":"-n","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"Do not ask any interactive question","default":false}}}},{"name":"descriptor:command2","usage":["descriptor:command2 [-o|--option_name] [--] <argument_name>", "descriptor:command2 -o|--option_name <argument_name>", "descriptor:command2 <argument_name>"],"description":"command 2 description","help":"command 2 help","definition":{"arguments":{"argument_name":{"name":"argument_name","is_required":true,"is_array":false,"description":"","default":null}},"options":{"option_name":{"name":"--option_name","shortcut":"-o","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"","default":false},"help":{"name":"--help","shortcut":"-h","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"Display this help message","default":false},"quiet":{"name":"--quiet","shortcut":"-q","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"Do not output any message","default":false},"verbose":{"name":"--verbose","shortcut":"-v|-vv|-vvv","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug","default":false},"version":{"name":"--version","shortcut":"-V","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"Display this application version","default":false},"ansi":{"name":"--ansi","shortcut":"","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"Force ANSI output","default":false},"no-ansi":{"name":"--no-ansi","shortcut":"","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"Disable ANSI output","default":false},"no-interaction":{"name":"--no-interaction","shortcut":"-n","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"Do not ask any interactive question","default":false}}}}],"namespaces":[{"id":"_global","commands":["alias1","alias2","help","list"]},{"id":"descriptor","commands":["descriptor:command1","descriptor:command2"]}]}
+{
+    "commands": [
+        {
+            "name": "help",
+            "usage": [
+                "help [--xml] [--format FORMAT] [--raw] [--] [<command_name>]"
+            ],
+            "description": "Displays help for a command",
+            "help": "The <info>help<\/info> command displays help for a given command:\n\n  <info>php app\/console help list<\/info>\n\nYou can also output the help in other formats by using the <comment>--format<\/comment> option:\n\n  <info>php app\/console help --format=xml list<\/info>\n\nTo display the list of available commands, please use the <info>list<\/info> command.",
+            "definition": {
+                "arguments": {
+                    "command_name": {
+                        "name": "command_name",
+                        "is_required": false,
+                        "is_array": false,
+                        "description": "The command name",
+                        "default": "help"
+                    }
+                },
+                "options": {
+                    "xml": {
+                        "name": "--xml",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "To output help as XML",
+                        "default": false
+                    },
+                    "format": {
+                        "name": "--format",
+                        "shortcut": "",
+                        "accept_value": true,
+                        "is_value_required": true,
+                        "is_multiple": false,
+                        "description": "The output format (txt, xml, json, or md)",
+                        "default": "txt"
+                    },
+                    "raw": {
+                        "name": "--raw",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "To output raw command help",
+                        "default": false
+                    },
+                    "help": {
+                        "name": "--help",
+                        "shortcut": "-h",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Display this help message",
+                        "default": false
+                    },
+                    "quiet": {
+                        "name": "--quiet",
+                        "shortcut": "-q",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Do not output any message",
+                        "default": false
+                    },
+                    "verbose": {
+                        "name": "--verbose",
+                        "shortcut": "-v|-vv|-vvv",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug",
+                        "default": false
+                    },
+                    "version": {
+                        "name": "--version",
+                        "shortcut": "-V",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Display this application version",
+                        "default": false
+                    },
+                    "ansi": {
+                        "name": "--ansi",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Force ANSI output",
+                        "default": false
+                    },
+                    "no-ansi": {
+                        "name": "--no-ansi",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Disable ANSI output",
+                        "default": false
+                    },
+                    "no-interaction": {
+                        "name": "--no-interaction",
+                        "shortcut": "-n",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Do not ask any interactive question",
+                        "default": false
+                    }
+                }
+            }
+        },
+        {
+            "name": "list",
+            "usage": [
+                "list [--xml] [--raw] [--format FORMAT] [--] [<namespace>]"
+            ],
+            "description": "Lists commands",
+            "help": "The <info>list<\/info> command lists all commands:\n\n  <info>php app\/console list<\/info>\n\nYou can also display the commands for a specific namespace:\n\n  <info>php app\/console list test<\/info>\n\nYou can also output the information in other formats by using the <comment>--format<\/comment> option:\n\n  <info>php app\/console list --format=xml<\/info>\n\nIt's also possible to get raw list of commands (useful for embedding command runner):\n\n  <info>php app\/console list --raw<\/info>",
+            "definition": {
+                "arguments": {
+                    "namespace": {
+                        "name": "namespace",
+                        "is_required": false,
+                        "is_array": false,
+                        "description": "The namespace name",
+                        "default": null
+                    }
+                },
+                "options": {
+                    "xml": {
+                        "name": "--xml",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "To output list as XML",
+                        "default": false
+                    },
+                    "raw": {
+                        "name": "--raw",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "To output raw command list",
+                        "default": false
+                    },
+                    "format": {
+                        "name": "--format",
+                        "shortcut": "",
+                        "accept_value": true,
+                        "is_value_required": true,
+                        "is_multiple": false,
+                        "description": "The output format (txt, xml, json, or md)",
+                        "default": "txt"
+                    }
+                }
+            }
+        },
+        {
+            "name": "descriptor:command1",
+            "usage": [
+                "descriptor:command1",
+                "alias1",
+                "alias2"
+            ],
+            "description": "command 1 description",
+            "help": "command 1 help",
+            "definition": {
+                "arguments": [],
+                "options": {
+                    "help": {
+                        "name": "--help",
+                        "shortcut": "-h",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Display this help message",
+                        "default": false
+                    },
+                    "quiet": {
+                        "name": "--quiet",
+                        "shortcut": "-q",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Do not output any message",
+                        "default": false
+                    },
+                    "verbose": {
+                        "name": "--verbose",
+                        "shortcut": "-v|-vv|-vvv",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug",
+                        "default": false
+                    },
+                    "version": {
+                        "name": "--version",
+                        "shortcut": "-V",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Display this application version",
+                        "default": false
+                    },
+                    "ansi": {
+                        "name": "--ansi",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Force ANSI output",
+                        "default": false
+                    },
+                    "no-ansi": {
+                        "name": "--no-ansi",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Disable ANSI output",
+                        "default": false
+                    },
+                    "no-interaction": {
+                        "name": "--no-interaction",
+                        "shortcut": "-n",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Do not ask any interactive question",
+                        "default": false
+                    }
+                }
+            }
+        },
+        {
+            "name": "descriptor:command2",
+            "usage": [
+                "descriptor:command2 [-o|--option_name] [--] <argument_name>",
+                "descriptor:command2 -o|--option_name <argument_name>",
+                "descriptor:command2 <argument_name>"
+            ],
+            "description": "command 2 description",
+            "help": "command 2 help",
+            "definition": {
+                "arguments": {
+                    "argument_name": {
+                        "name": "argument_name",
+                        "is_required": true,
+                        "is_array": false,
+                        "description": "",
+                        "default": null
+                    }
+                },
+                "options": {
+                    "option_name": {
+                        "name": "--option_name",
+                        "shortcut": "-o",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "",
+                        "default": false
+                    },
+                    "help": {
+                        "name": "--help",
+                        "shortcut": "-h",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Display this help message",
+                        "default": false
+                    },
+                    "quiet": {
+                        "name": "--quiet",
+                        "shortcut": "-q",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Do not output any message",
+                        "default": false
+                    },
+                    "verbose": {
+                        "name": "--verbose",
+                        "shortcut": "-v|-vv|-vvv",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug",
+                        "default": false
+                    },
+                    "version": {
+                        "name": "--version",
+                        "shortcut": "-V",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Display this application version",
+                        "default": false
+                    },
+                    "ansi": {
+                        "name": "--ansi",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Force ANSI output",
+                        "default": false
+                    },
+                    "no-ansi": {
+                        "name": "--no-ansi",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Disable ANSI output",
+                        "default": false
+                    },
+                    "no-interaction": {
+                        "name": "--no-interaction",
+                        "shortcut": "-n",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Do not ask any interactive question",
+                        "default": false
+                    }
+                }
+            }
+        }
+    ],
+    "namespaces": [
+        {
+            "id": "_global",
+            "commands": [
+                "alias1",
+                "alias2",
+                "help",
+                "list"
+            ]
+        },
+        {
+            "id": "descriptor",
+            "commands": [
+                "descriptor:command1",
+                "descriptor:command2"
+            ]
+        }
+    ]
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_1.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_1.json
@@ -1,1 +1,14 @@
-{"name":"descriptor:command1","usage":["descriptor:command1", "alias1", "alias2"],"description":"command 1 description","help":"command 1 help","definition":{"arguments":[],"options":[]}}
+{
+    "name": "descriptor:command1",
+    "usage": [
+        "descriptor:command1",
+        "alias1",
+        "alias2"
+    ],
+    "description": "command 1 description",
+    "help": "command 1 help",
+    "definition": {
+        "arguments": [],
+        "options": []
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_2.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_2.json
@@ -1,1 +1,32 @@
-{"name":"descriptor:command2","usage":["descriptor:command2 [-o|--option_name] [--] <argument_name>", "descriptor:command2 -o|--option_name <argument_name>", "descriptor:command2 <argument_name>"],"description":"command 2 description","help":"command 2 help","definition":{"arguments":{"argument_name":{"name":"argument_name","is_required":true,"is_array":false,"description":"","default":null}},"options":{"option_name":{"name":"--option_name","shortcut":"-o","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"","default":false}}}}
+{
+    "name": "descriptor:command2",
+    "usage": [
+        "descriptor:command2 [-o|--option_name] [--] <argument_name>",
+        "descriptor:command2 -o|--option_name <argument_name>",
+        "descriptor:command2 <argument_name>"
+    ],
+    "description": "command 2 description",
+    "help": "command 2 help",
+    "definition": {
+        "arguments": {
+            "argument_name": {
+                "name": "argument_name",
+                "is_required": true,
+                "is_array": false,
+                "description": "",
+                "default": null
+            }
+        },
+        "options": {
+            "option_name": {
+                "name": "--option_name",
+                "shortcut": "-o",
+                "accept_value": false,
+                "is_value_required": false,
+                "is_multiple": false,
+                "description": "",
+                "default": false
+            }
+        }
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_argument_1.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_argument_1.json
@@ -1,1 +1,7 @@
-{"name":"argument_name","is_required":true,"is_array":false,"description":"","default":null}
+{
+    "name": "argument_name",
+    "is_required": true,
+    "is_array": false,
+    "description": "",
+    "default": null
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_argument_2.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_argument_2.json
@@ -1,1 +1,7 @@
-{"name":"argument_name","is_required":false,"is_array":true,"description":"argument description","default":[]}
+{
+    "name": "argument_name",
+    "is_required": false,
+    "is_array": true,
+    "description": "argument description",
+    "default": []
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_argument_3.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_argument_3.json
@@ -1,1 +1,7 @@
-{"name":"argument_name","is_required":false,"is_array":false,"description":"argument description","default":"default_value"}
+{
+    "name": "argument_name",
+    "is_required": false,
+    "is_array": false,
+    "description": "argument description",
+    "default": "default_value"
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_argument_4.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_argument_4.json
@@ -1,1 +1,7 @@
-{"name":"argument_name","is_required":true,"is_array":false,"description":"multiline argument description","default":null}
+{
+    "name": "argument_name",
+    "is_required": true,
+    "is_array": false,
+    "description": "multiline argument description",
+    "default": null
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_definition_1.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_definition_1.json
@@ -1,1 +1,4 @@
-{"arguments":[],"options":[]}
+{
+    "arguments": [],
+    "options": []
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_definition_2.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_definition_2.json
@@ -1,1 +1,12 @@
-{"arguments":{"argument_name":{"name":"argument_name","is_required":true,"is_array":false,"description":"","default":null}},"options":[]}
+{
+    "arguments": {
+        "argument_name": {
+            "name": "argument_name",
+            "is_required": true,
+            "is_array": false,
+            "description": "",
+            "default": null
+        }
+    },
+    "options": []
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_definition_3.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_definition_3.json
@@ -1,1 +1,14 @@
-{"arguments":[],"options":{"option_name":{"name":"--option_name","shortcut":"-o","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"","default":false}}}
+{
+    "arguments": [],
+    "options": {
+        "option_name": {
+            "name": "--option_name",
+            "shortcut": "-o",
+            "accept_value": false,
+            "is_value_required": false,
+            "is_multiple": false,
+            "description": "",
+            "default": false
+        }
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_definition_4.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_definition_4.json
@@ -1,1 +1,22 @@
-{"arguments":{"argument_name":{"name":"argument_name","is_required":true,"is_array":false,"description":"","default":null}},"options":{"option_name":{"name":"--option_name","shortcut":"-o","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"","default":false}}}
+{
+    "arguments": {
+        "argument_name": {
+            "name": "argument_name",
+            "is_required": true,
+            "is_array": false,
+            "description": "",
+            "default": null
+        }
+    },
+    "options": {
+        "option_name": {
+            "name": "--option_name",
+            "shortcut": "-o",
+            "accept_value": false,
+            "is_value_required": false,
+            "is_multiple": false,
+            "description": "",
+            "default": false
+        }
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_option_1.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_option_1.json
@@ -1,1 +1,9 @@
-{"name":"--option_name","shortcut":"-o","accept_value":false,"is_value_required":false,"is_multiple":false,"description":"","default":false}
+{
+    "name": "--option_name",
+    "shortcut": "-o",
+    "accept_value": false,
+    "is_value_required": false,
+    "is_multiple": false,
+    "description": "",
+    "default": false
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_option_2.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_option_2.json
@@ -1,1 +1,9 @@
-{"name":"--option_name","shortcut":"-o","accept_value":true,"is_value_required":false,"is_multiple":false,"description":"option description","default":"default_value"}
+{
+    "name": "--option_name",
+    "shortcut": "-o",
+    "accept_value": true,
+    "is_value_required": false,
+    "is_multiple": false,
+    "description": "option description",
+    "default": "default_value"
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_option_3.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_option_3.json
@@ -1,1 +1,9 @@
-{"name":"--option_name","shortcut":"-o","accept_value":true,"is_value_required":true,"is_multiple":false,"description":"option description","default":null}
+{
+    "name": "--option_name",
+    "shortcut": "-o",
+    "accept_value": true,
+    "is_value_required": true,
+    "is_multiple": false,
+    "description": "option description",
+    "default": null
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_option_4.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_option_4.json
@@ -1,1 +1,9 @@
-{"name":"--option_name","shortcut":"-o","accept_value":true,"is_value_required":false,"is_multiple":true,"description":"option description","default":[]}
+{
+    "name": "--option_name",
+    "shortcut": "-o",
+    "accept_value": true,
+    "is_value_required": false,
+    "is_multiple": true,
+    "description": "option description",
+    "default": []
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_option_5.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_option_5.json
@@ -1,1 +1,9 @@
-{"name":"--option_name","shortcut":"-o","accept_value":true,"is_value_required":true,"is_multiple":false,"description":"multiline option description","default":null}
+{
+    "name": "--option_name",
+    "shortcut": "-o",
+    "accept_value": true,
+    "is_value_required": true,
+    "is_multiple": false,
+    "description": "multiline option description",
+    "default": null
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_option_6.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_option_6.json
@@ -1,1 +1,9 @@
-{"name":"--option_name","shortcut":"-o|-O","accept_value":true,"is_value_required":true,"is_multiple":false,"description":"option with multiple shortcuts","default":null}
+{
+    "name": "--option_name",
+    "shortcut": "-o|-O",
+    "accept_value": true,
+    "is_value_required": true,
+    "is_multiple": false,
+    "description": "option with multiple shortcuts",
+    "default": null
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

Should make merging upstream easier due better diffs.

``` php
foreach (glob('src/Symfony/Component/Console/Tests/Fixtures/*.json') as $file) {
    file_put_contents($file, str_replace(PHP_EOL, "\n", json_encode(json_decode(trim(file_get_contents($file))), JSON_PRETTY_PRINT))."\n");
}
```

Should be re-applied on 2.8, 3.1 and master.
