### PR TITLE
[RFC][HttpFoundation] Introduce RequestMatcher as a namespace

### DIFF
--- a/src/Symfony/Component/HttpFoundation/RequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher.php
@@ -11,6 +11,11 @@
 
 namespace Symfony\Component\HttpFoundation;
 
+use Symfony\Component\HttpFoundation\RequestMatcher\PathRequestMatcher;
+use Symfony\Component\HttpFoundation\RequestMatcher\RequestMatcher as BaseRequestMatcher;
+
+@trigger_error('The '.RequestMatcher::class.' class is deprecated since version 3.2 and will be removed in 4.0. Use the '.BaseRequestMatcher::class.' class instead.', E_USER_DEPRECATED);
+
 /**
  * RequestMatcher compares a pre-defined set of checks against a Request instance.
  *
@@ -96,6 +101,8 @@ class RequestMatcher implements RequestMatcherInterface
      */
     public function matchPath($regexp)
     {
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 3.2 and will be removed in 4.0. Use the '.PathRequestMatcher::class.' class instead.', E_USER_DEPRECATED);
+
         $this->path = $regexp;
     }
 

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher/ChainRequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher/ChainRequestMatcher.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\RequestMatcher;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @author Roland Franssen <franssen.roland@gmail.com>
+ */
+class ChainRequestMatcher implements RequestMatcherInterface
+{
+    private $matchers;
+
+    /**
+     * @param RequestMatcherInterface[] $matchers
+     */
+    public function __construct(array $matchers)
+    {
+        $this->matchers = $matchers;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function matches(Request $request)
+    {
+        foreach ($this->matchers as $matcher) {
+            if (!$matcher->matches($request)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher/ExpressionRequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher/ExpressionRequestMatcher.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\RequestMatcher;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+
+/**
+ * ExpressionRequestMatcher uses an expression to match a Request.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Roland Franssen <franssen.roland@gmail.com>
+ */
+class ExpressionRequestMatcher implements RequestMatcherInterface
+{
+    private $language;
+    private $expression;
+
+    public function __construct(ExpressionLanguage $language, $expression)
+    {
+        $this->language = $language;
+        $this->expression = $expression;
+    }
+
+    public function matches(Request $request)
+    {
+        return (bool) $this->language->evaluate($this->expression, array(
+            'request' => $request,
+            'method' => $request->getMethod(),
+            'path' => rawurldecode($request->getPathInfo()),
+            'host' => $request->getHost(),
+            'ip' => $request->getClientIp(),
+            'attributes' => $request->attributes->all(),
+        ));
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher/PathRequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher/PathRequestMatcher.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\RequestMatcher;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Roland Franssen <franssen.roland@gmail.com>
+ */
+class PathRequestMatcher implements RequestMatcherInterface
+{
+    private $path;
+    private $isRegex;
+
+    /**
+     * @param string $path
+     * @param bool   $isRegex
+     */
+    public function __construct($path, $isRegex = false)
+    {
+        $this->path = $path;
+        $this->isRegex = $isRegex;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function matches(Request $request)
+    {
+        return $this->isRegex
+            ? (bool) preg_match('{'.$this->path.'}', rawurldecode($request->getPathInfo()))
+            : $this->path === rawurldecode($request->getPathInfo());
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher/RequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher/RequestMatcher.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\RequestMatcher;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * RequestMatcher compares a pre-defined set of checks against a Request instance.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Roland Franssen <franssen.roland@gmail.com>
+ */
+class RequestMatcher extends ChainRequestMatcher
+{
+    private $host;
+    private $methods;
+    private $ips;
+    private $attributes;
+    private $schemes;
+
+    /**
+     * @param string|null $path
+     * @param string|null $host
+     * @param string[]    $methods
+     * @param string[]    $ips
+     * @param array       $attributes
+     * @param string[]    $schemes
+     */
+    public function __construct($path = null, $host = null, array $methods = array(), array $ips = array(), array $attributes = array(), array $schemes = array())
+    {
+        $matchers = array();
+        if (null !== $path) {
+            $matchers[] = new PathRequestMatcher($path, true);
+        }
+
+        parent::__construct($matchers);
+
+        // @todo
+        $this->host = $host;
+        $this->methods = $methods;
+        $this->ips = $ips;
+        $this->attributes = $attributes;
+        $this->schemes = $schemes;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function matches(Request $request)
+    {
+        if (!parent::matches($request)) {
+            return false;
+        }
+
+        if ($this->schemes && !in_array($request->getScheme(), $this->schemes)) {
+            return false;
+        }
+
+        if ($this->methods && !in_array($request->getMethod(), $this->methods)) {
+            return false;
+        }
+
+        foreach ($this->attributes as $key => $pattern) {
+            if (!preg_match('{'.$pattern.'}', $request->attributes->get($key))) {
+                return false;
+            }
+        }
+
+        if (!parent::matches($request)) {
+            return false;
+        }
+
+        if (null !== $this->host && !preg_match('{'.$this->host.'}i', $request->getHost())) {
+            return false;
+        }
+
+        if (IpUtils::checkIp($request->getClientIp(), $this->ips)) {
+            return true;
+        }
+
+        // Note to future implementors: add additional checks above the
+        // foreach above or else your check might not be run!
+        return count($this->ips) === 0;
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher/RequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher/RequestMatcher.php
@@ -57,10 +57,6 @@ class RequestMatcher extends ChainRequestMatcher
      */
     public function matches(Request $request)
     {
-        if (!parent::matches($request)) {
-            return false;
-        }
-
         if ($this->schemes && !in_array($request->getScheme(), $this->schemes)) {
             return false;
         }

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher/RequestMatcherInterface.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher/RequestMatcherInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\RequestMatcher;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * RequestMatcherInterface is an interface for strategies to match a Request.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+interface RequestMatcherInterface
+{
+    /**
+     * Decides whether the rule(s) implemented by the strategy matches the supplied request.
+     *
+     * @param Request $request The request to check for a match
+     *
+     * @return bool true if the request matches, false otherwise
+     */
+    public function matches(Request $request);
+}

--- a/src/Symfony/Component/HttpFoundation/RequestMatcherInterface.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcherInterface.php
@@ -11,19 +11,15 @@
 
 namespace Symfony\Component\HttpFoundation;
 
+use Symfony\Component\HttpFoundation\RequestMatcher\RequestMatcherInterface as BaseRequestMatcherInterface;
+
+@trigger_error('The '.RequestMatcherInterface::class.' class is deprecated since version 3.2 and will be removed in 4.0. Use the '.BaseRequestMatcherInterface::class.' class instead.', E_USER_DEPRECATED);
+
 /**
  * RequestMatcherInterface is an interface for strategies to match a Request.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-interface RequestMatcherInterface
+interface RequestMatcherInterface extends BaseRequestMatcherInterface
 {
-    /**
-     * Decides whether the rule(s) implemented by the strategy matches the supplied request.
-     *
-     * @param Request $request The request to check for a match
-     *
-     * @return bool true if the request matches, false otherwise
-     */
-    public function matches(Request $request);
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes/no |
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

Idea is to have many simple request matchers instead of several complex ones (allowing to built complex ones from simple ones) and make them immutable.
