### PR TITLE
[Config] Add ExprBuilder::ifNumeric()

### DIFF
--- a/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
@@ -86,6 +86,18 @@ class ExprBuilder
     }
 
     /**
+     * Tests if the value is numeric.
+     *
+     * @return ExprBuilder
+     */
+    public function ifNumeric()
+    {
+        $this->ifPart = function ($v) { return is_numeric($v); };
+
+        return $this;
+    }
+
+    /**
      * Tests if the value is null.
      *
      * @return ExprBuilder

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/ExprBuilderTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/ExprBuilderTest.php
@@ -90,6 +90,21 @@ class ExprBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertFinalizedValueIs('value', $test);
     }
 
+    public function testIfNumericExpression()
+    {
+        $test = $this->getTestBuilder()
+            ->ifNumeric()
+            ->then($this->returnClosure('new_value'))
+        ->end();
+        $this->assertFinalizedValueIs('value', $test);
+
+        $test = $this->getTestBuilder()
+            ->ifNumeric()
+            ->then($this->returnClosure('new_value'))
+        ->end();
+        $this->assertFinalizedValueIs('new_value', $test, array('key' => ('12345')));
+    }
+
     public function testIfArrayExpression()
     {
         $test = $this->getTestBuilder()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

In order to control the type of the final value, like transforming a given numeric string into an int or an object, for instance.
Useful for dealing with TTLs and such.
