### PR TITLE
Removing breaking echo for functional tests

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/SymfonyTestsListener.php
+++ b/src/Symfony/Bridge/PhpUnit/SymfonyTestsListener.php
@@ -74,7 +74,6 @@ class SymfonyTestsListener extends \PHPUnit_Framework_BaseTestListener
         $suiteName = $suite->getName();
 
         if (-1 === $this->state) {
-            echo "Testing $suiteName\n";
             $this->state = 0;
 
             if (!class_exists('Doctrine\Common\Annotations\AnnotationRegistry', false) && class_exists('Doctrine\Common\Annotations\AnnotationRegistry')) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" for new features / 2.7, 2.8 or 3.1 for fixes |
| Bug fix? | **yes** |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Whenever running **Codeception functional tests**, if your test requires any functionality that requires use of session, like, for example, a login, the line 77 of this file has the following:

```
echo "Testing $suiteName\n";
```

This echo breaks the generation of the session which consequently breaks the test.

An example of the exception thrown is bellow:

```
3) ViewCest: Test view
 Test  tests/functional/Profile/ViewCest.php:testView

  [RuntimeException] Failed to start the session because headers have already been sent by "/var/www/test/vendor/symfony/phpunit-bridge/SymfonyTestsListener.php" at line 77.


Scenario Steps:

 2. $I->amLoggedAs("dvader@deathstar.galaxy") at tests/functional/Profile/ViewCest.php:51
 1. // As a Darth Vader

#1  /var/www/test/vendor/symfony/symfony/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php:258
#2  /var/www/test/vendor/symfony/symfony/src/Symfony/Component/HttpFoundation/Session/Session.php:95
... 
```

The echo becomes incompatible with session setting because it echo out an string before setting the session.

Unfortunately, I'm not aware of why this line is there or what is the goal with it, so this pull request simply removes it. Possibly there is a better or more elegant way for this but without deeper knowledge of the what was the intent of this line, I can't provide a better fix.

This pull request has as goal to bring attention to the issue and to provide a possible fix.

**Environment**

PHP 7.0.8
Codeception 2.2.2
CentOS 6.5
MySQL 5.7
