### PR TITLE
[Ldap] Allow search scoping

### DIFF
--- a/src/Symfony/Component/Ldap/Adapter/AbstractQuery.php
+++ b/src/Symfony/Component/Ldap/Adapter/AbstractQuery.php
@@ -34,10 +34,10 @@ abstract class AbstractQuery implements QueryInterface
             'timeout' => 0,
             'deref' => static::DEREF_NEVER,
             'attrsOnly' => 0,
-            'scope' => static::SCOPE_SUBTREE,
+            'scope' => static::SCOPE_SUB,
         ));
         $resolver->setAllowedValues('deref', array(static::DEREF_ALWAYS, static::DEREF_NEVER, static::DEREF_FINDING, static::DEREF_SEARCHING));
-        $resolver->setAllowedValues('scope', array(static::SCOPE_BASE, static::SCOPE_ONELEVEL, static::SCOPE_SUBTREE));
+        $resolver->setAllowedValues('scope', array(static::SCOPE_BASE, static::SCOPE_ONE, static::SCOPE_SUB));
 
         $resolver->setNormalizer('filter', function (Options $options, $value) {
             return is_array($value) ? $value : array($value);

--- a/src/Symfony/Component/Ldap/Adapter/AbstractQuery.php
+++ b/src/Symfony/Component/Ldap/Adapter/AbstractQuery.php
@@ -34,8 +34,11 @@ abstract class AbstractQuery implements QueryInterface
             'timeout' => 0,
             'deref' => static::DEREF_NEVER,
             'attrsOnly' => 0,
+            'scope' => static::SCOPE_SUBTREE,
         ));
         $resolver->setAllowedValues('deref', array(static::DEREF_ALWAYS, static::DEREF_NEVER, static::DEREF_FINDING, static::DEREF_SEARCHING));
+        $resolver->setAllowedValues('scope', array(static::SCOPE_BASE, static::SCOPE_ONELEVEL, static::SCOPE_SUBTREE));
+
         $resolver->setNormalizer('filter', function (Options $options, $value) {
             return is_array($value) ? $value : array($value);
         });

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
@@ -60,7 +60,21 @@ class Query extends AbstractQuery
 
             $con = $this->connection->getResource();
 
-            $this->search = @ldap_search(
+            switch ($this->options['scope']) {
+                case static::SCOPE_BASE:
+                    $func = 'ldap_read';
+                    break;
+                case static::SCOPE_ONELEVEL:
+                    $func = 'ldap_list';
+                    break;
+                case static::SCOPE_SUBTREE:
+                    $func = 'ldap_search';
+                    break;
+                default:
+                    throw new LdapException(sprintf('Could not search in scope %s', $this->options['scopen']));
+            }
+
+            $this->search = @$func(
                 $con,
                 $this->dn,
                 $this->query,

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
@@ -64,10 +64,10 @@ class Query extends AbstractQuery
                 case static::SCOPE_BASE:
                     $func = 'ldap_read';
                     break;
-                case static::SCOPE_ONELEVEL:
+                case static::SCOPE_ONE:
                     $func = 'ldap_list';
                     break;
-                case static::SCOPE_SUBTREE:
+                case static::SCOPE_SUB:
                     $func = 'ldap_search';
                     break;
                 default:

--- a/src/Symfony/Component/Ldap/Adapter/QueryInterface.php
+++ b/src/Symfony/Component/Ldap/Adapter/QueryInterface.php
@@ -24,8 +24,8 @@ interface QueryInterface
     const DEREF_ALWAYS = 0x03;
 
     const SCOPE_BASE = 'base';
-    const SCOPE_ONELEVEL = 'one_level';
-    const SCOPE_SUBTREE = 'subtree';
+    const SCOPE_ONE = 'one';
+    const SCOPE_SUB = 'sub';
 
     /**
      * Executes a query and returns the list of Ldap entries.

--- a/src/Symfony/Component/Ldap/Adapter/QueryInterface.php
+++ b/src/Symfony/Component/Ldap/Adapter/QueryInterface.php
@@ -23,6 +23,10 @@ interface QueryInterface
     const DEREF_FINDING = 0x02;
     const DEREF_ALWAYS = 0x03;
 
+    const SCOPE_BASE = 'base';
+    const SCOPE_ONELEVEL = 'one_level';
+    const SCOPE_SUBTREE = 'subtree';
+
     /**
      * Executes a query and returns the list of Ldap entries.
      *

--- a/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Ldap\Tests;
 
 use Symfony\Component\Ldap\Adapter\ExtLdap\Adapter;
 use Symfony\Component\Ldap\Adapter\ExtLdap\Collection;
+use Symfony\Component\Ldap\Adapter\ExtLdap\Query;
 use Symfony\Component\Ldap\Entry;
 use Symfony\Component\Ldap\LdapInterface;
 
@@ -64,5 +65,38 @@ class AdapterTest extends LdapTestCase
         $this->assertInstanceOf(Entry::class, $entry);
         $this->assertEquals(array('Fabien Potencier'), $entry->getAttribute('cn'));
         $this->assertEquals(array('fabpot@symfony.com', 'fabien@potencier.com'), $entry->getAttribute('mail'));
+    }
+
+    public function testLdapQueryScopeBase()
+    {
+        $ldap = new Adapter($this->getLdapConfig());
+
+        $ldap->getConnection()->bind('cn=admin,dc=symfony,dc=com', 'symfony');
+
+        $query = $ldap->createQuery('cn=Fabien Potencier,dc=symfony,dc=com', '(objectclass=*)', array(
+           'scope' => Query::SCOPE_BASE,
+        ));
+        $result = $query->execute();
+
+        $entry = $result[0];
+        $this->assertEquals($result->count(), 1);
+        $this->assertEquals(array('Fabien Potencier'), $entry->getAttribute('cn'));
+    }
+
+    public function testLdapQueryScopeOneLevel()
+    {
+        $ldap = new Adapter($this->getLdapConfig());
+
+        $ldap->getConnection()->bind('cn=admin,dc=symfony,dc=com', 'symfony');
+
+        $one_level_result = $ldap->createQuery('ou=Components,dc=symfony,dc=com', '(objectclass=*)', array(
+            'scope' => Query::SCOPE_ONELEVEL,
+        ))->execute();
+
+        $subtree_count = $ldap->createQuery('ou=Components,dc=symfony,dc=com', '(objectclass=*)')->execute()->count();
+
+        $this->assertNotEquals($one_level_result->count(), $subtree_count);
+        $this->assertEquals($one_level_result->count(), 1);
+        $this->assertEquals($one_level_result[0]->getAttribute('ou'), array('Ldap'));
     }
 }

--- a/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
@@ -90,7 +90,7 @@ class AdapterTest extends LdapTestCase
         $ldap->getConnection()->bind('cn=admin,dc=symfony,dc=com', 'symfony');
 
         $one_level_result = $ldap->createQuery('ou=Components,dc=symfony,dc=com', '(objectclass=*)', array(
-            'scope' => Query::SCOPE_ONELEVEL,
+            'scope' => Query::SCOPE_ONE,
         ))->execute();
 
         $subtree_count = $ldap->createQuery('ou=Components,dc=symfony,dc=com', '(objectclass=*)')->execute()->count();

--- a/src/Symfony/Component/Ldap/Tests/Fixtures/data/fixtures.ldif
+++ b/src/Symfony/Component/Ldap/Tests/Fixtures/data/fixtures.ldif
@@ -12,3 +12,15 @@ ou: Maintainers
 ou: Founder
 givenName: Fabien Potencier
 description: Founder and project lead @Symfony
+
+dn: ou=Components,dc=symfony,dc=com
+objectclass: organizationalunit
+ou: Components
+
+dn: ou=Ldap,ou=Components,dc=symfony,dc=com
+objectclass: organizationalunit
+ou: Ldap
+
+dn: ou=Ldap scoping,ou=Ldap,ou=Components,dc=symfony,dc=com
+objectclass: organizationalunit
+ou: Ldap scoping


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Quite trivial, PR adds "scope" attribute to the query options. For example:

```php
    public function ldapAction()
    {
        $ldap = $this->get("app.ldap");
        $dn = $this->getParameter("dn");

        $results = $ldap->query($dn, "(objectClass=*)", [
            "scope" => Query::SCOPE_ONELEVEL
        ])->execute();

        foreach ($results as $entry) {
            var_dump($entry->getDn()); echo "<br/>";
        }

        return new Response("");
    }
```

SCOPE_BASE: http://php.net/manual/ru/function.ldap-read.php
SCOPE_ONELEVEL: http://php.net/manual/ru/function.ldap-list.php
SCOPE_SUBTREE: http://php.net/manual/ru/function.ldap-search.php
