### PR TITLE
[DependencyInjection] Fix extra arg in method call

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
@@ -43,7 +43,7 @@ class DecoratorServicePass implements CompilerPassInterface
                 $container->setAlias($renamedId, new Alias((string) $alias, false));
             } else {
                 $decoratedDefinition = $container->getDefinition($inner);
-                $definition->setTags($decoratedDefinition->getTags(), $definition->getTags());
+                $definition->setTags($decoratedDefinition->getTags());
                 $public = $decoratedDefinition->isPublic();
                 $decoratedDefinition->setPublic(false);
                 $decoratedDefinition->setTags(array());


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

There is an extra argument in the call of `$definition->setTags()`.

My guess it that the first intention is to merge the tags of the decorated definition with the decorating one, then move them all into the decorating, please correct me if I'm wrong (if the tags of the decorated should just squash the decorating tags if any, so we just remove the extra argument).
