### PR TITLE
[FrameworkBundle] removed the Doctrine Annotations lib dependency on FrameworkBundle

### DIFF
--- a/UPGRADE-3.2.md
+++ b/UPGRADE-3.2.md
@@ -4,6 +4,8 @@ UPGRADE FROM 3.1 to 3.2
 FrameworkBundle
 ---------------
 
+ * The `doctrine/annotations` dependency has been removed; require it via `composer
+   require doctrine/annotations` if you are using annotations in your project
  * The `symfony/security-core` and `symfony/security-csrf` dependencies have
    been removed; require them via `composer require symfony/security-core
    symfony/security-csrf` if you depend on them and don't already depend on

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 3.2.0
 -----
 
+ * Removed `doctrine/annotations` from the list of required dependencies in `composer.json`
  * Removed `symfony/security-core` and `symfony/security-csrf` from the list of required dependencies in `composer.json`
  * Removed `symfony/templating` from the list of required dependencies in `composer.json`
  * Removed `symfony/translation` from the list of required dependencies in `composer.json`

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -593,7 +593,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->arrayNode('annotations')
                     ->info('annotation configuration')
-                    ->addDefaultsIfNotSet()
+                    ->canBeDisabled()
                     ->children()
                         ->scalarNode('cache')->defaultValue('php_array')->end()
                         ->scalarNode('file_cache_dir')->defaultValue('%kernel.cache_dir%/annotations')->end()

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -188,6 +188,7 @@
         <xsd:attribute name="cache" type="xsd:string" />
         <xsd:attribute name="debug" type="xsd:string" />
         <xsd:attribute name="file-cache-dir" type="xsd:string" />
+        <xsd:attribute name="enabled" type="xsd:boolean" />
     </xsd:complexType>
 
     <xsd:complexType name="property_access">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -25,7 +25,6 @@
         <service id="kernel.class_cache.cache_warmer" class="Symfony\Bundle\FrameworkBundle\CacheWarmer\ClassCacheCacheWarmer">
             <tag name="kernel.cache_warmer" />
             <argument type="collection">
-                <argument>Doctrine\Common\Annotations\AnnotationRegistry</argument>
                 <argument>Symfony\Component\HttpFoundation\ParameterBag</argument>
                 <argument>Symfony\Component\HttpFoundation\HeaderBag</argument>
                 <argument>Symfony\Component\HttpFoundation\FileBag</argument>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -216,6 +216,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 'cache' => 'php_array',
                 'file_cache_dir' => '%kernel.cache_dir%/annotations',
                 'debug' => true,
+                'enabled' => true,
             ),
             'serializer' => array(
                 'enabled' => false,

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -29,8 +29,7 @@
         "symfony/finder": "~2.8|~3.0",
         "symfony/routing": "~3.0",
         "symfony/stopwatch": "~2.8|~3.0",
-        "doctrine/cache": "~1.0",
-        "doctrine/annotations": "~1.0"
+        "doctrine/cache": "~1.0"
     },
     "require-dev": {
         "symfony/asset": "~2.8|~3.0",
@@ -51,6 +50,7 @@
         "symfony/validator": "~3.2",
         "symfony/yaml": "~3.2",
         "symfony/property-info": "~2.8|~3.0",
+        "doctrine/annotations": "~1.0",
         "phpdocumentor/reflection-docblock": "^3.0",
         "twig/twig": "~1.23|~2.0"
     },

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -22,6 +22,7 @@
         "symfony/polyfill-php70": "~1.0"
     },
     "require-dev": {
+        "symfony/asset": "~2.8|~3.0",
         "symfony/browser-kit": "~2.8|~3.0",
         "symfony/console": "~2.8|~3.0",
         "symfony/css-selector": "~2.8|~3.0",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes (fixing this is easy by adding doctrine/annotations explicitly) |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #15748 partially |
| License | MIT |
| Doc PR | n/a |

Another PR to reduce the number of required dependencies on FrameworkBundle. This PR removes the Doctrine annotations library from the list.
