### PR TITLE
[TwigBundle] Adjust CacheWarmingTest for TemplateCacheWarmer introduced in 2.8

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Tests/Functional/CacheWarmingTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Functional/CacheWarmingTest.php
@@ -31,7 +31,7 @@ class NewCacheWamingTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(file_exists($kernel->getCacheDir().'/twig'));
     }
 
-    public function testCacheIsNotWarmedWhenTemplatingIsDisabled()
+    public function testCacheIsProperlyWarmedWhenTemplatingIsDisabled()
     {
         $kernel = new CacheWarmingKernel(false);
         $kernel->boot();
@@ -40,7 +40,7 @@ class NewCacheWamingTest extends \PHPUnit_Framework_TestCase
         $warmer->enableOptionalWarmers();
         $warmer->warmUp($kernel->getCacheDir());
 
-        $this->assertFalse(file_exists($kernel->getCacheDir().'/twig'));
+        $this->assertTrue(file_exists($kernel->getCacheDir().'/twig'));
     }
 
     protected function setUp()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

With #20103, issue reported in #20065 is fixed, however it will now break in 2.8+ as another cache warmer has been introduced with #16271.
