### PR TITLE
[Translation] Fix time ago display for local Thailand

### DIFF
--- a/src/Symfony/Component/Translation/PluralizationRules.php
+++ b/src/Symfony/Component/Translation/PluralizationRules.php
@@ -66,7 +66,6 @@ class PluralizationRules
             case 'kn':
             case 'ko':
             case 'ms':
-            case 'th':
             case 'tr':
             case 'vi':
             case 'zh':
@@ -120,6 +119,7 @@ class PluralizationRules
             case 'sw':
             case 'ta':
             case 'te':
+            case 'th':
             case 'tk':
             case 'ur':
             case 'zu':


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "all" |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

If set local Thailand time ago in carbon/carbon it's display only "1" seconds, minutes, hours .. 
ex.

| Eng | Thai |
| --- | --- |
| 3 minutes ago | 1 นาที ที่แล้ว |
| 4 days ago | 1 วัน ที่แล้ว |
| 2 weeks ago | 1 สัปดาห์ ที่แล้ว |
