### PR TITLE
[DependencyInjection] Support autowiring for EventDispatcher/EventDispatcherInterface

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -448,12 +448,6 @@ class FrameworkExtension extends Extension
 
         if ($debug) {
             $loader->load('debug.xml');
-
-            // replace the regular event_dispatcher service with the debug one
-            $definition = $container->findDefinition('event_dispatcher');
-            $definition->setPublic(false);
-            $container->setDefinition('debug.event_dispatcher.parent', $definition);
-            $container->setAlias('event_dispatcher', 'debug.event_dispatcher');
         }
 
         $definition = $container->findDefinition('debug.debug_handlers_listener');

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
@@ -9,9 +9,9 @@
     </parameters>
 
     <services>
-        <service id="debug.event_dispatcher" class="Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher">
+        <service id="debug.event_dispatcher" class="Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher" decorates="event_dispatcher">
             <tag name="monolog.logger" channel="event" />
-            <argument type="service" id="debug.event_dispatcher.parent" />
+            <argument type="service" id="debug.event_dispatcher.inner" />
             <argument type="service" id="debug.stopwatch" />
             <argument type="service" id="logger" on-invalid="null" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -7,6 +7,8 @@
     <services>
         <service id="event_dispatcher" class="Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher">
             <argument type="service" id="service_container" />
+            <autowiring-type>Symfony\Component\EventDispatcher\EventDispatcherInterface</autowiring-type>
+            <autowiring-type>Symfony\Component\EventDispatcher\EventDispatcher</autowiring-type>
         </service>
 
         <service id="http_kernel" class="Symfony\Component\HttpKernel\HttpKernel">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AutowiringTypesTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AutowiringTypesTest.php
@@ -14,6 +14,8 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\CachedReader;
 use Symfony\Component\Templating\EngineInterface as ComponentEngineInterface;
+use Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher;
+use Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface as FrameworkBundleEngineInterface;
 
 class AutowiringTypesTest extends WebTestCase
@@ -44,6 +46,21 @@ class AutowiringTypesTest extends WebTestCase
         $autowiredServices = $container->get('test.autowiring_types.autowired_services');
         $this->assertInstanceOf(FrameworkBundleEngineInterface::class, $autowiredServices->getFrameworkBundleEngine());
         $this->assertInstanceOf(ComponentEngineInterface::class, $autowiredServices->getEngine());
+    }
+
+    public function testEventDispatcherAutowiring()
+    {
+        static::bootKernel(array('debug' => false));
+        $container = static::$kernel->getContainer();
+
+        $autowiredServices = $container->get('test.autowiring_types.autowired_services');
+        $this->assertInstanceOf(ContainerAwareEventDispatcher::class, $autowiredServices->getDispatcher(), 'The event_dispatcher service should be injected if the debug is not enabled');
+
+        static::bootKernel(array('debug' => true));
+        $container = static::$kernel->getContainer();
+
+        $autowiredServices = $container->get('test.autowiring_types.autowired_services');
+        $this->assertInstanceOf(TraceableEventDispatcher::class, $autowiredServices->getDispatcher(), 'The debug.event_dispatcher service should be injected if the debug is enabled');
     }
 
     protected static function createKernel(array $options = array())

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/AutowiringTypes/AutowiredServices.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/AutowiringTypes/AutowiredServices.php
@@ -14,18 +14,21 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Auto
 use Doctrine\Common\Annotations\Reader;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface as FrameworkBundleEngineInterface;
 use Symfony\Component\Templating\EngineInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class AutowiredServices
 {
     private $annotationReader;
     private $frameworkBundleEngine;
     private $engine;
+    private $dispatcher;
 
-    public function __construct(Reader $annotationReader = null, FrameworkBundleEngineInterface $frameworkBundleEngine, EngineInterface $engine)
+    public function __construct(Reader $annotationReader = null, FrameworkBundleEngineInterface $frameworkBundleEngine, EngineInterface $engine, EventDispatcherInterface $dispatcher)
     {
         $this->annotationReader = $annotationReader;
         $this->frameworkBundleEngine = $frameworkBundleEngine;
         $this->engine = $engine;
+        $this->dispatcher = $dispatcher;
     }
 
     public function getAnnotationReader()
@@ -41,5 +44,10 @@ class AutowiredServices
     public function getEngine()
     {
         return $this->engine;
+    }
+
+    public function getDispatcher()
+    {
+        return $this->dispatcher;
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

As it is a very common dependency. Currently it gives:

> [Symfony\Component\DependencyInjection\Exception\RuntimeException]
> Unable to autowire argument of type "Symfony\Component\EventDispatcher\EventDispatcherInterface" for the service "dummy". Multiple services exist for this interface (debug.event_dispatcher, debug.event_dispatcher.parent).

After this, the `TraceableEventDispatcher` will be injected in dev and the `ContainerAwareEventDispatcher` in prod, as when injecting `@event_dispatcher` explicitly.

ping @weaverryan

IMHO this could be treated as a an enhancement for the autowiring feature and be part of 3.2.
