### PR TITLE
[VarDumper] Fix ReflectionNamedType->getName() detection

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/ReflectionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ReflectionCaster.php
@@ -115,7 +115,8 @@ class ReflectionCaster
         ));
 
         if (isset($a[$prefix.'returnType'])) {
-            $a[$prefix.'returnType'] = method_exists('ReflectionType', 'getName') ? $a[$prefix.'returnType']->getName() : $a[$prefix.'returnType']->__toString();
+            $v = $a[$prefix.'returnType'];
+            $a[$prefix.'returnType'] = $v instanceof \ReflectionNamedType ? $v->getName() : $v->__toString();
         }
         if (isset($a[$prefix.'this'])) {
             $a[$prefix.'this'] = new CutStub($a[$prefix.'this']);
@@ -168,9 +169,9 @@ class ReflectionCaster
         ));
 
         try {
-            if (method_exists($c, 'hasType')) {
-                if ($c->hasType()) {
-                    $a[$prefix.'typeHint'] = method_exists('ReflectionType', 'getName') ? $c->getType()->getName() : $c->getType()->__toString();
+            if (method_exists($c, 'getType')) {
+                if ($v = $c->getType()) {
+                    $a[$prefix.'typeHint'] = $v instanceof \ReflectionNamedType ? $v->getName() : $v->__toString();
                 }
             } else {
                 $v = explode(' ', $c->__toString(), 6);
@@ -196,7 +197,7 @@ class ReflectionCaster
                 unset($a[$prefix.'allowsNull']);
             }
         } catch (\ReflectionException $e) {
-            if (isset($a[$prefix.'typeHint']) && $c->allowsNull() && !method_exists('ReflectionType', 'getName')) {
+            if (isset($a[$prefix.'typeHint']) && $c->allowsNull() && !class_exists('ReflectionNamedType', false)) {
                 $a[$prefix.'default'] = null;
                 unset($a[$prefix.'allowsNull']);
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

There is no side effect to this patch, except that __toString were still used, whereas getName should have been (both methods return the same, but __toString is deprecated since 7.1).
I somehow missed that getName was on a new `ReflectionNamedType` class...
