### PR TITLE
Define a GitHub issue template to avoid support questions

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,3 @@
+Thanks for supporting Symfony!
+* Issues are used for reporting bugs and requesting new features.
+* If you have a question about using Symfony, ask it in https://symfony.com/support

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,13 @@
-Thanks for supporting Symfony!
-* Issues are used for reporting bugs and requesting new features.
-* If you have a question about using Symfony, ask it in https://symfony.com/support
+| Q                | A
+| ---------------- | -----
+| Bug report?      | yes/no
+| Feature request? | yes/no
+| BC Break report? | yes/no
+| RFC?             | yes/no
+| Symfony version  | x.y.z
+
+<!--
+- Please fill in this template according to your issue.
+- For support request or how-tos, visit https://symfony.com/support
+- Otherwise, replace this comment by the description of your issue.
+-->


### PR DESCRIPTION
We're getting a lot of issues that are in fact support questions. Should we give a try at defining a GitHub Issue template to try to minimize this problem?

The text contents are temporary. This is how they'd look:

![issue_template](https://cloud.githubusercontent.com/assets/73419/19683472/9be02128-9ab2-11e6-90a7-987ddcb49d97.png)
