### PR TITLE
[HttpKernel] Base DataCollector throws warning on unsupported scheme strings

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
@@ -130,7 +130,7 @@ abstract class DataCollector implements DataCollectorInterface, \Serializable
                     return new ClassStub($var);
                 }
             }
-            if (false !== strpos($var, DIRECTORY_SEPARATOR) && file_exists($var)) {
+            if (false !== strpos($var, DIRECTORY_SEPARATOR) && false === strpos($var, '://') && file_exists($var)) {
                 return new LinkStub($var);
             }
         }

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/DataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/DataCollectorTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\DataCollector;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Tests\Fixtures\DataCollector\CloneVarDataCollector;
+use Symfony\Component\VarDumper\Cloner\Stub;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\CliDumper;
+
+class DataCollectorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCloneVarStringWithScheme()
+    {
+        $c = new CloneVarDataCollector('scheme://foo');
+        $c->collect(new Request(), new Response());
+        $cloner = new VarCloner();
+
+        $this->assertEquals($cloner->cloneVar('scheme://foo'), $c->getData());
+    }
+
+    public function testCloneVarExistingFilePath()
+    {
+        $c = new CloneVarDataCollector($filePath = tempnam(sys_get_temp_dir(), 'clone_var_data_collector_'));
+        $c->collect(new Request(), new Response());
+
+        $data = $c->getData();
+        $this->assertInstanceOf(Stub::class, $data->getRawData()[0][0]);
+        $this->assertDumpEquals("\"$filePath\"", $data);
+    }
+
+    private function assertDumpEquals($dump, $data, $message = '')
+    {
+        $dumper = new CliDumper();
+        $dumper->setColors(false);
+
+        $this->assertSame(rtrim($dump), rtrim($dumper->dump($data, true)), $message);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/DataCollector/CloneVarDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/DataCollector/CloneVarDataCollector.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures\DataCollector;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+
+class CloneVarDataCollector extends DataCollector
+{
+    private $varToClone;
+
+    public function __construct($varToClone)
+    {
+        $this->varToClone = $varToClone;
+    }
+
+    public function collect(Request $request, Response $response, \Exception $exception = null)
+    {
+        $this->data = $this->cloneVar($this->varToClone);
+    }
+
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    public function getName()
+    {
+        return 'clone_var';
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

The issue concerns any collector based on the abstract `Symfony\Component\HttpKernel\DataCollector\DataCollector` class using `cloneVar` on a string containing a unsupported scheme.

The easiest way to reproduce the issue is to add a simple query parameter like `?uri=foo://bar` on any url of your application:

> ContextErrorException in DataCollector.php line 134:
> Warning: file_exists(): Unable to find the wrapper &quot;foo&quot; - did you forget to enable it when you configured PHP?

This PR simply fixes the issue by muting the warning on `file_exists`. But maybe there is a better strategy.
