### PR TITLE
[HttpKernel] Clean ArgumentMetadataFactory::getType()

### DIFF
--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadataFactory.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadataFactory.php
@@ -122,21 +122,8 @@ final class ArgumentMetadataFactory implements ArgumentMetadataFactoryInterface
             return $typeName;
         }
 
-        if ($parameter->isArray()) {
-            return 'array';
+        if (preg_match('/^(?:[^ ]++ ){4}([a-zA-Z_\x7F-\xFF][^ ]++)/', $parameter, $info)) {
+            return $info[1];
         }
-
-        if ($parameter->isCallable()) {
-            return 'callable';
-        }
-
-        try {
-            $refClass = $parameter->getClass();
-        } catch (\ReflectionException $e) {
-            // mandatory; extract it from the exception message
-            return str_replace(array('Class ', ' does not exist'), '', $e->getMessage());
-        }
-
-        return $refClass ? $refClass->getName() : null;
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

By using the string representation of the parameter to get the type hint (on PHP5 only of course), we prevent autoloading of the corresponding class.
