### PR TITLE
[Security] Expose Previous Exceptions in ChainUserProvider

### DIFF
--- a/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
@@ -65,24 +65,26 @@ class ChainUserProvider implements UserProviderInterface
     public function refreshUser(UserInterface $user)
     {
         $supportedUserFound = false;
+        $unsupportedUserException = null;
+        $usernameNotFoundException = null;
 
         foreach ($this->providers as $provider) {
             try {
                 return $provider->refreshUser($user);
-            } catch (UnsupportedUserException $e) {
+            } catch (UnsupportedUserException $unsupportedUserException) {
                 // try next one
-            } catch (UsernameNotFoundException $e) {
+            } catch (UsernameNotFoundException $usernameNotFoundException) {
                 $supportedUserFound = true;
                 // try next one
             }
         }
 
         if ($supportedUserFound) {
-            $e = new UsernameNotFoundException(sprintf('There is no user with name "%s".', $user->getUsername()));
+            $e = new UsernameNotFoundException(sprintf('There is no user with name "%s".', $user->getUsername()), 0, $usernameNotFoundException);
             $e->setUsername($user->getUsername());
             throw $e;
         } else {
-            throw new UnsupportedUserException(sprintf('The account "%s" is not supported.', get_class($user)));
+            throw new UnsupportedUserException(sprintf('The account "%s" is not supported.', get_class($user)), 0, $unsupportedUserException);
         }
     }
 

--- a/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
@@ -44,6 +44,8 @@ class ChainUserProvider implements UserProviderInterface
      */
     public function loadUserByUsername($username)
     {
+        $e = null;
+
         foreach ($this->providers as $provider) {
             try {
                 return $provider->loadUserByUsername($username);
@@ -52,7 +54,7 @@ class ChainUserProvider implements UserProviderInterface
             }
         }
 
-        $ex = new UsernameNotFoundException(sprintf('There is no user with name "%s".', $username));
+        $ex = new UsernameNotFoundException(sprintf('There is no user with name "%s".', $username), 0, $e);
         $ex->setUsername($username);
         throw $ex;
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | not sure |
| Bug fix? | maybe? |
| New feature? | maybe? |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #20181 |
| License | MIT |
| Doc PR | N/A |

To the maintainer, I don't know if this is a feature of a bugfix, so I don't know what branch it should be merged into. I had to break our style guide rule of calling exceptions $e because there are two possibilities.
