### PR TITLE
[Cache] Accept only array in TagAwareAdapter::invalidateTags()

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
@@ -67,11 +67,8 @@ class TagAwareAdapter implements TagAwareAdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function invalidateTags($tags)
+    public function invalidateTags(array $tags)
     {
-        if (!is_array($tags)) {
-            $tags = array($tags);
-        }
         foreach ($tags as $k => $tag) {
             if ('' !== $tag && is_string($tag)) {
                 $tags[$k] = $tag.static::TAGS_PREFIX;

--- a/src/Symfony/Component/Cache/Adapter/TagAwareAdapterInterface.php
+++ b/src/Symfony/Component/Cache/Adapter/TagAwareAdapterInterface.php
@@ -23,11 +23,11 @@ interface TagAwareAdapterInterface extends AdapterInterface
     /**
      * Invalidates cached items using tags.
      *
-     * @param string|string[] $tags A tag or an array of tags to invalidate
+     * @param string[] $tags An array of tags to invalidate
      *
      * @return bool True on success
      *
      * @throws InvalidArgumentException When $tags is not valid
      */
-    public function invalidateTags($tags);
+    public function invalidateTags(array $tags);
 }

--- a/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
@@ -55,7 +55,7 @@ class TagAwareAdapterTest extends AdapterTestCase
         $pool->save($i3->tag('foo')->tag('baz'));
         $pool->save($foo);
 
-        $pool->invalidateTags('bar');
+        $pool->invalidateTags(array('bar'));
 
         $this->assertFalse($pool->getItem('i0')->isHit());
         $this->assertTrue($pool->getItem('i1')->isHit());
@@ -63,7 +63,7 @@ class TagAwareAdapterTest extends AdapterTestCase
         $this->assertTrue($pool->getItem('i3')->isHit());
         $this->assertTrue($pool->getItem('foo')->isHit());
 
-        $pool->invalidateTags('foo');
+        $pool->invalidateTags(array('foo'));
 
         $this->assertFalse($pool->getItem('i1')->isHit());
         $this->assertFalse($pool->getItem('i3')->isHit());
@@ -80,7 +80,7 @@ class TagAwareAdapterTest extends AdapterTestCase
         $i = $pool->getItem('k');
         $pool->save($i->tag('bar'));
 
-        $pool->invalidateTags('foo');
+        $pool->invalidateTags(array('foo'));
         $this->assertTrue($pool->getItem('k')->isHit());
     }
 
@@ -93,7 +93,7 @@ class TagAwareAdapterTest extends AdapterTestCase
         $pool->deleteItem('k');
 
         $pool->save($pool->getItem('k'));
-        $pool->invalidateTags('foo');
+        $pool->invalidateTags(array('foo'));
 
         $this->assertTrue($pool->getItem('k')->isHit());
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Just to be sure that we won't suffer from some stupid incompatibility if a cache-tags PSR is published one day. See discussion: https://github.com/symfony/symfony/issues/19728#issuecomment-251674712
