### PR TITLE
[DependencyInjection] Fix duplication of placeholders

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
@@ -62,9 +62,17 @@ class EnvPlaceholderParameterBag extends ParameterBag
 
     /**
      * Merges the env placeholders of another EnvPlaceholderParameterBag.
+     *
+     * @param EnvPlaceholderParameterBag $bag
      */
     public function mergeEnvPlaceholders(self $bag)
     {
-        $this->envPlaceholders = array_merge_recursive($this->envPlaceholders, $bag->getEnvPlaceholders());
+        $newPlaceholders = $bag->getEnvPlaceholders();
+
+        foreach ($newPlaceholders as $key => $newEntries) {
+            $existingEntries = isset($this->envPlaceholders[$key]) ? $this->envPlaceholders[$key] : array();
+            $mergedEntries = array_merge($existingEntries, $newEntries);
+            $this->envPlaceholders[$key] = array_unique($mergedEntries);
+        }
     }
 }

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
@@ -71,9 +71,6 @@ class EnvPlaceholderParameterBag extends ParameterBag
      */
     public function mergeEnvPlaceholders(self $bag)
     {
-        $this->envPlaceholders = array_map(
-            'array_unique',
-            array_merge_recursive($this->envPlaceholders, $bag->getEnvPlaceholders())
-        );
+        $this->envPlaceholders = array_merge_recursive($this->envPlaceholders, $bag->getEnvPlaceholders());
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
@@ -23,4 +23,19 @@ class EnvPlaceholderParameterBagTest extends \PHPUnit_Framework_TestCase
         $bag = new EnvPlaceholderParameterBag();
         $bag->get('env(%foo%)');
     }
+
+    public function testMergeWillNotDuplicateIdenticalParameters()
+    {
+        $originalPlaceholders = array('database_host' => array('localhost'));
+        $firstBag = new EnvPlaceholderParameterBag($originalPlaceholders);
+
+        // initialize placeholders
+        $firstBag->get('env(database_host)');
+        $secondBag = clone $firstBag;
+
+        $firstBag->mergeEnvPlaceholders($secondBag);
+        $mergedPlaceholders = $firstBag->getEnvPlaceholders();
+
+        $this->assertEquals(1, count($mergedPlaceholders['database_host']));
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
@@ -36,6 +36,6 @@ class EnvPlaceholderParameterBagTest extends \PHPUnit_Framework_TestCase
         $firstBag->mergeEnvPlaceholders($secondBag);
         $mergedPlaceholders = $firstBag->getEnvPlaceholders();
 
-        $this->assertEquals(1, count($mergedPlaceholders['database_host']));
+        $this->assertCount(1, $mergedPlaceholders['database_host']);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #20198 |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

Fixes performance issues related to merging parameter bags when using the `env()` parameters introduced in #19681
