### PR TITLE
Uniformize exception vars according to our CS

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -208,7 +208,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
         // Use a ReflectionProperty instead of $class to get the parent class if applicable
         try {
             $reflectionProperty = new \ReflectionProperty($class, $property);
-        } catch (\ReflectionException $reflectionException) {
+        } catch (\ReflectionException $e) {
             return;
         }
 
@@ -260,7 +260,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
                 ) {
                     break;
                 }
-            } catch (\ReflectionException $reflectionException) {
+            } catch (\ReflectionException $e) {
                 // Try the next prefix if the method doesn't exist
             }
         }

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -51,7 +51,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
     {
         try {
             $reflectionClass = new \ReflectionClass($class);
-        } catch (\ReflectionException $reflectionException) {
+        } catch (\ReflectionException $e) {
             return;
         }
 
@@ -261,7 +261,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
             $reflectionProperty = new \ReflectionProperty($class, $property);
 
             return $reflectionProperty->isPublic();
-        } catch (\ReflectionException $reflectionExcetion) {
+        } catch (\ReflectionException $e) {
             // Return false if the property doesn't exist
         }
 
@@ -290,7 +290,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
                 if (0 === $reflectionMethod->getNumberOfRequiredParameters()) {
                     return array($reflectionMethod, $prefix);
                 }
-            } catch (\ReflectionException $reflectionException) {
+            } catch (\ReflectionException $e) {
                 // Return null if the property doesn't exist
             }
         }
@@ -319,7 +319,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
                 if ($reflectionMethod->getNumberOfParameters() >= 1) {
                     return array($reflectionMethod, $prefix);
                 }
-            } catch (\ReflectionException $reflectionException) {
+            } catch (\ReflectionException $e) {
                 // Try the next prefix if the method doesn't exist
             }
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

My initial intent was to [fix this typo](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php#L269). But we use `$e` almost everywhere else in this case, so I updated the whole component to be consistent.
