### PR TITLE
[Workflow] Public function to get possible transitions in base of the configuration

### DIFF
--- a/src/Symfony/Component/Workflow/Definition.php
+++ b/src/Symfony/Component/Workflow/Definition.php
@@ -46,6 +46,9 @@ class Definition
         return $this->places;
     }
 
+    /**
+     * @return Transition[]
+     */
     public function getTransitions()
     {
         return $this->transitions;

--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -226,7 +226,7 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('t5', $transitions['t5']->getName());
     }
 
-    public function teestGetPossibleTransitions()
+    public function testGetPossibleTransitions()
     {
         $definition = $this->createComplexWorkflow();
         $subject = new \stdClass();

--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -226,6 +226,27 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('t5', $transitions['t5']->getName());
     }
 
+    public function teestGetPossibleTransitions()
+    {
+        $definition = $this->createComplexWorkflow();
+        $subject = new \stdClass();
+        $subject->marking = null;
+        $workflow = new Workflow($definition, new PropertyAccessorMarkingStore());
+
+        $this->assertEmpty($workflow->getEnabledTransitions($subject));
+
+        $subject->marking = array('d' => true);
+        $transitions = $workflow->getPossibleTransitions($subject);
+        $this->assertCount(2, $transitions);
+        $this->assertSame('t3', $transitions['t3']->getName());
+        $this->assertSame('t4', $transitions['t4']->getName());
+
+        $subject->marking = array('c' => true, 'e' => true);
+        $transitions = $workflow->getPossibleTransitions($subject);
+        $this->assertCount(1, $transitions);
+        $this->assertSame('t5', $transitions['t5']->getName());
+    }
+
     private function createComplexWorkflow()
     {
         $definition = new Definition();

--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -233,7 +233,9 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
         $subject->marking = null;
         $workflow = new Workflow($definition, new PropertyAccessorMarkingStore());
 
-        $this->assertEmpty($workflow->getEnabledTransitions($subject));
+        $transitions = $workflow->getPossibleTransitions($subject);
+        $this->assertCount(1, $transitions);
+        $this->assertSame('t1', $transitions['t1']->getName());
 
         $subject->marking = array('d' => true);
         $transitions = $workflow->getPossibleTransitions($subject);

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -161,7 +161,6 @@ class Workflow
         $enabled = array();
         $marking = $this->getMarking($subject);
 
-        /** @var Transition $transition */
         foreach ($this->definition->getTransitions() as $transition) {
             if ($this->doCan($subject, $marking, $transition)) {
                 $enabled[$transition->getName()] = $transition;
@@ -182,7 +181,6 @@ class Workflow
         $marking = $this->getMarking($subject);
         $places = $marking->getPlaces();
 
-        /** @var Transition $transition */
         foreach ($this->definition->getTransitions() as $transition) {
             $diff = array_diff($transition->getFroms(), array_keys($places));
 

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -161,6 +161,7 @@ class Workflow
         $enabled = array();
         $marking = $this->getMarking($subject);
 
+        /** @var Transition $transition */
         foreach ($this->definition->getTransitions() as $transition) {
             if ($this->doCan($subject, $marking, $transition)) {
                 $enabled[$transition->getName()] = $transition;
@@ -168,6 +169,29 @@ class Workflow
         }
 
         return $enabled;
+    }
+
+    /**
+     * @param object $subject A subject
+     *
+     * @return Transition[] All possible transitions
+     */
+    public function getPossibleTransitions($subject)
+    {
+        $possibles = array();
+        $marking = $this->getMarking($subject);
+        $places = $marking->getPlaces();
+
+        /** @var Transition $transition */
+        foreach ($this->definition->getTransitions() as $transition) {
+            $diff = array_diff($transition->getFroms(), array_keys($places));
+
+            if (empty($diff)) {
+                $possibles[$transition->getName()] = $transition;
+            }
+        }
+
+        return $possibles;
     }
 
     public function getName()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Allow new functionality to know the possible transitions based on the current marking. Just a dynamic recognition of the possible transitions configured, no "can" function being checked to avoid launch guard events multiple times.
