### PR TITLE
[Console] Fix empty COLUMNS/LINES env vars

### DIFF
--- a/src/Symfony/Component/Console/Terminal.php
+++ b/src/Symfony/Component/Console/Terminal.php
@@ -31,7 +31,7 @@ class Terminal
             self::initDimensions();
         }
 
-        return self::$width;
+        return self::$width ?: 80;
     }
 
     /**
@@ -49,7 +49,7 @@ class Terminal
             self::initDimensions();
         }
 
-        return self::$height;
+        return self::$height ?: 50;
     }
 
     private static function initDimensions()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 3.2 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Here is a python app that fails otherwise:

test.py:

``` python
import os

int(os.environ.get('COLUMNS', 80))
```

test.php:

``` php
<?php
putenv('COLUMNS=');
passthru('python test.py');
```

result:

```
$ php test.php
Traceback (most recent call last):
 File "test.py", line 3, in <module>
   int(os.environ.get('COLUMNS', 80))
ValueError: invalid literal for int() with base 10: ''
```
