### PR TITLE
[Form] Keep existing entry options when resizing a collection.

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
@@ -85,15 +85,18 @@ class ResizeFormListener implements EventSubscriberInterface
         }
 
         // First remove all rows
+        $oldOptions = array();
         foreach ($form as $name => $child) {
+            $oldOptions[$name] = $form->get($name)->getConfig()->getOptions();
             $form->remove($name);
         }
 
         // Then add all rows again in the correct order
         foreach ($data as $name => $value) {
+            $options = isset($oldOptions[$name]) ? $oldOptions[$name] : $this->options;
             $form->add($name, $this->type, array_replace(array(
                 'property_path' => '['.$name.']',
-            ), $this->options));
+            ), $options));
         }
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
@@ -39,14 +39,14 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
         $this->form = null;
     }
 
-    protected function getBuilder($name = 'name')
+    protected function getBuilder($name = 'name', array $options = array())
     {
-        return new FormBuilder($name, null, $this->dispatcher, $this->factory);
+        return new FormBuilder($name, null, $this->dispatcher, $this->factory, $options);
     }
 
-    protected function getForm($name = 'name')
+    protected function getForm($name = 'name', array $options = array())
     {
-        return $this->getBuilder($name)->getForm();
+        return $this->getBuilder($name, $options)->getForm();
     }
 
     /**
@@ -64,8 +64,8 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testPreSetDataResizesForm()
     {
-        $this->form->add($this->getForm('0'));
-        $this->form->add($this->getForm('1'));
+        $this->form->add($this->getForm('0', array('attr' => array('maxlength' => 10))));
+        $this->form->add($this->getForm('1', array('attr' => array('maxlength' => 10))));
 
         $this->factory->expects($this->at(0))
             ->method('createNamed')


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ? |
| License | MIT |
| Doc PR |  |

Currently you can't edit a collection entry during a form event, because even if you do so, it will be erased by the ResizeFormListener.

This PR changes this behavior, by reusing options of the previous item it is replacing if possible.
Because of that I'm not sure which branch to target.
It should be considered a fix because nobody could rely on this "erase" behavior anyway.
