### PR TITLE
[Security][Guard] Add an option to try all authenticators before failing

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/GuardAuthenticationFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/GuardAuthenticationFactory.php
@@ -45,6 +45,10 @@ class GuardAuthenticationFactory implements SecurityFactoryInterface
                     ->info('A service id (of one of your authenticators) whose start() method should be called when an anonymous user hits a page that requires authentication')
                     ->defaultValue(null)
                 ->end()
+                ->booleanNode('break_on_failure')
+                    ->info('A boolean determining whether the authentication should break at the first unsatisfied authenticator (default) or continue until the last one.')
+                    ->defaultValue(true)
+                ->end()
                 ->arrayNode('authenticators')
                     ->info('An array of service ids for all of your "authenticators"')
                     ->requiresAtLeastOneElement()
@@ -77,6 +81,7 @@ class GuardAuthenticationFactory implements SecurityFactoryInterface
         $listener = $container->setDefinition($listenerId, new DefinitionDecorator('security.authentication.listener.guard'));
         $listener->replaceArgument(2, $id);
         $listener->replaceArgument(3, $authenticatorReferences);
+        $listener->replaceArgument(5, $config['break_on_failure']);
 
         // determine the entryPointId to use
         $entryPointId = $this->determineEntryPoint($defaultEntryPoint, $config);

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/guard.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/guard.xml
@@ -35,6 +35,7 @@
             <argument /> <!-- Provider-shared Key -->
             <argument /> <!-- Authenticator -->
             <argument type="service" id="logger" on-invalid="null" />
+            <argument /> <!-- Break on failure -->
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/GuardAuthenticationFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/GuardAuthenticationFactoryTest.php
@@ -60,11 +60,13 @@ class GuardAuthenticationFactoryTest extends \PHPUnit_Framework_TestCase
                 'authenticators' => array('authenticator1', 'authenticator2'),
                 'provider' => 'some_provider',
                 'entry_point' => 'the_entry_point',
+                'break_on_failure' => true,
             ),
             array(
                 'authenticators' => array('authenticator1', 'authenticator2'),
                 'provider' => 'some_provider',
                 'entry_point' => 'the_entry_point',
+                'break_on_failure' => true,
             ),
         );
 
@@ -76,6 +78,7 @@ class GuardAuthenticationFactoryTest extends \PHPUnit_Framework_TestCase
             array(
                 'authenticators' => array('authenticator1', 'authenticator2'),
                 'entry_point' => null,
+                'break_on_failure' => true,
             ),
         );
 
@@ -100,6 +103,7 @@ class GuardAuthenticationFactoryTest extends \PHPUnit_Framework_TestCase
         $config = array(
             'authenticators' => array('authenticator123'),
             'entry_point' => null,
+            'break_on_failure' => true,
         );
         list($container, $entryPointId) = $this->executeCreate($config, null);
         $this->assertEquals('authenticator123', $entryPointId);
@@ -123,6 +127,7 @@ class GuardAuthenticationFactoryTest extends \PHPUnit_Framework_TestCase
         $config = array(
             'authenticators' => array('authenticator123'),
             'entry_point' => null,
+            'break_on_failure' => true,
         );
         list(, $entryPointId) = $this->executeCreate($config, 'some_default_entry_point');
         $this->assertEquals('some_default_entry_point', $entryPointId);
@@ -137,6 +142,7 @@ class GuardAuthenticationFactoryTest extends \PHPUnit_Framework_TestCase
         $config = array(
             'authenticators' => array('authenticator123'),
             'entry_point' => 'authenticator123',
+            'break_on_failure' => true,
         );
         $this->executeCreate($config, 'some_default_entry_point');
     }
@@ -150,6 +156,7 @@ class GuardAuthenticationFactoryTest extends \PHPUnit_Framework_TestCase
         $config = array(
             'authenticators' => array('authenticator123', 'authenticatorABC'),
             'entry_point' => null,
+            'break_on_failure' => true,
         );
         $this->executeCreate($config, null);
     }
@@ -160,6 +167,7 @@ class GuardAuthenticationFactoryTest extends \PHPUnit_Framework_TestCase
         $config = array(
             'authenticators' => array('authenticator123', 'authenticatorABC'),
             'entry_point' => 'authenticatorABC',
+            'break_on_failure' => true,
         );
         list($container, $entryPointId) = $this->executeCreate($config, null);
         $this->assertEquals('authenticatorABC', $entryPointId);

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "symfony/security": "~3.2",
+        "symfony/security": "~3.2-dev",
         "symfony/http-kernel": "~3.2",
         "symfony/polyfill-php70": "~1.0"
     },


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | todo |

With Guard, [multiple authenticators](http://symfony.com/doc/current/security/multiple_guard_authenticators.html) can be configured on a firewall. In this case, the listener breaks the authentication at the first unsatisfied authenticator, calling `onAuthenticationFailure()` on this one which causes the (failure) response to be returned. 
If it is a success then it does the same but with `onAuthenticationSuccess()`, that's fine.
## Problem

If I want all of the authenticators configured on the firewall to be executed before the authentication fails (like using the chain provider), it's not possible or require some weird changes in the authenticators classes. 
Imho it's useful (and quite common) to have two possible ways to be authenticated on a firewall, which is what Guard seems to ease at first.
## Proposed solution

Adding an option to the `GuardAuthenticationFactory`. If set to true (default) the behavior stays the same as the current one. If set to false, all authenticators are executed before the authentication fails, calling `onAuthenticationFailure()` on the last authenticator if it doesn't succeed.

Naming was hard, I used `break_on_failure` but I'm open to change it if the feature looks good. 
Tests will be added depending on feedbacks. 
