### PR TITLE
[Form] [Extension] [FormTypeCsrfExtension] Make the csrf field options extensible

### DIFF
--- a/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
@@ -125,7 +125,7 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
             'csrf_field_options' => array(),
             'csrf_message' => 'The CSRF token is invalid. Please try to resubmit the form.',
             'csrf_token_manager' => $this->defaultTokenManager,
-            'csrf_token_id' => null
+            'csrf_token_id' => null,
         ));
     }
 

--- a/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
@@ -105,9 +105,9 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
             $tokenId = $options['csrf_token_id'] ?: ($form->getName() ?: get_class($form->getConfig()->getType()->getInnerType()));
             $data = (string) $options['csrf_token_manager']->getToken($tokenId);
 
-            $csrfForm = $factory->createNamed($options['csrf_field_name'], 'Symfony\Component\Form\Extension\Core\Type\HiddenType', $data, array(
+            $csrfForm = $factory->createNamed($options['csrf_field_name'], 'Symfony\Component\Form\Extension\Core\Type\HiddenType', $data, array_replace($options['csrf_field_options'], array(
                 'mapped' => false,
-            ));
+            )));
 
             $view->children[$options['csrf_field_name']] = $csrfForm->createView($view);
         }
@@ -124,6 +124,7 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
             'csrf_message' => 'The CSRF token is invalid. Please try to resubmit the form.',
             'csrf_token_manager' => $this->defaultTokenManager,
             'csrf_token_id' => null,
+            'csrf_field_options' => []
         ));
     }
 

--- a/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
@@ -124,7 +124,7 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
             'csrf_message' => 'The CSRF token is invalid. Please try to resubmit the form.',
             'csrf_token_manager' => $this->defaultTokenManager,
             'csrf_token_id' => null,
-            'csrf_field_options' => []
+            'csrf_field_options' => array()
         ));
     }
 

--- a/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
@@ -105,9 +105,9 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
             $tokenId = $options['csrf_token_id'] ?: ($form->getName() ?: get_class($form->getConfig()->getType()->getInnerType()));
             $data = (string) $options['csrf_token_manager']->getToken($tokenId);
 
-            $csrfForm = $factory->createNamed($options['csrf_field_name'], 'Symfony\Component\Form\Extension\Core\Type\HiddenType', $data, array_replace($options['csrf_field_options'], array(
+            $csrfForm = $factory->createNamed($options['csrf_field_name'], $options['csrf_field_type'], $data, array_replace(array(
                 'mapped' => false,
-            )));
+            ), $options['csrf_field_options']));
 
             $view->children[$options['csrf_field_name']] = $csrfForm->createView($view);
         }
@@ -121,10 +121,11 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
         $resolver->setDefaults(array(
             'csrf_protection' => $this->defaultEnabled,
             'csrf_field_name' => $this->defaultFieldName,
+            'csrf_field_type' => 'Symfony\Component\Form\Extension\Core\Type\HiddenType',
+            'csrf_field_options' => array(),
             'csrf_message' => 'The CSRF token is invalid. Please try to resubmit the form.',
             'csrf_token_manager' => $this->defaultTokenManager,
-            'csrf_token_id' => null,
-            'csrf_field_options' => array()
+            'csrf_token_id' => null
         ));
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

If you wana decorate the FormTypeCsrfExtension you have no control over options set by the extension, forcing you to reimplement the entire finishView. this way you have a bit more control over it. We required this approach to define custom options declared by another extension
