### PR TITLE
[DependencyInjection] fixed ini file values conversion

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ini/almostvalid.ini
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ini/almostvalid.ini
@@ -1,0 +1,2 @@
+foo = '
+bar = bar

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ini/types.ini
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ini/types.ini
@@ -1,0 +1,27 @@
+[parameters]
+  true = true
+  true_comment = true ; comment
+  false = false
+  null = null
+  on = on
+  off = off
+  yes = yes
+  no = no
+  none = none
+  constant = PHP_VERSION
+  12 = 12
+  12_string = '12'
+  12_comment = 12 ; comment
+  12_string_comment = '12' ; comment
+  12_string_comment_again = "12" ; comment
+  -12 = -12
+  0 = 0
+  1 = 1
+  0b0110 = 0b0110
+  11112222333344445555 = 1111,2222,3333,4444,5555
+  0777 = 0777
+  255 = 0xFF
+  100.0 = 1e2
+  -120.0 = -1.2E2
+  -10100.1 = -10100.1
+  -10,100.1 = -10,100.1

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -164,6 +164,7 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals(array_keys($expected), array_keys($actual), '->load() imports and merges imported files');
+        $this->assertTrue($actual['imported_from_ini']);
 
         // Bad import throws no exception due to ignore_errors value.
         $loader->load('services4_bad_import.xml');

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -115,6 +115,7 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $actual = $container->getParameterBag()->all();
         $expected = array('foo' => 'bar', 'values' => array(true, false, PHP_INT_MAX), 'bar' => '%foo%', 'escape' => '@escapeme', 'foo_bar' => new Reference('foo_bar'), 'mixedcase' => array('MixedCaseKey' => 'value'), 'imported_from_ini' => true, 'imported_from_xml' => true);
         $this->assertEquals(array_keys($expected), array_keys($actual), '->load() imports and merges imported files');
+        $this->assertTrue($actual['imported_from_ini']);
 
         // Bad import throws no exception due to ignore_errors value.
         $loader->load('services4_bad_import.yml');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no-ish |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

When using the ini format to load parameters in the Container, the parameter values were converted by PHP directly (`'true'` => `1` for instance). But when using the YAML or XML format, the conversions are much broader and more precise (`'true'` => `true` for instance). This PR fixed fixes this discrepancy by using the same rules as XML (we could use `INI_SCANNER_TYPED` for recent versions of PHP but the rules are not exactly the same, so I prefer consistency here).

One might argue that this is a new feature and that this should be merged into master, which I can accept as well. In master, the `XmlUtils::phpize()` method should be deprecated and replaced by a more generic phpize class.

ping @symfony/deciders
