### PR TITLE
added Twig runtimes for "critical" Twig extensions

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/HttpKernelExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/HttpKernelExtension.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Bridge\Twig\Extension;
 
-use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 
 /**
@@ -21,62 +20,16 @@ use Symfony\Component\HttpKernel\Controller\ControllerReference;
  */
 class HttpKernelExtension extends \Twig_Extension
 {
-    private $handler;
-
-    /**
-     * Constructor.
-     *
-     * @param FragmentHandler $handler A FragmentHandler instance
-     */
-    public function __construct(FragmentHandler $handler)
-    {
-        $this->handler = $handler;
-    }
-
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFunction('render', array($this, 'renderFragment'), array('is_safe' => array('html'))),
-            new \Twig_SimpleFunction('render_*', array($this, 'renderFragmentStrategy'), array('is_safe' => array('html'))),
-            new \Twig_SimpleFunction('controller', array($this, 'controller')),
+            new \Twig_SimpleFunction('render', array(HttpKernelRuntime::class, 'renderFragment'), array('is_safe' => array('html'))),
+            new \Twig_SimpleFunction('render_*', array(HttpKernelRuntime::class, 'renderFragmentStrategy'), array('is_safe' => array('html'))),
+            new \Twig_SimpleFunction('controller', HttpKernelRuntime::class.'::controller'),
         );
     }
 
-    /**
-     * Renders a fragment.
-     *
-     * @param string|ControllerReference $uri     A URI as a string or a ControllerReference instance
-     * @param array                      $options An array of options
-     *
-     * @return string The fragment content
-     *
-     * @see FragmentHandler::render()
-     */
-    public function renderFragment($uri, $options = array())
-    {
-        $strategy = isset($options['strategy']) ? $options['strategy'] : 'inline';
-        unset($options['strategy']);
-
-        return $this->handler->render($uri, $strategy, $options);
-    }
-
-    /**
-     * Renders a fragment.
-     *
-     * @param string                     $strategy A strategy name
-     * @param string|ControllerReference $uri      A URI as a string or a ControllerReference instance
-     * @param array                      $options  An array of options
-     *
-     * @return string The fragment content
-     *
-     * @see FragmentHandler::render()
-     */
-    public function renderFragmentStrategy($strategy, $uri, $options = array())
-    {
-        return $this->handler->render($uri, $strategy, $options);
-    }
-
-    public function controller($controller, $attributes = array(), $query = array())
+    public static function controller($controller, $attributes = array(), $query = array())
     {
         return new ControllerReference($controller, $attributes, $query);
     }

--- a/src/Symfony/Bridge/Twig/Extension/HttpKernelRuntime.php
+++ b/src/Symfony/Bridge/Twig/Extension/HttpKernelRuntime.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\Extension;
+
+use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+
+/**
+ * Provides integration with the HttpKernel component.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class HttpKernelRuntime
+{
+    private $handler;
+
+    public function __construct(FragmentHandler $handler)
+    {
+        $this->handler = $handler;
+    }
+
+    /**
+     * Renders a fragment.
+     *
+     * @param string|ControllerReference $uri     A URI as a string or a ControllerReference instance
+     * @param array                      $options An array of options
+     *
+     * @return string The fragment content
+     *
+     * @see FragmentHandler::render()
+     */
+    public function renderFragment($uri, $options = array())
+    {
+        $strategy = isset($options['strategy']) ? $options['strategy'] : 'inline';
+        unset($options['strategy']);
+
+        return $this->handler->render($uri, $strategy, $options);
+    }
+
+    /**
+     * Renders a fragment.
+     *
+     * @param string                     $strategy A strategy name
+     * @param string|ControllerReference $uri      A URI as a string or a ControllerReference instance
+     * @param array                      $options  An array of options
+     *
+     * @return string The fragment content
+     *
+     * @see FragmentHandler::render()
+     */
+    public function renderFragmentStrategy($strategy, $uri, $options = array())
+    {
+        return $this->handler->render($uri, $strategy, $options);
+    }
+}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Twig\Tests\Extension;
 
 use Symfony\Bridge\Twig\Extension\HttpKernelExtension;
+use Symfony\Bridge\Twig\Extension\HttpKernelRuntime;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
@@ -71,7 +72,13 @@ class HttpKernelExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $loader = new \Twig_Loader_Array(array('index' => $template));
         $twig = new \Twig_Environment($loader, array('debug' => true, 'cache' => false));
-        $twig->addExtension(new HttpKernelExtension($renderer));
+        $twig->addExtension(new HttpKernelExtension());
+
+        $loader = $this->getMock('Twig_RuntimeLoaderInterface');
+        $loader->expects($this->any())->method('load')->will($this->returnValueMap(array(
+            array('Symfony\Bridge\Twig\Extension\HttpKernelRuntime', new HttpKernelRuntime($renderer)),
+        )));
+        $twig->addRuntimeLoader($loader);
 
         return $twig->render('index');
     }

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
@@ -79,5 +79,9 @@ class ExtensionPass implements CompilerPassInterface
         if (class_exists('Symfony\Component\Stopwatch\Stopwatch')) {
             $container->getDefinition('twig.extension.debug.stopwatch')->addTag('twig.extension');
         }
+
+        if (class_exists('Symfony\Component\ExpressionLanguage\ExpressionLanguage')) {
+            $container->getDefinition('twig.extension.expression')->addTag('twig.extension');
+        }
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
@@ -75,5 +75,9 @@ class ExtensionPass implements CompilerPassInterface
         if (class_exists('Symfony\Component\Yaml\Parser')) {
             $container->getDefinition('twig.extension.yaml')->addTag('twig.extension');
         }
+
+        if (class_exists('Symfony\Component\Stopwatch\Stopwatch')) {
+            $container->getDefinition('twig.extension.debug.stopwatch')->addTag('twig.extension');
+        }
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
@@ -71,5 +71,9 @@ class ExtensionPass implements CompilerPassInterface
         if ($container->has('assets.packages')) {
             $container->getDefinition('twig.extension.assets')->addTag('twig.extension');
         }
+
+        if (class_exists('Symfony\Component\Yaml\Parser')) {
+            $container->getDefinition('twig.extension.yaml')->addTag('twig.extension');
+        }
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -104,8 +104,11 @@
 
         <service id="twig.extension.expression" class="Symfony\Bridge\Twig\Extension\ExpressionExtension" public="false" />
 
-        <service id="twig.extension.httpkernel" class="Symfony\Bridge\Twig\Extension\HttpKernelExtension" public="false">
+        <service id="twig.extension.httpkernel" class="Symfony\Bridge\Twig\Extension\HttpKernelExtension" public="false" />
+
+        <service id="twig.runtime.httpkernel" class="Symfony\Bridge\Twig\Extension\HttpKernelRuntime">
             <argument type="service" id="fragment.handler" />
+            <tag name="twig.runtime" />
         </service>
 
         <service id="twig.extension.httpfoundation" class="Symfony\Bridge\Twig\Extension\HttpFoundationExtension" public="false">

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -98,7 +98,6 @@
         <service id="twig.extension.yaml" class="Symfony\Bridge\Twig\Extension\YamlExtension" public="false" />
 
         <service id="twig.extension.debug.stopwatch" class="Symfony\Bridge\Twig\Extension\StopwatchExtension" public="false">
-            <tag name="twig.extension" />
             <argument type="service" id="debug.stopwatch" on-invalid="ignore" />
             <argument>%kernel.debug%</argument>
         </service>

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -95,9 +95,7 @@
             <argument type="service" id="router" />
         </service>
 
-        <service id="twig.extension.yaml" class="Symfony\Bridge\Twig\Extension\YamlExtension" public="false">
-            <tag name="twig.extension" />
-        </service>
+        <service id="twig.extension.yaml" class="Symfony\Bridge\Twig\Extension\YamlExtension" public="false" />
 
         <service id="twig.extension.debug.stopwatch" class="Symfony\Bridge\Twig\Extension\StopwatchExtension" public="false">
             <tag name="twig.extension" />

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -102,9 +102,7 @@
             <argument>%kernel.debug%</argument>
         </service>
 
-        <service id="twig.extension.expression" class="Symfony\Bridge\Twig\Extension\ExpressionExtension" public="false">
-            <tag name="twig.extension" />
-        </service>
+        <service id="twig.extension.expression" class="Symfony\Bridge\Twig\Extension\ExpressionExtension" public="false" />
 
         <service id="twig.extension.httpkernel" class="Symfony\Bridge\Twig\Extension\HttpKernelExtension" public="false">
             <argument type="service" id="fragment.handler" />

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
@@ -230,10 +230,11 @@ class TwigExtensionTest extends TestCase
         $container->compile();
 
         $loader = $container->getDefinition('twig.runtime_loader');
-        $this->assertEquals(array(
-            'Symfony\Bridge\Twig\Form\TwigRenderer' => 'twig.form.renderer',
-            'FooClass' => 'foo',
-        ), $loader->getArgument(1));
+        $args = $loader->getArgument(1);
+        $this->assertArrayHasKey('Symfony\Bridge\Twig\Form\TwigRenderer', $args);
+        $this->assertArrayHasKey('FooClass', $args);
+        $this->assertContains('twig.form.renderer', $args);
+        $this->assertContains('foo', $args);
     }
 
     private function createContainer()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This PR converts some Twig extensions to use a separate runtime. It also contains some optimizations to not load extensions when the associated component is not installed.
