### PR TITLE
[SecurityBundle] Cache contexts per request in FirewallMap

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
@@ -26,18 +26,24 @@ class FirewallMap implements FirewallMapInterface
 {
     protected $container;
     protected $map;
+    private $contexts;
 
     public function __construct(ContainerInterface $container, array $map)
     {
         $this->container = $container;
         $this->map = $map;
+        $this->contexts = new \SplObjectStorage();
     }
 
     public function getListeners(Request $request)
     {
+        if ($this->contexts->contains($request)) {
+            return $this->contexts[$request];
+        }
+
         foreach ($this->map as $contextId => $requestMatcher) {
             if (null === $requestMatcher || $requestMatcher->matches($request)) {
-                return $this->container->get($contextId)->getContext();
+                return $this->contexts[$request] = $this->container->get($contextId)->getContext();
             }
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/pull/19819#r77274093 |
| License | MIT |
| Doc PR | n/a |

From @HeahDude in https://github.com/symfony/symfony/pull/19819#r77274093, I propose to store and retrieve `Context` objects per `Request` using `SplObjectStorage`.

At the moment, contexts are consumed by the `Symfony\Components\Security\Http\Firewall` class only, but they could be indirectly by end users if #19490 and/or #19819 come to be merged.
