### PR TITLE
Fix YamlReferenceDumper unnamed nested prototypes

### DIFF
--- a/src/Symfony/Component/Config/Definition/Dumper/YamlReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/YamlReferenceDumper.php
@@ -201,7 +201,7 @@ class YamlReferenceDumper
             $keyNode = new ArrayNode($key, $node);
             $children = $prototype->getChildren();
 
-            if ($prototype instanceof PrototypedArrayNode) {
+            if ($prototype instanceof PrototypedArrayNode && $prototype->getKeyAttribute()) {
                 $children = $this->getPrototypeChildren($prototype);
             }
 

--- a/src/Symfony/Component/Config/Tests/Definition/Dumper/XmlReferenceDumperTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Dumper/XmlReferenceDumperTest.php
@@ -92,6 +92,14 @@ class XmlReferenceDumperTest extends \PHPUnit_Framework_TestCase
 
     </cms-page>
 
+    <!-- prototype -->
+    <pipou name="pipou name">
+
+        <!-- prototype -->
+        <name didou="" />
+
+    </pipou>
+
 </config>
 
 EOL

--- a/src/Symfony/Component/Config/Tests/Definition/Dumper/YamlReferenceDumperTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Dumper/YamlReferenceDumperTest.php
@@ -74,6 +74,10 @@ acme_root:
             locale:
                 title:                ~ # Required
                 path:                 ~ # Required
+    pipou:
+
+        # Prototype
+        name:                 []
 
 EOL;
     }

--- a/src/Symfony/Component/Config/Tests/Fixtures/Configuration/ExampleConfiguration.php
+++ b/src/Symfony/Component/Config/Tests/Fixtures/Configuration/ExampleConfiguration.php
@@ -80,6 +80,17 @@ class ExampleConfiguration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+                ->arrayNode('pipou')
+                    ->useAttributeAsKey('name')
+                    ->prototype('array')
+                        ->prototype('array')
+                            ->children()
+                                ->scalarNode('didou')
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
             ->end()
         ;
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/issues/20340 |
| License | MIT |
| Doc PR | N/A |

Ideally, I'd like to output something like:

``` yml
pipou:

    # Prototype
    name:

        # Prototype
        -
            didou:                ~
```

But for now, this should fix the regression.
