### PR TITLE
[WebProfilerBundle] check for <title> instead of </body>

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -1,7 +1,12 @@
 <div id="sfwdt{{ token }}" class="sf-toolbar" style="display: none"></div>
 {% include '@WebProfiler/Profiler/base_js.html.twig' %}
 <script>/*<![CDATA[*/
-    (function () {
+    document.addEventListener('DOMContentLoaded', function () {
+        var sfwdt = document.createElement('div');
+        sfwdt.id = 'sfwdt{{ token }}';
+        sfwdt.className = 'sf-toolbar';
+        sfwdt.style.display = 'none';
+
         {% if 'top' == position %}
             var sfwdt = document.getElementById('sfwdt{{ token }}');
             document.body.insertBefore(
@@ -63,5 +68,5 @@
             },
             {'maxTries': 5}
         );
-    })();
+    });
 /*]]>*/</script>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #20339 |
| License | MIT |
| Doc PR | - |

Valid HTML doesn't need `body` end tag but it need `title` element. As such we check for `<title>` instead of `</body>` before inserting the toolbar.

BC break will happen if response contains no `title` element. Dunno if it's a big deal.
