### PR TITLE
[FrameworkBundle] removed the Templating component dependency on FrameworkBundle

### DIFF
--- a/UPGRADE-3.2.md
+++ b/UPGRADE-3.2.md
@@ -4,6 +4,9 @@ UPGRADE FROM 3.1 to 3.2
 FrameworkBundle
 ---------------
 
+ * The `symfony/templating` dependency has been removed; require it via `composer
+   require symfony/templating` if you depend on it and don't already depend on
+   `symfony/symfony`
  * The `symfony/asset` dependency has been removed; require it via `composer
    require symfony/asset` if you depend on it and don't already depend on
    `symfony/symfony`

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 3.2.0
 -----
 
+ * Removed `symfony/templating` from the list of required dependencies in `composer.json`
  * Removed `symfony/asset` from the list of required dependencies in `composer.json`
  * The `Resources/public/images/*` files have been removed.
  * The `Resources/public/css/*.css` files have been removed (they are now inlined in TwigBundle).

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -142,6 +142,10 @@ class FrameworkExtension extends Extension
         }
 
         if ($this->isConfigEnabled($container, $config['templating'])) {
+            if (!class_exists('Symfony\Component\Templating\PhpEngine')) {
+                throw new LogicException('Templating support cannot be enabled as the Templating component is not installed.');
+            }
+
             $this->registerTemplatingConfiguration($config['templating'], $container, $loader);
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -31,7 +31,6 @@
         "symfony/security-core": "~3.2",
         "symfony/security-csrf": "~2.8|~3.0",
         "symfony/stopwatch": "~2.8|~3.0",
-        "symfony/templating": "~2.8|~3.0",
         "symfony/translation": "~2.8|~3.0",
         "doctrine/cache": "~1.0",
         "doctrine/annotations": "~1.0"
@@ -48,6 +47,7 @@
         "symfony/expression-language": "~2.8|~3.0",
         "symfony/process": "~2.8|~3.0",
         "symfony/serializer": "~2.8|~3.0",
+        "symfony/templating": "~2.8|~3.0",
         "symfony/validator": "~3.2",
         "symfony/yaml": "~3.2",
         "symfony/property-info": "~2.8|~3.0",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no (except for people using FrameworkBundle without requiring symfony/symfony which should be pretty rare; and fixing this is easy by adding symfony/templating explicitly) |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15748 partially |
| License | MIT |
| Doc PR | n/a |

Another PR to reduce the number of required dependencies on FrameworkBundle. This PR removes the Templating component from the list.

I made most of the work in previous version, so this change is really just about adding a good error message when templating is not enabled. For the record, this is also in the path of making possible to use Symfony with Twig without using the Templating component indirection (I think that this is in fact the last step).
