### PR TITLE
[Config] Enable cannotBeEmpty along with requiresAtLeastOneElement

### DIFF
--- a/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
@@ -428,7 +428,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
                 $node->setKeyAttribute($this->key, $this->removeKeyItem);
             }
 
-            if (true === $this->atLeastOne) {
+            if (true === $this->atLeastOne || false === $this->allowEmptyValue) {
                 $node->setMinNumberOfElements(1);
             }
 
@@ -487,6 +487,12 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
         if (null !== $this->key) {
             throw new InvalidDefinitionException(
                 sprintf('->useAttributeAsKey() is not applicable to concrete nodes at path "%s"', $path)
+            );
+        }
+
+        if (false === $this->allowEmptyValue) {
+            throw new InvalidDefinitionException(
+                sprintf('->cannotBeEmpty() is not applicable to concrete nodes at path "%s"', $path)
             );
         }
 

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/ArrayNodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/ArrayNodeDefinitionTest.php
@@ -294,6 +294,8 @@ class ArrayNodeDefinitionTest extends TestCase
             ->integerPrototype();
 
         $node->getNode()->finalize(array(1));
+
+        $this->addToAssertionCount(1);
     }
 
     /**

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/ArrayNodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/ArrayNodeDefinitionTest.php
@@ -54,6 +54,7 @@ class ArrayNodeDefinitionTest extends TestCase
             array('defaultValue', array(array())),
             array('addDefaultChildrenIfNoneSet', array()),
             array('requiresAtLeastOneElement', array()),
+            array('cannotBeEmpty', array()),
             array('useAttributeAsKey', array('foo')),
         );
     }
@@ -283,6 +284,30 @@ class ArrayNodeDefinitionTest extends TestCase
             array(array('enabled' => false, 'foo' => 'baz'), array(array('foo' => 'baz', 'enabled' => false)), 'An enableable node can be disabled'),
             array(array('enabled' => false, 'foo' => 'bar'), array(false), 'false disables an enableable node'),
         );
+    }
+
+    public function testRequiresAtLeastOneElement()
+    {
+        $node = new ArrayNodeDefinition('root');
+        $node
+            ->requiresAtLeastOneElement()
+            ->integerPrototype();
+
+        $node->getNode()->finalize(array(1));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage The path "root" should have at least 1 element(s) defined.
+     */
+    public function testCannotBeEmpty()
+    {
+        $node = new ArrayNodeDefinition('root');
+        $node
+            ->cannotBeEmpty()
+            ->integerPrototype();
+
+        $node->getNode()->finalize(array());
     }
 
     protected function getField($object, $field)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes
| Fixed tickets | #20356 |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

As @vudaltsov mentioned, we ignore any calls to `ArrayNodeDefinition::cannotBeEmpty`, which can lead to unexpected behavior. Imo. all subclasses should follow the base API.
