### PR TITLE
Properly format value in UniqueEntityValidator

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Test/DoctrineTestHelper.php
+++ b/src/Symfony/Bridge/Doctrine/Test/DoctrineTestHelper.php
@@ -12,6 +12,8 @@
 namespace Symfony\Bridge\Doctrine\Test;
 
 use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\ORM\Configuration;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\EntityManager;
 
@@ -25,22 +27,19 @@ class DoctrineTestHelper
     /**
      * Returns an entity manager for testing.
      *
+     * @param Configuration|null $config
+     *
      * @return EntityManager
      */
-    public static function createTestEntityManager()
+    public static function createTestEntityManager(Configuration $config = null)
     {
         if (!extension_loaded('pdo_sqlite')) {
             \PHPUnit_Framework_TestCase::markTestSkipped('Extension pdo_sqlite is required.');
         }
 
-        $config = new \Doctrine\ORM\Configuration();
-        $config->setEntityNamespaces(array('SymfonyTestsDoctrine' => 'Symfony\Bridge\Doctrine\Tests\Fixtures'));
-        $config->setAutoGenerateProxyClasses(true);
-        $config->setProxyDir(\sys_get_temp_dir());
-        $config->setProxyNamespace('SymfonyTests\Doctrine');
-        $config->setMetadataDriverImpl(new AnnotationDriver(new AnnotationReader()));
-        $config->setQueryCacheImpl(new \Doctrine\Common\Cache\ArrayCache());
-        $config->setMetadataCacheImpl(new \Doctrine\Common\Cache\ArrayCache());
+        if (null === $config) {
+            $config = self::createTestConfiguration();
+        }
 
         $params = array(
             'driver' => 'pdo_sqlite',
@@ -48,6 +47,23 @@ class DoctrineTestHelper
         );
 
         return EntityManager::create($params, $config);
+    }
+
+    /**
+     * @return Configuration
+     */
+    public static function createTestConfiguration()
+    {
+        $config = new Configuration();
+        $config->setEntityNamespaces(array('SymfonyTestsDoctrine' => 'Symfony\Bridge\Doctrine\Tests\Fixtures'));
+        $config->setAutoGenerateProxyClasses(true);
+        $config->setProxyDir(\sys_get_temp_dir());
+        $config->setProxyNamespace('SymfonyTests\Doctrine');
+        $config->setMetadataDriverImpl(new AnnotationDriver(new AnnotationReader()));
+        $config->setQueryCacheImpl(new ArrayCache());
+        $config->setMetadataCacheImpl(new ArrayCache());
+
+        return $config;
     }
 
     /**

--- a/src/Symfony/Bridge/Doctrine/Test/TestRepositoryFactory.php
+++ b/src/Symfony/Bridge/Doctrine/Test/TestRepositoryFactory.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Test;
+
+use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Repository\RepositoryFactory;
+
+/**
+ * @author Andreas Braun <alcaeus@alcaeus.org>
+ */
+final class TestRepositoryFactory implements RepositoryFactory
+{
+    /**
+     * The list of EntityRepository instances.
+     *
+     * @var ObjectRepository[]
+     */
+    private $repositoryList = array();
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRepository(EntityManagerInterface $entityManager, $entityName)
+    {
+        $repositoryHash = $this->getRepositoryHash($entityManager, $entityName);
+
+        if (isset($this->repositoryList[$repositoryHash])) {
+            return $this->repositoryList[$repositoryHash];
+        }
+
+        return $this->repositoryList[$repositoryHash] = $this->createRepository($entityManager, $entityName);
+    }
+
+    /**
+     * @param EntityManagerInterface $entityManager
+     * @param string                 $entityName
+     * @param ObjectRepository       $repository
+     */
+    public function setRepository(EntityManagerInterface $entityManager, $entityName, ObjectRepository $repository)
+    {
+        $repositoryHash = $this->getRepositoryHash($entityManager, $entityName);
+
+        $this->repositoryList[$repositoryHash] = $repository;
+    }
+
+    /**
+     * Create a new repository instance for an entity class.
+     *
+     * @param EntityManagerInterface $entityManager The EntityManager instance.
+     * @param string                 $entityName    The name of the entity.
+     *
+     * @return ObjectRepository
+     */
+    private function createRepository(EntityManagerInterface $entityManager, $entityName)
+    {
+        /* @var $metadata ClassMetadata */
+        $metadata = $entityManager->getClassMetadata($entityName);
+        $repositoryClassName = $metadata->customRepositoryClassName
+            ?: $entityManager->getConfiguration()->getDefaultRepositoryClassName();
+
+        return new $repositoryClassName($entityManager, $metadata);
+    }
+
+    /**
+     * @param EntityManagerInterface $entityManager
+     * @param string                 $entityName
+     *
+     * @return string
+     */
+    private function getRepositoryHash(EntityManagerInterface $entityManager, $entityName)
+    {
+        return $entityManager->getClassMetadata($entityName)->getName().spl_object_hash($entityManager);
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/SingleIntIdEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/SingleIntIdEntity.php
@@ -24,6 +24,9 @@ class SingleIntIdEntity
     /** @Column(type="string", nullable=true) */
     public $name;
 
+    /** @Column(type="array", nullable=true) */
+    public $phoneNumbers = array();
+
     public function __construct($id, $name)
     {
         $this->id = $id;

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -133,7 +133,7 @@ class UniqueEntityValidator extends ConstraintValidator
 
         $this->context->buildViolation($constraint->message)
             ->atPath($errorPath)
-            ->setParameter('{{ value }}', $invalidValue)
+            ->setParameter('{{ value }}', $this->formatValue($invalidValue, static::OBJECT_TO_STRING | static::PRETTY_DATE))
             ->setInvalidValue($invalidValue)
             ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
             ->addViolation();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.1 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | / |
| License | MIT |

This PR fixes a small issue introduced in #15279. Having an array in a field considered for a unique check causes an array to string conversion error in the translator. This can be avoided by formatting the value parameter with `formatValue`.
