### PR TITLE
[FrameworkBundle] Allow IDE path mappings for built-in protocols

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -112,6 +112,10 @@ class FrameworkExtension extends Extension
                     'phpstorm' => 'phpstorm://open?url=file://%%f&line=%%l',
                 );
                 $ide = $config['ide'];
+                $i = strpos($ide, '&');
+                if (false !== $i && isset($links[$link = substr($ide, 0, $i)])) {
+                    $ide = $links[$link].substr($ide, $i);
+                }
 
                 $container->setParameter('templating.helper.code.file_link_format', str_replace('%', '%%', ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format')) ?: (isset($links[$ide]) ? $links[$ide] : $ide));
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

Before/After:

``` diff
#config.yml
framework:
-   ide: "phpstorm://open?file=file://%%f&line=%%l&/src/>/dest/"
+   ide: "phpstorm&/src/>/dest/"
```
