### PR TITLE
[2.7][Console] consistent application help with 3.2

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -172,7 +172,7 @@ class Application
         if (true === $input->hasParameterOption(array('--help', '-h'))) {
             if (!$name) {
                 $name = 'help';
-                $input = new ArrayInput(array('command' => 'help'));
+                $input = new ArrayInput(array('command_name' => $this->defaultCommand));
             } else {
                 $this->wantHelps = true;
             }

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run2.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run2.txt
@@ -1,29 +1,27 @@
 Usage:
-  help [options] [--] [<command_name>]
+  list [options] [--] [<namespace>]
 
 Arguments:
-  command               The command to execute
-  command_name          The command name [default: "help"]
+  namespace            The namespace name
 
 Options:
-      --xml             To output help as XML
-      --format=FORMAT   The output format (txt, xml, json, or md) [default: "txt"]
-      --raw             To output raw command help
-  -h, --help            Display this help message
-  -q, --quiet           Do not output any message
-  -V, --version         Display this application version
-      --ansi            Force ANSI output
-      --no-ansi         Disable ANSI output
-  -n, --no-interaction  Do not ask any interactive question
-  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+      --xml            To output list as XML
+      --raw            To output raw command list
+      --format=FORMAT  The output format (txt, xml, json, or md) [default: "txt"]
 
 Help:
-  The help command displays help for a given command:
+  The list command lists all commands:
   
-    php app/console help list
+    php app/console list
   
-  You can also output the help in other formats by using the --format option:
+  You can also display the commands for a specific namespace:
   
-    php app/console help --format=xml list
+    php app/console list test
   
-  To display the list of available commands, please use the list command.
+  You can also output the information in other formats by using the --format option:
+  
+    php app/console list --format=xml
+  
+  It's also possible to get raw list of commands (useful for embedding command runner):
+  
+    php app/console list --raw


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17804, #19181, partially #20030 |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

Fix from #16906 that should have targeted 2.7 as well imo.

**2.7 / before**

```
$ app/console -h
Usage:
  help [options] [--] [<command_name>]
  ^ list is the default command...
Arguments:
  command                  The command to execute
  ^ The problem
  command_name             The command name [default: "help"]

Options:
      --xml                To output help as XML
      --format=FORMAT      The output format (txt, xml, json, or md) [default: "txt"]
      --raw                To output raw command help
  -h, --help               Display this help message
  -q, --quiet              Do not output any message
  -V, --version            Display this application version
      --ansi               Force ANSI output
      --no-ansi            Disable ANSI output
  -n, --no-interaction     Do not ask any interactive question
  -s, --shell              Launch the shell.
      --process-isolation  Launch commands from shell as a separate process.
  -e, --env=ENV            The Environment name. [default: "dev"]
      --no-debug           Switches off debug mode.
  -v|vv|vvv, --verbose     Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
```

**2.7 / after**

```
$ app/console -h
Usage:
  list [options] [--] [<namespace>]

Arguments:
  namespace            The namespace name

Options:
      --xml            To output list as XML
      --raw            To output raw command list
      --format=FORMAT  The output format (txt, xml, json, or md) [default: "txt"]
```

**master / current**

```
$ bin/console -h
Usage:
  list [options] [--] [<namespace>]

Arguments:
  namespace            The namespace name

Options:
      --raw            To output raw command list
      --format=FORMAT  The output format (txt, xml, json, or md) [default: "txt"]
```

Also shows the problem with `ListCommand::getNativeDefinition` as now the options are incorrect. Fixed that in #20054.. so these should probably both go on 2.7.

Hopes this makes it clear.
