### PR TITLE
Trim constant values in XmlFileLoader

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -391,7 +391,7 @@ class XmlFileLoader extends FileLoader
                     $arguments[$key] = $arg->nodeValue;
                     break;
                 case 'constant':
-                    $arguments[$key] = constant(trim(arg->nodeValue));
+                    $arguments[$key] = constant(trim($arg->nodeValue));
                     break;
                 default:
                     $arguments[$key] = XmlUtils::phpize($arg->nodeValue);

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -391,7 +391,7 @@ class XmlFileLoader extends FileLoader
                     $arguments[$key] = $arg->nodeValue;
                     break;
                 case 'constant':
-                    $arguments[$key] = constant($arg->nodeValue);
+                    $arguments[$key] = constant(trim(arg->nodeValue));
                     break;
                 default:
                     $arguments[$key] = XmlUtils::phpize($arg->nodeValue);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7, 2.8, 3.1 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n.A. |
| License | MIT |
| Doc PR | n.A. |

When an XML config file gets long, it's nice to put the constant name into the next line like this:

``` xml
<parameter key="som_very_very_long_constant_name" type="constant">
    Some\Namespace\That\Is\Sufficiently\Long\To\Require\A\LineBreak::someLongishConstantName
</parameter>
```

If that’s the case, `constant()` will try and find a constant including the spaces. While it is theoretically possible to have a constant in PHP that starts or ends with a space, it’s impossible for class constants and only doable using `define(" FOO ", …);`. So that’s probably an edge case we can ignore.
