### PR TITLE
[DependencyInjection] merge tags instead of completely replacing them

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
@@ -43,7 +43,7 @@ class DecoratorServicePass implements CompilerPassInterface
                 $container->setAlias($renamedId, new Alias((string) $alias, false));
             } else {
                 $decoratedDefinition = $container->getDefinition($inner);
-                $definition->setTags($decoratedDefinition->getTags(), $definition->getTags());
+                $definition->setTags(array_merge($decoratedDefinition->getTags(), $definition->getTags()));
                 $public = $decoratedDefinition->isPublic();
                 $decoratedDefinition->setPublic(false);
                 $decoratedDefinition->setTags(array());

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/DecoratorServicePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/DecoratorServicePassTest.php
@@ -87,17 +87,18 @@ class DecoratorServicePassTest extends \PHPUnit_Framework_TestCase
         $container = new ContainerBuilder();
         $container
             ->register('foo')
-            ->setTags(array('name' => 'bar'))
+            ->setTags(array('bar' => array('attr' => 'baz')))
         ;
         $container
             ->register('baz')
+            ->setTags(array('foobar' => array('attr' => 'bar')))
             ->setDecoratedService('foo')
         ;
 
         $this->process($container);
 
         $this->assertEmpty($container->getDefinition('baz.inner')->getTags());
-        $this->assertEquals(array('name' => 'bar'), $container->getDefinition('baz')->getTags());
+        $this->assertEquals(array('bar' => array('attr' => 'baz'), 'foobar' => array('attr' => 'bar')), $container->getDefinition('baz')->getTags());
     }
 
     protected function process(ContainerBuilder $container)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | yes/no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #20150, #20207 |
| License | MIT |
| Doc PR |  |

In #20207, I missed the `array_merge()` call. Thus, previously set tags of the decorating service would have been discarded by the compiler pass.
