### PR TITLE
[Validator] Add option to allow empty file in FileValidator

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -581,6 +581,7 @@ class Configuration implements ConfigurationInterface
                         ->end()
                         ->scalarNode('translation_domain')->defaultValue('validators')->end()
                         ->booleanNode('strict_email')->defaultFalse()->end()
+                        ->booleanNode('allow_empty_file')->defaultFalse()->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -894,6 +894,9 @@ class FrameworkExtension extends Extension
         $definition = $container->findDefinition('validator.email');
         $definition->replaceArgument(0, $config['strict_email']);
 
+        $definition = $container->findDefinition('validator.file');
+        $definition->addMethodCall('setAllowEmpty', array($config['allow_empty_file']));
+
         if (array_key_exists('enable_annotations', $config) && $config['enable_annotations']) {
             if (!$this->annotationsConfigEnabled) {
                 throw new \LogicException('"enable_annotations" on the validator cannot be set as Annotations support is disabled.');

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
@@ -69,5 +69,9 @@
             <argument></argument>
             <tag name="validator.constraint_validator" alias="Symfony\Component\Validator\Constraints\EmailValidator" />
         </service>
+
+        <service id="validator.file" class="Symfony\Component\Validator\Constraints\FileValidator">
+            <tag name="validator.constraint_validator" alias="Symfony\Component\Validator\Constraints\FileValidator" />
+        </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -211,6 +211,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 'static_method' => array('loadValidatorMetadata'),
                 'translation_domain' => 'validators',
                 'strict_email' => false,
+                'allow_empty_file' => false,
             ),
             'annotations' => array(
                 'cache' => 'php_array',

--- a/src/Symfony/Component/Validator/Constraints/File.php
+++ b/src/Symfony/Component/Validator/Constraints/File.php
@@ -40,7 +40,7 @@ class File extends Constraint
 
     public $binaryFormat;
     public $mimeTypes = array();
-    public $allowEmpty = false;
+    public $allowEmpty;
     public $notFoundMessage = 'The file could not be found.';
     public $notReadableMessage = 'The file is not readable.';
     public $maxSizeMessage = 'The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.';

--- a/src/Symfony/Component/Validator/Constraints/File.php
+++ b/src/Symfony/Component/Validator/Constraints/File.php
@@ -40,6 +40,7 @@ class File extends Constraint
 
     public $binaryFormat;
     public $mimeTypes = array();
+    public $allowEmpty = false;
     public $notFoundMessage = 'The file could not be found.';
     public $notReadableMessage = 'The file is not readable.';
     public $maxSizeMessage = 'The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.';

--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -139,7 +139,7 @@ class FileValidator extends ConstraintValidator
 
         $sizeInBytes = filesize($path);
 
-        if (0 === $sizeInBytes) {
+        if (!$constraint->allowEmpty && 0 === $sizeInBytes) {
             $this->context->buildViolation($constraint->disallowEmptyMessage)
                 ->setParameter('{{ file }}', $this->formatValue($path))
                 ->setCode(File::EMPTY_ERROR)

--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -35,6 +35,13 @@ class FileValidator extends ConstraintValidator
         self::MIB_BYTES => 'MiB',
     );
 
+    private $allowEmpty;
+
+    public function setAllowEmpty($allowEmpty)
+    {
+        $this->allowEmpty = $allowEmpty;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -138,6 +145,10 @@ class FileValidator extends ConstraintValidator
         }
 
         $sizeInBytes = filesize($path);
+
+        if (null === $constraint->allowEmpty) {
+            $constraint->allowEmpty = $this->allowEmpty;
+        }
 
         if (!$constraint->allowEmpty && 0 === $sizeInBytes) {
             $this->context->buildViolation($constraint->disallowEmptyMessage)

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -406,15 +406,56 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    public function testAllowEmpty()
+    /**
+     * @dataProvider allowEmptyOptionProvider
+     */
+    public function testAllowEmptyOption($configurationOption, $constraintOption)
     {
         ftruncate($this->file, 0);
 
-        $constraint = new File(array('allowEmpty' => true));
+        $constraint = new File(array('allowEmpty' => $constraintOption));
+        $this->validator->setAllowEmpty($configurationOption);
 
         $this->validator->validate($this->getFile($this->path), $constraint);
 
         $this->assertNoViolation();
+    }
+
+    public static function allowEmptyOptionProvider()
+    {
+        return array(
+            array(true, true),
+            array(true, null),
+            array(false, true),
+        );
+    }
+
+    /**
+     * @dataProvider disallowEmptyOptionProvider
+     */
+    public function testDisallowEmptyOption($configurationOption, $constraintOption)
+    {
+        ftruncate($this->file, 0);
+
+        $constraint = new File(array('allowEmpty' => $constraintOption));
+        $this->validator->setAllowEmpty($configurationOption);
+
+        $this->validator->validate($this->getFile($this->path), $constraint);
+
+        $this
+            ->buildViolation($constraint->disallowEmptyMessage)
+            ->setParameter('{{ file }}', '"'.$this->path.'"')
+            ->setCode(File::EMPTY_ERROR)
+            ->assertRaised();
+    }
+
+    public static function disallowEmptyOptionProvider()
+    {
+        return array(
+            array(false, false),
+            array(false, null),
+            array(true, false),
+        );
     }
 
     /**

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -406,6 +406,17 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
+    public function testAllowEmpty()
+    {
+        ftruncate($this->file, 0);
+
+        $constraint = new File(array('allowEmpty' => true));
+
+        $this->validator->validate($this->getFile($this->path), $constraint);
+
+        $this->assertNoViolation();
+    }
+
     /**
      * @dataProvider uploadedFileErrorProvider
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/7094 |

This PR add an option to allow empty file. This is helpful for test purpose.
What do you think of it ?

Thanks.
