### PR TITLE
add toolbar & profiler SVG style classes

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -464,7 +464,8 @@ tr.status-warning td {
     margin-top: -4px;
     vertical-align: middle;
 }
-#header h1 svg path {
+#header h1 svg path,
+#header h1 svg .sf-profiler-path {
     fill: #FFF;
 }
 #header .search {
@@ -647,7 +648,8 @@ tr.status-warning td {
     height: 24px;
     max-width: 24px;
 }
-#menu-profiler li a .label .icon svg path {
+#menu-profiler li a .label .icon svg path,
+#menu-profiler li a .label .icon svg .sf-profiler-path {
     fill: #DDD;
 }
 #menu-profiler li a .label strong {
@@ -674,7 +676,9 @@ tr.status-warning td {
     color: #FFF;
 }
 #menu-profiler li.selected a .icon svg path,
-#menu-profiler li a:hover .icon svg path {
+#menu-profiler li.selected a .icon svg .sf-profiler-path,
+#menu-profiler li a:hover .icon svg path,
+#menu-profiler li a:hover .icon svg .sf-profiler-path {
     fill: #FFF;
 }
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -465,7 +465,7 @@ tr.status-warning td {
     vertical-align: middle;
 }
 #header h1 svg path,
-#header h1 svg .sf-profiler-path {
+#header h1 svg .sf-svg-path {
     fill: #FFF;
 }
 #header .search {
@@ -649,7 +649,7 @@ tr.status-warning td {
     max-width: 24px;
 }
 #menu-profiler li a .label .icon svg path,
-#menu-profiler li a .label .icon svg .sf-profiler-path {
+#menu-profiler li a .label .icon svg .sf-svg-path {
     fill: #DDD;
 }
 #menu-profiler li a .label strong {
@@ -676,9 +676,9 @@ tr.status-warning td {
     color: #FFF;
 }
 #menu-profiler li.selected a .icon svg path,
-#menu-profiler li.selected a .icon svg .sf-profiler-path,
+#menu-profiler li.selected a .icon svg .sf-svg-path,
 #menu-profiler li a:hover .icon svg path,
-#menu-profiler li a:hover .icon svg .sf-profiler-path {
+#menu-profiler li a:hover .icon svg .sf-svg-path {
     fill: #FFF;
 }
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -240,11 +240,15 @@
     color: #FFF;
 }
 .sf-toolbar-status-green svg path,
+.sf-toolbar-status-green svg .sf-toolbar-path,
 .sf-toolbar-status-red svg path,
-.sf-toolbar-status-yellow svg path {
+.sf-toolbar-status-red svg .sf-toolbar-path,
+.sf-toolbar-status-yellow svg path,
+.sf-toolbar-status-yellow svg .sf-toolbar-path {
     fill: #FFF;
 }
-.sf-toolbar-block-config svg path {
+.sf-toolbar-block-config svg path,
+.sf-toolbar-block-config svg .sf-toolbar-path {
     fill: #FFF;
 }
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -240,15 +240,15 @@
     color: #FFF;
 }
 .sf-toolbar-status-green svg path,
-.sf-toolbar-status-green svg .sf-toolbar-path,
+.sf-toolbar-status-green svg .sf-svg-path,
 .sf-toolbar-status-red svg path,
-.sf-toolbar-status-red svg .sf-toolbar-path,
+.sf-toolbar-status-red svg .sf-svg-path,
 .sf-toolbar-status-yellow svg path,
-.sf-toolbar-status-yellow svg .sf-toolbar-path {
+.sf-toolbar-status-yellow svg .sf-svg-path {
     fill: #FFF;
 }
 .sf-toolbar-block-config svg path,
-.sf-toolbar-block-config svg .sf-toolbar-path {
+.sf-toolbar-block-config svg .sf-svg-path {
     fill: #FFF;
 }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | Technically, yes - but actually not |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

This allows the usage of SVG not only containing `path` elements. I opted for a generic solution using the two classes to apply to any SVG, one would like to use within the toolbar (`sf-toolbar-path`) and/or profiler (`sf-profiler-path`).
