### PR TITLE
Compatibility with Twig 1.27

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
+++ b/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
@@ -87,7 +87,11 @@ class FilesystemLoader extends \Twig_Loader_Filesystem
         }
 
         if (false === $file || null === $file) {
-            throw $twigLoaderException;
+            if ($throw) {
+                throw $twigLoaderException;
+            }
+
+            return false;
         }
 
         return $this->cache[$logicalName] = $file;

--- a/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
+++ b/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
@@ -58,7 +58,7 @@ class FilesystemLoader extends \Twig_Loader_Filesystem
      * Otherwise the template is located using the locator from the twig library.
      *
      * @param string|TemplateReferenceInterface $template The template
-     * @param bool $throw Throw \Twig_Error_Loader exception if template is not found
+     * @param bool                              $throw    When true, a \Twig_Error_Loader exception will be thrown if a template could not be found
      *
      * @return string The path to the template file
      *

--- a/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
+++ b/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
@@ -58,6 +58,7 @@ class FilesystemLoader extends \Twig_Loader_Filesystem
      * Otherwise the template is located using the locator from the twig library.
      *
      * @param string|TemplateReferenceInterface $template The template
+     * @param bool $throw Throw \Twig_Error_Loader exception if template is not found
      *
      * @return string The path to the template file
      *

--- a/src/Symfony/Bundle/TwigBundle/Tests/Loader/FilesystemLoaderTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Loader/FilesystemLoaderTest.php
@@ -115,4 +115,17 @@ class FilesystemLoaderTest extends TestCase
         $method->setAccessible(true);
         $method->invoke($loader, 'name.format.engine');
     }
+    
+    public function testTwigSoftErrorIfTemplateDoesNotExist()
+    {
+        $parser = $this->getMock('Symfony\Component\Templating\TemplateNameParserInterface');
+        $locator = $this->getMock('Symfony\Component\Config\FileLocatorInterface');
+
+        $loader = new FilesystemLoader($locator, $parser);
+        $loader->addPath(__DIR__.'/../DependencyInjection/Fixtures/Resources/views');
+
+        $method = new \ReflectionMethod('Symfony\Bundle\TwigBundle\Loader\FilesystemLoader', 'findTemplate');
+        $method->setAccessible(true);
+        $this->assertFalse($method->invoke($loader, 'name.format.engine', false));
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" for new features / 2.7, 2.8 or 3.1 for fixes |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

In FilesystemLoader::findTemplate(), you must accept a second argument that when set to "false" returns "false" instead of throwing an exception. Not supporting this argument is deprecated since version 1.27.
