### PR TITLE
[HttpKernel] Fix a regression in the RequestDataCollector

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -374,7 +374,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
             );
         }
 
-        return (string) $controller ?: 'n/a';
+        return is_string($controller) ? $controller : 'n/a';
     }
 
     private function getCookieHeader($name, $value, $expires, $path, $domain, $secure, $httponly)

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
@@ -70,16 +70,28 @@ class RequestDataCollectorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test various types of controller callables.
+     * @dataProvider provideControllerCallables
      */
-    public function testControllerInspection()
+    public function testControllerInspection($name, $callable, $expected)
+    {
+        $c = new RequestDataCollector();
+        $request = $this->createRequest();
+        $response = $this->createResponse();
+        $this->injectController($c, $callable, $request);
+        $c->collect($request, $response);
+
+        $this->assertSame($expected, $c->getController(), sprintf('Testing: %s', $name));
+    }
+
+    public function provideControllerCallables()
     {
         // make sure we always match the line number
         $r1 = new \ReflectionMethod($this, 'testControllerInspection');
         $r2 = new \ReflectionMethod($this, 'staticControllerMethod');
         $r3 = new \ReflectionClass($this);
+
         // test name, callable, expected
-        $controllerTests = array(
+        return array(
             array(
                 '"Regular" callable',
                 array($this, 'testControllerInspection'),
@@ -168,15 +180,6 @@ class RequestDataCollectorTest extends \PHPUnit_Framework_TestCase
                 ),
             ),
         );
-
-        $c = new RequestDataCollector();
-        $request = $this->createRequest();
-        $response = $this->createResponse();
-        foreach ($controllerTests as $controllerTest) {
-            $this->injectController($c, $controllerTest[1], $request);
-            $c->collect($request, $response);
-            $this->assertSame($controllerTest[2], $c->getController(), sprintf('Testing: %s', $controllerTest[0]));
-        }
     }
 
     protected function createRequest()

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\Tests\DataCollector;
 
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface;
@@ -182,6 +183,17 @@ class RequestDataCollectorTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testItIgnoresInvalidCallables()
+    {
+        $request = $this->createRequestWithSession();
+        $response = new RedirectResponse('/');
+
+        $c = new RequestDataCollector();
+        $c->collect($request, $response);
+
+        $this->assertSame('n/a', $c->getController());
+    }
+
     protected function createRequest()
     {
         $request = Request::create('http://test.com/foo?bar=baz');
@@ -190,6 +202,16 @@ class RequestDataCollectorTest extends \PHPUnit_Framework_TestCase
         $request->attributes->set('_route_params', array('name' => 'foo'));
         $request->attributes->set('resource', fopen(__FILE__, 'r'));
         $request->attributes->set('object', new \stdClass());
+
+        return $request;
+    }
+
+    private function createRequestWithSession()
+    {
+        $request = $this->createRequest();
+        $request->attributes->set('_controller', 'Foo::bar');
+        $request->setSession(new Session(new MockArraySessionStorage()));
+        $request->getSession()->start();
 
         return $request;
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #19701 |
| License | MIT |
| Doc PR | - |

The regression was introduced by refactoring made as part of #17589 (if/else statements where rearranged).
