### PR TITLE
[Routing] PhpDumper should follow coding standards

### DIFF
--- a/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
+++ b/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
@@ -93,11 +93,16 @@ EOF;
             $properties[] = $compiledRoute->getHostTokens();
             $properties[] = $route->getSchemes();
 
-            $routes .= sprintf("        '%s' => %s,\n", $name, str_replace("\n", '', var_export($properties, true)));
+            $routes .= sprintf("                '%s' => %s,\n", $name, $this->exportArray($properties));
         }
-        $routes .= '    )';
+        $routes .= '            )';
 
         return $routes;
+    }
+
+    protected function exportArray($array)
+    {
+        return preg_replace(array('/array \(/', '/,\n *\)/', '/,\n */', '/\n */'), array('array(', ')', ', ', ''), var_export($array, true));
     }
 
     /**

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
@@ -29,7 +29,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
         // foo
         if (0 === strpos($pathinfo, '/foo') && preg_match('#^/foo/(?P<bar>baz|symfony)$#s', $pathinfo, $matches)) {
-            return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo')), array (  'def' => 'test',));
+            return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo')), array('def' => 'test'));
         }
 
         if (0 === strpos($pathinfo, '/bar')) {
@@ -40,7 +40,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                     goto not_bar;
                 }
 
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar')), array ());
+                return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar')), array());
             }
             not_bar:
 
@@ -51,10 +51,9 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                     goto not_barhead;
                 }
 
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'barhead')), array ());
+                return $this->mergeDefaults(array_replace($matches, array('_route' => 'barhead')), array());
             }
             not_barhead:
-
         }
 
         if (0 === strpos($pathinfo, '/test')) {
@@ -73,12 +72,11 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                 if ($pathinfo === '/test/baz3/') {
                     return array('_route' => 'baz3');
                 }
-
             }
 
             // baz4
             if (preg_match('#^/test/(?P<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'baz4')), array ());
+                return $this->mergeDefaults(array_replace($matches, array('_route' => 'baz4')), array());
             }
 
             // baz5
@@ -88,7 +86,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                     goto not_baz5;
                 }
 
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'baz5')), array ());
+                return $this->mergeDefaults(array_replace($matches, array('_route' => 'baz5')), array());
             }
             not_baz5:
 
@@ -99,20 +97,19 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                     goto not_bazbaz6;
                 }
 
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'baz.baz6')), array ());
+                return $this->mergeDefaults(array_replace($matches, array('_route' => 'baz.baz6')), array());
             }
             not_bazbaz6:
-
         }
 
         // foofoo
         if ($pathinfo === '/foofoo') {
-            return array (  'def' => 'test',  '_route' => 'foofoo',);
+            return array('def' => 'test', '_route' => 'foofoo');
         }
 
         // quoter
         if (preg_match('#^/(?P<quoter>[\']+)$#s', $pathinfo, $matches)) {
-            return $this->mergeDefaults(array_replace($matches, array('_route' => 'quoter')), array ());
+            return $this->mergeDefaults(array_replace($matches, array('_route' => 'quoter')), array());
         }
 
         // space
@@ -124,40 +121,37 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
             if (0 === strpos($pathinfo, '/a/b\'b')) {
                 // foo1
                 if (preg_match('#^/a/b\'b/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo1')), array ());
+                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo1')), array());
                 }
 
                 // bar1
                 if (preg_match('#^/a/b\'b/(?P<bar>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar1')), array ());
+                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar1')), array());
                 }
-
             }
 
             // overridden
             if (preg_match('#^/a/(?P<var>.*)$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'overridden')), array ());
+                return $this->mergeDefaults(array_replace($matches, array('_route' => 'overridden')), array());
             }
 
             if (0 === strpos($pathinfo, '/a/b\'b')) {
                 // foo2
                 if (preg_match('#^/a/b\'b/(?P<foo1>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo2')), array ());
+                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo2')), array());
                 }
 
                 // bar2
                 if (preg_match('#^/a/b\'b/(?P<bar1>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar2')), array ());
+                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar2')), array());
                 }
-
             }
-
         }
 
         if (0 === strpos($pathinfo, '/multi')) {
             // helloWorld
             if (0 === strpos($pathinfo, '/multi/hello') && preg_match('#^/multi/hello(?:/(?P<who>[^/]++))?$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'helloWorld')), array (  'who' => 'World!',));
+                return $this->mergeDefaults(array_replace($matches, array('_route' => 'helloWorld')), array('who' => 'World!'));
             }
 
             // overridden2
@@ -169,17 +163,16 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
             if ($pathinfo === '/multi/hey/') {
                 return array('_route' => 'hey');
             }
-
         }
 
         // foo3
         if (preg_match('#^/(?P<_locale>[^/]++)/b/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-            return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo3')), array ());
+            return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo3')), array());
         }
 
         // bar3
         if (preg_match('#^/(?P<_locale>[^/]++)/b/(?P<bar>[^/]++)$#s', $pathinfo, $matches)) {
-            return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar3')), array ());
+            return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar3')), array());
         }
 
         if (0 === strpos($pathinfo, '/aba')) {
@@ -190,9 +183,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
             // foo4
             if (preg_match('#^/aba/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo4')), array ());
+                return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo4')), array());
             }
-
         }
 
         $host = $this->context->getHost();
@@ -207,7 +199,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
             if ($pathinfo === '/c2/route2') {
                 return array('_route' => 'route2');
             }
-
         }
 
         if (preg_match('#^b\\.example\\.com$#si', $host, $hostMatches)) {
@@ -215,7 +206,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
             if ($pathinfo === '/c2/route3') {
                 return array('_route' => 'route3');
             }
-
         }
 
         if (preg_match('#^a\\.example\\.com$#si', $host, $hostMatches)) {
@@ -223,7 +213,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
             if ($pathinfo === '/route4') {
                 return array('_route' => 'route4');
             }
-
         }
 
         if (preg_match('#^c\\.example\\.com$#si', $host, $hostMatches)) {
@@ -231,7 +220,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
             if ($pathinfo === '/route5') {
                 return array('_route' => 'route5');
             }
-
         }
 
         // route6
@@ -243,47 +231,43 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
             if (0 === strpos($pathinfo, '/route1')) {
                 // route11
                 if ($pathinfo === '/route11') {
-                    return $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route11')), array ());
+                    return $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route11')), array());
                 }
 
                 // route12
                 if ($pathinfo === '/route12') {
-                    return $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route12')), array (  'var1' => 'val',));
+                    return $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route12')), array('var1' => 'val'));
                 }
 
                 // route13
                 if (0 === strpos($pathinfo, '/route13') && preg_match('#^/route13/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($hostMatches, $matches, array('_route' => 'route13')), array ());
+                    return $this->mergeDefaults(array_replace($hostMatches, $matches, array('_route' => 'route13')), array());
                 }
 
                 // route14
                 if (0 === strpos($pathinfo, '/route14') && preg_match('#^/route14/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($hostMatches, $matches, array('_route' => 'route14')), array (  'var1' => 'val',));
+                    return $this->mergeDefaults(array_replace($hostMatches, $matches, array('_route' => 'route14')), array('var1' => 'val'));
                 }
-
             }
-
         }
 
         if (preg_match('#^c\\.example\\.com$#si', $host, $hostMatches)) {
             // route15
             if (0 === strpos($pathinfo, '/route15') && preg_match('#^/route15/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'route15')), array ());
+                return $this->mergeDefaults(array_replace($matches, array('_route' => 'route15')), array());
             }
-
         }
 
         if (0 === strpos($pathinfo, '/route1')) {
             // route16
             if (0 === strpos($pathinfo, '/route16') && preg_match('#^/route16/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'route16')), array (  'var1' => 'val',));
+                return $this->mergeDefaults(array_replace($matches, array('_route' => 'route16')), array('var1' => 'val'));
             }
 
             // route17
             if ($pathinfo === '/route17') {
                 return array('_route' => 'route17');
             }
-
         }
 
         if (0 === strpos($pathinfo, '/a')) {
@@ -295,16 +279,14 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
             if (0 === strpos($pathinfo, '/a/b')) {
                 // b
                 if (preg_match('#^/a/b/(?P<var>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'b')), array ());
+                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'b')), array());
                 }
 
                 // c
                 if (0 === strpos($pathinfo, '/a/b/c') && preg_match('#^/a/b/c/(?P<var>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'c')), array ());
+                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'c')), array());
                 }
-
             }
-
         }
 
         throw 0 < count($allow) ? new MethodNotAllowedException(array_unique($allow)) : new ResourceNotFoundException();

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
@@ -29,7 +29,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
         // foo
         if (0 === strpos($pathinfo, '/foo') && preg_match('#^/foo/(?P<bar>baz|symfony)$#s', $pathinfo, $matches)) {
-            return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo')), array (  'def' => 'test',));
+            return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo')), array('def' => 'test'));
         }
 
         if (0 === strpos($pathinfo, '/bar')) {
@@ -40,7 +40,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                     goto not_bar;
                 }
 
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar')), array ());
+                return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar')), array());
             }
             not_bar:
 
@@ -51,10 +51,9 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                     goto not_barhead;
                 }
 
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'barhead')), array ());
+                return $this->mergeDefaults(array_replace($matches, array('_route' => 'barhead')), array());
             }
             not_barhead:
-
         }
 
         if (0 === strpos($pathinfo, '/test')) {
@@ -77,7 +76,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
                     return array('_route' => 'baz3');
                 }
-
             }
 
             // baz4
@@ -86,7 +84,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                     return $this->redirect($pathinfo.'/', 'baz4');
                 }
 
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'baz4')), array ());
+                return $this->mergeDefaults(array_replace($matches, array('_route' => 'baz4')), array());
             }
 
             // baz5
@@ -96,7 +94,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                     goto not_baz5;
                 }
 
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'baz5')), array ());
+                return $this->mergeDefaults(array_replace($matches, array('_route' => 'baz5')), array());
             }
             not_baz5:
 
@@ -107,20 +105,19 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                     goto not_bazbaz6;
                 }
 
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'baz.baz6')), array ());
+                return $this->mergeDefaults(array_replace($matches, array('_route' => 'baz.baz6')), array());
             }
             not_bazbaz6:
-
         }
 
         // foofoo
         if ($pathinfo === '/foofoo') {
-            return array (  'def' => 'test',  '_route' => 'foofoo',);
+            return array('def' => 'test', '_route' => 'foofoo');
         }
 
         // quoter
         if (preg_match('#^/(?P<quoter>[\']+)$#s', $pathinfo, $matches)) {
-            return $this->mergeDefaults(array_replace($matches, array('_route' => 'quoter')), array ());
+            return $this->mergeDefaults(array_replace($matches, array('_route' => 'quoter')), array());
         }
 
         // space
@@ -132,40 +129,37 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
             if (0 === strpos($pathinfo, '/a/b\'b')) {
                 // foo1
                 if (preg_match('#^/a/b\'b/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo1')), array ());
+                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo1')), array());
                 }
 
                 // bar1
                 if (preg_match('#^/a/b\'b/(?P<bar>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar1')), array ());
+                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar1')), array());
                 }
-
             }
 
             // overridden
             if (preg_match('#^/a/(?P<var>.*)$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'overridden')), array ());
+                return $this->mergeDefaults(array_replace($matches, array('_route' => 'overridden')), array());
             }
 
             if (0 === strpos($pathinfo, '/a/b\'b')) {
                 // foo2
                 if (preg_match('#^/a/b\'b/(?P<foo1>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo2')), array ());
+                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo2')), array());
                 }
 
                 // bar2
                 if (preg_match('#^/a/b\'b/(?P<bar1>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar2')), array ());
+                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar2')), array());
                 }
-
             }
-
         }
 
         if (0 === strpos($pathinfo, '/multi')) {
             // helloWorld
             if (0 === strpos($pathinfo, '/multi/hello') && preg_match('#^/multi/hello(?:/(?P<who>[^/]++))?$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'helloWorld')), array (  'who' => 'World!',));
+                return $this->mergeDefaults(array_replace($matches, array('_route' => 'helloWorld')), array('who' => 'World!'));
             }
 
             // overridden2
@@ -181,17 +175,16 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
                 return array('_route' => 'hey');
             }
-
         }
 
         // foo3
         if (preg_match('#^/(?P<_locale>[^/]++)/b/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-            return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo3')), array ());
+            return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo3')), array());
         }
 
         // bar3
         if (preg_match('#^/(?P<_locale>[^/]++)/b/(?P<bar>[^/]++)$#s', $pathinfo, $matches)) {
-            return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar3')), array ());
+            return $this->mergeDefaults(array_replace($matches, array('_route' => 'bar3')), array());
         }
 
         if (0 === strpos($pathinfo, '/aba')) {
@@ -202,9 +195,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
             // foo4
             if (preg_match('#^/aba/(?P<foo>[^/]++)$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo4')), array ());
+                return $this->mergeDefaults(array_replace($matches, array('_route' => 'foo4')), array());
             }
-
         }
 
         $host = $this->context->getHost();
@@ -219,7 +211,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
             if ($pathinfo === '/c2/route2') {
                 return array('_route' => 'route2');
             }
-
         }
 
         if (preg_match('#^b\\.example\\.com$#si', $host, $hostMatches)) {
@@ -227,7 +218,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
             if ($pathinfo === '/c2/route3') {
                 return array('_route' => 'route3');
             }
-
         }
 
         if (preg_match('#^a\\.example\\.com$#si', $host, $hostMatches)) {
@@ -235,7 +225,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
             if ($pathinfo === '/route4') {
                 return array('_route' => 'route4');
             }
-
         }
 
         if (preg_match('#^c\\.example\\.com$#si', $host, $hostMatches)) {
@@ -243,7 +232,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
             if ($pathinfo === '/route5') {
                 return array('_route' => 'route5');
             }
-
         }
 
         // route6
@@ -255,47 +243,43 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
             if (0 === strpos($pathinfo, '/route1')) {
                 // route11
                 if ($pathinfo === '/route11') {
-                    return $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route11')), array ());
+                    return $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route11')), array());
                 }
 
                 // route12
                 if ($pathinfo === '/route12') {
-                    return $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route12')), array (  'var1' => 'val',));
+                    return $this->mergeDefaults(array_replace($hostMatches, array('_route' => 'route12')), array('var1' => 'val'));
                 }
 
                 // route13
                 if (0 === strpos($pathinfo, '/route13') && preg_match('#^/route13/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($hostMatches, $matches, array('_route' => 'route13')), array ());
+                    return $this->mergeDefaults(array_replace($hostMatches, $matches, array('_route' => 'route13')), array());
                 }
 
                 // route14
                 if (0 === strpos($pathinfo, '/route14') && preg_match('#^/route14/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($hostMatches, $matches, array('_route' => 'route14')), array (  'var1' => 'val',));
+                    return $this->mergeDefaults(array_replace($hostMatches, $matches, array('_route' => 'route14')), array('var1' => 'val'));
                 }
-
             }
-
         }
 
         if (preg_match('#^c\\.example\\.com$#si', $host, $hostMatches)) {
             // route15
             if (0 === strpos($pathinfo, '/route15') && preg_match('#^/route15/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'route15')), array ());
+                return $this->mergeDefaults(array_replace($matches, array('_route' => 'route15')), array());
             }
-
         }
 
         if (0 === strpos($pathinfo, '/route1')) {
             // route16
             if (0 === strpos($pathinfo, '/route16') && preg_match('#^/route16/(?P<name>[^/]++)$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'route16')), array (  'var1' => 'val',));
+                return $this->mergeDefaults(array_replace($matches, array('_route' => 'route16')), array('var1' => 'val'));
             }
 
             // route17
             if ($pathinfo === '/route17') {
                 return array('_route' => 'route17');
             }
-
         }
 
         if (0 === strpos($pathinfo, '/a')) {
@@ -307,21 +291,19 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
             if (0 === strpos($pathinfo, '/a/b')) {
                 // b
                 if (preg_match('#^/a/b/(?P<var>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'b')), array ());
+                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'b')), array());
                 }
 
                 // c
                 if (0 === strpos($pathinfo, '/a/b/c') && preg_match('#^/a/b/c/(?P<var>[^/]++)$#s', $pathinfo, $matches)) {
-                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'c')), array ());
+                    return $this->mergeDefaults(array_replace($matches, array('_route' => 'c')), array());
                 }
-
             }
-
         }
 
         // secure
         if ($pathinfo === '/secure') {
-            $requiredSchemes = array (  'https' => 0,);
+            $requiredSchemes = array('https' => 0);
             if (!isset($requiredSchemes[$this->context->getScheme()])) {
                 return $this->redirect($pathinfo, 'secure', key($requiredSchemes));
             }
@@ -331,7 +313,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
         // nonsecure
         if ($pathinfo === '/nonsecure') {
-            $requiredSchemes = array (  'http' => 0,);
+            $requiredSchemes = array('http' => 0);
             if (!isset($requiredSchemes[$this->context->getScheme()])) {
                 return $this->redirect($pathinfo, 'nonsecure', key($requiredSchemes));
             }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
@@ -35,9 +35,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
             // dynamic
             if (preg_match('#^/rootprefix/(?P<var>[^/]++)$#s', $pathinfo, $matches)) {
-                return $this->mergeDefaults(array_replace($matches, array('_route' => 'dynamic')), array ());
+                return $this->mergeDefaults(array_replace($matches, array('_route' => 'dynamic')), array());
             }
-
         }
 
         // with-condition


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

While working on #19562 I noticed that Fabbot does not like the PHP code generated by the `PhpGeneratorDumper` and `PhpMatcherDumper`.

This patch makes the generated code comply with Symfony's conding standards.
