### PR TITLE
[DependencyInjection] A decorated service should not keep the autowiring types

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
@@ -54,9 +54,11 @@ class DecoratorServicePass implements CompilerPassInterface
             } else {
                 $decoratedDefinition = $container->getDefinition($inner);
                 $definition->setTags($decoratedDefinition->getTags(), $definition->getTags());
+                $definition->setAutowiringTypes(array_merge($decoratedDefinition->getAutowiringTypes(), $definition->getAutowiringTypes()));
                 $public = $decoratedDefinition->isPublic();
                 $decoratedDefinition->setPublic(false);
                 $decoratedDefinition->setTags(array());
+                $decoratedDefinition->setAutowiringTypes(array());
                 $container->setDefinition($renamedId, $decoratedDefinition);
             }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/DecoratorServicePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/DecoratorServicePassTest.php
@@ -142,6 +142,27 @@ class DecoratorServicePassTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('name' => 'bar'), $container->getDefinition('baz')->getTags());
     }
 
+    public function testProcessMergesAutowiringTypesInDecoratingDefinitionAndRemoveThemFromDecoratedDefinition()
+    {
+        $container = new ContainerBuilder();
+
+        $container
+            ->register('parent')
+            ->addAutowiringType('Bar')
+        ;
+
+        $container
+            ->register('child')
+            ->setDecoratedService('parent')
+            ->addAutowiringType('Foo')
+        ;
+
+        $this->process($container);
+
+        $this->assertEquals(array('Bar', 'Foo'), $container->getDefinition('child')->getAutowiringTypes());
+        $this->assertEmpty($container->getDefinition('child.inner')->getAutowiringTypes());
+    }
+
     protected function process(ContainerBuilder $container)
     {
         $repeatedPass = new DecoratorServicePass();

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveDefinitionTemplatesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveDefinitionTemplatesPassTest.php
@@ -360,8 +360,11 @@ class ResolveDefinitionTemplatesPassTest extends \PHPUnit_Framework_TestCase
 
         $this->process($container);
 
-        $def = $container->getDefinition('child');
-        $this->assertEquals(array('Foo', 'Bar'), $def->getAutowiringTypes());
+        $childDef = $container->getDefinition('child');
+        $this->assertEquals(array('Foo', 'Bar'), $childDef->getAutowiringTypes());
+
+        $parentDef = $container->getDefinition('parent');
+        $this->assertSame(array('Foo'), $parentDef->getAutowiringTypes());
     }
 
     protected function process(ContainerBuilder $container)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/pull/20260#issuecomment-255364862 |
| License | MIT |
| Doc PR | n/a |

When decorating a service which is not abstract and has `autowiring_types`, the decorator should be the one used for autowiring methods of autowired services, so we should explicitly empty them on the decorated definition after merged them into the child. See  https://github.com/symfony/symfony/pull/20260#issuecomment-255364862 for a use case where we are forced to manually empty the decorated service's `autowiring_types`.
