### PR TITLE
[Console] Fix validation of empty values using SymfonyQuestionHelper::ask()

### DIFF
--- a/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
@@ -34,11 +34,11 @@ class SymfonyQuestionHelper extends QuestionHelper
         $question->setValidator(function ($value) use ($validator) {
             if (null !== $validator) {
                 $value = $validator($value);
-            }
-
-            // make required
-            if (!is_array($value) && !is_bool($value) && 0 === strlen($value)) {
-                throw new \Exception('A value is required.');
+            } else {
+                // make required
+                if (!is_array($value) && !is_bool($value) && 0 === strlen($value)) {
+                    throw new \Exception('A value is required.');
+                }
             }
 
             return $value;

--- a/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
@@ -6,6 +6,7 @@ use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\SymfonyQuestionHelper;
 use Symfony\Component\Console\Output\StreamOutput;
+use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 
 /**
@@ -71,6 +72,15 @@ class SymfonyQuestionHelperTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(array('Superman', 'Batman'), $questionHelper->ask($this->createInputInterfaceMock(), $output = $this->createOutputInterface(), $question));
         $this->assertOutputContains('What is your favorite superhero? [Superman, Batman]', $output);
+    }
+
+    public function testAskReturnsNullIfValidatorAllowsIt()
+    {
+        $questionHelper = new SymfonyQuestionHelper();
+        $questionHelper->setInputStream($this->getInputStream("\n"));
+        $question = new Question('What is your favorite superhero?');
+        $question->setValidator(function ($value) { return $value; });
+        $this->assertNull($questionHelper->ask($this->createInputInterfaceMock(), $this->createOutputInterface(), $question));
     }
 
     protected function getInputStream($input)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

When using `QuestionHelper::ask()` it's allowed to return an empty value as answer, e.g:

``` php
$helper = new QuestionHelper();
$question = new Question('foo', false);
$question->setValidator(function ($v) { return $v; });
$answer = $helper->ask($input, $output, $question);
```

Just typing `enter` for answering this question works, the value of `$answer` would be `false`.
But doing the same with `SymfonyQuestionHelper::ask()`:

``` php
$helper = new SymfonyQuestionHelper();
$question = new Question('foo', false);
$question->setValidator(function ($v) { return $v; });
$answer = $helper->ask($input, $output, $question);
```

>  [ERROR] A value is required.

Same for `''` or `null`.
Here I kept the same check but used as default validator, if a validator is set and allows an empty value to be returned then it's ok.

Also I am not sure about if this default validator should be kept, imho we should be consistent with the default question helper, using the `SymfonyQuestionHelper` should only impact the output.

Diff best viewed [like this](https://github.com/symfony/symfony/pull/20141/files?w=1)
ping @kbond
