### PR TITLE
[TwigBridge] Use non-deprecated Twig_Node::getTemplateLine()

### DIFF
--- a/src/Symfony/Bridge/Twig/Node/SearchAndRenderBlockNode.php
+++ b/src/Symfony/Bridge/Twig/Node/SearchAndRenderBlockNode.php
@@ -37,7 +37,7 @@ class SearchAndRenderBlockNode extends \Twig_Node_Expression_Function
                     // the variables in the third argument
                     $label = $arguments[1];
                     $variables = isset($arguments[2]) ? $arguments[2] : null;
-                    $lineno = $label->getLine();
+                    $lineno = $label->getTemplateLine();
 
                     if ($label instanceof \Twig_Node_Expression_Constant) {
                         // If the label argument is given as a constant, we can either

--- a/src/Symfony/Bridge/Twig/Node/TransNode.php
+++ b/src/Symfony/Bridge/Twig/Node/TransNode.php
@@ -109,18 +109,18 @@ class TransNode extends \Twig_Node
         preg_match_all('/(?<!%)%([^%]+)%/', $msg, $matches);
 
         foreach ($matches[1] as $var) {
-            $key = new \Twig_Node_Expression_Constant('%'.$var.'%', $body->getLine());
+            $key = new \Twig_Node_Expression_Constant('%'.$var.'%', $body->getTemplateLine());
             if (!$vars->hasElement($key)) {
                 if ('count' === $var && $this->hasNode('count')) {
                     $vars->addElement($this->getNode('count'), $key);
                 } else {
-                    $varExpr = new \Twig_Node_Expression_Name($var, $body->getLine());
+                    $varExpr = new \Twig_Node_Expression_Name($var, $body->getTemplateLine());
                     $varExpr->setAttribute('ignore_strict_check', $ignoreStrictCheck);
                     $vars->addElement($varExpr, $key);
                 }
             }
         }
 
-        return array(new \Twig_Node_Expression_Constant(str_replace('%%', '%', trim($msg)), $body->getLine()), $vars);
+        return array(new \Twig_Node_Expression_Constant(str_replace('%%', '%', trim($msg)), $body->getTemplateLine()), $vars);
     }
 }

--- a/src/Symfony/Bridge/Twig/NodeVisitor/TranslationDefaultDomainNodeVisitor.php
+++ b/src/Symfony/Bridge/Twig/NodeVisitor/TranslationDefaultDomainNodeVisitor.php
@@ -50,10 +50,10 @@ class TranslationDefaultDomainNodeVisitor extends \Twig_BaseNodeVisitor
                 return $node;
             } else {
                 $var = $env->getParser()->getVarName();
-                $name = new \Twig_Node_Expression_AssignName($var, $node->getLine());
-                $this->scope->set('domain', new \Twig_Node_Expression_Name($var, $node->getLine()));
+                $name = new \Twig_Node_Expression_AssignName($var, $node->getTemplateLine());
+                $this->scope->set('domain', new \Twig_Node_Expression_Name($var, $node->getTemplateLine()));
 
-                return new \Twig_Node_Set(false, new \Twig_Node(array($name)), new \Twig_Node(array($node->getNode('expr'))), $node->getLine());
+                return new \Twig_Node_Set(false, new \Twig_Node(array($name)), new \Twig_Node(array($node->getNode('expr'))), $node->getTemplateLine());
             }
         }
 
@@ -71,7 +71,7 @@ class TranslationDefaultDomainNodeVisitor extends \Twig_BaseNodeVisitor
             } else {
                 if (!$arguments->hasNode($ind)) {
                     if (!$arguments->hasNode($ind - 1)) {
-                        $arguments->setNode($ind - 1, new \Twig_Node_Expression_Array(array(), $node->getLine()));
+                        $arguments->setNode($ind - 1, new \Twig_Node_Expression_Array(array(), $node->getTemplateLine()));
                     }
 
                     $arguments->setNode($ind, $this->scope->get('domain'));

--- a/src/Symfony/Bridge/Twig/TokenParser/TransChoiceTokenParser.php
+++ b/src/Symfony/Bridge/Twig/TokenParser/TransChoiceTokenParser.php
@@ -64,7 +64,7 @@ class TransChoiceTokenParser extends TransTokenParser
         $body = $this->parser->subparse(array($this, 'decideTransChoiceFork'), true);
 
         if (!$body instanceof \Twig_Node_Text && !$body instanceof \Twig_Node_Expression) {
-            throw new \Twig_Error_Syntax('A message inside a transchoice tag must be a simple text.', $body->getLine(), $stream->getSourceContext()->getName());
+            throw new \Twig_Error_Syntax('A message inside a transchoice tag must be a simple text.', $body->getTemplateLine(), $stream->getSourceContext()->getName());
         }
 
         $stream->expect(\Twig_Token::BLOCK_END_TYPE);

--- a/src/Symfony/Bridge/Twig/TokenParser/TransTokenParser.php
+++ b/src/Symfony/Bridge/Twig/TokenParser/TransTokenParser.php
@@ -64,7 +64,7 @@ class TransTokenParser extends \Twig_TokenParser
         $body = $this->parser->subparse(array($this, 'decideTransFork'), true);
 
         if (!$body instanceof \Twig_Node_Text && !$body instanceof \Twig_Node_Expression) {
-            throw new \Twig_Error_Syntax('A message inside a trans tag must be a simple text.', $body->getLine(), $stream->getSourceContext()->getName());
+            throw new \Twig_Error_Syntax('A message inside a trans tag must be a simple text.', $body->getTemplateLine(), $stream->getSourceContext()->getName());
         }
 
         $stream->expect(\Twig_Token::BLOCK_END_TYPE);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |
