### PR TITLE
Simplified link-to-source mapping definitions in debug.file_link_format

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Extension/CodeExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/CodeExtensionTest.php
@@ -64,6 +64,6 @@ class CodeExtensionTest extends \PHPUnit_Framework_TestCase
 
     protected function getExtension()
     {
-        return new CodeExtension('proto://%f#&line=%l#'.json_encode(substr(__FILE__, 0, 5)).':"foobar"', '/root', 'UTF-8');
+        return new CodeExtension('proto://%f#&line=%l&'.substr(__FILE__, 0, 5).'>foobar', '/root', 'UTF-8');
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
@@ -35,10 +35,8 @@ class CodeHelper extends Helper
     {
         $fileLinkFormat = $fileLinkFormat ?: ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format');
         if ($fileLinkFormat && !is_array($fileLinkFormat)) {
-            $i = max(strpos($fileLinkFormat, '%f'), strpos($fileLinkFormat, '%l'));
-            $i = strpos($fileLinkFormat, '#"', $i) ?: strlen($fileLinkFormat);
-            $fileLinkFormat = array(substr($fileLinkFormat, 0, $i), substr($fileLinkFormat, $i + 1));
-            $fileLinkFormat[1] = @json_decode('{'.$fileLinkFormat[1].'}', true) ?: array();
+            $i = strpos($f = $fileLinkFormat, '&', max(strrpos($f, '%f'), strrpos($f, '%l'))) ?: strlen($f);
+            $fileLinkFormat = array(substr($f, 0, $i)) + preg_split('/&([^>]++)>/', substr($f, $i), -1, PREG_SPLIT_DELIM_CAPTURE);
         }
         $this->fileLinkFormat = $fileLinkFormat;
         $this->rootDir = str_replace('\\', '/', $rootDir).'/';
@@ -193,9 +191,9 @@ class CodeHelper extends Helper
     public function getFileLink($file, $line)
     {
         if ($this->fileLinkFormat && is_file($file)) {
-            foreach ($this->fileLinkFormat[1] as $k => $v) {
-                if (0 === strpos($file, $k)) {
-                    $file = substr_replace($file, $v, 0, strlen($k));
+            for ($i = 1; isset($this->fileLinkFormat[$i]); ++$i) {
+                if (0 === strpos($file, $k = $this->fileLinkFormat[$i++])) {
+                    $file = substr_replace($path, $this->fileLinkFormat[$i], 0, strlen($k));
                     break;
                 }
             }

--- a/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
@@ -42,10 +42,8 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
     {
         $fileLinkFormat = $fileLinkFormat ?: ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format');
         if ($fileLinkFormat && !is_array($fileLinkFormat)) {
-            $i = max(strpos($fileLinkFormat, '%f'), strpos($fileLinkFormat, '%l'));
-            $i = strpos($fileLinkFormat, '#"', $i) ?: strlen($fileLinkFormat);
-            $fileLinkFormat = array(substr($fileLinkFormat, 0, $i), substr($fileLinkFormat, $i + 1));
-            $fileLinkFormat[1] = @json_decode('{'.$fileLinkFormat[1].'}', true) ?: array();
+            $i = strpos($f = $fileLinkFormat, '&', max(strrpos($f, '%f'), strrpos($f, '%l'))) ?: strlen($f);
+            $fileLinkFormat = array(substr($f, 0, $i)) + preg_split('/&([^>]++)>/', substr($f, $i), -1, PREG_SPLIT_DELIM_CAPTURE);
         }
         $this->stopwatch = $stopwatch;
         $this->fileLinkFormat = $fileLinkFormat;
@@ -268,9 +266,9 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
                         $name = strip_tags($this->style('', $name));
                         $file = strip_tags($this->style('', $file));
                         if ($fileLinkFormat) {
-                            foreach ($fileLinkFormat[1] as $k => $v) {
-                                if (0 === strpos($file, $k)) {
-                                    $file = substr_replace($file, $v, 0, strlen($k));
+                            for ($i = 1; isset($fileLinkFormat[$i]); ++$i) {
+                                if (0 === strpos($file, $k = $fileLinkFormat[$i++])) {
+                                    $file = substr_replace($file, $fileLinkFormat[$i], 0, strlen($k));
                                     break;
                                 }
                             }

--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -542,16 +542,12 @@ EOHTML
             return false;
         }
         if (!is_array($fileLinkFormat)) {
-            $i = max(strpos($fileLinkFormat, '%f'), strpos($fileLinkFormat, '%l'));
-            $i = strpos($fileLinkFormat, '#"', $i) ?: strlen($fileLinkFormat);
-            $fileLinkFormat = array(substr($fileLinkFormat, 0, $i), substr($fileLinkFormat, $i + 1));
-            $fileLinkFormat[1] = @json_decode('{'.$fileLinkFormat[1].'}', true) ?: array();
-            $this->extraDisplayOptions['fileLinkFormat'] = $fileLinkFormat;
+            $i = strpos($f = $fileLinkFormat, '&', max(strrpos($f, '%f'), strrpos($f, '%l'))) ?: strlen($f);
+            $fileLinkFormat = array(substr($f, 0, $i)) + preg_split('/&([^>]++)>/', substr($f, $i), -1, PREG_SPLIT_DELIM_CAPTURE);
         }
-
-        foreach ($fileLinkFormat[1] as $k => $v) {
-            if (0 === strpos($file, $k)) {
-                $file = substr_replace($file, $v, 0, strlen($k));
+        for ($i = 1; isset($fileLinkFormat[$i]); ++$i) {
+            if (0 === strpos($file, $k = $fileLinkFormat[$i++])) {
+                $file = substr_replace($file, $fileLinkFormat[$i], 0, strlen($k));
                 break;
             }
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #19950 |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/7019 |

Having to json_encode here (or any other kind of encoding) is really tedious to deal with: it makes it hard to have things working quickly. `%f` and `%l` aren't encoded anyway, so let's use very unlikely chars as separators here also instead.
