### PR TITLE
Fix/broken merging of parameter bag env placeholders

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
@@ -48,7 +48,7 @@ class EnvPlaceholderParameterBag extends ParameterBag
 
             $uniqueName = md5($name.uniqid(mt_rand(), true));
             $placeholder = sprintf('env_%s_%s', $env, $uniqueName);
-            $this->envPlaceholders[$env][] = $placeholder;
+            $this->envPlaceholders[$env][$placeholder] = $placeholder;
 
             return $placeholder;
         }
@@ -71,12 +71,12 @@ class EnvPlaceholderParameterBag extends ParameterBag
      */
     public function mergeEnvPlaceholders(self $bag)
     {
-        $newPlaceholders = $bag->getEnvPlaceholders();
+        if ($newPlaceholders = $bag->getEnvPlaceholders()) {
+            $this->envPlaceholders += $newPlaceholders;
 
-        foreach ($newPlaceholders as $key => $newEntries) {
-            $existingEntries = isset($this->envPlaceholders[$key]) ? $this->envPlaceholders[$key] : array();
-            $mergedEntries = array_merge($existingEntries, $newEntries);
-            $this->envPlaceholders[$key] = array_unique($mergedEntries);
+            foreach ($newPlaceholders as $env => $placeholders) {
+                $this->envPlaceholders[$env] += $placeholders;
+            }
         }
     }
 }

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
@@ -48,7 +48,7 @@ class EnvPlaceholderParameterBag extends ParameterBag
 
             $uniqueName = md5($name.uniqid(mt_rand(), true));
             $placeholder = sprintf('env_%s_%s', $env, $uniqueName);
-            $this->envPlaceholders[$env][$placeholder] = $placeholder;
+            $this->envPlaceholders[$env][] = $placeholder;
 
             return $placeholder;
         }
@@ -71,6 +71,12 @@ class EnvPlaceholderParameterBag extends ParameterBag
      */
     public function mergeEnvPlaceholders(self $bag)
     {
-        $this->envPlaceholders = array_merge_recursive($this->envPlaceholders, $bag->getEnvPlaceholders());
+        $newPlaceholders = $bag->getEnvPlaceholders();
+
+        foreach ($newPlaceholders as $key => $newEntries) {
+            $existingEntries = isset($this->envPlaceholders[$key]) ? $this->envPlaceholders[$key] : array();
+            $mergedEntries = array_merge($existingEntries, $newEntries);
+            $this->envPlaceholders[$key] = array_unique($mergedEntries);
+        }
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
@@ -67,4 +67,46 @@ class EnvPlaceholderParameterBagTest extends \PHPUnit_Framework_TestCase
         $this->assertInternalType('string', $placeholder);
         $this->assertContains($envVariableName, $placeholder);
     }
+
+    public function testMergeWherePlaceholderOnlyExistsInSecond()
+    {
+        $uniqueEnvName = 'DB_HOST';
+        $commonEnvName = 'DB_USER';
+
+        $uniqueParamName = sprintf('env(%s)', $uniqueEnvName);
+        $commonParamName = sprintf('env(%s)', $commonEnvName);
+
+        $firstBag = new EnvPlaceholderParameterBag();
+        // initialize common placeholder
+        $firstBag->get($commonParamName);
+        $secondBag = clone $firstBag;
+
+        // initialize unique placeholder
+        $secondBag->get($uniqueParamName);
+
+        $firstBag->mergeEnvPlaceholders($secondBag);
+        $merged = $firstBag->getEnvPlaceholders();
+
+        $this->assertCount(1, $merged[$uniqueEnvName]);
+        // second bag has same placeholder for commonEnvName
+        $this->assertCount(1, $merged[$commonEnvName]);
+    }
+
+    public function testMergeWithDifferentIdentifiersForPlaceholders()
+    {
+        $envName = 'DB_USER';
+        $paramName = sprintf('env(%s)', $envName);
+
+        $firstBag = new EnvPlaceholderParameterBag();
+        $secondBag = new EnvPlaceholderParameterBag();
+        // initialize placeholders
+        $firstPlaceholder = $firstBag->get($paramName);
+        $secondPlaceholder = $secondBag->get($paramName);
+
+        $firstBag->mergeEnvPlaceholders($secondBag);
+        $merged = $firstBag->getEnvPlaceholders();
+
+        $this->assertNotEquals($firstPlaceholder, $secondPlaceholder);
+        $this->assertCount(2, $merged[$envName]);
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
@@ -26,16 +26,22 @@ class EnvPlaceholderParameterBagTest extends \PHPUnit_Framework_TestCase
 
     public function testMergeWillNotDuplicateIdenticalParameters()
     {
-        $originalPlaceholders = array('database_host' => array('localhost'));
-        $firstBag = new EnvPlaceholderParameterBag($originalPlaceholders);
+        $envVariableName = 'DB_HOST';
+        $parameter = sprintf('env(%s)', $envVariableName);
+        $firstBag = new EnvPlaceholderParameterBag();
 
         // initialize placeholders
-        $firstBag->get('env(database_host)');
+        $firstBag->get($parameter);
         $secondBag = clone $firstBag;
 
         $firstBag->mergeEnvPlaceholders($secondBag);
         $mergedPlaceholders = $firstBag->getEnvPlaceholders();
 
-        $this->assertCount(1, $mergedPlaceholders['database_host']);
+        $placeholderForVariable = $mergedPlaceholders[$envVariableName];
+        $placeholder = array_values($placeholderForVariable)[0];
+
+        $this->assertCount(1, $placeholderForVariable);
+        $this->assertInternalType('string', $placeholder);
+        $this->assertContains($envVariableName, $placeholder);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
@@ -44,4 +44,27 @@ class EnvPlaceholderParameterBagTest extends \PHPUnit_Framework_TestCase
         $this->assertInternalType('string', $placeholder);
         $this->assertContains($envVariableName, $placeholder);
     }
+
+    public function testMergeWhereFirstBagIsEmptyWillWork()
+    {
+        $envVariableName = 'DB_HOST';
+        $parameter = sprintf('env(%s)', $envVariableName);
+        $firstBag = new EnvPlaceholderParameterBag();
+        $secondBag = new EnvPlaceholderParameterBag();
+
+        // initialize placeholder only in second bag
+        $secondBag->get($parameter);
+
+        $this->assertEmpty($firstBag->getEnvPlaceholders());
+
+        $firstBag->mergeEnvPlaceholders($secondBag);
+        $mergedPlaceholders = $firstBag->getEnvPlaceholders();
+
+        $placeholderForVariable = $mergedPlaceholders[$envVariableName];
+        $placeholder = array_values($placeholderForVariable)[0];
+
+        $this->assertCount(1, $placeholderForVariable);
+        $this->assertInternalType('string', $placeholder);
+        $this->assertContains($envVariableName, $placeholder);
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #20213 |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

In PR https://github.com/symfony/symfony/pull/20199 I made changes after review that broke the use of env variables, sorry about that - should have checked it a bit more before making the changes.

@nicolas-grekas, I know you're very busy with all that merging, but if you could take a look at this it would be great since you know most about it.
