### PR TITLE
[VarDumper] Fix ArgsStub

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/ArgsStub.php
+++ b/src/Symfony/Component/VarDumper/Caster/ArgsStub.php
@@ -22,14 +22,13 @@ class ArgsStub extends EnumStub
 {
     private static $parameters = array();
 
-    public function __construct(array $values, $function, $class)
+    public function __construct(array $args, $function, $class)
     {
         list($variadic, $params) = self::getParameters($function, $class);
 
-        foreach ($values as $k => $v) {
-            if (!is_scalar($v) && !$v instanceof Stub) {
-                $values[$k] = new CutStub($v);
-            }
+        $values = array();
+        foreach ($args as $k => $v) {
+            $values[$k] = !is_scalar($v) && !$v instanceof Stub ? new CutStub($v) : $v;
         }
         if (null === $params) {
             parent::__construct($values, false);

--- a/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
@@ -109,7 +109,7 @@ class ExceptionCaster
                     'type' => isset($f['type']) ? $f['type'] : null,
                     'function' => isset($f['function']) ? $f['function'] : null,
                 ) + $frames[$i - 1],
-                $trace->keepArgs,
+                false,
                 true
             );
             $f = self::castFrameStub($frame, array(), $frame, true);
@@ -117,8 +117,9 @@ class ExceptionCaster
                 foreach ($f[$prefix.'src']->value as $label => $frame) {
                     $label = substr_replace($label, "title=Stack level $j.&", 2, 0);
                 }
-                if (isset($f[$prefix.'arguments']) && $frame instanceof EnumStub) {
-                    $frame->value['arguments'] = $f[$prefix.'arguments'];
+                $f = $frames[$i - 1];
+                if ($trace->keepArgs && !empty($f['args']) && $frame instanceof EnumStub) {
+                    $frame->value['arguments'] = new ArgsStub($f['args'], isset($f['function']) ? $f['function'] : null, isset($f['class']) ? $f['class'] : null);
                 }
             }
             $a[$label] = $frame;

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php
@@ -21,9 +21,9 @@ class ExceptionCasterTest extends \PHPUnit_Framework_TestCase
 {
     use VarDumperTestTrait;
 
-    private function getTestException()
+    private function getTestException($msg, &$ref = null)
     {
-        return new \Exception('foo');
+        return new \Exception(''.$msg);
     }
 
     protected function tearDown()
@@ -34,7 +34,8 @@ class ExceptionCasterTest extends \PHPUnit_Framework_TestCase
 
     public function testDefaultSettings()
     {
-        $e = $this->getTestException($this);
+        $ref = array('foo');
+        $e = $this->getTestException('foo', $ref);
 
         $expectedDump = <<<'EODUMP'
 Exception {
@@ -45,21 +46,23 @@ Exception {
   -trace: {
     %sExceptionCasterTest.php:26: {
       : {
-      :     return new \Exception('foo');
+      :     return new \Exception(''.$msg);
       : }
     }
     %sExceptionCasterTest.php:%d: {
-      : {
-      :     $e = $this->getTestException($this);
+      : $ref = array('foo');
+      : $e = $this->getTestException('foo', $ref);
       : 
       arguments: {
-        Symfony\Component\VarDumper\Tests\Caster\ExceptionCasterTest {#1 …}
+        $msg: "foo"
+        &$ref: array:1 [ …1]
       }
     }
 %A
 EODUMP;
 
         $this->assertDumpMatchesFormat($expectedDump, $e);
+        $this->assertSame(array('foo'), $ref);
     }
 
     public function testSeek()
@@ -70,7 +73,7 @@ EODUMP;
 {
   %sExceptionCasterTest.php:26: {
     : {
-    :     return new \Exception('foo');
+    :     return new \Exception(''.$msg);
     : }
   }
   %sExceptionCasterTest.php:%d: {
@@ -78,7 +81,7 @@ EODUMP;
     :     $e = $this->getTestException(2);
     : 
     arguments: {
-      2
+      $msg: 2
     }
   }
 %A
@@ -94,14 +97,14 @@ EODUMP;
 
         $expectedDump = <<<'EODUMP'
 Exception {
-  #message: "foo"
+  #message: "1"
   #code: 0
   #file: "%sExceptionCasterTest.php"
   #line: 26
   -trace: {
     %sExceptionCasterTest.php:26: {
       : {
-      :     return new \Exception('foo');
+      :     return new \Exception(''.$msg);
       : }
     }
     %sExceptionCasterTest.php:%d: {
@@ -122,7 +125,7 @@ EODUMP;
 
         $expectedDump = <<<'EODUMP'
 Exception {
-  #message: "foo"
+  #message: "1"
   #code: 0
   #file: "%sExceptionCasterTest.php"
   #line: 26
@@ -149,7 +152,7 @@ EODUMP;
 
         $expectedDump = <<<'EODUMP'
 <foo></foo><bar><span class=sf-dump-note>Exception</span> {<samp>
-  #<span class=sf-dump-protected title="Protected property">message</span>: "<span class=sf-dump-str title="3 characters">foo</span>"
+  #<span class=sf-dump-protected title="Protected property">message</span>: "<span class=sf-dump-str>1</span>"
   #<span class=sf-dump-protected title="Protected property">code</span>: <span class=sf-dump-num>0</span>
   #<span class=sf-dump-protected title="Protected property">file</span>: "<span class=sf-dump-str title="%sExceptionCasterTest.php
 %d characters"><span class=sf-dump-ellipsis>%sTests</span>%eCaster%eExceptionCasterTest.php</span>"


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.2 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Two bugs fixed here:
- ArgsStub changing the value of arguments passed by reference
- `class::function` used with off-by-one `args`
