### PR TITLE
[PhpUnitBridge] Replace ErrorAssert by `@expectedDeprecation`

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/SymfonyTestsListener.php
+++ b/src/Symfony/Bridge/PhpUnit/SymfonyTestsListener.php
@@ -25,6 +25,9 @@ class SymfonyTestsListener extends \PHPUnit_Framework_BaseTestListener
     private $skippedFile = false;
     private $wasSkipped = array();
     private $isSkipped = array();
+    private $expectedDeprecations;
+    private $gatheredDeprecations;
+    private $previousErrorHandler;
 
     /**
      * @param array $mockedNamespaces List of namespaces, indexed by mocked features (time-sensitive or dns-sensitive)
@@ -142,7 +145,7 @@ class SymfonyTestsListener extends \PHPUnit_Framework_BaseTestListener
     public function startTest(\PHPUnit_Framework_Test $test)
     {
         if (-2 < $this->state && $test instanceof \PHPUnit_Framework_TestCase) {
-            $groups = \PHPUnit_Util_Test::getGroups(get_class($test), $test->getName());
+            $groups = \PHPUnit_Util_Test::getGroups(get_class($test), $test->getName(false));
 
             if (in_array('time-sensitive', $groups, true)) {
                 ClockMock::register(get_class($test));
@@ -151,13 +154,37 @@ class SymfonyTestsListener extends \PHPUnit_Framework_BaseTestListener
             if (in_array('dns-sensitive', $groups, true)) {
                 DnsMock::register(get_class($test));
             }
+
+            $annotations = \PHPUnit_Util_Test::parseTestMethodAnnotations(get_class($test), $test->getName(false));
+
+            if (isset($annotations['class']['expectedDeprecation'])) {
+                $test->getTestResultObject()->addError($test, new \PHPUnit_Framework_AssertionFailedError('`@expectedDeprecation` annotations are not allowed at the class level.'), 0);
+            }
+            if (isset($annotations['method']['expectedDeprecation'])) {
+                if (!in_array('legacy', $groups, true)) {
+                    $test->getTestResultObject()->addError($test, new \PHPUnit_Framework_AssertionFailedError('Only tests with the `@group legacy` annotation can have `@expectedDeprecation`.'), 0);
+                }
+                $this->expectedDeprecations = $annotations['method']['expectedDeprecation'];
+                $this->previousErrorHandler = set_error_handler(array($this, 'handleError'));
+            }
         }
     }
 
     public function endTest(\PHPUnit_Framework_Test $test, $time)
     {
+        if ($this->expectedDeprecations) {
+            restore_error_handler();
+            try {
+                $prefix = "@expectedDeprecation:\n  ";
+                $test->assertStringMatchesFormat($prefix.implode("\n  ", $this->expectedDeprecations), $prefix.implode("\n  ", $this->gatheredDeprecations));
+            } catch (\PHPUnit_Framework_AssertionFailedError $e) {
+                $test->getTestResultObject()->addFailure($test, $e, $time);
+            }
+
+            $this->expectedDeprecations = $this->gatheredDeprecations = $this->previousErrorHandler = null;
+        }
         if (-2 < $this->state && $test instanceof \PHPUnit_Framework_TestCase) {
-            $groups = \PHPUnit_Util_Test::getGroups(get_class($test), $test->getName());
+            $groups = \PHPUnit_Util_Test::getGroups(get_class($test), $test->getName(false));
 
             if (in_array('time-sensitive', $groups, true)) {
                 ClockMock::withClockMock(false);
@@ -166,5 +193,18 @@ class SymfonyTestsListener extends \PHPUnit_Framework_BaseTestListener
                 DnsMock::withMockedHosts(array());
             }
         }
+    }
+
+    public function handleError($type, $msg, $file, $line, $context)
+    {
+        if (E_USER_DEPRECATED !== $type && E_DEPRECATED !== $type) {
+            $h = $this->previousErrorHandler;
+
+            return $h ? $h($type, $msg, $file, $line, $context) : false;
+        }
+        if (error_reporting()) {
+            $msg = 'Unsilenced deprecation: '.$msg;
+        }
+        $this->gatheredDeprecations[] = $msg;
     }
 }

--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
@@ -11,7 +11,7 @@
  */
 
 // Please update when phpunit needs to be reinstalled with fresh deps:
-// Cache-Id-Version: 2016-09-12 09:00 UTC
+// Cache-Id-Version: 2016-10-20 14:00 UTC
 
 error_reporting(-1);
 

--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -221,7 +221,7 @@ class OutputFormatter implements OutputFormatterInterface
                     try {
                         $style->setOption($option);
                     } catch (\InvalidArgumentException $e) {
-                        trigger_error(sprintf('Unknown style options are deprecated since version 3.2 and will be removed in 4.0. Exception "%s".', $e->getMessage()), E_USER_DEPRECATED);
+                        @trigger_error(sprintf('Unknown style options are deprecated since version 3.2 and will be removed in 4.0. Exception "%s".', $e->getMessage()), E_USER_DEPRECATED);
 
                         return false;
                     }

--- a/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Console\Tests\Formatter;
 
-use Symfony\Bridge\PhpUnit\ErrorAssert;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 
@@ -196,17 +195,12 @@ class OutputFormatterTest extends \PHPUnit_Framework_TestCase
     /**
      * @group legacy
      * @dataProvider provideInlineStyleTagsWithUnknownOptions
-     * @requires function Symfony\Bridge\PhpUnit\ErrorAssert::assertDeprecationsAreTriggered
+     * @expectedDeprecation Unknown style options are deprecated since version 3.2 and will be removed in 4.0. Exception "Invalid option specified: "%s". Expected one of (bold, underscore, blink, reverse, conceal)".
      */
     public function testInlineStyleOptionsUnknownAreDeprecated($tag, $option)
     {
-        ErrorAssert::assertDeprecationsAreTriggered(
-            array(sprintf('Unknown style options are deprecated since version 3.2 and will be removed in 4.0. Exception "Invalid option specified: "%s". Expected one of (bold, underscore, blink, reverse, conceal)".', $option)),
-            function () use ($tag) {
-                $formatter = new OutputFormatter(true);
-                $formatter->format($tag);
-            }
-        );
+        $formatter = new OutputFormatter(true);
+        $formatter->format($tag);
     }
 
     public function provideInlineStyleTagsWithUnknownOptions()

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\DependencyInjection\Tests;
 
-use Symfony\Bridge\PhpUnit\ErrorAssert;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
@@ -131,20 +130,14 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @group legacy
-     * @requires function Symfony\Bridge\PhpUnit\ErrorAssert::assertDeprecationsAreTriggered
+     * @expectedDeprecation Generating a dumped container without populating the method map is deprecated since 3.2 and will be unsupported in 4.0. Update your dumper to generate the method map.
      */
     public function testGetLegacyServiceIds()
     {
         $sc = new LegacyProjectServiceContainer();
         $sc->set('foo', $obj = new \stdClass());
 
-        $deprecations = array(
-            'Generating a dumped container without populating the method map is deprecated since 3.2 and will be unsupported in 4.0. Update your dumper to generate the method map.',
-        );
-
-        ErrorAssert::assertDeprecationsAreTriggered($deprecations, function () use ($sc) {
-            $this->assertEquals(array('internal', 'bar', 'foo_bar', 'foo.baz', 'circular', 'throw_exception', 'throws_exception_on_service_configuration', 'service_container', 'foo'), $sc->getServiceIds(), '->getServiceIds() returns defined service ids by getXXXService() methods, followed by service ids defined by set()');
-        });
+        $this->assertEquals(array('internal', 'bar', 'foo_bar', 'foo.baz', 'circular', 'throw_exception', 'throws_exception_on_service_configuration', 'service_container', 'foo'), $sc->getServiceIds(), '->getServiceIds() returns defined service ids by getXXXService() methods, followed by service ids defined by set()');
     }
 
     public function testSet()
@@ -193,39 +186,33 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @group legacy
-     * @requires function Symfony\Bridge\PhpUnit\ErrorAssert::assertDeprecationsAreTriggered
+     * @expectedDeprecation Generating a dumped container without populating the method map is deprecated since 3.2 and will be unsupported in 4.0. Update your dumper to generate the method map.
+     * @expectedDeprecation Generating a dumped container without populating the method map is deprecated since 3.2 and will be unsupported in 4.0. Update your dumper to generate the method map.
+     * @expectedDeprecation Generating a dumped container without populating the method map is deprecated since 3.2 and will be unsupported in 4.0. Update your dumper to generate the method map.
+     * @expectedDeprecation Generating a dumped container without populating the method map is deprecated since 3.2 and will be unsupported in 4.0. Update your dumper to generate the method map.
      */
     public function testLegacyGet()
     {
         $sc = new LegacyProjectServiceContainer();
         $sc->set('foo', $foo = new \stdClass());
 
-        $deprecations = array(
-            'Generating a dumped container without populating the method map is deprecated since 3.2 and will be unsupported in 4.0. Update your dumper to generate the method map.',
-            'Generating a dumped container without populating the method map is deprecated since 3.2 and will be unsupported in 4.0. Update your dumper to generate the method map.',
-            'Generating a dumped container without populating the method map is deprecated since 3.2 and will be unsupported in 4.0. Update your dumper to generate the method map.',
-            'Generating a dumped container without populating the method map is deprecated since 3.2 and will be unsupported in 4.0. Update your dumper to generate the method map.',
-        );
+        $this->assertEquals($foo, $sc->get('foo'), '->get() returns the service for the given id');
+        $this->assertEquals($foo, $sc->get('Foo'), '->get() returns the service for the given id, and converts id to lowercase');
+        $this->assertEquals($sc->__bar, $sc->get('bar'), '->get() returns the service for the given id');
+        $this->assertEquals($sc->__foo_bar, $sc->get('foo_bar'), '->get() returns the service if a get*Method() is defined');
+        $this->assertEquals($sc->__foo_baz, $sc->get('foo.baz'), '->get() returns the service if a get*Method() is defined');
+        $this->assertEquals($sc->__foo_baz, $sc->get('foo\\baz'), '->get() returns the service if a get*Method() is defined');
 
-        ErrorAssert::assertDeprecationsAreTriggered($deprecations, function () use ($sc, $foo) {
-            $this->assertEquals($foo, $sc->get('foo'), '->get() returns the service for the given id');
-            $this->assertEquals($foo, $sc->get('Foo'), '->get() returns the service for the given id, and converts id to lowercase');
-            $this->assertEquals($sc->__bar, $sc->get('bar'), '->get() returns the service for the given id');
-            $this->assertEquals($sc->__foo_bar, $sc->get('foo_bar'), '->get() returns the service if a get*Method() is defined');
-            $this->assertEquals($sc->__foo_baz, $sc->get('foo.baz'), '->get() returns the service if a get*Method() is defined');
-            $this->assertEquals($sc->__foo_baz, $sc->get('foo\\baz'), '->get() returns the service if a get*Method() is defined');
+        $sc->set('bar', $bar = new \stdClass());
+        $this->assertEquals($bar, $sc->get('bar'), '->get() prefers to return a service defined with set() than one defined with a getXXXMethod()');
 
-            $sc->set('bar', $bar = new \stdClass());
-            $this->assertEquals($bar, $sc->get('bar'), '->get() prefers to return a service defined with set() than one defined with a getXXXMethod()');
-
-            try {
-                $sc->get('');
-                $this->fail('->get() throws a \InvalidArgumentException exception if the service is empty');
-            } catch (\Exception $e) {
-                $this->assertInstanceOf('Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException', $e, '->get() throws a ServiceNotFoundException exception if the service is empty');
-            }
-            $this->assertNull($sc->get('', ContainerInterface::NULL_ON_INVALID_REFERENCE), '->get() returns null if the service is empty');
-        });
+        try {
+            $sc->get('');
+            $this->fail('->get() throws a \InvalidArgumentException exception if the service is empty');
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException', $e, '->get() throws a ServiceNotFoundException exception if the service is empty');
+        }
+        $this->assertNull($sc->get('', ContainerInterface::NULL_ON_INVALID_REFERENCE), '->get() returns null if the service is empty');
     }
 
     public function testGetThrowServiceNotFoundException()
@@ -288,28 +275,22 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @group legacy
-     * @requires function Symfony\Bridge\PhpUnit\ErrorAssert::assertDeprecationsAreTriggered
+     * @expectedDeprecation Generating a dumped container without populating the method map is deprecated since 3.2 and will be unsupported in 4.0. Update your dumper to generate the method map.
+     * @expectedDeprecation Generating a dumped container without populating the method map is deprecated since 3.2 and will be unsupported in 4.0. Update your dumper to generate the method map.
+     * @expectedDeprecation Generating a dumped container without populating the method map is deprecated since 3.2 and will be unsupported in 4.0. Update your dumper to generate the method map.
+     * @expectedDeprecation Generating a dumped container without populating the method map is deprecated since 3.2 and will be unsupported in 4.0. Update your dumper to generate the method map.
      */
     public function testLegacyHas()
     {
         $sc = new LegacyProjectServiceContainer();
         $sc->set('foo', new \stdClass());
 
-        $deprecations = array(
-            'Generating a dumped container without populating the method map is deprecated since 3.2 and will be unsupported in 4.0. Update your dumper to generate the method map.',
-            'Generating a dumped container without populating the method map is deprecated since 3.2 and will be unsupported in 4.0. Update your dumper to generate the method map.',
-            'Generating a dumped container without populating the method map is deprecated since 3.2 and will be unsupported in 4.0. Update your dumper to generate the method map.',
-            'Generating a dumped container without populating the method map is deprecated since 3.2 and will be unsupported in 4.0. Update your dumper to generate the method map.',
-        );
-
-        ErrorAssert::assertDeprecationsAreTriggered($deprecations, function () use ($sc) {
-            $this->assertFalse($sc->has('foo1'), '->has() returns false if the service does not exist');
-            $this->assertTrue($sc->has('foo'), '->has() returns true if the service exists');
-            $this->assertTrue($sc->has('bar'), '->has() returns true if a get*Method() is defined');
-            $this->assertTrue($sc->has('foo_bar'), '->has() returns true if a get*Method() is defined');
-            $this->assertTrue($sc->has('foo.baz'), '->has() returns true if a get*Method() is defined');
-            $this->assertTrue($sc->has('foo\\baz'), '->has() returns true if a get*Method() is defined');
-        });
+        $this->assertFalse($sc->has('foo1'), '->has() returns false if the service does not exist');
+        $this->assertTrue($sc->has('foo'), '->has() returns true if the service exists');
+        $this->assertTrue($sc->has('bar'), '->has() returns true if a get*Method() is defined');
+        $this->assertTrue($sc->has('foo_bar'), '->has() returns true if a get*Method() is defined');
+        $this->assertTrue($sc->has('foo.baz'), '->has() returns true if a get*Method() is defined');
+        $this->assertTrue($sc->has('foo\\baz'), '->has() returns true if a get*Method() is defined');
     }
 
     public function testInitialized()
@@ -400,66 +381,42 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @group legacy
-     * @requires function Symfony\Bridge\PhpUnit\ErrorAssert::assertDeprecationsAreTriggered
+     * @expectedDeprecation Unsetting the "internal" private service is deprecated since Symfony 3.2 and won't be supported anymore in Symfony 4.0.
      */
     public function testUnsetInternalPrivateServiceIsDeprecated()
     {
-        $deprecations = array(
-            'Unsetting the "internal" private service is deprecated since Symfony 3.2 and won\'t be supported anymore in Symfony 4.0.',
-        );
-
-        ErrorAssert::assertDeprecationsAreTriggered($deprecations, function () {
-            $c = new ProjectServiceContainer();
-            $c->set('internal', null);
-        });
+        $c = new ProjectServiceContainer();
+        $c->set('internal', null);
     }
 
     /**
      * @group legacy
-     * @requires function Symfony\Bridge\PhpUnit\ErrorAssert::assertDeprecationsAreTriggered
+     * @expectedDeprecation Setting the "internal" private service is deprecated since Symfony 3.2 and won't be supported anymore in Symfony 4.0. A new public service will be created instead.
      */
     public function testChangeInternalPrivateServiceIsDeprecated()
     {
-        $deprecations = array(
-            'Setting the "internal" private service is deprecated since Symfony 3.2 and won\'t be supported anymore in Symfony 4.0. A new public service will be created instead.',
-        );
-
-        ErrorAssert::assertDeprecationsAreTriggered($deprecations, function () {
-            $c = new ProjectServiceContainer();
-            $c->set('internal', new \stdClass());
-        });
+        $c = new ProjectServiceContainer();
+        $c->set('internal', new \stdClass());
     }
 
     /**
      * @group legacy
-     * @requires function Symfony\Bridge\PhpUnit\ErrorAssert::assertDeprecationsAreTriggered
+     * @expectedDeprecation Checking for the existence of the "internal" private service is deprecated since Symfony 3.2 and won't be supported anymore in Symfony 4.0.
      */
     public function testCheckExistenceOfAnInternalPrivateServiceIsDeprecated()
     {
-        $deprecations = array(
-            'Checking for the existence of the "internal" private service is deprecated since Symfony 3.2 and won\'t be supported anymore in Symfony 4.0.',
-        );
-
-        ErrorAssert::assertDeprecationsAreTriggered($deprecations, function () {
-            $c = new ProjectServiceContainer();
-            $c->has('internal');
-        });
+        $c = new ProjectServiceContainer();
+        $c->has('internal');
     }
 
     /**
      * @group legacy
-     * @requires function Symfony\Bridge\PhpUnit\ErrorAssert::assertDeprecationsAreTriggered
+     * @expectedDeprecation Requesting the "internal" private service is deprecated since Symfony 3.2 and won't be supported anymore in Symfony 4.0.
      */
     public function testRequestAnInternalSharedPrivateServiceIsDeprecated()
     {
-        $deprecations = array(
-            'Requesting the "internal" private service is deprecated since Symfony 3.2 and won\'t be supported anymore in Symfony 4.0.',
-        );
-
-        ErrorAssert::assertDeprecationsAreTriggered($deprecations, function () {
-            $c = new ProjectServiceContainer();
-            $c->get('internal');
-        });
+        $c = new ProjectServiceContainer();
+        $c->get('internal');
     }
 }
 

--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Form\Tests;
 
-use Symfony\Bridge\PhpUnit\ErrorAssert;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
@@ -316,13 +315,11 @@ class SimpleFormTest extends AbstractFormTest
 
     /**
      * @group legacy
-     * @requires function Symfony\Bridge\PhpUnit\ErrorAssert::assertDeprecationsAreTriggered
+     * @expectedDeprecation Call Form::isValid() with an unsubmitted form %s.
      */
     public function testNotValidIfNotSubmitted()
     {
-        ErrorAssert::assertDeprecationsAreTriggered(array('Call Form::isValid() with an unsubmitted form'), function () {
-            $this->assertFalse($this->form->isValid());
-        });
+        $this->assertFalse($this->form->isValid());
     }
 
     public function testNotValidIfErrors()

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -11,9 +11,6 @@
 
 namespace Symfony\Component\HttpFoundation\Tests;
 
-use Response\DefaultResponse;
-use Response\ExtendedResponse;
-use Symfony\Bridge\PhpUnit\ErrorAssert;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -846,32 +843,23 @@ class ResponseTest extends ResponseTestCase
         }
     }
 
-    /**
-     * @requires function Symfony\Bridge\PhpUnit\ErrorAssert::assertDeprecationsAreTriggered
-     */
-    public function testNoDeprecations()
+    public function testNoDeprecationsAreTriggered()
     {
-        ErrorAssert::assertDeprecationsAreTriggered(array(), function () {
-            new DefaultResponse();
-            $this->getMock(Response::class);
-        });
+        new DefaultResponse();
+        $this->getMock(Response::class);
     }
 
     /**
-     * @requires function Symfony\Bridge\PhpUnit\ErrorAssert::assertDeprecationsAreTriggered
+     * @group legacy
+     * @expectedDeprecation Extending Symfony\Component\HttpFoundation\Response::getDate() in Symfony\Component\HttpFoundation\Tests\ExtendedResponse is deprecated %s.
+     * @expectedDeprecation Extending Symfony\Component\HttpFoundation\Response::setLastModified() in Symfony\Component\HttpFoundation\Tests\ExtendedResponse is deprecated %s.
      */
     public function testDeprecations()
     {
-        $deprecationMessages = array();
-        foreach (array('getDate', 'setLastModified') as $method) {
-            $deprecationMessages[] = sprintf('Extending %s::%s() in Response\ExtendedResponse is deprecated', Response::class, $method);
-        }
-        ErrorAssert::assertDeprecationsAreTriggered($deprecationMessages, function () {
-            new ExtendedResponse();
+        new ExtendedResponse();
 
-            // Deprecations should not be triggered twice
-            new ExtendedResponse();
-        });
+        // Deprecations should not be triggered twice
+        new ExtendedResponse();
     }
 
     public function validContentProvider()
@@ -922,10 +910,6 @@ class StringableObject
         return 'Foo';
     }
 }
-
-namespace Response;
-
-use Symfony\Component\HttpFoundation\Response;
 
 class DefaultResponse extends Response
 {

--- a/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Routing\Tests;
 
-use Symfony\Bridge\PhpUnit\ErrorAssert;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCompiler;
 
@@ -184,25 +183,20 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @group legacy
      * @dataProvider provideCompileImplicitUtf8Data
-     * @requires function Symfony\Bridge\PhpUnit\ErrorAssert::assertDeprecationsAreTriggered
+     * @expectedDeprecation Using UTF-8 route %s without setting the "utf8" option is deprecated %s.
      */
     public function testCompileImplicitUtf8Data($name, $arguments, $prefix, $regex, $variables, $tokens, $deprecationType)
     {
-        $deprecations = array(
-            sprintf('Using UTF-8 route %s without setting the "utf8" option is deprecated', $deprecationType),
-        );
+        $r = new \ReflectionClass('Symfony\\Component\\Routing\\Route');
+        $route = $r->newInstanceArgs($arguments);
 
-        ErrorAssert::assertDeprecationsAreTriggered($deprecations, function () use ($name, $arguments, $prefix, $regex, $variables, $tokens) {
-            $r = new \ReflectionClass('Symfony\\Component\\Routing\\Route');
-            $route = $r->newInstanceArgs($arguments);
-
-            $compiled = $route->compile();
-            $this->assertEquals($prefix, $compiled->getStaticPrefix(), $name.' (static prefix)');
-            $this->assertEquals($regex, $compiled->getRegex(), $name.' (regex)');
-            $this->assertEquals($variables, $compiled->getVariables(), $name.' (variables)');
-            $this->assertEquals($tokens, $compiled->getTokens(), $name.' (tokens)');
-        });
+        $compiled = $route->compile();
+        $this->assertEquals($prefix, $compiled->getStaticPrefix(), $name.' (static prefix)');
+        $this->assertEquals($regex, $compiled->getRegex(), $name.' (regex)');
+        $this->assertEquals($variables, $compiled->getVariables(), $name.' (variables)');
+        $this->assertEquals($tokens, $compiled->getTokens(), $name.' (tokens)');
     }
 
     public function provideCompileImplicitUtf8Data()

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -166,14 +166,13 @@ class InlineTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @requires function Symfony\Bridge\PhpUnit\ErrorAssert::assertDeprecationsAreTriggered
+     * @group legacy
+     * @expectedDeprecation Omitting the space after the colon that follows a mapping key definition is deprecated since version 3.2 and will throw a ParseException in 4.0.
      * throws \Symfony\Component\Yaml\Exception\ParseException in 4.0
      */
     public function testParseMappingKeyWithColonNotFollowedBySpace()
     {
-        ErrorAssert::assertDeprecationsAreTriggered('Omitting the space after the colon that follows a mapping key definition is deprecated since version 3.2 and will throw a ParseException in 4.0.', function () {
-            Inline::parse('{1:""}');
-        });
+        Inline::parse('{1:""}');
     }
 
     /**

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Yaml\Tests;
 
-use Symfony\Bridge\PhpUnit\ErrorAssert;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\Yaml\Parser;
 
@@ -809,15 +808,14 @@ EOD;
     }
 
     /**
+     * @group legacy
      * @dataProvider getParseExceptionOnDuplicateData
-     * @requires function Symfony\Bridge\PhpUnit\ErrorAssert::assertDeprecationsAreTriggered
+     * @expectedDeprecation Duplicate key "%s" detected on line %d whilst parsing YAML. Silent handling of duplicate mapping keys in YAML is deprecated %s.
      * throws \Symfony\Component\Yaml\Exception\ParseException in 4.0
      */
     public function testParseExceptionOnDuplicate($input, $duplicateKey, $lineNumber)
     {
-        ErrorAssert::assertDeprecationsAreTriggered(sprintf('Duplicate key "%s" detected on line %d whilst parsing YAML. Silent handling of duplicate mapping keys in YAML is deprecated since version 3.2 and will throw \Symfony\Component\Yaml\Exception\ParseException in 4.0.', $duplicateKey, $lineNumber), function () use ($input) {
-            Yaml::parse($input);
-        });
+        Yaml::parse($input);
     }
 
     public function getParseExceptionOnDuplicateData()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.2 |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #18880 |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/7074 |

For 3.2, that's what the feat. freeze is for in this case. ping @xabbuh 

See https://github.com/symfony/symfony/pull/20255/files?w=1
