### PR TITLE
[TwigBundle] made Twig cache independent of the project root directory

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -45,7 +45,8 @@
         </service>
 
         <service id="twig.loader.native_filesystem" class="Twig_Loader_Filesystem" public="false">
-            <argument type="collection" />
+            <argument type="collection" /> <!-- paths -->
+            <argument>%kernel.root_dir%</argument>
         </service>
 
         <service id="twig.loader.filesystem" class="Symfony\Bundle\TwigBundle\Loader\FilesystemLoader" public="false">


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no (except if people configured relative paths instead of absolute ones, but this was not supported in earlier versions of Twig) |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This makes Twig cache keys independent of the project root directory, thanks to Twig 1.27.

It cannot be merged in 2.7 as a bug fix as people might have used relative paths for some Twig paths (no officially supported by Twig anyway), which would have resolved to `getcwd()` before, but will now be interpreted as being relative to `%kernel.root_dir%` now.
