### PR TITLE
[FrameworkBundle][HttpKernel] move test to the HttpKernel component

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddConsoleCommandPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddConsoleCommandPassTest.php
@@ -88,26 +88,6 @@ class AddConsoleCommandPassTest extends \PHPUnit_Framework_TestCase
 
         $container->compile();
     }
-
-    public function testHttpKernelRegisterCommandsIngoreCommandAsAService()
-    {
-        $container = new ContainerBuilder();
-        $container->addCompilerPass(new AddConsoleCommandPass());
-        $definition = new Definition('Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler\MyCommand');
-        $definition->addTag('console.command');
-        $container->setDefinition('my-command', $definition);
-        $container->compile();
-
-        $application = $this->getMock('Symfony\Component\Console\Application');
-        // Never called, because it's the
-        // Symfony\Bundle\FrameworkBundle\Console\Application that register
-        // commands as a service
-        $application->expects($this->never())->method('add');
-
-        $bundle = new ExtensionPresentBundle();
-        $bundle->setContainer($container);
-        $bundle->registerCommands($application);
-    }
 }
 
 class MyCommand extends Command

--- a/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\Tests\Bundle;
 
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Tests\Fixtures\ExtensionNotValidBundle\ExtensionNotValidBundle;
 use Symfony\Component\HttpKernel\Tests\Fixtures\ExtensionPresentBundle\ExtensionPresentBundle;
 use Symfony\Component\HttpKernel\Tests\Fixtures\ExtensionAbsentBundle\ExtensionAbsentBundle;
@@ -40,5 +41,19 @@ class BundleTest extends \PHPUnit_Framework_TestCase
     {
         $bundle = new ExtensionNotValidBundle();
         $bundle->getContainerExtension();
+    }
+
+    public function testHttpKernelRegisterCommandsIgnoresCommandsThatAreRegisteredAsServices()
+    {
+        $container = new ContainerBuilder();
+        $container->register('console.command.Symfony_Component_HttpKernel_Tests_Fixtures_ExtensionPresentBundle_Command_FooCommand', 'Symfony\Component\HttpKernel\Tests\Fixtures\ExtensionPresentBundle\Command\FooCommand');
+
+        $application = $this->getMock('Symfony\Component\Console\Application');
+        // add() is never called when the found command classes are already registered as services
+        $application->expects($this->never())->method('add');
+
+        $bundle = new ExtensionPresentBundle();
+        $bundle->setContainer($container);
+        $bundle->registerCommands($application);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/pull/19443#discussion_r83414612 |
| License | MIT |
| Doc PR |  |

The moved test case does not test the `AddConsoleCommandPass` class, but ensures certain behavior in the `registerCommands()` method of the `Bundle` class from the HttpKernel component.
