### PR TITLE
[TwigBundle] made Twig cache independent of the project root directory

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -52,7 +52,8 @@
         </service>
 
         <service id="twig.loader.native_filesystem" class="Twig_Loader_Filesystem" public="false">
-            <argument type="collection" />
+            <argument type="collection" /> <!-- paths -->
+            <argument>%kernel.root_dir%</argument>
         </service>
 
         <service id="twig.loader.filesystem" class="%twig.loader.filesystem.class%" public="false">


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This makes Twig cache keys independent of the project root directory, thanks to Twig 1.27.
