### PR TITLE
[PropertyInfo] Correct a typo in the ReflectionExtractor's description

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -17,7 +17,7 @@ use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\PropertyInfo\Type;
 
 /**
- * Extracts PHP informations using the reflection API.
+ * Extracts data using the reflection API.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Information is uncountable. Standardize with the description of the `PhpDocExtractor`. 
