### PR TITLE
[DependencyInjection] Make method (setter) autowiring configurable

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/LoggingFormatter.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/LoggingFormatter.php
@@ -38,6 +38,11 @@ class LoggingFormatter
         return $this->format($pass, sprintf('Resolving inheritance for "%s" (parent: %s).', $childId, $parentId));
     }
 
+    public function formatUnusedAutowiringPatterns(CompilerPassInterface $pass, $id, array $patterns)
+    {
+        return $this->format($pass, sprintf('Autowiring\'s patterns "%s" for service "%s" don\'t match any method.', implode('", "', $patterns), $id));
+    }
+
     public function format(CompilerPassInterface $pass, $message)
     {
         return sprintf('%s: %s', get_class($pass), $message);

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -36,7 +36,7 @@ class Definition
     private $abstract = false;
     private $lazy = false;
     private $decoratedService;
-    private $autowired = false;
+    private $autowiredMethods = array();
     private $autowiringTypes = array();
 
     protected $arguments;
@@ -662,11 +662,25 @@ class Definition
      */
     public function isAutowired()
     {
-        return $this->autowired;
+        return !empty($this->autowiredMethods);
+    }
+
+    /**
+     * Gets autowired methods.
+     *
+     * @return string[]
+     */
+    public function getAutowiredMethods()
+    {
+        return $this->autowiredMethods;
     }
 
     /**
      * Sets autowired.
+     *
+     * Allowed values:
+     *   - true: constructor autowiring, same as $this->setAutowiredMethods(array('__construct'))
+     *   - false: no autowiring, same as $this->setAutowiredMethods(array())
      *
      * @param bool $autowired
      *
@@ -674,7 +688,24 @@ class Definition
      */
     public function setAutowired($autowired)
     {
-        $this->autowired = $autowired;
+        $this->autowiredMethods = $autowired ? array('__construct') : array();
+
+        return $this;
+    }
+
+    /**
+     * Sets autowired methods.
+     *
+     * Example of allowed value:
+     *   - array('__construct', 'set*', 'initialize'): autowire whitelisted methods only
+     *
+     * @param string[] $autowiredMethods
+     *
+     * @return Definition The current instance
+     */
+    public function setAutowiredMethods(array $autowiredMethods)
+    {
+        $this->autowiredMethods = $autowiredMethods;
 
         return $this;
     }

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -239,6 +239,19 @@ class XmlFileLoader extends FileLoader
             $definition->addAutowiringType($type->textContent);
         }
 
+        $autowireTags = array();
+        foreach ($this->getChildren($service, 'autowire') as $type) {
+            $autowireTags[] = $type->textContent;
+        }
+
+        if ($autowireTags) {
+            if ($service->hasAttribute('autowire')) {
+                throw new InvalidArgumentException(sprintf('The "autowire" attribute cannot be used together with "<autowire>" tags for service "%s" in %s.', (string) $service->getAttribute('id'), $file));
+            }
+
+            $definition->setAutowiredMethods($autowireTags);
+        }
+
         if ($value = $service->getAttribute('decorates')) {
             $renameId = $service->hasAttribute('decoration-inner-name') ? $service->getAttribute('decoration-inner-name') : null;
             $priority = $service->hasAttribute('decoration-priority') ? $service->getAttribute('decoration-priority') : 0;

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -302,7 +302,11 @@ class YamlFileLoader extends FileLoader
         }
 
         if (isset($service['autowire'])) {
-            $definition->setAutowired($service['autowire']);
+            if (is_array($service['autowire'])) {
+                $definition->setAutowiredMethods($service['autowire']);
+            } else {
+                $definition->setAutowired($service['autowire']);
+            }
         }
 
         if (isset($service['autowiring_types'])) {

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -100,6 +100,7 @@
       <xsd:element name="tag" type="tag" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="property" type="property" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="autowiring-type" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+      <xsd:element name="autowire" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
     </xsd:choice>
     <xsd:attribute name="id" type="xsd:string" />
     <xsd:attribute name="class" type="xsd:string" />

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -429,6 +429,74 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testSetterInjection()
+    {
+        $container = new ContainerBuilder();
+        $container->register('app_foo', Foo::class);
+        $container->register('app_a', A::class);
+        $container->register('app_collision_a', CollisionA::class);
+        $container->register('app_collision_b', CollisionB::class);
+
+        // manually configure *one* call, to override autowiring
+        $container
+            ->register('setter_injection', SetterInjection::class)
+            ->setAutowiredMethods(array('__construct', 'set*'))
+            ->addMethodCall('setWithCallsConfigured', array('manual_arg1', 'manual_arg2'))
+        ;
+
+        $pass = new AutowirePass();
+        $pass->process($container);
+
+        $methodCalls = $container->getDefinition('setter_injection')->getMethodCalls();
+
+        // grab the call method names
+        $actualMethodNameCalls = array_map(function ($call) {
+            return $call[0];
+        }, $methodCalls);
+        $this->assertEquals(
+            array('setWithCallsConfigured', 'setFoo', 'setDependencies'),
+            $actualMethodNameCalls
+        );
+
+        // test setWithCallsConfigured args
+        $this->assertEquals(
+            array('manual_arg1', 'manual_arg2'),
+            $methodCalls[0][1]
+        );
+        // test setFoo args
+        $this->assertEquals(
+            array(new Reference('app_foo')),
+            $methodCalls[1][1]
+        );
+    }
+
+    public function testExplicitMethodInjection()
+    {
+        $container = new ContainerBuilder();
+        $container->register('app_foo', Foo::class);
+        $container->register('app_a', A::class);
+        $container->register('app_collision_a', CollisionA::class);
+        $container->register('app_collision_b', CollisionB::class);
+
+        $container
+            ->register('setter_injection', SetterInjection::class)
+            ->setAutowiredMethods(array('setFoo', 'notASetter'))
+        ;
+
+        $pass = new AutowirePass();
+        $pass->process($container);
+
+        $methodCalls = $container->getDefinition('setter_injection')->getMethodCalls();
+
+        $actualMethodNameCalls = array_map(function ($call) {
+            return $call[0];
+        }, $methodCalls);
+        $this->assertEquals(
+            array('setFoo', 'notASetter'),
+            $actualMethodNameCalls
+        );
+    }
+
     /**
      * @dataProvider getCreateResourceTests
      */
@@ -475,6 +543,37 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
         $pass->process($container);
 
         $this->assertTrue($container->hasDefinition('bar'));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
+     * @expectedExceptionMessage Unable to autowire argument of type "Symfony\Component\DependencyInjection\Tests\Compiler\CollisionInterface" for the service "setter_injection_collision". Multiple services exist for this interface (c1, c2).
+     * @expectedExceptionCode 1
+     */
+    public function testSetterInjectionCollisionThrowsException()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('c1', CollisionA::class);
+        $container->register('c2', CollisionB::class);
+        $aDefinition = $container->register('setter_injection_collision', SetterInjectionCollision::class);
+        $aDefinition->setAutowiredMethods(array('__construct', 'set*'));
+
+        $pass = new AutowirePass();
+        $pass->process($container);
+    }
+
+    public function testLogUnusedPatterns()
+    {
+        $container = new ContainerBuilder();
+
+        $definition = $container->register('foo', Foo::class);
+        $definition->setAutowiredMethods(array('not', 'exist*'));
+
+        $pass = new AutowirePass();
+        $pass->process($container);
+
+        $this->assertEquals(array(AutowirePass::class.': Autowiring\'s patterns "not", "exist*" for service "foo" don\'t match any method.'), $container->getCompiler()->getLog());
     }
 }
 
@@ -648,9 +747,74 @@ class ClassForResource
 class IdenticalClassResource extends ClassForResource
 {
 }
+
 class ClassChangedConstructorArgs extends ClassForResource
 {
     public function __construct($foo, Bar $bar, $baz)
     {
+    }
+}
+
+class SetterInjection
+{
+    public function setFoo(Foo $foo)
+    {
+        // should be called
+    }
+
+    public function setDependencies(Foo $foo, A $a)
+    {
+        // should be called
+    }
+
+    public function setBar()
+    {
+        // should not be called
+    }
+
+    public function setNotAutowireable(NotARealClass $n)
+    {
+        // should not be called
+    }
+
+    public function setArgCannotAutowire($foo)
+    {
+        // should not be called
+    }
+
+    public function setOptionalNotAutowireable(NotARealClass $n = null)
+    {
+        // should not be called
+    }
+
+    public function setOptionalNoTypeHint($foo = null)
+    {
+        // should not be called
+    }
+
+    public function setOptionalArgNoAutowireable($other = 'default_val')
+    {
+        // should not be called
+    }
+
+    public function setWithCallsConfigured(A $a)
+    {
+        // this method has a calls configured on it
+        // should not be called
+    }
+
+    public function notASetter(A $a)
+    {
+        // should be called only when explicitly specified
+    }
+}
+
+class SetterInjectionCollision
+{
+    public function setMultipleInstancesForOneArg(CollisionInterface $collision)
+    {
+        // The CollisionInterface cannot be autowired - there are multiple
+
+        // should throw an exception
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
@@ -290,6 +290,16 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($def->isAutowired());
         $def->setAutowired(true);
         $this->assertTrue($def->isAutowired());
+        $this->assertEquals(array('__construct'), $def->getAutowiredMethods());
+
+        $def->setAutowiredMethods(array('foo'));
+        $def->setAutowired(false);
+        $this->assertSame(array(), $def->getAutowiredMethods());
+        $this->assertFalse($def->isAutowired());
+
+        $def->setAutowiredMethods(array('getFoo', 'getBar'));
+        $this->assertEquals(array('getFoo', 'getBar'), $def->getAutowiredMethods());
+        $this->assertTrue($def->isAutowired());
     }
 
     public function testTypes()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services27.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services27.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="autowire_array" class="Foo">
+            <autowire>set*</autowire>
+            <autowire>bar</autowire>
+        </service>
+    </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services28.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services28.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="autowire_array" class="Foo" autowire="*">
+            <autowire>setFoo</autowire>
+        </service>
+    </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services27.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services27.yml
@@ -1,0 +1,4 @@
+services:
+    autowire_array:
+        class: Foo
+        autowire: ['set*', 'bar']

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -554,6 +554,20 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $loader->load('services23.xml');
 
         $this->assertTrue($container->getDefinition('bar')->isAutowired());
+        $this->assertEquals(array('__construct'), $container->getDefinition('bar')->getAutowiredMethods());
+
+        $loader->load('services27.xml');
+        $this->assertEquals(array('set*', 'bar'), $container->getDefinition('autowire_array')->getAutowiredMethods());
+    }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
+     */
+    public function testAutowireAttributeAndTag()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader->load('services28.xml');
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -324,6 +324,10 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $loader->load('services23.yml');
 
         $this->assertTrue($container->getDefinition('bar_service')->isAutowired());
+        $this->assertEquals(array('__construct'), $container->getDefinition('bar_service')->getAutowiredMethods());
+
+        $loader->load('services27.yml');
+        $this->assertEquals(array('set*', 'bar'), $container->getDefinition('autowire_array')->getAutowiredMethods());
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | maybe? |
| Tests pass? | yes |
| Fixed tickets | #19631 |
| License | MIT |
| Doc PR | symfony/symfony-docs#7041 |

Follow up of #19631. Implements https://github.com/symfony/symfony/pull/19631#issuecomment-240646169:

Edit: the last supported format:

``` yaml
services:
    foo:
        class: Foo
        autowire: ['__construct', 'set*'] # Autowire constructor and all setters
        autowire: true # Converted by loaders in `autowire: ['__construct']` for BC
        autowire: ['foo', 'bar'] # Autowire only `foo` and `bar` methods
```

Outdated:

``` yaml
autowire: true # constructor autowiring
autowire: [__construct, setFoo, setBar] # autowire whitelisted methods only
autowire: '*' # autowire constructor + every setters (following existing rules for setters autowiring)
```
- [x] Allow to specify the list of methods in the XML loader
- [x] Add tests for the YAML loader
