### PR TITLE
[FrameworkBundle] removed the Translation component dependency on FrameworkBundle

### DIFF
--- a/UPGRADE-3.2.md
+++ b/UPGRADE-3.2.md
@@ -4,6 +4,9 @@ UPGRADE FROM 3.1 to 3.2
 FrameworkBundle
 ---------------
 
+ * The `symfony/translation` dependency has been removed; require it via `composer
+   require symfony/translation` if you depend on it and don't already depend on
+   `symfony/symfony`
  * The `symfony/asset` dependency has been removed; require it via `composer
    require symfony/asset` if you depend on it and don't already depend on
    `symfony/symfony`

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 3.2.0
 -----
 
+ * Removed `symfony/translation` from the list of required dependencies in `composer.json`
  * Removed `symfony/asset` from the list of required dependencies in `composer.json`
  * The `Resources/public/images/*` files have been removed.
  * The `Resources/public/css/*.css` files have been removed (they are now inlined in TwigBundle).

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -87,6 +87,18 @@ EOF
     /**
      * {@inheritdoc}
      */
+    public function isEnabled()
+    {
+        if (!class_exists('Symfony\Component\Translation\Translator')) {
+            return false;
+        }
+
+        return parent::isEnabled();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $io = new SymfonyStyle($input, $output);

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -69,6 +69,18 @@ EOF
     /**
      * {@inheritdoc}
      */
+    public function isEnabled()
+    {
+        if (!class_exists('Symfony\Component\Translation\Translator')) {
+            return false;
+        }
+
+        return parent::isEnabled();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $io = new SymfonyStyle($input, $output);

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -70,11 +70,6 @@ class FrameworkExtension extends Extension
         $loader->load('services.xml');
         $loader->load('fragment_renderer.xml');
 
-        // A translator must always be registered (as support is included by
-        // default in the Form component). If disabled, an identity translator
-        // will be used and everything will still work as expected.
-        $loader->load('translation.xml');
-
         // Property access is used by both the Form and the Validator component
         $loader->load('property_access.xml');
 
@@ -83,6 +78,17 @@ class FrameworkExtension extends Extension
 
         $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
+
+        // A translator must always be registered (as support is included by
+        // default in the Form component). If disabled, an identity translator
+        // will be used and everything will still work as expected.
+        if (class_exists('Symfony\Component\Translation\Translator') || $this->isConfigEnabled($container, $config['form'])) {
+            if (!class_exists('Symfony\Component\Translation\Translator')) {
+                throw new LogicException('Form support cannot be enabled as the Translation component is not installed.');
+            }
+
+            $loader->load('translation.xml');
+        }
 
         if (isset($config['secret'])) {
             $container->setParameter('kernel.secret', $config['secret']);
@@ -762,6 +768,11 @@ class FrameworkExtension extends Extension
         if (!$this->isConfigEnabled($container, $config)) {
             return;
         }
+
+        if (!class_exists('Symfony\Component\Translation\Translator')) {
+            throw new LogicException('Translation support cannot be enabled as the Translator component is not installed.');
+        }
+
         $this->translationConfigEnabled = true;
 
         // Use the "real" translator instead of the identity default

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -85,8 +85,10 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new AddCacheWarmerPass());
         $container->addCompilerPass(new AddCacheClearerPass());
         $container->addCompilerPass(new AddExpressionLanguageProvidersPass());
-        $container->addCompilerPass(new TranslationExtractorPass());
-        $container->addCompilerPass(new TranslationDumperPass());
+        if (class_exists('Symfony\Component\Translation\Translator')) {
+            $container->addCompilerPass(new TranslationExtractorPass());
+            $container->addCompilerPass(new TranslationDumperPass());
+        }
         $container->addCompilerPass(new FragmentRendererPass(), PassConfig::TYPE_AFTER_REMOVING);
         $container->addCompilerPass(new SerializerPass());
         $container->addCompilerPass(new PropertyInfoPass());

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
@@ -131,5 +131,11 @@
             <argument type="service" id="translator" />
             <tag name="kernel.cache_warmer" />
         </service>
+
+        <service id="translator_listener" class="Symfony\Component\HttpKernel\EventListener\TranslatorListener">
+            <argument type="service" id="translator" />
+            <argument type="service" id="request_stack" />
+            <tag name="kernel.event_subscriber" />
+        </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
@@ -56,12 +56,6 @@
             <argument type="service" id="router" on-invalid="ignore" />
         </service>
 
-        <service id="translator_listener" class="Symfony\Component\HttpKernel\EventListener\TranslatorListener">
-            <argument type="service" id="translator" />
-            <argument type="service" id="request_stack" />
-            <tag name="kernel.event_subscriber" />
-        </service>
-
         <service id="validate_request_listener" class="Symfony\Component\HttpKernel\EventListener\ValidateRequestListener">
             <tag name="kernel.event_subscriber" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -32,7 +32,6 @@
         "symfony/security-csrf": "~2.8|~3.0",
         "symfony/stopwatch": "~2.8|~3.0",
         "symfony/templating": "~2.8|~3.0",
-        "symfony/translation": "~2.8|~3.0",
         "doctrine/cache": "~1.0",
         "doctrine/annotations": "~1.0"
     },
@@ -48,6 +47,7 @@
         "symfony/expression-language": "~2.8|~3.0",
         "symfony/process": "~2.8|~3.0",
         "symfony/serializer": "~2.8|~3.0",
+        "symfony/translation": "~2.8|~3.0",
         "symfony/validator": "~3.2",
         "symfony/yaml": "~3.2",
         "symfony/property-info": "~2.8|~3.0",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no (except for people using FrameworkBundle without requiring symfony/symfony which should be pretty rare; and fixing this is easy by adding symfony/translation explicitly) |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15748 partially |
| License | MIT |
| Doc PR | n/a |

Another PR to reduce the number of required dependencies on FrameworkBundle. This PR removes the Translation component from the list.
