### PR TITLE
[HttpKernel] removed implicit dep on Console

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/DumpListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/DumpListener.php
@@ -49,6 +49,10 @@ class DumpListener implements EventSubscriberInterface
 
     public static function getSubscribedEvents()
     {
+        if (!class_exists(ConsoleEvents::class)) {
+            return array();
+        }
+
         // Register early to have a working dump() as early as possible
         return array(ConsoleEvents::COMMAND => array('configure', 1024));
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

HttpKernel does not have console as a dependency, so we must ensure that this is not implicitly required (`DebugHandlersListener` already has this check).
