### PR TITLE
[Form] compound forms without children should be considered rendered implicitly

### DIFF
--- a/src/Symfony/Component/Form/FormView.php
+++ b/src/Symfony/Component/Form/FormView.php
@@ -65,8 +65,12 @@ class FormView implements \ArrayAccess, \IteratorAggregate, \Countable
      */
     public function isRendered()
     {
-        if (true === $this->rendered || 0 === count($this->children)) {
-            return $this->rendered;
+        if ($this->rendered) {
+            return true;
+        }
+
+        if (isset($this->vars['compound']) ? !$this->vars['compound'] : 0 === count($this->children)) {
+            return false;
         }
 
         foreach ($this->children as $child) {

--- a/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
@@ -453,7 +453,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
         $form = $this->factory->createNamedBuilder('name', 'form')
             ->add($this->factory
                 ->createNamedBuilder('child', 'form', null, array('error_bubbling' => false))
-                ->add('grandChild', 'form')
+                ->add('grandChild', 'text')
             )
             ->getForm();
 

--- a/src/Symfony/Component/Form/Tests/AbstractTableLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractTableLayoutTest.php
@@ -318,7 +318,7 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
         $form = $this->factory->createNamedBuilder('name', 'form')
             ->add($this->factory
                 ->createNamedBuilder('child', 'form', null, array('error_bubbling' => false))
-                ->add('grandChild', 'form')
+                ->add('grandChild', 'text')
             )
             ->getForm();
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -488,14 +488,65 @@ class FormTypeTest extends BaseTypeTest
         $this->assertTrue($view->vars['multipart']);
     }
 
-    public function testViewIsNotRenderedByDefault()
+    public function testViewIsConsideredRenderedForRenderedNonCompoundForms()
     {
-        $view = $this->factory->createBuilder('form')
-                ->add('foo', 'form')
-                ->getForm()
-                ->createView();
+        $view = $this->factory->createBuilder('form', null, array(
+                'compound' => false,
+            ))
+            ->getForm()
+            ->createView();
+
+        $view->setRendered();
+
+        $this->assertTrue($view->isRendered());
+    }
+
+    public function testViewIsNotConsideredRenderedImplicitlyForNonCompoundForms()
+    {
+        $view = $this->factory->createBuilder('form', null, array(
+                'compound' => false,
+            ))
+            ->getForm()
+            ->createView();
 
         $this->assertFalse($view->isRendered());
+    }
+
+    public function testViewIsNotConsideredRenderedImplicitlyForCompoundFormsWithNonCompoundChildren()
+    {
+        $view = $this->factory->createBuilder('form')
+            ->add('foo', 'form', array(
+                'compound' => false,
+            ))
+            ->getForm()
+            ->createView();
+
+        $this->assertFalse($view->isRendered());
+    }
+
+    public function testViewIsConsideredRenderedImplicitlyForCompoundFormsWithRenderedNonCompoundChildren()
+    {
+        $view = $this->factory->createBuilder('form')
+            ->add('foo', 'form', array(
+                'compound' => false,
+            ))
+            ->getForm()
+            ->createView();
+
+        foreach ($view as $child) {
+            $child->setRendered();
+        }
+
+        $this->assertTrue($view->isRendered());
+    }
+
+    public function testViewIsConsideredRenderedImplicitlyForCompoundFormsWithoutChildren()
+    {
+        $view = $this->factory->createBuilder('form')
+            ->getForm()
+            ->createView();
+
+        $this->assertTrue($view->isRendered());
     }
 
     public function testErrorBubblingIfCompound()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | possibly |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #17580 |
| License | MIT |
| Doc PR | n/a |

second try, obsoletes #20080 
