### PR TITLE
[FrameworkBundle] removed the Asset component dependency on FrameworkBundle

### DIFF
--- a/UPGRADE-3.2.md
+++ b/UPGRADE-3.2.md
@@ -4,6 +4,9 @@ UPGRADE FROM 3.1 to 3.2
 FrameworkBundle
 ---------------
 
+ * The `symfony/asset` dependency has been removed; require it via `composer
+   require symfony/asset` if you depend on it and don't already depend on
+   `symfony/symfony`
  * The `Resources/public/images/*` files have been removed.
  * The `Resources/public/css/*.css` files have been removed (they are now inlined
    in TwigBundle).

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 3.2.0
 -----
 
+ * Removed `symfony/asset` from the list of required dependencies in `composer.json`
  * The `Resources/public/images/*` files have been removed.
  * The `Resources/public/css/*.css` files have been removed (they are now inlined in TwigBundle).
  * The `Controller::getUser()` method has been deprecated and will be removed in

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -134,6 +134,10 @@ class FrameworkExtension extends Extension
         $this->registerSecurityCsrfConfiguration($config['csrf_protection'], $container, $loader);
 
         if ($this->isConfigEnabled($container, $config['assets'])) {
+            if (!class_exists('Symfony\Component\Asset\Package')) {
+                throw new LogicException('Asset support cannot be enabled as the Asset component is not installed.');
+            }
+
             $this->registerAssetsConfiguration($config['assets'], $container, $loader);
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -17,7 +17,6 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "symfony/asset": "~2.8|~3.0",
         "symfony/cache": "~3.2",
         "symfony/class-loader": "~3.2",
         "symfony/dependency-injection": "~3.2",
@@ -38,6 +37,7 @@
         "doctrine/annotations": "~1.0"
     },
     "require-dev": {
+        "symfony/asset": "~2.8|~3.0",
         "symfony/browser-kit": "~2.8|~3.0",
         "symfony/console": "~2.8.8|~3.0.8|~3.1.2|~3.2",
         "symfony/css-selector": "~2.8|~3.0",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no (except for people using FrameworkBundle without requiring symfony/symfony which should be pretty rare; and fixing this is easy by adding symfony/asset explicitly) |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15748 partially |
| License | MIT |
| Doc PR | n/a |

Trying to reduce the number of required dependencies on FrameworkBundle. This PR removes the Asset component from the list.
