### PR TITLE
DomCrawler: Allow pipe (|) character in link tags when using Xpath expressions

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -1034,7 +1034,8 @@ class Crawler implements \Countable, \IteratorAggregate
         $inDoubleQuotedString = false;
         $openedBrackets = 0;
         $lastUnion = 0;
-        for ($i = 0; $i < strlen($xpath); ++$i) {
+        $xpathLength = strlen($xpath);
+        for ($i = 0; $i < $xpathLength; ++$i) {
             $char = $xpath[$i];
 
             if ($char === "'" && !$inDoubleQuotedString) {

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -970,13 +970,12 @@ class Crawler implements \Countable, \IteratorAggregate
     {
         $expressions = array();
 
-        $unionPattern = '/\|(?![^\[]*\])/';
         // An expression which will never match to replace expressions which cannot match in the crawler
         // We cannot simply drop
         $nonMatchingExpression = 'a[name() = "b"]';
 
         // Split any unions into individual expressions.
-        foreach (preg_split($unionPattern, $xpath) as $expression) {
+        foreach ($this->splitUnionParts($xpath) as $expression) {
             $expression = trim($expression);
             $parenthesis = '';
 
@@ -1016,6 +1015,45 @@ class Crawler implements \Countable, \IteratorAggregate
         }
 
         return implode(' | ', $expressions);
+    }
+
+    /**
+     * Splits the XPath into parts that are separated by the union operator.
+     *
+     * @param string $xpath
+     *
+     * @return string[]
+     */
+    private function splitUnionParts($xpath)
+    {
+        // Split any unions into individual expressions. We need to iterate
+        // through the string to correctly parse opening/closing quotes and
+        // braces which is not possible with regular expressions.
+        $unionParts = array();
+        $inSingleQuotedString = false;
+        $inDoubleQuotedString = false;
+        $openedBrackets = 0;
+        $lastUnion = 0;
+        for ($i = 0; $i < strlen($xpath); $i++) {
+            $char = $xpath[$i];
+
+            if ($char === "'" && !$inDoubleQuotedString) {
+                $inSingleQuotedString = !$inSingleQuotedString;
+            } elseif ($char === '"' && !$inSingleQuotedString) {
+                $inDoubleQuotedString = !$inDoubleQuotedString;
+            } elseif (!$inSingleQuotedString && !$inDoubleQuotedString) {
+                if ($char === '[') {
+                    $openedBrackets++;
+                } elseif ($char === ']') {
+                    $openedBrackets--;
+                } elseif ($char === '|' && $openedBrackets === 0) {
+                    $unionParts[] = substr($xpath, $lastUnion, $i - $lastUnion);
+                    $lastUnion = $i + 1;
+                }
+            }
+        }
+        $unionParts[] = substr($xpath, $lastUnion);
+        return $unionParts;
     }
 
     /**

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -1034,7 +1034,7 @@ class Crawler implements \Countable, \IteratorAggregate
         $inDoubleQuotedString = false;
         $openedBrackets = 0;
         $lastUnion = 0;
-        for ($i = 0; $i < strlen($xpath); $i++) {
+        for ($i = 0; $i < strlen($xpath); ++$i) {
             $char = $xpath[$i];
 
             if ($char === "'" && !$inDoubleQuotedString) {
@@ -1043,9 +1043,9 @@ class Crawler implements \Countable, \IteratorAggregate
                 $inDoubleQuotedString = !$inDoubleQuotedString;
             } elseif (!$inSingleQuotedString && !$inDoubleQuotedString) {
                 if ($char === '[') {
-                    $openedBrackets++;
+                    ++$openedBrackets;
                 } elseif ($char === ']') {
-                    $openedBrackets--;
+                    --$openedBrackets;
                 } elseif ($char === '|' && $openedBrackets === 0) {
                     $unionParts[] = substr($xpath, $lastUnion, $i - $lastUnion);
                     $lastUnion = $i + 1;
@@ -1053,6 +1053,7 @@ class Crawler implements \Countable, \IteratorAggregate
             }
         }
         $unionParts[] = substr($xpath, $lastUnion);
+
         return $unionParts;
     }
 

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -430,6 +430,7 @@ EOF
         $this->assertCount(5, $crawler->filterXPath('(//a | //div)//img'));
         $this->assertCount(7, $crawler->filterXPath('((//a | //div)//img | //ul)'));
         $this->assertCount(7, $crawler->filterXPath('( ( //a | //div )//img | //ul )'));
+        $this->assertCount(1, $crawler->filterXPath("//a[./@href][((./@id = 'Klausi|Claudiu' or normalize-space(string(.)) = 'Klausi|Claudiu' or ./@title = 'Klausi|Claudiu' or ./@rel = 'Klausi|Claudiu') or .//img[./@alt = 'Klausi|Claudiu'])]"));
     }
 
     public function testFilterXPath()
@@ -596,7 +597,7 @@ EOF
 
         $this->assertCount(0, $crawler->filterXPath('self::a'), 'The fake root node has no "real" element name');
         $this->assertCount(0, $crawler->filterXPath('self::a/img'), 'The fake root node has no "real" element name');
-        $this->assertCount(9, $crawler->filterXPath('self::*/a'));
+        $this->assertCount(10, $crawler->filterXPath('self::*/a'));
     }
 
     public function testFilter()
@@ -1123,6 +1124,8 @@ HTML;
                     <a href="/bar"><img alt="\' Fabien&quot;s Bar"/></a>
 
                     <a href="?get=param">GetLink</a>
+
+                    <a href="/example">Klausi|Claudiu</a>
 
                     <form action="foo" id="FooFormId">
                         <input type="text" value="TextValue" name="TextName" />


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Drupal issue: https://www.drupal.org/node/2808085
Mink issue: https://github.com/minkphp/Mink/pull/720

We need the pipe (|) character for testing in Drupal. Example: `<a href="/example">Klausi|Claudiu</a>` should be findable with an XPath expression targeting the tag content Klausi|Claudiu.
