### PR TITLE
Improved the design of the metrics in the profiler

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
@@ -60,10 +60,19 @@
             <span class="label">Symfony initialization</span>
         </div>
 
+        {% if profile.collectors.memory %}
+            <div class="metric">
+                <span class="value">{{ '%.2f'|format(profile.collectors.memory.memory / 1024 / 1024) }} <span class="unit">MB</span></span>
+                <span class="label">Peak memory usage</span>
+            </div>
+        {% endif %}
+
         {% if profile.children|length > 0 %}
+            <div class="metric-divider"></div>
+
             <div class="metric">
                 <span class="value">{{ profile.children|length }}</span>
-                <span class="label">Sub-Requests</span>
+                <span class="label">Sub-Request{{ profile.children|length > 1 ? 's' }}</span>
             </div>
 
             {% set subrequests_time = 0 %}
@@ -73,14 +82,7 @@
 
             <div class="metric">
                 <span class="value">{{ subrequests_time }} <span class="unit">ms</span></span>
-                <span class="label">Sub-Requests time</span>
-            </div>
-        {% endif %}
-
-        {% if profile.collectors.memory %}
-            <div class="metric">
-                <span class="value">{{ '%.2f'|format(profile.collectors.memory.memory / 1024 / 1024) }} <span class="unit">MB</span></span>
-                <span class="label">Peak memory usage</span>
+                <span class="label">Sub-Request{{ profile.children|length > 1 ? 's' }} time</span>
             </div>
         {% endif %}
     </div>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -255,7 +255,7 @@ table tbody ul {
 }
 .metrics .metric {
     float: left;
-    margin-right: 1em;
+    margin: 0 1em 1em 0;
 }
 
 .metric {

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -250,7 +250,7 @@ table tbody ul {
 {# Metrics
    ------------------------------------------------------------------------- #}
 .metrics {
-    margin: 1em 0;
+    margin: 1em 0 0;
     overflow: auto;
 }
 .metrics .metric {

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -310,6 +310,12 @@ table tbody ul {
     vertical-align: middle;
 }
 
+.metric-divider {
+    float: left;
+    margin: 0 1em;
+    min-height: 1px; {# required to apply 'margin' to an empty 'div' #}
+}
+
 {# Cards
    ------------------------------------------------------------------------- #}
 .card {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR |  |
- Performance panel now displays Sub-Requests a bit separated from the normal metrics
- Singular/plural: when there is 1 sub-request, we don't display "sub-request**s**" anymore
### Before

![before_subrequests](https://cloud.githubusercontent.com/assets/73419/19680261/5289fd26-9aa5-11e6-8702-1ac50997da78.png)
### After

![after_subrequests](https://cloud.githubusercontent.com/assets/73419/19680272/57324b44-9aa5-11e6-8d85-44cc089bd9f4.png)
- Add bottom margin to metrics so they are correctly displayed when the screen is very small.
### Before & After

![metrics-small-screens](https://cloud.githubusercontent.com/assets/73419/19680259/4f826654-9aa5-11e6-9ed8-1ffe9a3db8bf.png)
