### PR TITLE
[Form] render hidden empty inputs for checkboxes

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -85,7 +85,7 @@
 {%- endblock choice_widget_options -%}
 
 {%- block checkbox_widget -%}
-    <input type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %} />
+    <input type="hidden" name="{{ full_name }}" /><input type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %} />
 {%- endblock checkbox_widget -%}
 
 {%- block radio_widget -%}

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "symfony/asset": "~2.7",
         "symfony/finder": "~2.3",
-        "symfony/form": "~2.7.11|~2.8.4",
+        "symfony/form": "~2.7.20|~2.8.13",
         "symfony/http-kernel": "~2.3",
         "symfony/intl": "~2.3",
         "symfony/routing": "~2.2",

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/checkbox_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/checkbox_widget.html.php
@@ -1,4 +1,4 @@
-<input type="checkbox"
+<input type="hidden" name="<?php echo $view->escape($full_name) ?>" /><input type="checkbox"
     <?php echo $view['form']->block($form, 'widget_attributes') ?>
     <?php if (strlen($value) > 0): ?> value="<?php echo $view->escape($value) ?>"<?php endif ?>
     <?php if ($checked): ?> checked="checked"<?php endif ?>

--- a/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
@@ -805,7 +805,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
         /following-sibling::input[@type="checkbox"][@name="name[]"][@id="name_1"][@value="&b"][not(@checked)]
         /following-sibling::input[@type="hidden"][@id="name__token"]
     ]
-    [count(./input)=3]
+    [count(./input)=5]
     [count(./label)=1]
 '
         );
@@ -837,7 +837,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
         /following-sibling::label[@for="name_2"][.="[trans]label.&c[/trans]"]
         /following-sibling::input[@type="hidden"][@id="name__token"]
     ]
-    [count(./input)=4]
+    [count(./input)=7]
     [count(./label)=3]
 '
         );
@@ -862,7 +862,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
         /following-sibling::input[@type="checkbox"][@name="name[]"][@id="name_1"][@value="&b"][not(@checked)]
         /following-sibling::input[@type="hidden"][@id="name__token"]
     ]
-    [count(./input)=3]
+    [count(./input)=5]
     [count(./label)=1]
 '
         );

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -1133,7 +1133,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         /following-sibling::label[@for="name_2"][.="[trans]Choice&C[/trans]"]
         /following-sibling::input[@type="hidden"][@id="name__token"]
     ]
-    [count(./input)=4]
+    [count(./input)=7]
 '
         );
     }
@@ -1160,7 +1160,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         /following-sibling::label[@for="name_2"][.="Choice&C"]
         /following-sibling::input[@type="hidden"][@id="name__token"]
     ]
-    [count(./input)=4]
+    [count(./input)=7]
 '
         );
     }
@@ -1189,7 +1189,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         /following-sibling::label[@for="name_2"][.="[trans]Choice&C[/trans]"]
         /following-sibling::input[@type="hidden"][@id="name__token"]
     ]
-    [count(./input)=4]
+    [count(./input)=7]
 '
         );
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #20179 |
| License | MIT |
| Doc PR |  |

This ensures that a form is always considered submitted even if it contains only checkboxes which all haven't been checked by the user.
