### PR TITLE
Added a build method to the kernel to replace Bundle::build()

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -467,6 +467,17 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     }
 
     /**
+     * The extension point similar to the Bundle::build() method.
+     *
+     * Use this method to register compiler passes and manipulate the container during the building process.
+     *
+     * @param ContainerBuilder $container
+     */
+    protected function build(ContainerBuilder $container)
+    {
+    }
+
+    /**
      * Gets the container class.
      *
      * @return string The container class
@@ -625,9 +636,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
                 $container->addObjectResource($bundle);
             }
         }
+
         foreach ($this->bundles as $bundle) {
             $bundle->build($container);
         }
+
+        $this->build($container);
 
         // ensure these extensions are implicitly loaded
         $container->getCompilerPassConfig()->setMergePass(new MergeExtensionConfigurationPass($extensions));

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelWithoutBundles.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelWithoutBundles.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures;
+
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+
+class KernelWithoutBundles extends Kernel
+{
+    public function registerBundles()
+    {
+        return array();
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+    }
+
+    protected function build(ContainerBuilder $container)
+    {
+        $container->setParameter('test_executed', true);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest;
 use Symfony\Component\HttpKernel\Tests\Fixtures\KernelForOverrideName;
+use Symfony\Component\HttpKernel\Tests\Fixtures\KernelWithoutBundles;
 
 class KernelTest extends TestCase
 {
@@ -723,6 +724,14 @@ EOF;
 
         $kernel->boot();
         $kernel->terminate(Request::create('/'), new Response());
+    }
+
+    public function testKernelWithoutBundles()
+    {
+        $kernel = new KernelWithoutBundles('test', true);
+        $kernel->boot();
+
+        $this->assertTrue($kernel->getContainer()->getParameter('test_executed'));
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #20099 |
| License | MIT |
| Doc PR | ~ |

Adds a DX method to make it easier to omit using an AppBundle in your application.

**Old situation**

``` php
// src/AppBundle.php
class AppBundle extends Bundle
{
    public function build(ContainerBuilder $container)
    {
        $container->addCompilerPass(new SomeCompilerPass());
        $container->addCompilerPass(new AnotherCompilerPass());
        $container->addCompilerPass(new YetAnotherCompilerPass());
    }
}

// src/DependencyInjection/AppExtension.php
class AppExtension extends Extension
{
    public function load(array $config, ContainerBuilder $container)
    {
        $binary = ExecutableResolver::getPath($container->getParameter('kernel.root_dir').'/../');
        $snappyConfig = ['pdf' => ['binary' => realpath($binary)]];

        $container->prependExtensionConfig('knp_snappy', $snappyConfig);
    }
}
```

**New situation**

``` php
// rm src/AppBundle.php
// rm src/DependencyInjection/AppExtension.php

// app/AppKernel.php
class AppKernel extends Kernel
{
    protected function build(ContainerBuilder $container)
    {
        $binary = ExecutableResolver::getPath($container->getParameter('kernel.root_dir').'/../');
        $snappyConfig = ['pdf' => ['binary' => realpath($binary)]];

        $container->prependExtensionConfig('knp_snappy', $snappyConfig);
        $container->addCompilerPass(new SomeCompilerPass());
        $container->addCompilerPass(new AnotherCompilerPass());
        $container->addCompilerPass(new YetAnotherCompilerPass());
    }
}
```

Still missing tests, wondering if worth adding in this state first.
