### PR TITLE
[Routing][WIP] Support routes parameters names that are longer than 32 characters

### DIFF
--- a/src/Symfony/Component/Routing/CompiledRoute.php
+++ b/src/Symfony/Component/Routing/CompiledRoute.php
@@ -28,18 +28,30 @@ class CompiledRoute implements \Serializable
     private $hostTokens;
 
     /**
+     * @var array
+     */
+    private $regexVariablesAliases;
+
+    /**
+     * @var array
+     */
+    private $hostRegexVariablesAliases;
+
+    /**
      * Constructor.
      *
-     * @param string      $staticPrefix  The static prefix of the compiled route
-     * @param string      $regex         The regular expression to use to match this route
-     * @param array       $tokens        An array of tokens to use to generate URL for this route
-     * @param array       $pathVariables An array of path variables
-     * @param string|null $hostRegex     Host regex
-     * @param array       $hostTokens    Host tokens
-     * @param array       $hostVariables An array of host variables
-     * @param array       $variables     An array of variables (variables defined in the path and in the host patterns)
+     * @param string      $staticPrefix              The static prefix of the compiled route
+     * @param string      $regex                     The regular expression to use to match this route
+     * @param array       $tokens                    An array of tokens to use to generate URL for this route
+     * @param array       $pathVariables             An array of path variables
+     * @param string|null $hostRegex                 Host regex
+     * @param array       $hostTokens                Host tokens
+     * @param array       $hostVariables             An array of host variables
+     * @param array       $variables                 An array of variables (variables defined in the path and in the host patterns)
+     * @param array       $regexVariablesAliases     An array containing path variables aliases as keys and actual path variables names as values
+     * @param array       $hostRegexVariablesAliases An array containing host variables aliases as keys and actual host variables names as values
      */
-    public function __construct($staticPrefix, $regex, array $tokens, array $pathVariables, $hostRegex = null, array $hostTokens = array(), array $hostVariables = array(), array $variables = array())
+    public function __construct($staticPrefix, $regex, array $tokens, array $pathVariables, $hostRegex = null, array $hostTokens = array(), array $hostVariables = array(), array $variables = array(), array $regexVariablesAliases = array(), array $hostRegexVariablesAliases = array())
     {
         $this->staticPrefix = (string) $staticPrefix;
         $this->regex = $regex;
@@ -49,6 +61,8 @@ class CompiledRoute implements \Serializable
         $this->hostTokens = $hostTokens;
         $this->hostVariables = $hostVariables;
         $this->variables = $variables;
+        $this->regexVariablesAliases = $regexVariablesAliases;
+        $this->hostRegexVariablesAliases = $hostRegexVariablesAliases;
     }
 
     /**
@@ -62,9 +76,11 @@ class CompiledRoute implements \Serializable
             'path_regex' => $this->regex,
             'path_tokens' => $this->tokens,
             'path_vars' => $this->pathVariables,
+            'path_regex_vars_aliases' => $this->regexVariablesAliases,
             'host_regex' => $this->hostRegex,
             'host_tokens' => $this->hostTokens,
             'host_vars' => $this->hostVariables,
+            'host_regex_vars_aliases' => $this->hostRegexVariablesAliases,
         ));
     }
 
@@ -79,9 +95,11 @@ class CompiledRoute implements \Serializable
         $this->regex = $data['path_regex'];
         $this->tokens = $data['path_tokens'];
         $this->pathVariables = $data['path_vars'];
+        $this->regexVariablesAliases = $data['path_regex_vars_aliases'];
         $this->hostRegex = $data['host_regex'];
         $this->hostTokens = $data['host_tokens'];
         $this->hostVariables = $data['host_vars'];
+        $this->hostRegexVariablesAliases = $data['host_regex_vars_aliases'];
     }
 
     /**
@@ -162,5 +180,21 @@ class CompiledRoute implements \Serializable
     public function getHostVariables()
     {
         return $this->hostVariables;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRegexVariablesAliases()
+    {
+        return $this->regexVariablesAliases;
+    }
+
+    /**
+     * @return array
+     */
+    public function getHostRegexVariablesAliases()
+    {
+        return $this->hostRegexVariablesAliases;
     }
 }

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -316,9 +316,25 @@ EOF;
             $vars = array();
             if ($hostMatches) {
                 $vars[] = '$hostMatches';
+                foreach ($compiledRoute->getHostRegexVariablesAliases() as $hostRegexVariableAlias => $actualHostRegexVariableName) {
+                    $code .= <<<EOF
+            \$hostMatches['$actualHostRegexVariableName'] = \$hostMatches['$hostRegexVariableAlias'];
+            unset(\$hostMatches['$hostRegexVariableAlias']);
+
+
+EOF;
+                }
             }
             if ($matches) {
                 $vars[] = '$matches';
+                foreach ($compiledRoute->getRegexVariablesAliases() as $regexVariableAlias => $actualRegexVariableName) {
+                    $code .= <<<EOF
+            \$matches['$actualRegexVariableName'] = \$matches['$regexVariableAlias'];
+            unset(\$matches['$regexVariableAlias']);
+
+
+EOF;
+                }
             }
             $vars[] = "array('_route' => '$name')";
 

--- a/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
@@ -162,6 +162,15 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
                     array('text', '/foo'),
                 ),
             ),
+
+            array(
+                'Route with a variable name longer than 32 characters',
+                array('/foo/{pneumonoultramicroscopicsilicovolcanoconiosis}'),
+                '/foo', '#^/foo/(?P<variableAlias1>[^/]++)$#s', array('pneumonoultramicroscopicsilicovolcanoconiosis'), array(
+                    array('variable', '/', '[^/]++', 'pneumonoultramicroscopicsilicovolcanoconiosis'),
+                    array('text', '/foo'),
+                ),
+            ),
         );
     }
 
@@ -260,6 +269,17 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
                     array('variable', '.', '[^\.]++', 'tld'),
                     array('text', '.example'),
                     array('variable', '', '[^\.]++', 'locale'),
+                ),
+            ),
+            array(
+                'Route with a variable name longer than 32 characters in the host',
+                array('/hello', array(), array(), array(), 'www.example.{pneumonoultramicroscopicsilicovolcanoconiosis}'),
+                '/hello', '#^/hello$#s', array('pneumonoultramicroscopicsilicovolcanoconiosis'), array(), array(
+                    array('text', '/hello'),
+                ),
+                '#^www\.example\.(?P<variableAlias1>[^\.]++)$#si', array('pneumonoultramicroscopicsilicovolcanoconiosis'), array(
+                    array('variable', '.', '[^\.]++', 'pneumonoultramicroscopicsilicovolcanoconiosis'),
+                    array('text', 'www.example'),
                 ),
             ),
         );


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | #8933 |
| License | MIT |
| Doc PR | - |

Currently, if in one of your route you have a parameter name that exceeds a length of 32 characters, the compilation of the regex fail in the generated `UrlMatcher` because the subpattern name used for the route parameter is too long (cf https://github.com/symfony/symfony/issues/8933).

There is not a single warning about this before you actually try to reach the generated url and you end up with a 500 error.

I fixed this problem by using an alias system that replaces parameters names that are too long by aliases when the route is compiled, and then that replace those aliases by their real names once the request url has been matched with a route.

I need feedback on my idea as this is my first contribution : 
- One test is failing and will always fail because I added properties to the `CompiledRoute` class (https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Routing/Tests/RouteTest.php#L227) : what can I do about this ?
- I don't know where / how I can test a generated `UrlMatcher`
