### PR TITLE
fix ClassNotFoundException for global exceptions

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddConstraintValidatorsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddConstraintValidatorsPass.php
@@ -32,11 +32,11 @@ class AddConstraintValidatorsPass implements CompilerPassInterface
             $definition = $container->getDefinition($id);
 
             if (!$definition->isPublic()) {
-                throw new InvalidArgumentException(sprintf('The service "%s" must be public as it can be lazy-loaded.', $id));
+                throw new \InvalidArgumentException(sprintf('The service "%s" must be public as it can be lazy-loaded.', $id));
             }
 
             if ($definition->isAbstract()) {
-                throw new InvalidArgumentException(sprintf('The service "%s" must not be abstract as it can be lazy-loaded.', $id));
+                throw new \InvalidArgumentException(sprintf('The service "%s" must not be abstract as it can be lazy-loaded.', $id));
             }
 
             $validators[$definition->getClass()] = $id;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.8 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

This fixes the following exception being raised.

> Attempted to load class "InvalidArgumentException" from namespace "Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler".
