### PR TITLE
added catching of php7 fatal exceptions in application #20110

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -126,7 +126,7 @@ class Application
         } catch (\Throwable $e) {
         }
 
-        if ($e) {
+        if (isset($e)) {
             if (!$this->catchExceptions) {
                 throw $e;
             }

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -106,7 +106,7 @@ class Application
      *
      * @return int 0 if everything went fine, or an error code
      *
-     * @throws \Exception When doRun returns Exception or Throwable
+     * @throws \Exception When doRun returns Exception
      */
     public function run(InputInterface $input = null, OutputInterface $output = null)
     {
@@ -120,28 +120,24 @@ class Application
 
         $this->configureIO($input, $output);
 
-        $exception = null;
-        $exitCode = null;
         try {
             $exitCode = $this->doRun($input, $output);
         } catch (\Exception $e) {
-            $exception = $e;
         } catch (\Throwable $e) {
-            $exception = new FatalThrowableError($e);
         }
 
-        if ($exception) {
+        if ($e) {
             if (!$this->catchExceptions) {
-                throw $exception;
+                throw $e;
             }
 
             if ($output instanceof ConsoleOutputInterface) {
-                $this->renderException($exception, $output->getErrorOutput());
+                $this->renderException($e, $output->getErrorOutput());
             } else {
-                $this->renderException($exception, $output);
+                $this->renderException($e, $output);
             }
 
-            $exitCode = $exception->getCode();
+            $exitCode = $e->getCode();
             if (is_numeric($exitCode)) {
                 $exitCode = (int) $exitCode;
                 if (0 === $exitCode) {

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -123,25 +123,9 @@ class Application
         try {
             $exitCode = $this->doRun($input, $output);
         } catch (\Exception $e) {
-            if (!$this->catchExceptions) {
-                throw $e;
-            }
-
-            if ($output instanceof ConsoleOutputInterface) {
-                $this->renderException($e, $output->getErrorOutput());
-            } else {
-                $this->renderException($e, $output);
-            }
-
-            $exitCode = $e->getCode();
-            if (is_numeric($exitCode)) {
-                $exitCode = (int) $exitCode;
-                if (0 === $exitCode) {
-                    $exitCode = 1;
-                }
-            } else {
-                $exitCode = 1;
-            }
+            $exitCode = $this->handleCommandRunException($e, $output);
+        } catch (\Throwable $e) {
+            $exitCode = $this->handleCommandRunException($e, $output);
         }
 
         if ($this->autoExit) {
@@ -150,6 +134,39 @@ class Application
             }
 
             exit($exitCode);
+        }
+
+        return $exitCode;
+    }
+
+    /**
+     * Handler command run exception and provides with the exit code in return
+     *
+     * @param \Exception|\Throwable $e
+     * @param OutputInterface $output
+     * @return int|mixed
+     * @throws \Throwable
+     */
+    private function handleCommandRunException($e, OutputInterface $output)
+    {
+        if (!$this->catchExceptions) {
+            throw $e;
+        }
+
+        if ($output instanceof ConsoleOutputInterface) {
+            $this->renderException($e, $output->getErrorOutput());
+        } else {
+            $this->renderException($e, $output);
+        }
+
+        $exitCode = $e->getCode();
+        if (is_numeric($exitCode)) {
+            $exitCode = (int) $exitCode;
+            if (0 === $exitCode) {
+                $exitCode = 1;
+            }
+        } else {
+            $exitCode = 1;
         }
 
         return $exitCode;

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -127,7 +127,7 @@ class Application
         } catch (\Exception $e) {
             $exception = $e;
         } catch (\Throwable $e) {
-            $exception = new FatalThrowableError($e);;
+            $exception = new FatalThrowableError($e);
         }
 
         if ($exception) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | ~~2.8~~ 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #20110 |
| License | MIT |
| Doc PR | \- - - |
- added new private method to application, which would process the exception and return the exit code / throw it
- added another catch into command run method, which would ensure that under PHP7 all exceptions are being catched as well
