### PR TITLE
[DependencyInjection] Decorating service should inherit autowire from decorated

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
@@ -54,6 +54,7 @@ class DecoratorServicePass implements CompilerPassInterface
             } else {
                 $decoratedDefinition = $container->getDefinition($inner);
                 $definition->setTags($decoratedDefinition->getTags(), $definition->getTags());
+                $definition->setAutowired($decoratedDefinition->isAutowired());
                 $public = $decoratedDefinition->isPublic();
                 $decoratedDefinition->setPublic(false);
                 $decoratedDefinition->setTags(array());

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/DecoratorServicePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/DecoratorServicePassTest.php
@@ -142,6 +142,23 @@ class DecoratorServicePassTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('name' => 'bar'), $container->getDefinition('baz')->getTags());
     }
 
+    public function testDecoratingDefinitionInheritsAutowireFromDecoratedDefinition()
+    {
+        $container = new ContainerBuilder();
+        $container
+            ->register('foo')
+            ->setAutowired(true)
+        ;
+        $container
+            ->register('baz')
+            ->setDecoratedService('foo')
+        ;
+
+        $this->process($container);
+
+        $this->assertTrue($container->getDefinition('baz')->isAutowired());
+    }
+
     protected function process(ContainerBuilder $container)
     {
         $repeatedPass = new DecoratorServicePass();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | _n/a_ |
| License | MIT |
| Doc PR | n/a |

Same as #19643 for decoration.

ping @dunglas 
