### PR TITLE
[WebProfilerBundle] Improve Ajax Profiling Performance (javascript)

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -230,86 +230,86 @@
         }
 
         {% if excluded_ajax_paths is defined %}
-        if (window.fetch && window.fetch.polyfill === undefined) {
-            var oldFetch = window.fetch;
-            window.fetch = function () {
-                var promise = oldFetch.apply(this, arguments);
-                if (!arguments[0].match(new RegExp({{ excluded_ajax_paths|json_encode|raw }}))) {
-                    var method = 'GET';
-                    if (arguments[1] && arguments[1].method !== undefined) {
-                        method = arguments[1].method;
-                    }
-
-                    var stackElement = {
-                        error: false,
-                        url: arguments[0],
-                        method: method,
-                        type: 'fetch',
-                        start: new Date()
-                    };
-
-                    var idx = requestStack.push(stackElement) - 1;
-                    promise.then(function (r) {
-                        stackElement.duration = new Date() - stackElement.start;
-                        stackElement.error = r.status < 200 || r.status >= 400;
-                        stackElement.statusCode = r.status;
-                        stackElement.profile = r.headers.get('x-debug-token');
-                        stackElement.profilerUrl = r.headers.get('x-debug-token-link');
-                        finishAjaxRequest(idx);
-                    }, function (e){
-                        stackElement.error = true;
-                    });
-                    startAjaxRequest(idx);
-                }
-
-                return promise;
-            };
-        }
-        if (window.XMLHttpRequest && XMLHttpRequest.prototype.addEventListener) {
-            var proxied = XMLHttpRequest.prototype.open;
-
-            XMLHttpRequest.prototype.open = function(method, url, async, user, pass) {
-                var self = this;
-
-                /* prevent logging AJAX calls to static and inline files, like templates */
-                var path = url;
-                if (url.substr(0, 1) === '/') {
-                    if (0 === url.indexOf('{{ request.basePath|e('js') }}')) {
-                        path = url.substr({{ request.basePath|length }});
-                    }
-                }
-                else if (0 === url.indexOf('{{ (request.schemeAndHttpHost ~ request.basePath)|e('js') }}')) {
-                    path = url.substr({{ (request.schemeAndHttpHost ~ request.basePath)|length }});
-                }
-
-                if (!path.match(new RegExp({{ excluded_ajax_paths|json_encode|raw }}))) {
-                    var stackElement = {
-                        error: false,
-                        url: url,
-                        method: method,
-                        type: 'xhr',
-                        start: new Date()
-                    };
-
-                    var idx = requestStack.push(stackElement) - 1;
-
-                    this.addEventListener('readystatechange', function() {
-                        if (self.readyState == 4) {
-                            stackElement.duration = new Date() - stackElement.start;
-                            stackElement.error = self.status < 200 || self.status >= 400;
-                            stackElement.statusCode = self.status;
-                            extractHeaders(self, stackElement);
-
-                            finishAjaxRequest(idx);
+            if (window.fetch && window.fetch.polyfill === undefined) {
+                var oldFetch = window.fetch;
+                window.fetch = function () {
+                    var promise = oldFetch.apply(this, arguments);
+                    if (!arguments[0].match(new RegExp({{ excluded_ajax_paths|json_encode|raw }}))) {
+                        var method = 'GET';
+                        if (arguments[1] && arguments[1].method !== undefined) {
+                            method = arguments[1].method;
                         }
-                    }, false);
 
-                    startAjaxRequest(idx);
-                }
+                        var stackElement = {
+                            error: false,
+                            url: arguments[0],
+                            method: method,
+                            type: 'fetch',
+                            start: new Date()
+                        };
 
-                proxied.apply(this, Array.prototype.slice.call(arguments));
-            };
-        }
+                        var idx = requestStack.push(stackElement) - 1;
+                        promise.then(function (r) {
+                            stackElement.duration = new Date() - stackElement.start;
+                            stackElement.error = r.status < 200 || r.status >= 400;
+                            stackElement.statusCode = r.status;
+                            stackElement.profile = r.headers.get('x-debug-token');
+                            stackElement.profilerUrl = r.headers.get('x-debug-token-link');
+                            finishAjaxRequest(idx);
+                        }, function (e){
+                            stackElement.error = true;
+                        });
+                        startAjaxRequest(idx);
+                    }
+
+                    return promise;
+                };
+            }
+            if (window.XMLHttpRequest && XMLHttpRequest.prototype.addEventListener) {
+                var proxied = XMLHttpRequest.prototype.open;
+
+                XMLHttpRequest.prototype.open = function(method, url, async, user, pass) {
+                    var self = this;
+
+                    /* prevent logging AJAX calls to static and inline files, like templates */
+                    var path = url;
+                    if (url.substr(0, 1) === '/') {
+                        if (0 === url.indexOf('{{ request.basePath|e('js') }}')) {
+                            path = url.substr({{ request.basePath|length }});
+                        }
+                    }
+                    else if (0 === url.indexOf('{{ (request.schemeAndHttpHost ~ request.basePath)|e('js') }}')) {
+                        path = url.substr({{ (request.schemeAndHttpHost ~ request.basePath)|length }});
+                    }
+
+                    if (!path.match(new RegExp({{ excluded_ajax_paths|json_encode|raw }}))) {
+                        var stackElement = {
+                            error: false,
+                            url: url,
+                            method: method,
+                            type: 'xhr',
+                            start: new Date()
+                        };
+
+                        var idx = requestStack.push(stackElement) - 1;
+
+                        this.addEventListener('readystatechange', function() {
+                            if (self.readyState == 4) {
+                                stackElement.duration = new Date() - stackElement.start;
+                                stackElement.error = self.status < 200 || self.status >= 400;
+                                stackElement.statusCode = self.status;
+                                extractHeaders(self, stackElement);
+
+                                finishAjaxRequest(idx);
+                            }
+                        }, false);
+
+                        startAjaxRequest(idx);
+                    }
+
+                    proxied.apply(this, Array.prototype.slice.call(arguments));
+                };
+            }
         {% endif %}
 
         return {

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -22,17 +22,6 @@
 
         var noop = function() {};
 
-        var collectionToArray = function (collection) {
-            var length = collection.length || 0,
-                results = new Array(length);
-
-            while (length--) {
-                results[length] = collection[length];
-            }
-
-            return results;
-        };
-
         var profilerStorageKey = 'sf2/profiler/';
 
         var request = function(url, onSuccess, onError, payload, options) {

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -96,131 +96,135 @@
             }
         };
 
+        var successStreak = 4;
+        var pendingRequests = 0;
         var renderAjaxRequests = function() {
-            var requestCounter = document.querySelectorAll('.sf-toolbar-ajax-requests');
-            if (!requestCounter.length) {
+            var requestCounter = document.querySelectorAll('.sf-toolbar-ajax-requests')[0];
+            if (!requestCounter) {
                 return;
+            }
+            requestCounter.textContent = requestStack.length;
+            requestCounter.className = 'sf-toolbar-ajax-requests sf-toolbar-value';
+
+            var infoSpan = document.querySelectorAll(".sf-toolbar-ajax-info")[0];
+            if (infoSpan) {
+                infoSpan.textContent = requestStack.length + ' AJAX request' + (requestStack.length > 1 ? 's' : '');
             }
 
             var ajaxToolbarPanel = document.querySelector('.sf-toolbar-block-ajax');
-            var tbodies = document.querySelectorAll('.sf-toolbar-ajax-request-list');
-            var state = 'ok';
-            if (tbodies.length) {
-                var tbody = tbodies[0];
-
-                var rows = document.createDocumentFragment();
-
-                if (requestStack.length) {
-                    for (var i = 0; i < requestStack.length; i++) {
-                        var request = requestStack[i];
-
-                        var row = document.createElement('tr');
-                        rows.insertBefore(row, rows.firstChild);
-
-                        var methodCell = document.createElement('td');
-                        if (request.error) {
-                            methodCell.className = 'sf-ajax-request-error';
-                        }
-                        methodCell.textContent = request.method;
-                        row.appendChild(methodCell);
-
-                        var typeCell = document.createElement('td');
-                        typeCell.textContent = request.type;
-                        row.appendChild(typeCell);
-
-                        var statusCodeCell = document.createElement('td');
-                        var statusCode = document.createElement('span');
-                        if (request.statusCode < 300) {
-                            statusCode.setAttribute('class', 'sf-toolbar-status');
-                        } else if (request.statusCode < 400) {
-                            statusCode.setAttribute('class', 'sf-toolbar-status sf-toolbar-status-yellow');
-                        } else {
-                            statusCode.setAttribute('class', 'sf-toolbar-status sf-toolbar-status-red');
-                        }
-                        statusCode.textContent = request.statusCode || '-';
-                        statusCodeCell.appendChild(statusCode);
-                        row.appendChild(statusCodeCell);
-
-                        var pathCell = document.createElement('td');
-                        pathCell.className = 'sf-ajax-request-url';
-                        if ('GET' === request.method) {
-                            var pathLink = document.createElement('a');
-                            pathLink.setAttribute('href', request.url);
-                            pathLink.textContent = request.url;
-                            pathCell.appendChild(pathLink);
-                        } else {
-                            pathCell.textContent = request.url;
-                        }
-                        pathCell.setAttribute('title', request.url);
-                        row.appendChild(pathCell);
-
-                        var durationCell = document.createElement('td');
-                        durationCell.className = 'sf-ajax-request-duration';
-
-                        if (request.duration) {
-                            durationCell.textContent = request.duration + "ms";
-                        } else {
-                            durationCell.textContent = '-';
-                        }
-                        row.appendChild(durationCell);
-
-                        row.appendChild(document.createTextNode(' '));
-                        var profilerCell = document.createElement('td');
-
-                        if (request.profilerUrl) {
-                            var profilerLink = document.createElement('a');
-                            profilerLink.setAttribute('href', request.profilerUrl);
-                            profilerLink.textContent = request.profile;
-                            profilerCell.appendChild(profilerLink);
-                        } else {
-                            profilerCell.textContent = 'n/a';
-                        }
-
-                        row.appendChild(profilerCell);
-
-                        var requestState = 'ok';
-                        if (request.error) {
-                            requestState = 'error';
-                            if (state != "loading" && i > requestStack.length - 4) {
-                                state = 'error';
-                            }
-                        } else if (request.loading) {
-                            requestState = 'loading';
-                            state = 'loading';
-                        }
-                        row.className = 'sf-ajax-request sf-ajax-request-' + requestState;
-                    }
-
-                    var infoSpan = document.querySelectorAll(".sf-toolbar-ajax-info")[0];
-                    var children = collectionToArray(tbody.children);
-                    for (var i = 0; i < children.length; i++) {
-                        tbody.removeChild(children[i]);
-                    }
-                    tbody.appendChild(rows);
-
-                    if (infoSpan) {
-                        infoSpan.textContent = requestStack.length + ' AJAX request' + (requestStack.length > 1 ? 's' : '');
-                    }
-
-                    ajaxToolbarPanel.style.display = 'block';
-                } else {
-                    ajaxToolbarPanel.style.display = 'none';
-                }
-            }
-
-            requestCounter[0].textContent = requestStack.length;
-
-            requestCounter[0].className = 'sf-toolbar-ajax-requests sf-toolbar-value';
-
-            if (state == 'ok') {
-                Sfjs.removeClass(ajaxToolbarPanel, 'sf-ajax-request-loading');
-                Sfjs.removeClass(ajaxToolbarPanel, 'sf-toolbar-status-red');
-            } else if (state == 'error') {
-                Sfjs.addClass(ajaxToolbarPanel, 'sf-toolbar-status-red');
-                Sfjs.removeClass(ajaxToolbarPanel, 'sf-ajax-request-loading');
+            if (requestStack.length) {
+                ajaxToolbarPanel.style.display = 'block';
             } else {
-                Sfjs.addClass(ajaxToolbarPanel, 'sf-ajax-request-loading');
+                ajaxToolbarPanel.style.display = 'none';
             }
+            if (pendingRequests > 0) {
+                addClass(ajaxToolbarPanel, 'sf-ajax-request-loading');
+            } else if (successStreak < 4) {
+                addClass(ajaxToolbarPanel, 'sf-toolbar-status-red');
+                removeClass(ajaxToolbarPanel, 'sf-ajax-request-loading');
+            } else {
+                removeClass(ajaxToolbarPanel, 'sf-ajax-request-loading');
+                removeClass(ajaxToolbarPanel, 'sf-toolbar-status-red');
+            }
+        };
+
+        var startAjaxRequest = function(index) {
+            var request = requestStack[index];
+            pendingRequests++;
+            var row = document.createElement('tr');
+            request.DOMNode = row;
+
+            var tbody = document.querySelectorAll('.sf-toolbar-ajax-request-list')[0];
+            if (!tbody) {
+                return;
+            }
+
+            var methodCell = document.createElement('td');
+            methodCell.textContent = request.method;
+            row.appendChild(methodCell);
+
+            var typeCell = document.createElement('td');
+            typeCell.textContent = request.type;
+            row.appendChild(typeCell);
+
+            var statusCodeCell = document.createElement('td');
+            var statusCode = document.createElement('span');
+            statusCode.textContent = '-';
+            statusCodeCell.appendChild(statusCode);
+            row.appendChild(statusCodeCell);
+
+            var pathCell = document.createElement('td');
+            pathCell.className = 'sf-ajax-request-url';
+            if ('GET' === request.method) {
+                var pathLink = document.createElement('a');
+                pathLink.setAttribute('href', request.url);
+                pathLink.textContent = request.url;
+                pathCell.appendChild(pathLink);
+            } else {
+                pathCell.textContent = request.url;
+            }
+            pathCell.setAttribute('title', request.url);
+            row.appendChild(pathCell);
+
+            var durationCell = document.createElement('td');
+            durationCell.className = 'sf-ajax-request-duration';
+            durationCell.textContent = '-';
+            row.appendChild(durationCell);
+
+            var profilerCell = document.createElement('td');
+            profilerCell.textContent = 'n/a';
+            row.appendChild(profilerCell);
+
+            row.className = 'sf-ajax-request sf-ajax-request-loading';
+            tbody.insertBefore(row, tbody.firstChild);
+
+            renderAjaxRequests();
+        };
+
+        var finishAjaxRequest = function(index) {
+            var request = requestStack[index];
+            pendingRequests--;
+            var row = request.DOMNode;
+            /* Unpack the children from the row */
+            var methodCell = row.children[0];
+            var statusCodeCell = row.children[2];
+            var statusCodeElem = statusCodeCell.children[0];
+            var durationCell = row.children[4];
+            var profilerCell = row.children[5];
+
+            if (request.error) {
+                row.className = 'sf-ajax-request sf-ajax-request-error';
+                methodCell.className = 'sf-ajax-request-error';
+                successStreak = 0;
+            } else {
+                row.className = 'sf-ajax-request sf-ajax-request-ok';
+                successStreak++;
+            }
+
+            if (request.statusCode) {
+                if (request.statusCode < 300) {
+                    statusCodeElem.setAttribute('class', 'sf-toolbar-status');
+                } else if (request.statusCode < 400) {
+                    statusCodeElem.setAttribute('class', 'sf-toolbar-status sf-toolbar-status-yellow');
+                } else {
+                    statusCodeElem.setAttribute('class', 'sf-toolbar-status sf-toolbar-status-red');
+                }
+                statusCodeElem.textContent = request.statusCode;
+            }
+
+            if (request.duration) {
+                durationCell.textContent = request.duration + 'ms';
+            }
+
+            if (request.profilerUrl) {
+                profilerCell.textContent = '';
+                var profilerLink = document.createElement('a');
+                profilerLink.setAttribute('href', request.profilerUrl);
+                profilerLink.textContent = request.profile;
+                profilerCell.appendChild(profilerLink);
+            }
+
+            renderAjaxRequests();
         };
 
         var addEventListener;
@@ -237,91 +241,86 @@
         }
 
         {% if excluded_ajax_paths is defined %}
-            if (window.fetch && window.fetch.polyfill === undefined) {
-                var oldFetch = window.fetch;
-                window.fetch = function () {
-                    var promise = oldFetch.apply(this, arguments);
-                    if (!arguments[0].match(new RegExp({{ excluded_ajax_paths|json_encode|raw }}))) {
-                        var method = 'GET';
-                        if (arguments[1] && arguments[1].method !== undefined) {
-                            method = arguments[1].method;
-                        }
+        if (window.fetch && window.fetch.polyfill === undefined) {
+            var oldFetch = window.fetch;
+            window.fetch = function () {
+                var promise = oldFetch.apply(this, arguments);
+                if (!arguments[0].match(new RegExp({{ excluded_ajax_paths|json_encode|raw }}))) {
+                    var method = 'GET';
+                    if (arguments[1] && arguments[1].method !== undefined) {
+                        method = arguments[1].method;
+                    }
 
-                        var stackElement = {
-                            loading: true,
-                            error: false,
-                            url: arguments[0],
-                            method: method,
-                            type: 'fetch',
-                            start: new Date()
-                        };
+                    var stackElement = {
+                        error: false,
+                        url: arguments[0],
+                        method: method,
+                        type: 'fetch',
+                        start: new Date()
+                    };
 
-                        requestStack.push(stackElement);
-                        promise.then(function (r) {
+                    var idx = requestStack.push(stackElement) - 1;
+                    promise.then(function (r) {
+                        stackElement.duration = new Date() - stackElement.start;
+                        stackElement.error = r.status < 200 || r.status >= 400;
+                        stackElement.statusCode = r.status;
+                        stackElement.profile = r.headers.get('x-debug-token');
+                        stackElement.profilerUrl = r.headers.get('x-debug-token-link');
+                        finishAjaxRequest(idx);
+                    }, function (e){
+                        stackElement.error = true;
+                    });
+                    startAjaxRequest(idx);
+                }
+
+                return promise;
+            };
+        }
+        if (window.XMLHttpRequest && XMLHttpRequest.prototype.addEventListener) {
+            var proxied = XMLHttpRequest.prototype.open;
+
+            XMLHttpRequest.prototype.open = function(method, url, async, user, pass) {
+                var self = this;
+
+                /* prevent logging AJAX calls to static and inline files, like templates */
+                var path = url;
+                if (url.substr(0, 1) === '/') {
+                    if (0 === url.indexOf('{{ request.basePath|e('js') }}')) {
+                        path = url.substr({{ request.basePath|length }});
+                    }
+                }
+                else if (0 === url.indexOf('{{ (request.schemeAndHttpHost ~ request.basePath)|e('js') }}')) {
+                    path = url.substr({{ (request.schemeAndHttpHost ~ request.basePath)|length }});
+                }
+
+                if (!path.match(new RegExp({{ excluded_ajax_paths|json_encode|raw }}))) {
+                    var stackElement = {
+                        error: false,
+                        url: url,
+                        method: method,
+                        type: 'xhr',
+                        start: new Date()
+                    };
+
+                    var idx = requestStack.push(stackElement) - 1;
+
+                    this.addEventListener('readystatechange', function() {
+                        if (self.readyState == 4) {
                             stackElement.duration = new Date() - stackElement.start;
-                            stackElement.loading = false;
-                            stackElement.error = r.status < 200 || r.status >= 400;
-                            stackElement.statusCode = r.status;
-                            stackElement.profile = r.headers.get('x-debug-token');
-                            stackElement.profilerUrl = r.headers.get('x-debug-token-link');
-                            renderAjaxRequests();
-                        }, function (e){
-                            stackElement.loading = false;
-                            stackElement.error = true;
-                        });
-                        renderAjaxRequests();
-                    }
+                            stackElement.error = self.status < 200 || self.status >= 400;
+                            stackElement.statusCode = self.status;
+                            extractHeaders(self, stackElement);
 
-                    return promise;
-                };
-            }
-            if (window.XMLHttpRequest && XMLHttpRequest.prototype.addEventListener) {
-                var proxied = XMLHttpRequest.prototype.open;
-
-                XMLHttpRequest.prototype.open = function(method, url, async, user, pass) {
-                    var self = this;
-
-                    /* prevent logging AJAX calls to static and inline files, like templates */
-                    var path = url;
-                    if (url.substr(0, 1) === '/') {
-                        if (0 === url.indexOf('{{ request.basePath|e('js') }}')) {
-                            path = url.substr({{ request.basePath|length }});
+                            finishAjaxRequest(idx);
                         }
-                    }
-                    else if (0 === url.indexOf('{{ (request.schemeAndHttpHost ~ request.basePath)|e('js') }}')) {
-                        path = url.substr({{ (request.schemeAndHttpHost ~ request.basePath)|length }});
-                    }
+                    }, false);
 
-                    if (!path.match(new RegExp({{ excluded_ajax_paths|json_encode|raw }}))) {
-                        var stackElement = {
-                            loading: true,
-                            error: false,
-                            url: url,
-                            method: method,
-                            type: 'xhr',
-                            start: new Date()
-                        };
+                    startAjaxRequest(idx);
+                }
 
-                        requestStack.push(stackElement);
-
-                        this.addEventListener('readystatechange', function() {
-                            if (self.readyState == 4) {
-                                stackElement.duration = new Date() - stackElement.start;
-                                stackElement.loading = false;
-                                stackElement.error = self.status < 200 || self.status >= 400;
-                                stackElement.statusCode = self.status;
-                                extractHeaders(self, stackElement);
-
-                                renderAjaxRequests();
-                            }
-                        }, false);
-
-                        renderAjaxRequests();
-                    }
-
-                    proxied.apply(this, Array.prototype.slice.call(arguments));
-                };
-            }
+                proxied.apply(this, Array.prototype.slice.call(arguments));
+            };
+        }
         {% endif %}
 
         return {
@@ -497,6 +496,7 @@
     Sfjs.addEventListener(window, 'load', function() {
         Sfjs.createTabs();
         Sfjs.createToggles();
+        Sfjs.renderAjaxRequests();
     });
 
 /*]]>*/</script>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -20,210 +20,208 @@
             var toggleClass = function(el, cssClass) { hasClass(el, cssClass) ? removeClass(el, cssClass) : addClass(el, cssClass); };
         }
 
-        var noop = function() {},
+        var noop = function() {};
 
-            collectionToArray = function (collection) {
-                var length = collection.length || 0,
-                    results = new Array(length);
+        var collectionToArray = function (collection) {
+            var length = collection.length || 0,
+                results = new Array(length);
 
-                while (length--) {
-                    results[length] = collection[length];
-                }
+            while (length--) {
+                results[length] = collection[length];
+            }
 
-                return results;
-            },
+            return results;
+        };
 
-            profilerStorageKey = 'sf2/profiler/',
+        var profilerStorageKey = 'sf2/profiler/';
 
-            request = function(url, onSuccess, onError, payload, options) {
-                var xhr = window.XMLHttpRequest ? new XMLHttpRequest() : new ActiveXObject('Microsoft.XMLHTTP');
-                options = options || {};
-                options.maxTries = options.maxTries || 0;
-                xhr.open(options.method || 'GET', url, true);
-                xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
-                xhr.onreadystatechange = function(state) {
-                    if (4 !== xhr.readyState) {
-                        return null;
-                    }
-
-                    if (xhr.status == 404 && options.maxTries > 1) {
-                        setTimeout(function(){
-                            options.maxTries--;
-                            request(url, onSuccess, onError, payload, options);
-                        }, 500);
-
-                        return null;
-                    }
-
-                    if (200 === xhr.status) {
-                        (onSuccess || noop)(xhr);
-                    } else {
-                        (onError || noop)(xhr);
-                    }
-                };
-                xhr.send(payload || '');
-            },
-
-            getPreference = function(name) {
-                if (!window.localStorage) {
+        var request = function(url, onSuccess, onError, payload, options) {
+            var xhr = window.XMLHttpRequest ? new XMLHttpRequest() : new ActiveXObject('Microsoft.XMLHTTP');
+            options = options || {};
+            options.maxTries = options.maxTries || 0;
+            xhr.open(options.method || 'GET', url, true);
+            xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+            xhr.onreadystatechange = function(state) {
+                if (4 !== xhr.readyState) {
                     return null;
                 }
 
-                return localStorage.getItem(profilerStorageKey + name);
-            },
+                if (xhr.status == 404 && options.maxTries > 1) {
+                    setTimeout(function(){
+                        options.maxTries--;
+                        request(url, onSuccess, onError, payload, options);
+                    }, 500);
 
-            setPreference = function(name, value) {
-                if (!window.localStorage) {
                     return null;
                 }
 
-                localStorage.setItem(profilerStorageKey + name, value);
-            },
-
-            requestStack = [],
-
-            extractHeaders = function(xhr, stackElement) {
-                /* Here we avoid to call xhr.getResponseHeader in order to */
-                /* prevent polluting the console with CORS security errors */
-                var allHeaders = xhr.getAllResponseHeaders();
-                var ret;
-
-                if (ret = allHeaders.match(/^x-debug-token:\s+(.*)$/im)) {
-                    stackElement.profile = ret[1];
-                }
-                if (ret = allHeaders.match(/^x-debug-token-link:\s+(.*)$/im)) {
-                    stackElement.profilerUrl = ret[1];
-                }
-            },
-
-            renderAjaxRequests = function() {
-                var requestCounter = document.querySelectorAll('.sf-toolbar-ajax-requests');
-                if (!requestCounter.length) {
-                    return;
-                }
-
-                var ajaxToolbarPanel = document.querySelector('.sf-toolbar-block-ajax');
-                var tbodies = document.querySelectorAll('.sf-toolbar-ajax-request-list');
-                var state = 'ok';
-                if (tbodies.length) {
-                    var tbody = tbodies[0];
-
-                    var rows = document.createDocumentFragment();
-
-                    if (requestStack.length) {
-                        for (var i = 0; i < requestStack.length; i++) {
-                            var request = requestStack[i];
-
-                            var row = document.createElement('tr');
-                            rows.insertBefore(row, rows.firstChild);
-
-                            var methodCell = document.createElement('td');
-                            if (request.error) {
-                                methodCell.className = 'sf-ajax-request-error';
-                            }
-                            methodCell.textContent = request.method;
-                            row.appendChild(methodCell);
-
-                            var typeCell = document.createElement('td');
-                            typeCell.textContent = request.type;
-                            row.appendChild(typeCell);
-
-                            var statusCodeCell = document.createElement('td');
-                            var statusCode = document.createElement('span');
-                            if (request.statusCode < 300) {
-                                statusCode.setAttribute('class', 'sf-toolbar-status');
-                            } else if (request.statusCode < 400) {
-                                statusCode.setAttribute('class', 'sf-toolbar-status sf-toolbar-status-yellow');
-                            } else {
-                                statusCode.setAttribute('class', 'sf-toolbar-status sf-toolbar-status-red');
-                            }
-                            statusCode.textContent = request.statusCode || '-';
-                            statusCodeCell.appendChild(statusCode);
-                            row.appendChild(statusCodeCell);
-
-                            var pathCell = document.createElement('td');
-                            pathCell.className = 'sf-ajax-request-url';
-                            if ('GET' === request.method) {
-                                var pathLink = document.createElement('a');
-                                pathLink.setAttribute('href', request.url);
-                                pathLink.textContent = request.url;
-                                pathCell.appendChild(pathLink);
-                            } else {
-                                pathCell.textContent = request.url;
-                            }
-                            pathCell.setAttribute('title', request.url);
-                            row.appendChild(pathCell);
-
-                            var durationCell = document.createElement('td');
-                            durationCell.className = 'sf-ajax-request-duration';
-
-                            if (request.duration) {
-                                durationCell.textContent = request.duration + "ms";
-                            } else {
-                                durationCell.textContent = '-';
-                            }
-                            row.appendChild(durationCell);
-
-                            row.appendChild(document.createTextNode(' '));
-                            var profilerCell = document.createElement('td');
-
-                            if (request.profilerUrl) {
-                                var profilerLink = document.createElement('a');
-                                profilerLink.setAttribute('href', request.profilerUrl);
-                                profilerLink.textContent = request.profile;
-                                profilerCell.appendChild(profilerLink);
-                            } else {
-                                profilerCell.textContent = 'n/a';
-                            }
-
-                            row.appendChild(profilerCell);
-
-                            var requestState = 'ok';
-                            if (request.error) {
-                                requestState = 'error';
-                                if (state != "loading" && i > requestStack.length - 4) {
-                                    state = 'error';
-                                }
-                            } else if (request.loading) {
-                                requestState = 'loading';
-                                state = 'loading';
-                            }
-                            row.className = 'sf-ajax-request sf-ajax-request-' + requestState;
-                        }
-
-                        var infoSpan = document.querySelectorAll(".sf-toolbar-ajax-info")[0];
-                        var children = collectionToArray(tbody.children);
-                        for (var i = 0; i < children.length; i++) {
-                            tbody.removeChild(children[i]);
-                        }
-                        tbody.appendChild(rows);
-
-                        if (infoSpan) {
-                            var text = requestStack.length + ' AJAX request' + (requestStack.length > 1 ? 's' : '');
-                            infoSpan.textContent = text;
-                        }
-
-                        ajaxToolbarPanel.style.display = 'block';
-                    } else {
-                        ajaxToolbarPanel.style.display = 'none';
-                    }
-                }
-
-                requestCounter[0].textContent = requestStack.length;
-
-                var className = 'sf-toolbar-ajax-requests sf-toolbar-value';
-                requestCounter[0].className = className;
-
-                if (state == 'ok') {
-                    Sfjs.removeClass(ajaxToolbarPanel, 'sf-ajax-request-loading');
-                    Sfjs.removeClass(ajaxToolbarPanel, 'sf-toolbar-status-red');
-                } else if (state == 'error') {
-                    Sfjs.addClass(ajaxToolbarPanel, 'sf-toolbar-status-red');
-                    Sfjs.removeClass(ajaxToolbarPanel, 'sf-ajax-request-loading');
+                if (200 === xhr.status) {
+                    (onSuccess || noop)(xhr);
                 } else {
-                    Sfjs.addClass(ajaxToolbarPanel, 'sf-ajax-request-loading');
+                    (onError || noop)(xhr);
                 }
             };
+            xhr.send(payload || '');
+        };
+
+        var getPreference = function(name) {
+            if (!window.localStorage) {
+                return null;
+            }
+
+            return localStorage.getItem(profilerStorageKey + name);
+        };
+
+        var setPreference = function(name, value) {
+            if (!window.localStorage) {
+                return null;
+            }
+
+            localStorage.setItem(profilerStorageKey + name, value);
+        };
+
+        var requestStack = [];
+
+        var extractHeaders = function(xhr, stackElement) {
+            /* Here we avoid to call xhr.getResponseHeader in order to */
+            /* prevent polluting the console with CORS security errors */
+            var allHeaders = xhr.getAllResponseHeaders();
+            var ret;
+
+            if (ret = allHeaders.match(/^x-debug-token:\s+(.*)$/im)) {
+                stackElement.profile = ret[1];
+            }
+            if (ret = allHeaders.match(/^x-debug-token-link:\s+(.*)$/im)) {
+                stackElement.profilerUrl = ret[1];
+            }
+        };
+
+        var renderAjaxRequests = function() {
+            var requestCounter = document.querySelectorAll('.sf-toolbar-ajax-requests');
+            if (!requestCounter.length) {
+                return;
+            }
+
+            var ajaxToolbarPanel = document.querySelector('.sf-toolbar-block-ajax');
+            var tbodies = document.querySelectorAll('.sf-toolbar-ajax-request-list');
+            var state = 'ok';
+            if (tbodies.length) {
+                var tbody = tbodies[0];
+
+                var rows = document.createDocumentFragment();
+
+                if (requestStack.length) {
+                    for (var i = 0; i < requestStack.length; i++) {
+                        var request = requestStack[i];
+
+                        var row = document.createElement('tr');
+                        rows.insertBefore(row, rows.firstChild);
+
+                        var methodCell = document.createElement('td');
+                        if (request.error) {
+                            methodCell.className = 'sf-ajax-request-error';
+                        }
+                        methodCell.textContent = request.method;
+                        row.appendChild(methodCell);
+
+                        var typeCell = document.createElement('td');
+                        typeCell.textContent = request.type;
+                        row.appendChild(typeCell);
+
+                        var statusCodeCell = document.createElement('td');
+                        var statusCode = document.createElement('span');
+                        if (request.statusCode < 300) {
+                            statusCode.setAttribute('class', 'sf-toolbar-status');
+                        } else if (request.statusCode < 400) {
+                            statusCode.setAttribute('class', 'sf-toolbar-status sf-toolbar-status-yellow');
+                        } else {
+                            statusCode.setAttribute('class', 'sf-toolbar-status sf-toolbar-status-red');
+                        }
+                        statusCode.textContent = request.statusCode || '-';
+                        statusCodeCell.appendChild(statusCode);
+                        row.appendChild(statusCodeCell);
+
+                        var pathCell = document.createElement('td');
+                        pathCell.className = 'sf-ajax-request-url';
+                        if ('GET' === request.method) {
+                            var pathLink = document.createElement('a');
+                            pathLink.setAttribute('href', request.url);
+                            pathLink.textContent = request.url;
+                            pathCell.appendChild(pathLink);
+                        } else {
+                            pathCell.textContent = request.url;
+                        }
+                        pathCell.setAttribute('title', request.url);
+                        row.appendChild(pathCell);
+
+                        var durationCell = document.createElement('td');
+                        durationCell.className = 'sf-ajax-request-duration';
+
+                        if (request.duration) {
+                            durationCell.textContent = request.duration + "ms";
+                        } else {
+                            durationCell.textContent = '-';
+                        }
+                        row.appendChild(durationCell);
+
+                        row.appendChild(document.createTextNode(' '));
+                        var profilerCell = document.createElement('td');
+
+                        if (request.profilerUrl) {
+                            var profilerLink = document.createElement('a');
+                            profilerLink.setAttribute('href', request.profilerUrl);
+                            profilerLink.textContent = request.profile;
+                            profilerCell.appendChild(profilerLink);
+                        } else {
+                            profilerCell.textContent = 'n/a';
+                        }
+
+                        row.appendChild(profilerCell);
+
+                        var requestState = 'ok';
+                        if (request.error) {
+                            requestState = 'error';
+                            if (state != "loading" && i > requestStack.length - 4) {
+                                state = 'error';
+                            }
+                        } else if (request.loading) {
+                            requestState = 'loading';
+                            state = 'loading';
+                        }
+                        row.className = 'sf-ajax-request sf-ajax-request-' + requestState;
+                    }
+
+                    var infoSpan = document.querySelectorAll(".sf-toolbar-ajax-info")[0];
+                    var children = collectionToArray(tbody.children);
+                    for (var i = 0; i < children.length; i++) {
+                        tbody.removeChild(children[i]);
+                    }
+                    tbody.appendChild(rows);
+
+                    if (infoSpan) {
+                        infoSpan.textContent = requestStack.length + ' AJAX request' + (requestStack.length > 1 ? 's' : '');
+                    }
+
+                    ajaxToolbarPanel.style.display = 'block';
+                } else {
+                    ajaxToolbarPanel.style.display = 'none';
+                }
+            }
+
+            requestCounter[0].textContent = requestStack.length;
+
+            requestCounter[0].className = 'sf-toolbar-ajax-requests sf-toolbar-value';
+
+            if (state == 'ok') {
+                Sfjs.removeClass(ajaxToolbarPanel, 'sf-ajax-request-loading');
+                Sfjs.removeClass(ajaxToolbarPanel, 'sf-toolbar-status-red');
+            } else if (state == 'error') {
+                Sfjs.addClass(ajaxToolbarPanel, 'sf-toolbar-status-red');
+                Sfjs.removeClass(ajaxToolbarPanel, 'sf-ajax-request-loading');
+            } else {
+                Sfjs.addClass(ajaxToolbarPanel, 'sf-ajax-request-loading');
+            }
+        };
 
         var addEventListener;
 
@@ -266,12 +264,12 @@
                             stackElement.statusCode = r.status;
                             stackElement.profile = r.headers.get('x-debug-token');
                             stackElement.profilerUrl = r.headers.get('x-debug-token-link');
-                            Sfjs.renderAjaxRequests();
+                            renderAjaxRequests();
                         }, function (e){
                             stackElement.loading = false;
                             stackElement.error = true;
                         });
-                        Sfjs.renderAjaxRequests();
+                        renderAjaxRequests();
                     }
 
                     return promise;
@@ -314,11 +312,11 @@
                                 stackElement.statusCode = self.status;
                                 extractHeaders(self, stackElement);
 
-                                Sfjs.renderAjaxRequests();
+                                renderAjaxRequests();
                             }
                         }, false);
 
-                        Sfjs.renderAjaxRequests();
+                        renderAjaxRequests();
                     }
 
                     proxied.apply(this, Array.prototype.slice.call(arguments));
@@ -395,8 +393,8 @@
 
                         var tabNavigationItem = document.createElement('li');
                         tabNavigationItem.setAttribute('data-tab-id', tabId);
-                        if (j == 0) { Sfjs.addClass(tabNavigationItem, 'active'); }
-                        if (Sfjs.hasClass(tabs[j], 'disabled')) { Sfjs.addClass(tabNavigationItem, 'disabled'); }
+                        if (j == 0) { addClass(tabNavigationItem, 'active'); }
+                        if (hasClass(tabs[j], 'disabled')) { addClass(tabNavigationItem, 'disabled'); }
                         tabNavigationItem.innerHTML = tabTitle;
                         tabNavigation.appendChild(tabNavigationItem);
 
@@ -415,7 +413,7 @@
                         tabId = tabNavigation[j].getAttribute('data-tab-id');
                         document.getElementById(tabId).querySelector('.tab-title').className = 'hidden';
 
-                        if (Sfjs.hasClass(tabNavigation[j], 'active')) {
+                        if (hasClass(tabNavigation[j], 'active')) {
                             document.getElementById(tabId).className = 'block';
                         } else {
                             document.getElementById(tabId).className = 'hidden';
@@ -435,10 +433,10 @@
                             for (var k = 0; k < tabNavigation.length; k++) {
                                 var tabId = tabNavigation[k].getAttribute('data-tab-id');
                                 document.getElementById(tabId).className = 'hidden';
-                                Sfjs.removeClass(tabNavigation[k], 'active');
+                                removeClass(tabNavigation[k], 'active');
                             }
 
-                            Sfjs.addClass(activeTab, 'active');
+                            addClass(activeTab, 'active');
                             var activeTabId = activeTab.getAttribute('data-tab-id');
                             document.getElementById(activeTabId).className = 'block';
                         });
@@ -453,29 +451,29 @@
                     var elementSelector = toggles[i].getAttribute('data-toggle-selector');
                     var element = document.querySelector(elementSelector);
 
-                    Sfjs.addClass(element, 'sf-toggle-content');
+                    addClass(element, 'sf-toggle-content');
 
                     if (toggles[i].hasAttribute('data-toggle-initial') && toggles[i].getAttribute('data-toggle-initial') == 'display') {
-                        Sfjs.addClass(element, 'sf-toggle-visible');
+                        addClass(element, 'sf-toggle-visible');
                     } else {
-                        Sfjs.addClass(element, 'sf-toggle-hidden');
+                        addClass(element, 'sf-toggle-hidden');
                     }
 
-                    Sfjs.addEventListener(toggles[i], 'click', function(e) {
+                    addEventListener(toggles[i], 'click', function(e) {
                         e.preventDefault();
 
                         var toggle = e.target || e.srcElement;
 
                         /* needed because when the toggle contains HTML contents, user can click */
                         /* on any of those elements instead of their parent '.sf-toggle' element */
-                        while (!Sfjs.hasClass(toggle, 'sf-toggle')) {
+                        while (!hasClass(toggle, 'sf-toggle')) {
                             toggle = toggle.parentNode;
                         }
 
                         var element = document.querySelector(toggle.getAttribute('data-toggle-selector'));
 
-                        Sfjs.toggleClass(element, 'sf-toggle-hidden');
-                        Sfjs.toggleClass(element, 'sf-toggle-visible');
+                        toggleClass(element, 'sf-toggle-hidden');
+                        toggleClass(element, 'sf-toggle-visible');
 
                         /* the toggle doesn't change its contents when clicking on it */
                         if (!toggle.hasAttribute('data-toggle-alt-content')) {

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -88,14 +88,14 @@
         var successStreak = 4;
         var pendingRequests = 0;
         var renderAjaxRequests = function() {
-            var requestCounter = document.querySelectorAll('.sf-toolbar-ajax-requests')[0];
+            var requestCounter = document.querySelector('.sf-toolbar-ajax-requests');
             if (!requestCounter) {
                 return;
             }
             requestCounter.textContent = requestStack.length;
             requestCounter.className = 'sf-toolbar-ajax-requests sf-toolbar-value';
 
-            var infoSpan = document.querySelectorAll(".sf-toolbar-ajax-info")[0];
+            var infoSpan = document.querySelector(".sf-toolbar-ajax-info");
             if (infoSpan) {
                 infoSpan.textContent = requestStack.length + ' AJAX request' + (requestStack.length > 1 ? 's' : '');
             }
@@ -123,7 +123,7 @@
             var row = document.createElement('tr');
             request.DOMNode = row;
 
-            var tbody = document.querySelectorAll('.sf-toolbar-ajax-request-list')[0];
+            var tbody = document.querySelector('.sf-toolbar-ajax-request-list');
             if (!tbody) {
                 return;
             }

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -38,8 +38,6 @@
                     document.getElementById('sfMiniToolbar-{{ token }}').style.display = 'none';
                 }
 
-                Sfjs.renderAjaxRequests();
-
                 /* Handle toolbar-info position */
                 var toolbarBlocks = [].slice.call(el.querySelectorAll('.sf-toolbar-block'));
                 for (i = 0; i < toolbarBlocks.length; ++i) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | kinda (is bad performance a bug?) |
| New feature? | kinda (is increased performance a feature?) |
| BC breaks? | no (unless performance is a BC break) |
| Deprecations? | no |
| Tests pass? | do we have JS tests? |
| Fixed tickets | #20155 |
| License | MIT |
| Doc PR | n/a |

The old version of this JS re-rendered the entire list of ajax calls which was causing some performance issues when people had high numbers of ajax requests (increasingly common as people create SPAs.

This PR changes the behavior of the ajax profiler to be more smart about the DOM manipulations it makes. Instead of re-rendering the entire list, on any AJAX requests/responses, it instead adds the row to the profiler when an AJAX request is made, adding the DOM node as a property of the request on the requestStack. When the AJAX response comes back, it updates the existing DOM node instead of re-creating it (and all of the others).

I've tested this on my machine using a modern version of chrome. I don't think I'm doing anything fancy, so I think the likelihood that I broke something is minimal.

I've left a couple of the commits separate, because they represent distinct ideas. The first commit is just some consistency/cleanup. The second commit is the meat of the work. Its diff is basically useless since I've added two new functions and modified one function heavily. I tried to make the diff as easy to read as possible, but it's still pretty rough. The third commit removes some functions/calls that I don't think need to be there now that this is re-written, but I wanted to leave them in a separate commit for ease of revert if they are indeed needed.
