### PR TITLE
[HttpCache] fix: do not cache OPTIONS request

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1474,6 +1474,16 @@ class Request
     }
 
     /**
+     * Checks whether the method is cachaeble or not.
+     *
+     * @return bool
+     */
+    public function isMethodCacheable()
+    {
+        return in_array($this->getMethod(), array('GET', 'HEAD'));
+    }
+
+    /**
      * Returns the request body content.
      *
      * @param bool $asResource If true, a resource will be returned

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1948,6 +1948,32 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             array('CONNECT', false),
         );
     }
+
+    /**
+     * @dataProvider methodCacheableProvider
+     */
+    public function testMethodCacheable($method, $chacheable)
+    {
+        $request = new Request();
+        $request->setMethod($method);
+        $this->assertEquals($chacheable, $request->isMethodCacheable());
+    }
+
+    public function methodCacheableProvider()
+    {
+        return array(
+            array('HEAD', true),
+            array('GET', true),
+            array('POST', false),
+            array('PUT', false),
+            array('PATCH', false),
+            array('DELETE', false),
+            array('PURGE', false),
+            array('OPTIONS', false),
+            array('TRACE', false),
+            array('CONNECT', false),
+        );
+    }
 }
 
 class RequestContentProxy extends Request

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -204,7 +204,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
 
         if (!$request->isMethodSafe()) {
             $response = $this->invalidate($request, $catch);
-        } elseif ($request->headers->has('expect')) {
+        } elseif ($request->headers->has('expect') || !$request->isMethodCacheable()) {
             $response = $this->pass($request, $catch);
         } else {
             $response = $this->lookup($request, $catch);

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
@@ -1264,6 +1264,21 @@ class HttpCacheTest extends HttpCacheTestCase
         $this->assertNull($this->response->getETag());
         $this->assertNull($this->response->getLastModified());
     }
+
+    public function testDoesNotCacheOptionsRequest()
+    {
+        $this->setNextResponse(200, array('Cache-Control' => 'public, s-maxage=60'), 'get');
+        $this->request('GET', '/');
+        $this->assertHttpKernelIsCalled();
+
+        $this->setNextResponse(200, array('Cache-Control' => 'public, s-maxage=60'), 'options');
+        $this->request('OPTIONS', '/');
+        $this->assertHttpKernelIsCalled();
+
+        $this->request('GET', '/');
+        $this->assertHttpKernelIsNotCalled();
+        $this->assertSame('get', $this->response->getContent());
+    }
 }
 
 class TestKernel implements HttpKernelInterface

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.9",
         "symfony/event-dispatcher": "~2.6,>=2.6.7",
-        "symfony/http-foundation": "~2.7.15|~2.8.8",
+        "symfony/http-foundation": "~2.7.20|~2.8.13",
         "symfony/debug": "~2.6,>=2.6.2",
         "psr/log": "~1.0"
     },


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/issues/20202 |
| License | MIT |
| Doc PR | - |

The HttpCache should not cache any OPTIONS request as they are by spec not cacheable (mentioned here https://github.com/symfony/symfony/issues/20202#issuecomment-253033144 by @xabbuh).
