### PR TITLE
[FrameworkBundle] fix yaml:lint when yaml is not installed along side framework-bundle

### DIFF
--- a/src/Symfony/Component/Yaml/Command/LintCommand.php
+++ b/src/Symfony/Component/Yaml/Command/LintCommand.php
@@ -30,6 +30,16 @@ class LintCommand extends Command
     private $parser;
     private $format;
     private $displayCorrectFiles;
+    private $directoryIteratorProvider;
+    private $isReadableProvider;
+
+    public function __construct($name = null, $directoryIteratorProvider = null, $isReadableProvider = null)
+    {
+        parent::__construct($name);
+
+        $this->directoryIteratorProvider = $directoryIteratorProvider;
+        $this->isReadableProvider = $isReadableProvider;
+    }
 
     /**
      * {@inheritdoc}
@@ -170,14 +180,6 @@ EOF
         }
     }
 
-    protected function getDirectoryIterator($directory)
-    {
-        return new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::FOLLOW_SYMLINKS),
-            \RecursiveIteratorIterator::LEAVES_ONLY
-        );
-    }
-
     private function getStdin()
     {
         if (0 !== ftell(STDIN)) {
@@ -201,8 +203,32 @@ EOF
         return $this->parser;
     }
 
-    protected function isReadable($fileOrDirectory)
+    private function getDirectoryIterator($directory)
     {
-        return is_readable($fileOrDirectory);
+        $default = function ($directory) {
+            return new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::FOLLOW_SYMLINKS),
+                \RecursiveIteratorIterator::LEAVES_ONLY
+            );
+        };
+
+        if (null !== $this->directoryIteratorProvider) {
+            return call_user_func($this->directoryIteratorProvider, $directory, $default);
+        }
+
+        return $default($directory);
+    }
+
+    private function isReadable($fileOrDirectory)
+    {
+        $default = function ($fileOrDirectory) {
+            return is_readable($fileOrDirectory);
+        };
+
+        if (null !== $this->isReadableProvider) {
+            return call_user_func($this->isReadableProvider, $fileOrDirectory, $default);
+        }
+
+        return $default($fileOrDirectory);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

YAML is not an explicit dependency of FrameworkBundle. If it is not installed, the console is broken as the yaml:lint commands tries to extends the one in the YAML component. This bug only exists in master as this refactoring happened in 3.2
