### PR TITLE
[TwigBridge] Handle form label attributes like others

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -79,7 +79,7 @@
                 {{- block('choice_widget_options') -}}
             </optgroup>
         {%- else -%}
-            <option value="{{ choice.value }}"{% if choice.attr %} {% set attr = choice.attr %}{{ block('attributes') }}{% endif %}{% if choice is selectedchoice(value) %} selected="selected"{% endif %}>{{ choice_translation_domain is same as(false) ? choice.label : choice.label|trans({}, choice_translation_domain) }}</option>
+            <option value="{{ choice.value }}"{% if choice.attr %} {% with { attr: choice.attr } %}{{ block('attributes') }}{% endwith %}{% endif %}{% if choice is selectedchoice(value) %} selected="selected"{% endif %}>{{ choice_translation_domain is same as(false) ? choice.label : choice.label|trans({}, choice_translation_domain) }}</option>
         {%- endif -%}
     {% endfor %}
 {%- endblock choice_widget_options -%}
@@ -242,7 +242,7 @@
                 {% set label = name|humanize %}
             {%- endif -%}
         {%- endif -%}
-        <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>{{ translation_domain is same as(false) ? label : label|trans({}, translation_domain) }}</label>
+        <label{% if label_attr %} {% with { attr: label_attr } %}{{ block('attributes') }}{% endwith %}{% endif %}>{{ translation_domain is same as(false) ? label : label|trans({}, translation_domain) }}</label>
     {%- endif -%}
 {%- endblock form_label -%}
 
@@ -334,44 +334,17 @@
     id="{{ id }}" name="{{ full_name }}"
     {%- if disabled %} disabled="disabled"{% endif -%}
     {%- if required %} required="required"{% endif -%}
-    {%- for attrname, attrvalue in attr -%}
-        {{- " " -}}
-        {%- if attrname in ['placeholder', 'title'] -%}
-            {{- attrname }}="{{ translation_domain is same as(false) ? attrvalue : attrvalue|trans({}, translation_domain) }}"
-        {%- elseif attrvalue is same as(true) -%}
-            {{- attrname }}="{{ attrname }}"
-        {%- elseif attrvalue is not same as(false) -%}
-            {{- attrname }}="{{ attrvalue }}"
-        {%- endif -%}
-    {%- endfor -%}
+    {{ block('attributes') }}
 {%- endblock widget_attributes -%}
 
 {%- block widget_container_attributes -%}
     {%- if id is not empty %}id="{{ id }}"{% endif -%}
-    {%- for attrname, attrvalue in attr -%}
-        {{- " " -}}
-        {%- if attrname in ['placeholder', 'title'] -%}
-            {{- attrname }}="{{ translation_domain is same as(false) ? attrvalue : attrvalue|trans({}, translation_domain) }}"
-        {%- elseif attrvalue is same as(true) -%}
-            {{- attrname }}="{{ attrname }}"
-        {%- elseif attrvalue is not same as(false) -%}
-            {{- attrname }}="{{ attrvalue }}"
-        {%- endif -%}
-    {%- endfor -%}
+    {{ block('attributes') }}
 {%- endblock widget_container_attributes -%}
 
 {%- block button_attributes -%}
     id="{{ id }}" name="{{ full_name }}"{% if disabled %} disabled="disabled"{% endif -%}
-    {%- for attrname, attrvalue in attr -%}
-        {{- " " -}}
-        {%- if attrname in ['placeholder', 'title'] -%}
-            {{- attrname }}="{{ translation_domain is same as(false) ? attrvalue : attrvalue|trans({}, translation_domain) }}"
-        {%- elseif attrvalue is same as(true) -%}
-            {{- attrname }}="{{ attrname }}"
-        {%- elseif attrvalue is not same as(false) -%}
-            {{- attrname }}="{{ attrvalue }}"
-        {%- endif -%}
-    {%- endfor -%}
+    {{ block('attributes') }}
 {%- endblock button_attributes -%}
 
 {% block attributes -%}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/attributes.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/attributes.html.php
@@ -1,1 +1,9 @@
-<?php echo $view['form']->block($form, 'widget_attributes') ?>
+<?php foreach ($attr as $k => $v): ?>
+<?php if (in_array($k, array('placeholder', 'title'), true)): ?>
+<?php printf('%s="%s" ', $view->escape($k), $view->escape(false !== $translation_domain ? $view['translator']->trans($v, array(), $translation_domain) : $v)) ?>
+<?php elseif ($v === true): ?>
+<?php printf('%s="%s" ', $view->escape($k), $view->escape($k)) ?>
+<?php elseif ($v !== false): ?>
+<?php printf('%s="%s" ', $view->escape($k), $view->escape($v)) ?>
+<?php endif ?>
+<?php endforeach ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/attributes.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/attributes.html.php
@@ -1,9 +1,9 @@
 <?php foreach ($attr as $k => $v): ?>
-<?php if (in_array($k, array('placeholder', 'title'), true)): ?>
+<?php if ('placeholder' === $k || 'title' === $k): ?>
 <?php printf('%s="%s" ', $view->escape($k), $view->escape(false !== $translation_domain ? $view['translator']->trans($v, array(), $translation_domain) : $v)) ?>
-<?php elseif ($v === true): ?>
+<?php elseif (true === $v): ?>
 <?php printf('%s="%s" ', $view->escape($k), $view->escape($k)) ?>
-<?php elseif ($v !== false): ?>
+<?php elseif (false !== $v): ?>
 <?php printf('%s="%s" ', $view->escape($k), $view->escape($v)) ?>
 <?php endif ?>
 <?php endforeach ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/button_attributes.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/button_attributes.html.php
@@ -1,10 +1,2 @@
-id="<?php echo $view->escape($id) ?>" name="<?php echo $view->escape($full_name) ?>" <?php if ($disabled): ?>disabled="disabled" <?php endif ?>
-<?php foreach ($attr as $k => $v): ?>
-<?php if (in_array($k, array('placeholder', 'title'), true)): ?>
-<?php printf('%s="%s" ', $view->escape($k), $view->escape(false !== $translation_domain ? $view['translator']->trans($v, array(), $translation_domain) : $v)) ?>
-<?php elseif ($v === true): ?>
-<?php printf('%s="%s" ', $view->escape($k), $view->escape($k)) ?>
-<?php elseif ($v !== false): ?>
-<?php printf('%s="%s" ', $view->escape($k), $view->escape($v)) ?>
-<?php endif ?>
-<?php endforeach ?>
+id="<?php echo $view->escape($id) ?>" name="<?php echo $view->escape($full_name) ?>"<?php if ($disabled): ?> disabled="disabled"<?php endif ?>
+<?php echo $attr ? ' '.$view['form']->block($form, 'attributes') : '' ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_label.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_label.html.php
@@ -4,5 +4,5 @@
 <?php if (!$label) { $label = isset($label_format)
     ? strtr($label_format, array('%name%' => $name, '%id%' => $id))
     : $view['form']->humanize($name); } ?>
-<label <?php foreach ($label_attr as $k => $v) { printf('%s="%s" ', $view->escape($k), $view->escape($v)); } ?>><?php echo $view->escape(false !== $translation_domain ? $view['translator']->trans($label, array(), $translation_domain) : $label) ?></label>
+<label<?php if ($label_attr) { echo ' '.$view['form']->block($form, 'attributes', array('attr' => $label_attr)); } ?>><?php echo $view->escape(false !== $translation_domain ? $view['translator']->trans($label, array(), $translation_domain) : $label) ?></label>
 <?php endif ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/widget_attributes.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/widget_attributes.html.php
@@ -1,11 +1,3 @@
 id="<?php echo $view->escape($id) ?>" name="<?php echo $view->escape($full_name) ?>"<?php if ($disabled): ?> disabled="disabled"<?php endif ?>
 <?php if ($required): ?> required="required"<?php endif ?>
-<?php foreach ($attr as $k => $v): ?>
-<?php if (in_array($k, array('placeholder', 'title'), true)): ?>
-<?php printf(' %s="%s"', $view->escape($k), $view->escape(false !== $translation_domain ? $view['translator']->trans($v, array(), $translation_domain) : $v)) ?>
-<?php elseif ($v === true): ?>
-<?php printf(' %s="%s"', $view->escape($k), $view->escape($k)) ?>
-<?php elseif ($v !== false): ?>
-<?php printf(' %s="%s"', $view->escape($k), $view->escape($v)) ?>
-<?php endif ?>
-<?php endforeach ?>
+<?php echo $attr ? ' '.$view['form']->block($form, 'attributes') : '' ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/widget_container_attributes.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/widget_container_attributes.html.php
@@ -1,10 +1,2 @@
-<?php if (!empty($id)): ?>id="<?php echo $view->escape($id) ?>" <?php endif ?>
-<?php foreach ($attr as $k => $v): ?>
-<?php if (in_array($k, array('placeholder', 'title'), true)): ?>
-<?php printf('%s="%s" ', $view->escape($k), $view->escape(false !== $translation_domain ? $view['translator']->trans($v, array(), $translation_domain) : $v)) ?>
-<?php elseif ($v === true): ?>
-<?php printf('%s="%s" ', $view->escape($k), $view->escape($k)) ?>
-<?php elseif ($v !== false): ?>
-<?php printf('%s="%s" ', $view->escape($k), $view->escape($v)) ?>
-<?php endif ?>
-<?php endforeach ?>
+<?php if (!empty($id)): ?>id="<?php echo $view->escape($id) ?>"<?php endif ?>
+<?php echo $attr ? ' '.$view['form']->block($form, 'attributes') : '' ?>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | master
| Bug fix? | no
| New feature? | yes
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes
| Fixed tickets | -
| License | MIT |
| Doc PR | -

The HTML for rendering attributes is duplicated in multiple blocks, making it error prone/hard to maintain. 

Next, the label attributes followed a different approach. Imo. all should follow the same base rendering, showing the above is actually an issue.
