### PR TITLE
[FrameworkBundle] Alter container class instead of kernel name in cache:clear command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -157,22 +157,13 @@ EOF
             file_put_contents($file, $content);
         }
 
-        // fix references to kernel/container related classes
-        $fileSearch = $tempKernel->getName().ucfirst($tempKernel->getEnvironment()).'*';
-        $search = array(
-            $tempKernel->getName().ucfirst($tempKernel->getEnvironment()),
-            sprintf('\'kernel.name\' => \'%s\'', $tempKernel->getName()),
-            sprintf('key="kernel.name">%s<', $tempKernel->getName()),
-        );
-        $replace = array(
-            $realKernel->getName().ucfirst($realKernel->getEnvironment()),
-            sprintf('\'kernel.name\' => \'%s\'', $realKernel->getName()),
-            sprintf('key="kernel.name">%s<', $realKernel->getName()),
-        );
-        foreach (Finder::create()->files()->name($fileSearch)->in($warmupDir) as $file) {
-            $content = str_replace($search, $replace, file_get_contents($file));
-            file_put_contents(str_replace($search, $replace, $file), $content);
-            unlink($file);
+        // fix references to container's class
+        $tempContainerClass = get_class($tempKernel->getContainer());
+        $realContainerClass = get_class($realKernel->getContainer());
+        foreach (Finder::create()->files()->name($tempContainerClass.'*')->in($warmupDir) as $file) {
+            $content = str_replace($tempContainerClass, $realContainerClass, file_get_contents($file));
+            file_put_contents($file, $content);
+            rename($file, str_replace(DIRECTORY_SEPARATOR.$tempContainerClass, DIRECTORY_SEPARATOR.$realContainerClass, $file));
         }
 
         // remove temp kernel file after cache warmed up
@@ -195,8 +186,8 @@ EOF
         // the temp kernel class name must have the same length than the real one
         // to avoid the many problems in serialized resources files
         $class = substr($parentClass, 0, -1).'_';
-        // the temp kernel name must be changed too
-        $name = var_export(substr($parent->getName(), 0, -1).'_', true);
+        // the temp container class must be changed too
+        $containerClass = var_export(substr(get_class($parent->getContainer()), 0, -1).'_', true);
         $code = <<<EOF
 <?php
 
@@ -209,11 +200,6 @@ namespace $namespace
             return $cacheDir;
         }
 
-        public function getName()
-        {
-            return $name;
-        }
-
         public function getRootDir()
         {
             return $rootDir;
@@ -222,6 +208,11 @@ namespace $namespace
         public function getLogDir()
         {
             return $logDir;
+        }
+
+        protected function getContainerClass()
+        {
+            return $containerClass;
         }
 
         protected function buildContainer()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -367,7 +367,7 @@ class FrameworkExtension extends Extension
         $loader->load('routing.xml');
 
         $container->setParameter('router.resource', $config['resource']);
-        $container->setParameter('router.cache_class_prefix', $container->getParameter('kernel.name').ucfirst($container->getParameter('kernel.environment')));
+        $container->setParameter('router.cache_class_prefix', $container->getParameter('kernel.container_class'));
         $router = $container->findDefinition('router.default');
         $argument = $router->getArgument(2);
         $argument['strict_requirements'] = $config['strict_requirements'];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/CacheClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/CacheClearCommandTest.php
@@ -83,6 +83,6 @@ class CacheClearCommandTest extends TestCase
             }
         }
         $this->assertTrue($found, 'Kernel file should present as resource');
-        $this->assertRegExp(sprintf('/\'kernel.name\'\s*=>\s*\'%s\'/', $this->kernel->getName()), file_get_contents($containerFile), 'kernel.name is properly set on the dumped container');
+        $this->assertRegExp(sprintf('/\'kernel.container_class\'\s*=>\s*\'%s\'/', get_class($this->kernel->getContainer())), file_get_contents($containerFile), 'kernel.container_class is properly set on the dumped container');
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -477,6 +477,7 @@ abstract class FrameworkExtensionTest extends TestCase
             'kernel.environment' => 'test',
             'kernel.name' => 'kernel',
             'kernel.root_dir' => __DIR__,
+            'kernel.container_class' => 'testContainer',
         ), $data)));
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #19912 |
| License | MIT |
| Doc PR | - |

The decision to alter kernel's name instead of the container's class dates from cc3a40ed7868d537fa2c59a6adf437795467ca5f
But this is causing issues such as #19912. Looking more carefully, the real intent is to change the container class and there is no need to alter also the kernel's name at this stage.
