### PR TITLE
CS: apply phpdoc_annotation_without_dot reworked

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
@@ -304,7 +304,7 @@ abstract class AbstractDoctrineExtension extends Extension
      * @param ContainerBuilder $container     A ContainerBuilder instance
      * @param string           $cacheName
      *
-     * @throws \InvalidArgumentException In case of unknown driver type.
+     * @throws \InvalidArgumentException in case of unknown driver type
      */
     protected function loadObjectManagerCacheDriver(array $objectManager, ContainerBuilder $container, $cacheName)
     {

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterMappingsPass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterMappingsPass.php
@@ -108,15 +108,15 @@ abstract class RegisterMappingsPass implements CompilerPassInterface
      *
      * @param Definition|Reference $driver                  Driver DI definition or reference
      * @param string[]             $namespaces              List of namespaces handled by $driver
-     * @param string[]             $managerParameters       List of container parameters that could
-     *                                                      hold the manager name.
+     * @param string[]             $managerParameters       list of container parameters that could
+     *                                                      hold the manager name
      * @param string               $driverPattern           Pattern for the metadata driver service name
      * @param string|false         $enabledParameter        Service container parameter that must be
      *                                                      present to enable the mapping. Set to false
      *                                                      to not do any check, optional.
      * @param string               $configurationPattern    Pattern for the Configuration service name
-     * @param string               $registerAliasMethodName Name of Configuration class method to
-     *                                                      register alias.
+     * @param string               $registerAliasMethodName name of Configuration class method to
+     *                                                      register alias
      * @param string[]             $aliasMap                Map of alias to namespace
      */
     public function __construct($driver, array $namespaces, array $managerParameters, $driverPattern, $enabledParameter = false, $configurationPattern = '', $registerAliasMethodName = '', array $aliasMap = array())
@@ -174,7 +174,7 @@ abstract class RegisterMappingsPass implements CompilerPassInterface
      * @return string The name of the chain driver service
      *
      * @throws ParameterNotFoundException if non of the managerParameters has a
-     *                                    non-empty value.
+     *                                    non-empty value
      */
     protected function getChainDriverServiceName(ContainerBuilder $container)
     {
@@ -185,7 +185,7 @@ abstract class RegisterMappingsPass implements CompilerPassInterface
      * Create the service definition for the metadata driver.
      *
      * @param ContainerBuilder $container passed on in case an extending class
-     *                                    needs access to the container.
+     *                                    needs access to the container
      *
      * @return Definition|Reference the metadata driver to add to all chain drivers
      */
@@ -202,7 +202,7 @@ abstract class RegisterMappingsPass implements CompilerPassInterface
      * @return string a service definition name
      *
      * @throws ParameterNotFoundException if none of the managerParameters has a
-     *                                    non-empty value.
+     *                                    non-empty value
      */
     private function getConfigurationServiceName(ContainerBuilder $container)
     {
@@ -219,7 +219,7 @@ abstract class RegisterMappingsPass implements CompilerPassInterface
      *
      * @return string The name of the active manager
      *
-     * @throws ParameterNotFoundException If none of the managerParameters is found in the container.
+     * @throws ParameterNotFoundException if none of the managerParameters is found in the container
      */
     private function getManagerName(ContainerBuilder $container)
     {

--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/DoctrineChoiceLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/DoctrineChoiceLoader.php
@@ -65,8 +65,8 @@ class DoctrineChoiceLoader implements ChoiceLoaderInterface
      * @param ObjectManager              $manager      The object manager
      * @param string                     $class        The class name of the
      *                                                 loaded objects
-     * @param IdReader                   $idReader     The reader for the object
-     *                                                 IDs.
+     * @param IdReader                   $idReader     the reader for the object
+     *                                                 IDs
      * @param null|EntityLoaderInterface $objectLoader The objects loader
      */
     public function __construct(ChoiceListFactoryInterface $factory, ObjectManager $manager, $class, IdReader $idReader = null, EntityLoaderInterface $objectLoader = null)

--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
@@ -389,8 +389,8 @@ class EntityChoiceList extends ObjectChoiceList
      *
      * @param mixed $entity The choice to create an index for
      *
-     * @return int|string A unique index containing only ASCII letters,
-     *                    digits and underscores.
+     * @return int|string a unique index containing only ASCII letters,
+     *                    digits and underscores
      */
     protected function createIndex($entity)
     {

--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/IdReader.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/IdReader.php
@@ -20,7 +20,7 @@ use Symfony\Component\Form\Exception\RuntimeException;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @internal This class is meant for internal use only.
+ * @internal this class is meant for internal use only
  */
 class IdReader
 {
@@ -79,8 +79,8 @@ class IdReader
     /**
      * Returns whether the class has a single-column ID.
      *
-     * @return bool Returns `true` if the class has a single-column ID and
-     *              `false` otherwise.
+     * @return bool returns `true` if the class has a single-column ID and
+     *              `false` otherwise
      */
     public function isSingleId()
     {
@@ -90,8 +90,8 @@ class IdReader
     /**
      * Returns whether the class has a single-column integer ID.
      *
-     * @return bool Returns `true` if the class has a single-column integer ID
-     *              and `false` otherwise.
+     * @return bool returns `true` if the class has a single-column integer ID
+     *              and `false` otherwise
      */
     public function isIntId()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
@@ -257,7 +257,7 @@ class FormHelper extends Helper
      *
      * @return string A CSRF token
      *
-     * @throws \BadMethodCallException When no CSRF provider was injected in the constructor.
+     * @throws \BadMethodCallException when no CSRF provider was injected in the constructor
      */
     public function csrfToken($intention)
     {

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -38,7 +38,7 @@ abstract class BaseNode implements NodeInterface
      * @param string        $name   The name of the node
      * @param NodeInterface $parent The parent of this node
      *
-     * @throws \InvalidArgumentException if the name contains a period.
+     * @throws \InvalidArgumentException if the name contains a period
      */
     public function __construct($name, NodeInterface $parent = null)
     {

--- a/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
@@ -97,9 +97,9 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
     /**
      * Adds children with a default value when none are defined.
      *
-     * @param int|string|array|null $children The number of children|The child name|The children names to be added
-     *
      * This method is applicable to prototype nodes only.
+     *
+     * @param int|string|array|null $children the number of children|the child name|the children names to be added
      *
      * @return ArrayNodeDefinition
      */

--- a/src/Symfony/Component/Console/Question/Question.php
+++ b/src/Symfony/Component/Console/Question/Question.php
@@ -187,7 +187,7 @@ class Question
      *
      * @return Question The current instance
      *
-     * @throws \InvalidArgumentException In case the number of attempts is invalid.
+     * @throws \InvalidArgumentException in case the number of attempts is invalid
      */
     public function setMaxAttempts($attempts)
     {

--- a/src/Symfony/Component/Debug/Tests/Fixtures/DeprecatedClass.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/DeprecatedClass.php
@@ -4,7 +4,7 @@ namespace Symfony\Component\Debug\Tests\Fixtures;
 
 /**
  * @deprecated but this is a test
- *             deprecation notice.
+ *             deprecation notice
  * @foobar
  */
 class DeprecatedClass

--- a/src/Symfony/Component/Debug/Tests/Fixtures/DeprecatedInterface.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/DeprecatedInterface.php
@@ -4,7 +4,7 @@ namespace Symfony\Component\Debug\Tests\Fixtures;
 
 /**
  * @deprecated but this is a test
- *             deprecation notice.
+ *             deprecation notice
  * @foobar
  */
 interface DeprecatedInterface

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckCircularReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckCircularReferencesPass.php
@@ -51,7 +51,7 @@ class CheckCircularReferencesPass implements CompilerPassInterface
      *
      * @param ServiceReferenceGraphEdge[] $edges An array of Edges
      *
-     * @throws ServiceCircularReferenceException When a circular reference is found.
+     * @throws ServiceCircularReferenceException when a circular reference is found
      */
     private function checkOutEdges(array $edges)
     {

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckReferenceValidityPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckReferenceValidityPass.php
@@ -85,7 +85,7 @@ class CheckReferenceValidityPass implements CompilerPassInterface
      *
      * @param array $arguments An array of Reference objects
      *
-     * @throws RuntimeException when there is a reference to an abstract definition.
+     * @throws RuntimeException when there is a reference to an abstract definition
      */
     private function validateReferences(array $arguments)
     {

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -140,7 +140,7 @@ class Definition
      *
      * @return Definition The current instance
      *
-     * @throws InvalidArgumentException In case the decorated service id and the new decorated service id are equals.
+     * @throws InvalidArgumentException in case the decorated service id and the new decorated service id are equals
      */
     public function setDecoratedService($id, $renamedId = null)
     {

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -151,7 +151,7 @@ class ParameterBag implements ParameterBagInterface
      *
      * @throws ParameterNotFoundException          if a placeholder references a parameter that does not exist
      * @throws ParameterCircularReferenceException if a circular reference if detected
-     * @throws RuntimeException                    when a given parameter has a type problem.
+     * @throws RuntimeException                    when a given parameter has a type problem
      */
     public function resolveValue($value, array $resolving = array())
     {
@@ -181,7 +181,7 @@ class ParameterBag implements ParameterBagInterface
      *
      * @throws ParameterNotFoundException          if a placeholder references a parameter that does not exist
      * @throws ParameterCircularReferenceException if a circular reference if detected
-     * @throws RuntimeException                    when a given parameter has a type problem.
+     * @throws RuntimeException                    when a given parameter has a type problem
      */
     public function resolveString($value, array $resolving = array())
     {

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -71,7 +71,7 @@ class Crawler extends \SplObjectStorage
      *
      * @param \DOMNodeList|\DOMNode|array|string|null $node A node
      *
-     * @throws \InvalidArgumentException When node is not the expected type.
+     * @throws \InvalidArgumentException when node is not the expected type
      */
     public function add($node)
     {

--- a/src/Symfony/Component/EventDispatcher/EventDispatcherInterface.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcherInterface.php
@@ -26,8 +26,8 @@ interface EventDispatcherInterface
      * @param string $eventName The name of the event to dispatch. The name of
      *                          the event is the name of the method that is
      *                          invoked on listeners.
-     * @param Event  $event     The event to pass to the event handlers/listeners
-     *                          If not supplied, an empty Event instance is created.
+     * @param Event  $event     the event to pass to the event handlers/listeners
+     *                          If not supplied, an empty Event instance is created
      *
      * @return Event
      */

--- a/src/Symfony/Component/EventDispatcher/GenericEvent.php
+++ b/src/Symfony/Component/EventDispatcher/GenericEvent.php
@@ -63,7 +63,7 @@ class GenericEvent extends Event implements \ArrayAccess, \IteratorAggregate
      *
      * @return mixed Contents of array key
      *
-     * @throws \InvalidArgumentException If key is not found.
+     * @throws \InvalidArgumentException if key is not found
      */
     public function getArgument($key)
     {
@@ -132,7 +132,7 @@ class GenericEvent extends Event implements \ArrayAccess, \IteratorAggregate
      *
      * @return mixed
      *
-     * @throws \InvalidArgumentException If key does not exist in $this->args.
+     * @throws \InvalidArgumentException if key does not exist in $this->args
      */
     public function offsetGet($key)
     {

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -490,7 +490,7 @@ class Filesystem
      * @param null|int $mode     The file mode (octal). If null, file permissions are not modified
      *                           Deprecated since version 2.3.12, to be removed in 3.0.
      *
-     * @throws IOException If the file cannot be written to.
+     * @throws IOException if the file cannot be written to
      */
     public function dumpFile($filename, $content, $mode = 0666)
     {

--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -681,7 +681,7 @@ class Finder implements \IteratorAggregate, \Countable
      *
      * @return Finder|SplFileInfo[] The finder
      *
-     * @throws \InvalidArgumentException When the given argument is not iterable.
+     * @throws \InvalidArgumentException when the given argument is not iterable
      */
     public function append($iterator)
     {

--- a/src/Symfony/Component/Form/AbstractRendererEngine.php
+++ b/src/Symfony/Component/Form/AbstractRendererEngine.php
@@ -139,14 +139,14 @@ abstract class AbstractRendererEngine implements FormRendererEngineInterface
      *
      * @see getResourceForBlockHierarchy()
      *
-     * @param string   $cacheKey           The cache key used for storing the
-     *                                     resource.
-     * @param FormView $view               The form view for finding the applying
-     *                                     themes.
-     * @param array    $blockNameHierarchy The block hierarchy, with the most
-     *                                     specific block name at the end.
-     * @param int      $hierarchyLevel     The level in the block hierarchy that
-     *                                     should be loaded.
+     * @param string   $cacheKey           the cache key used for storing the
+     *                                     resource
+     * @param FormView $view               the form view for finding the applying
+     *                                     themes
+     * @param array    $blockNameHierarchy the block hierarchy, with the most
+     *                                     specific block name at the end
+     * @param int      $hierarchyLevel     the level in the block hierarchy that
+     *                                     should be loaded
      *
      * @return bool True if the resource could be loaded, false otherwise
      */

--- a/src/Symfony/Component/Form/Button.php
+++ b/src/Symfony/Component/Form/Button.php
@@ -371,7 +371,7 @@ class Button implements \IteratorAggregate, FormInterface
      *
      * @return Button The button instance
      *
-     * @throws Exception\AlreadySubmittedException If the button has already been submitted.
+     * @throws Exception\AlreadySubmittedException if the button has already been submitted
      */
     public function submit($submittedData, $clearMissing = true)
     {

--- a/src/Symfony/Component/Form/ButtonBuilder.php
+++ b/src/Symfony/Component/Form/ButtonBuilder.php
@@ -58,7 +58,7 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      * @param string $name    The name of the button
      * @param array  $options The button's options
      *
-     * @throws InvalidArgumentException If the name is empty.
+     * @throws InvalidArgumentException if the name is empty
      */
     public function __construct($name, array $options = array())
     {

--- a/src/Symfony/Component/Form/ChoiceList/ArrayChoiceList.php
+++ b/src/Symfony/Component/Form/ChoiceList/ArrayChoiceList.php
@@ -222,8 +222,8 @@ class ArrayChoiceList implements ChoiceListInterface
      * @param array      $choices The choices
      * @param array|null $cache   The cache for previously checked entries. Internal
      *
-     * @return bool Returns true if the choices can be cast to strings and
-     *              false otherwise.
+     * @return bool returns true if the choices can be cast to strings and
+     *              false otherwise
      */
     private function castableToString(array $choices, array &$cache = array())
     {

--- a/src/Symfony/Component/Form/ChoiceList/Factory/CachingFactoryDecorator.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/CachingFactoryDecorator.php
@@ -48,7 +48,7 @@ class CachingFactoryDecorator implements ChoiceListFactoryInterface
      *
      * @return string The SHA-256 hash
      *
-     * @internal Should not be used by user-land code.
+     * @internal should not be used by user-land code
      */
     public static function generateHash($value, $namespace = '')
     {

--- a/src/Symfony/Component/Form/ChoiceList/View/ChoiceGroupView.php
+++ b/src/Symfony/Component/Form/ChoiceList/View/ChoiceGroupView.php
@@ -36,8 +36,8 @@ class ChoiceGroupView implements \IteratorAggregate
      * Creates a new choice group view.
      *
      * @param string                         $label   The label of the group
-     * @param ChoiceGroupView[]|ChoiceView[] $choices The choice views in the
-     *                                                group.
+     * @param ChoiceGroupView[]|ChoiceView[] $choices the choice views in the
+     *                                                group
      */
     public function __construct($label, array $choices = array())
     {

--- a/src/Symfony/Component/Form/ChoiceList/View/ChoiceListView.php
+++ b/src/Symfony/Component/Form/ChoiceList/View/ChoiceListView.php
@@ -40,8 +40,8 @@ class ChoiceListView
      * Creates a new choice list view.
      *
      * @param ChoiceGroupView[]|ChoiceView[] $choices          The choice views
-     * @param ChoiceGroupView[]|ChoiceView[] $preferredChoices The preferred
-     *                                                         choice views.
+     * @param ChoiceGroupView[]|ChoiceView[] $preferredChoices the preferred
+     *                                                         choice views
      */
     public function __construct(array $choices = array(), array $preferredChoices = array())
     {

--- a/src/Symfony/Component/Form/DataMapperInterface.php
+++ b/src/Symfony/Component/Form/DataMapperInterface.php
@@ -22,7 +22,7 @@ interface DataMapperInterface
      * @param mixed           $data  Structured data
      * @param FormInterface[] $forms A list of {@link FormInterface} instances
      *
-     * @throws Exception\UnexpectedTypeException if the type of the data parameter is not supported.
+     * @throws Exception\UnexpectedTypeException if the type of the data parameter is not supported
      */
     public function mapDataToForms($data, $forms);
 
@@ -32,7 +32,7 @@ interface DataMapperInterface
      * @param FormInterface[] $forms A list of {@link FormInterface} instances
      * @param mixed           $data  Structured data
      *
-     * @throws Exception\UnexpectedTypeException if the type of the data parameter is not supported.
+     * @throws Exception\UnexpectedTypeException if the type of the data parameter is not supported
      */
     public function mapFormsToData($forms, &$data);
 }

--- a/src/Symfony/Component/Form/DataTransformerInterface.php
+++ b/src/Symfony/Component/Form/DataTransformerInterface.php
@@ -45,7 +45,7 @@ interface DataTransformerInterface
      *
      * @return mixed The value in the transformed representation
      *
-     * @throws TransformationFailedException When the transformation fails.
+     * @throws TransformationFailedException when the transformation fails
      */
     public function transform($value);
 
@@ -71,7 +71,7 @@ interface DataTransformerInterface
      *
      * @return mixed The value in the original representation
      *
-     * @throws TransformationFailedException When the transformation fails.
+     * @throws TransformationFailedException when the transformation fails
      */
     public function reverseTransform($value);
 }

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/ChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/ChoiceList.php
@@ -82,10 +82,10 @@ class ChoiceList implements ChoiceListInterface
      *                                             level of the hierarchy may also be a \Traversable.
      * @param array              $labels           The array of labels. The structure of this array
      *                                             should match the structure of $choices.
-     * @param array              $preferredChoices A flat array of choices that should be
-     *                                             presented to the user with priority.
+     * @param array              $preferredChoices a flat array of choices that should be
+     *                                             presented to the user with priority
      *
-     * @throws UnexpectedTypeException If the choices are not an array or \Traversable.
+     * @throws UnexpectedTypeException if the choices are not an array or \Traversable
      */
     public function __construct($choices, array $labels, array $preferredChoices = array())
     {
@@ -260,16 +260,16 @@ class ChoiceList implements ChoiceListInterface
     /**
      * Recursively adds the given choices to the list.
      *
-     * @param array              $bucketForPreferred The bucket where to store the preferred
-     *                                               view objects.
-     * @param array              $bucketForRemaining The bucket where to store the
-     *                                               non-preferred view objects.
+     * @param array              $bucketForPreferred the bucket where to store the preferred
+     *                                               view objects
+     * @param array              $bucketForRemaining the bucket where to store the
+     *                                               non-preferred view objects
      * @param array|\Traversable $choices            The list of choices
      * @param array              $labels             The labels corresponding to the choices
      * @param array              $preferredChoices   The preferred choices
      *
-     * @throws InvalidArgumentException      If the structures of the choices and labels array do not match.
-     * @throws InvalidConfigurationException If no valid value or index could be created for a choice.
+     * @throws InvalidArgumentException      if the structures of the choices and labels array do not match
+     * @throws InvalidConfigurationException if no valid value or index could be created for a choice
      */
     protected function addChoices(array &$bucketForPreferred, array &$bucketForRemaining, $choices, array $labels, array $preferredChoices)
     {
@@ -307,15 +307,15 @@ class ChoiceList implements ChoiceListInterface
      * Recursively adds a choice group.
      *
      * @param string $group              The name of the group
-     * @param array  $bucketForPreferred The bucket where to store the preferred
-     *                                   view objects.
-     * @param array  $bucketForRemaining The bucket where to store the
-     *                                   non-preferred view objects.
+     * @param array  $bucketForPreferred the bucket where to store the preferred
+     *                                   view objects
+     * @param array  $bucketForRemaining the bucket where to store the
+     *                                   non-preferred view objects
      * @param array  $choices            The list of choices in the group
      * @param array  $labels             The labels corresponding to the choices in the group
      * @param array  $preferredChoices   The preferred choices
      *
-     * @throws InvalidConfigurationException If no valid value or index could be created for a choice.
+     * @throws InvalidConfigurationException if no valid value or index could be created for a choice
      */
     protected function addChoiceGroup($group, array &$bucketForPreferred, array &$bucketForRemaining, array $choices, array $labels, array $preferredChoices)
     {
@@ -344,15 +344,15 @@ class ChoiceList implements ChoiceListInterface
     /**
      * Adds a new choice.
      *
-     * @param array  $bucketForPreferred The bucket where to store the preferred
-     *                                   view objects.
-     * @param array  $bucketForRemaining The bucket where to store the
-     *                                   non-preferred view objects.
+     * @param array  $bucketForPreferred the bucket where to store the preferred
+     *                                   view objects
+     * @param array  $bucketForRemaining the bucket where to store the
+     *                                   non-preferred view objects
      * @param mixed  $choice             The choice to add
      * @param string $label              The label for the choice
      * @param array  $preferredChoices   The preferred choices
      *
-     * @throws InvalidConfigurationException If no valid value or index could be created.
+     * @throws InvalidConfigurationException if no valid value or index could be created
      */
     protected function addChoice(array &$bucketForPreferred, array &$bucketForRemaining, $choice, $label, array $preferredChoices)
     {
@@ -404,8 +404,8 @@ class ChoiceList implements ChoiceListInterface
      *
      * @param mixed $choice The choice to create an index for
      *
-     * @return int|string A unique index containing only ASCII letters,
-     *                    digits and underscores.
+     * @return int|string a unique index containing only ASCII letters,
+     *                    digits and underscores
      */
     protected function createIndex($choice)
     {

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/ObjectChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/ObjectChoiceList.php
@@ -80,8 +80,8 @@ class ObjectChoiceList extends ChoiceList
      *                                                    by calling the getter on the object. If the
      *                                                    path is NULL, the object's __toString() method
      *                                                    is used instead.
-     * @param array                     $preferredChoices A flat array of choices that should be
-     *                                                    presented to the user with priority.
+     * @param array                     $preferredChoices a flat array of choices that should be
+     *                                                    presented to the user with priority
      * @param string                    $groupPath        A property path pointing to the property used
      *                                                    to group the choices. Only allowed if
      *                                                    the choices are given as flat array.
@@ -109,8 +109,8 @@ class ObjectChoiceList extends ChoiceList
      * @param array              $labels           Ignored
      * @param array              $preferredChoices The choices to display with priority
      *
-     * @throws InvalidArgumentException When passing a hierarchy of choices and using
-     *                                  the "groupPath" option at the same time.
+     * @throws InvalidArgumentException when passing a hierarchy of choices and using
+     *                                  the "groupPath" option at the same time
      */
     protected function initialize($choices, array $labels, array $preferredChoices)
     {

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/SimpleChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/SimpleChoiceList.php
@@ -44,8 +44,8 @@ class SimpleChoiceList extends ChoiceList
      *                                as hierarchy of unlimited depth by creating nested
      *                                arrays. The title of the sub-hierarchy is stored
      *                                in the array key pointing to the nested array.
-     * @param array $preferredChoices A flat array of choices that should be
-     *                                presented to the user with priority.
+     * @param array $preferredChoices a flat array of choices that should be
+     *                                presented to the user with priority
      */
     public function __construct(array $choices, array $preferredChoices = array())
     {
@@ -83,10 +83,10 @@ class SimpleChoiceList extends ChoiceList
      * Takes care of splitting the single $choices array passed in the
      * constructor into choices and labels.
      *
-     * @param array              $bucketForPreferred The bucket where to store the preferred
-     *                                               view objects.
-     * @param array              $bucketForRemaining The bucket where to store the
-     *                                               non-preferred view objects.
+     * @param array              $bucketForPreferred the bucket where to store the preferred
+     *                                               view objects
+     * @param array              $bucketForRemaining the bucket where to store the
+     *                                               non-preferred view objects
      * @param array|\Traversable $choices            The list of choices
      * @param array              $labels             Ignored
      * @param array              $preferredChoices   The preferred choices

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/BooleanToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/BooleanToStringTransformer.php
@@ -46,7 +46,7 @@ class BooleanToStringTransformer implements DataTransformerInterface
      *
      * @return string String value
      *
-     * @throws TransformationFailedException If the given value is not a Boolean.
+     * @throws TransformationFailedException if the given value is not a Boolean
      */
     public function transform($value)
     {
@@ -68,7 +68,7 @@ class BooleanToStringTransformer implements DataTransformerInterface
      *
      * @return bool Boolean value
      *
-     * @throws TransformationFailedException If the given value is not a string.
+     * @throws TransformationFailedException if the given value is not a string
      */
     public function reverseTransform($value)
     {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToBooleanArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToBooleanArrayTransformer.php
@@ -49,13 +49,13 @@ class ChoiceToBooleanArrayTransformer implements DataTransformerInterface
      * depending on whether a given option is selected. If this field is rendered
      * as select tag, the value is not modified.
      *
-     * @param mixed $choice An array if "multiple" is set to true, a scalar
-     *                      value otherwise.
+     * @param mixed $choice an array if "multiple" is set to true, a scalar
+     *                      value otherwise
      *
      * @return mixed An array
      *
-     * @throws TransformationFailedException If the given value is not scalar or
-     *                                       if the choices can not be retrieved.
+     * @throws TransformationFailedException if the given value is not scalar or
+     *                                       if the choices can not be retrieved
      */
     public function transform($choice)
     {
@@ -89,10 +89,10 @@ class ChoiceToBooleanArrayTransformer implements DataTransformerInterface
      *
      * @return mixed A scalar value
      *
-     * @throws TransformationFailedException If the given value is not an array,
+     * @throws TransformationFailedException if the given value is not an array,
      *                                       if the recuperation of the choices
      *                                       fails or if some choice can't be
-     *                                       found.
+     *                                       found
      */
     public function reverseTransform($values)
     {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToBooleanArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToBooleanArrayTransformer.php
@@ -44,8 +44,8 @@ class ChoicesToBooleanArrayTransformer implements DataTransformerInterface
      *
      * @return mixed An array
      *
-     * @throws TransformationFailedException If the given value is not an array
-     *                                       or if the choices can not be retrieved.
+     * @throws TransformationFailedException if the given value is not an array
+     *                                       or if the choices can not be retrieved
      */
     public function transform($array)
     {
@@ -83,10 +83,10 @@ class ChoicesToBooleanArrayTransformer implements DataTransformerInterface
      *
      * @return mixed An array
      *
-     * @throws TransformationFailedException If the given value is not an array,
+     * @throws TransformationFailedException if the given value is not an array,
      *                                       if the recuperation of the choices
      *                                       fails or if some choice can't be
-     *                                       found.
+     *                                       found
      */
     public function reverseTransform($values)
     {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToValuesTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToValuesTransformer.php
@@ -37,7 +37,7 @@ class ChoicesToValuesTransformer implements DataTransformerInterface
      *
      * @return array
      *
-     * @throws TransformationFailedException If the given value is not an array.
+     * @throws TransformationFailedException if the given value is not an array
      */
     public function transform($array)
     {
@@ -57,9 +57,9 @@ class ChoicesToValuesTransformer implements DataTransformerInterface
      *
      * @return array
      *
-     * @throws TransformationFailedException If the given value is not an array
+     * @throws TransformationFailedException if the given value is not an array
      *                                       or if no matching choice could be
-     *                                       found for some given value.
+     *                                       found for some given value
      */
     public function reverseTransform($array)
     {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
@@ -74,9 +74,9 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
      *
      * @return string|array Localized date string/array
      *
-     * @throws TransformationFailedException If the given value is not an instance
+     * @throws TransformationFailedException if the given value is not an instance
      *                                       of \DateTime or \DateTimeInterface or
-     *                                       if the date could not be transformed.
+     *                                       if the date could not be transformed
      */
     public function transform($dateTime)
     {
@@ -152,11 +152,11 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
     /**
      * Returns a preconfigured IntlDateFormatter instance.
      *
-     * @param bool $ignoreTimezone Use UTC regardless of the configured timezone.
+     * @param bool $ignoreTimezone use UTC regardless of the configured timezone
      *
      * @return \IntlDateFormatter
      *
-     * @throws TransformationFailedException in case the date formatter can not be constructed.
+     * @throws TransformationFailedException in case the date formatter can not be constructed
      */
     protected function getIntlDateFormatter($ignoreTimezone = false)
     {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php
@@ -49,8 +49,8 @@ class MoneyToLocalizedStringTransformer extends NumberToLocalizedStringTransform
      *
      * @return string Localized money string
      *
-     * @throws TransformationFailedException If the given value is not numeric or
-     *                                       if the value can not be transformed.
+     * @throws TransformationFailedException if the given value is not numeric or
+     *                                       if the value can not be transformed
      */
     public function transform($value)
     {
@@ -72,8 +72,8 @@ class MoneyToLocalizedStringTransformer extends NumberToLocalizedStringTransform
      *
      * @return int|float Normalized number
      *
-     * @throws TransformationFailedException If the given value is not a string
-     *                                       or if the value can not be transformed.
+     * @throws TransformationFailedException if the given value is not a string
+     *                                       or if the value can not be transformed
      */
     public function reverseTransform($value)
     {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
@@ -124,8 +124,8 @@ class NumberToLocalizedStringTransformer implements DataTransformerInterface
      *
      * @return string Localized value
      *
-     * @throws TransformationFailedException If the given value is not numeric
-     *                                       or if the value can not be transformed.
+     * @throws TransformationFailedException if the given value is not numeric
+     *                                       or if the value can not be transformed
      */
     public function transform($value)
     {
@@ -157,8 +157,8 @@ class NumberToLocalizedStringTransformer implements DataTransformerInterface
      *
      * @return int|float The numeric value
      *
-     * @throws TransformationFailedException If the given value is not a string
-     *                                       or if the value can not be transformed.
+     * @throws TransformationFailedException if the given value is not a string
+     *                                       or if the value can not be transformed
      */
     public function reverseTransform($value)
     {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/PercentToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/PercentToLocalizedStringTransformer.php
@@ -70,8 +70,8 @@ class PercentToLocalizedStringTransformer implements DataTransformerInterface
      *
      * @return string Percentage value
      *
-     * @throws TransformationFailedException If the given value is not numeric or
-     *                                       if the value could not be transformed.
+     * @throws TransformationFailedException if the given value is not numeric or
+     *                                       if the value could not be transformed
      */
     public function transform($value)
     {
@@ -105,8 +105,8 @@ class PercentToLocalizedStringTransformer implements DataTransformerInterface
      *
      * @return int|float Normalized value
      *
-     * @throws TransformationFailedException If the given value is not a string or
-     *                                       if the value could not be transformed.
+     * @throws TransformationFailedException if the given value is not a string or
+     *                                       if the value could not be transformed
      */
     public function reverseTransform($value)
     {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToDuplicatesTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToDuplicatesTransformer.php
@@ -51,8 +51,8 @@ class ValueToDuplicatesTransformer implements DataTransformerInterface
      *
      * @return mixed The value
      *
-     * @throws TransformationFailedException If the given value is not an array or
-     *                                       if the given array can not be transformed.
+     * @throws TransformationFailedException if the given value is not an array or
+     *                                       if the given array can not be transformed
      */
     public function reverseTransform($array)
     {

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/MergeCollectionListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/MergeCollectionListener.php
@@ -38,10 +38,10 @@ class MergeCollectionListener implements EventSubscriberInterface
     /**
      * Creates a new listener.
      *
-     * @param bool $allowAdd    Whether values might be added to the
-     *                          collection.
-     * @param bool $allowDelete Whether values might be removed from the
-     *                          collection.
+     * @param bool $allowAdd    whether values might be added to the
+     *                          collection
+     * @param bool $allowDelete whether values might be removed from the
+     *                          collection
      */
     public function __construct($allowAdd = false, $allowDelete = false)
     {

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -500,8 +500,8 @@ class ChoiceType extends AbstractType
      * "choice_label" closure by default.
      *
      * @param array|\Traversable $choices      The choice labels indexed by choices
-     * @param object             $choiceLabels The object that receives the choice labels
-     *                                         indexed by generated keys.
+     * @param object             $choiceLabels the object that receives the choice labels
+     *                                         indexed by generated keys
      * @param int                $nextKey      The next generated key
      *
      * @return array The choices in a normalized array with labels replaced by generated keys

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
@@ -258,8 +258,8 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
      * @param string   $property     The property for which to find constraints
      * @param \Closure $closure      The closure that returns a guess
      *                               for a given constraint
-     * @param mixed    $defaultValue The default value assumed if no other value
-     *                               can be guessed.
+     * @param mixed    $defaultValue the default value assumed if no other value
+     *                               can be guessed
      *
      * @return Guess|null The guessed value with the highest confidence
      */

--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapperInterface.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapperInterface.php
@@ -24,10 +24,10 @@ interface ViolationMapperInterface
      * the given form.
      *
      * @param ConstraintViolation $violation            The violation to map
-     * @param FormInterface       $form                 The root form of the tree
-     *                                                  to map it to.
-     * @param bool                $allowNonSynchronized Whether to allow
-     *                                                  mapping to non-synchronized forms.
+     * @param FormInterface       $form                 the root form of the tree
+     *                                                  to map it to
+     * @param bool                $allowNonSynchronized whether to allow
+     *                                                  mapping to non-synchronized forms
      */
     public function mapViolation(ConstraintViolation $violation, FormInterface $form, $allowNonSynchronized = false);
 }

--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationPath.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationPath.php
@@ -48,8 +48,8 @@ class ViolationPath implements \IteratorAggregate, PropertyPathInterface
     /**
      * Creates a new violation path from a string.
      *
-     * @param string $violationPath The property path of a {@link \Symfony\Component\Validator\ConstraintViolation}
-     *                              object.
+     * @param string $violationPath the property path of a {@link \Symfony\Component\Validator\ConstraintViolation}
+     *                              object
      */
     public function __construct($violationPath)
     {
@@ -210,7 +210,7 @@ class ViolationPath implements \IteratorAggregate, PropertyPathInterface
      *
      * @return bool Whether the element maps to a form
      *
-     * @throws OutOfBoundsException If the offset is invalid.
+     * @throws OutOfBoundsException if the offset is invalid
      */
     public function mapsForm($index)
     {

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -984,7 +984,7 @@ class Form implements \IteratorAggregate, FormInterface
      *
      * @return FormInterface The child form
      *
-     * @throws \OutOfBoundsException If the named child does not exist.
+     * @throws \OutOfBoundsException if the named child does not exist
      */
     public function offsetGet($name)
     {
@@ -997,8 +997,8 @@ class Form implements \IteratorAggregate, FormInterface
      * @param string        $name  Ignored. The name of the child is used
      * @param FormInterface $child The child to be added
      *
-     * @throws AlreadySubmittedException If the form has already been submitted.
-     * @throws LogicException            When trying to add a child to a non-compound form.
+     * @throws AlreadySubmittedException if the form has already been submitted
+     * @throws LogicException            when trying to add a child to a non-compound form
      *
      * @see self::add()
      */
@@ -1012,7 +1012,7 @@ class Form implements \IteratorAggregate, FormInterface
      *
      * @param string $name The name of the child to remove
      *
-     * @throws AlreadySubmittedException If the form has already been submitted.
+     * @throws AlreadySubmittedException if the form has already been submitted
      */
     public function offsetUnset($name)
     {

--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -185,8 +185,8 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      * @param EventDispatcherInterface $dispatcher The event dispatcher
      * @param array                    $options    The form options
      *
-     * @throws InvalidArgumentException If the data class is not a valid class or if
-     *                                  the name contains invalid characters.
+     * @throws InvalidArgumentException if the data class is not a valid class or if
+     *                                  the name contains invalid characters
      */
     public function __construct($name, $dataClass, EventDispatcherInterface $dispatcher, array $options = array())
     {
@@ -884,8 +884,8 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      *
      * @param string|int $name The tested form name
      *
-     * @throws UnexpectedTypeException  If the name is not a string or an integer.
-     * @throws InvalidArgumentException If the name contains invalid characters.
+     * @throws UnexpectedTypeException  if the name is not a string or an integer
+     * @throws InvalidArgumentException if the name contains invalid characters
      */
     public static function validateName($name)
     {

--- a/src/Symfony/Component/Form/FormConfigBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormConfigBuilderInterface.php
@@ -154,7 +154,7 @@ interface FormConfigBuilderInterface extends FormConfigInterface
      *
      * @param null|string|PropertyPathInterface $propertyPath
      *                                                        The property path or null if the path should be set
-     *                                                        automatically based on the form's name.
+     *                                                        automatically based on the form's name
      *
      * @return self The configuration object
      */
@@ -173,8 +173,8 @@ interface FormConfigBuilderInterface extends FormConfigInterface
     /**
      * Sets whether the form's data should be modified by reference.
      *
-     * @param bool $byReference Whether the data should be
-     *                          modified by reference.
+     * @param bool $byReference whether the data should be
+     *                          modified by reference
      *
      * @return self The configuration object
      */

--- a/src/Symfony/Component/Form/FormConfigInterface.php
+++ b/src/Symfony/Component/Form/FormConfigInterface.php
@@ -213,8 +213,8 @@ interface FormConfigInterface
     /**
      * Returns whether the form should be initialized upon creation.
      *
-     * @return bool Returns true if the form should be initialized
-     *              when created, false otherwise.
+     * @return bool returns true if the form should be initialized
+     *              when created, false otherwise
      */
     public function getAutoInitialize();
 

--- a/src/Symfony/Component/Form/FormErrorIterator.php
+++ b/src/Symfony/Component/Form/FormErrorIterator.php
@@ -107,8 +107,8 @@ class FormErrorIterator implements \RecursiveIterator, \SeekableIterator, \Array
     /**
      * Returns the current element of the iterator.
      *
-     * @return FormError|FormErrorIterator An error or an iterator containing
-     *                                     nested errors.
+     * @return FormError|FormErrorIterator an error or an iterator containing
+     *                                     nested errors
      */
     public function current()
     {

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -27,9 +27,9 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
      *
      * @return FormInterface The form instance
      *
-     * @throws Exception\AlreadySubmittedException If the form has already been submitted.
-     * @throws Exception\LogicException            When trying to set a parent for a form with
-     *                                             an empty name.
+     * @throws Exception\AlreadySubmittedException if the form has already been submitted
+     * @throws Exception\LogicException            when trying to set a parent for a form with
+     *                                             an empty name
      */
     public function setParent(FormInterface $parent = null);
 
@@ -49,9 +49,9 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
      *
      * @return FormInterface The form instance
      *
-     * @throws Exception\AlreadySubmittedException If the form has already been submitted.
-     * @throws Exception\LogicException            When trying to add a child to a non-compound form.
-     * @throws Exception\UnexpectedTypeException   If $child or $type has an unexpected type.
+     * @throws Exception\AlreadySubmittedException if the form has already been submitted
+     * @throws Exception\LogicException            when trying to add a child to a non-compound form
+     * @throws Exception\UnexpectedTypeException   if $child or $type has an unexpected type
      */
     public function add($child, $type = null, array $options = array());
 
@@ -62,7 +62,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
      *
      * @return FormInterface The child form
      *
-     * @throws \OutOfBoundsException If the named child does not exist.
+     * @throws \OutOfBoundsException if the named child does not exist
      */
     public function get($name);
 
@@ -82,7 +82,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
      *
      * @return FormInterface The form instance
      *
-     * @throws Exception\AlreadySubmittedException If the form has already been submitted.
+     * @throws Exception\AlreadySubmittedException if the form has already been submitted
      */
     public function remove($name);
 
@@ -112,7 +112,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
      *
      * @return FormInterface The form instance
      *
-     * @throws Exception\AlreadySubmittedException If the form has already been submitted.
+     * @throws Exception\AlreadySubmittedException if the form has already been submitted
      * @throws Exception\LogicException            If listeners try to call setData in a cycle. Or if
      *                                             the view data does not match the expected type
      *                                             according to {@link FormConfigInterface::getDataClass}.
@@ -129,9 +129,9 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Returns the normalized data of the field.
      *
-     * @return mixed When the field is not submitted, the default data is returned
+     * @return mixed when the field is not submitted, the default data is returned
      *               When the field is submitted, the normalized submitted data is
-     *               returned if the field is valid, null otherwise.
+     *               returned if the field is valid, null otherwise
      */
     public function getNormData();
 
@@ -270,13 +270,13 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
      * Submits data to the form, transforms and validates it.
      *
      * @param null|string|array $submittedData The submitted data
-     * @param bool              $clearMissing  Whether to set fields to NULL
+     * @param bool              $clearMissing  whether to set fields to NULL
      *                                         when they are missing in the
-     *                                         submitted data.
+     *                                         submitted data
      *
      * @return FormInterface The form instance
      *
-     * @throws Exception\AlreadySubmittedException If the form has already been submitted.
+     * @throws Exception\AlreadySubmittedException if the form has already been submitted
      */
     public function submit($submittedData, $clearMissing = true);
 

--- a/src/Symfony/Component/Form/FormRendererEngineInterface.php
+++ b/src/Symfony/Component/Form/FormRendererEngineInterface.php
@@ -36,10 +36,10 @@ interface FormRendererEngineInterface
      * The type of the resource is decided by the implementation. The resource
      * is later passed to {@link renderBlock()} by the rendering algorithm.
      *
-     * @param FormView $view      The view for determining the used themes
+     * @param FormView $view      the view for determining the used themes
      *                            First the themes attached directly to the
      *                            view with {@link setTheme()} are considered,
-     *                            then the ones of its parent etc.
+     *                            then the ones of its parent etc
      * @param string   $blockName The name of the block to render
      *
      * @return mixed The renderer resource or false, if none was found
@@ -70,12 +70,12 @@ interface FormRendererEngineInterface
      * The type of the resource is decided by the implementation. The resource
      * is later passed to {@link renderBlock()} by the rendering algorithm.
      *
-     * @param FormView $view               The view for determining the used themes
+     * @param FormView $view               the view for determining the used themes
      *                                     First the themes  attached directly to
      *                                     the view with {@link setTheme()} are
-     *                                     considered, then the ones of its parent etc.
-     * @param array    $blockNameHierarchy The block name hierarchy, with the root block
-     *                                     at the beginning.
+     *                                     considered, then the ones of its parent etc
+     * @param array    $blockNameHierarchy the block name hierarchy, with the root block
+     *                                     at the beginning
      * @param int      $hierarchyLevel     The level in the hierarchy at which to start
      *                                     looking. Level 0 indicates the root block, i.e.
      *                                     the first element of $blockNameHierarchy.
@@ -110,12 +110,12 @@ interface FormRendererEngineInterface
      * The type of the resource is decided by the implementation. The resource
      * is later passed to {@link renderBlock()} by the rendering algorithm.
      *
-     * @param FormView $view               The view for determining the used themes
+     * @param FormView $view               the view for determining the used themes
      *                                     First the themes  attached directly to
      *                                     the view with {@link setTheme()} are
-     *                                     considered, then the ones of its parent etc.
-     * @param array    $blockNameHierarchy The block name hierarchy, with the root block
-     *                                     at the beginning.
+     *                                     considered, then the ones of its parent etc
+     * @param array    $blockNameHierarchy the block name hierarchy, with the root block
+     *                                     at the beginning
      * @param int      $hierarchyLevel     The level in the hierarchy at which to start
      *                                     looking. Level 0 indicates the root block, i.e.
      *                                     the first element of $blockNameHierarchy.

--- a/src/Symfony/Component/Form/SubmitButton.php
+++ b/src/Symfony/Component/Form/SubmitButton.php
@@ -39,7 +39,7 @@ class SubmitButton extends Button implements ClickableInterface
      *
      * @return SubmitButton The button instance
      *
-     * @throws Exception\AlreadySubmittedException If the form has already been submitted.
+     * @throws Exception\AlreadySubmittedException if the form has already been submitted
      */
     public function submit($submittedData, $clearMissing = true)
     {

--- a/src/Symfony/Component/Form/Util/OrderedHashMapIterator.php
+++ b/src/Symfony/Component/Form/Util/OrderedHashMapIterator.php
@@ -58,10 +58,10 @@ class OrderedHashMapIterator implements \Iterator
     /**
      * Creates a new iterator.
      *
-     * @param array $elements       The elements of the map, indexed by their
-     *                              keys.
-     * @param array $orderedKeys    The keys of the map in the order in which
-     *                              they should be iterated.
+     * @param array $elements       the elements of the map, indexed by their
+     *                              keys
+     * @param array $orderedKeys    the keys of the map in the order in which
+     *                              they should be iterated
      * @param array $managedCursors An array from which to reference the
      *                              iterator's cursor as long as it is alive.
      *                              This array is managed by the corresponding

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -442,10 +442,10 @@ class Response
      * Sets the response status code.
      *
      * @param int   $code HTTP status code
-     * @param mixed $text HTTP status text
+     * @param mixed $text hTTP status text
      *
      * If the status text is null it will be automatically populated for the known
-     * status codes and left empty otherwise.
+     * status codes and left empty otherwise
      *
      * @return Response
      *

--- a/src/Symfony/Component/HttpFoundation/Session/SessionInterface.php
+++ b/src/Symfony/Component/HttpFoundation/Session/SessionInterface.php
@@ -25,7 +25,7 @@ interface SessionInterface
      *
      * @return bool True if session started
      *
-     * @throws \RuntimeException If session fails to start.
+     * @throws \RuntimeException if session fails to start
      */
     public function start();
 

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/SessionStorageInterface.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/SessionStorageInterface.php
@@ -26,7 +26,7 @@ interface SessionStorageInterface
      *
      * @return bool True if started
      *
-     * @throws \RuntimeException If something goes wrong starting the session.
+     * @throws \RuntimeException if something goes wrong starting the session
      */
     public function start();
 
@@ -104,8 +104,8 @@ interface SessionStorageInterface
      * a real PHP session would interfere with testing, in which case
      * it should actually persist the session data if required.
      *
-     * @throws \RuntimeException If the session is saved without being started, or if the session
-     *                           is already closed.
+     * @throws \RuntimeException if the session is saved without being started, or if the session
+     *                           is already closed
      */
     public function save();
 

--- a/src/Symfony/Component/HttpKernel/EventListener/FragmentListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/FragmentListener.php
@@ -51,7 +51,7 @@ class FragmentListener implements EventSubscriberInterface
      *
      * @param GetResponseEvent $event A GetResponseEvent instance
      *
-     * @throws AccessDeniedHttpException if the request does not come from a trusted IP.
+     * @throws AccessDeniedHttpException if the request does not come from a trusted IP
      */
     public function onKernelRequest(GetResponseEvent $event)
     {

--- a/src/Symfony/Component/Intl/Data/Bundle/Compiler/GenrbCompiler.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Compiler/GenrbCompiler.php
@@ -34,7 +34,7 @@ class GenrbCompiler implements BundleCompilerInterface
      * @param string $envVars Optional. Environment variables to be loaded when
      *                        running "genrb".
      *
-     * @throws RuntimeException If the "genrb" cannot be found.
+     * @throws RuntimeException if the "genrb" cannot be found
      */
     public function __construct($genrb = 'genrb', $envVars = '')
     {

--- a/src/Symfony/Component/Intl/Data/Bundle/Reader/BufferedBundleReader.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Reader/BufferedBundleReader.php
@@ -31,8 +31,8 @@ class BufferedBundleReader implements BundleReaderInterface
      * Buffers a given reader.
      *
      * @param BundleReaderInterface $reader     The reader to buffer
-     * @param int                   $bufferSize The number of entries to store
-     *                                          in the buffer.
+     * @param int                   $bufferSize the number of entries to store
+     *                                          in the buffer
      */
     public function __construct(BundleReaderInterface $reader, $bufferSize)
     {

--- a/src/Symfony/Component/Intl/Data/Bundle/Reader/BundleEntryReaderInterface.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Reader/BundleEntryReaderInterface.php
@@ -46,8 +46,8 @@ interface BundleEntryReaderInterface extends BundleReaderInterface
      *                           (i.e. array or \ArrayAccess) or cannot be found
      *                           in the requested locale.
      *
-     * @return mixed Returns an array or {@link \ArrayAccess} instance for
-     *               complex data and a scalar value for simple data.
+     * @return mixed returns an array or {@link \ArrayAccess} instance for
+     *               complex data and a scalar value for simple data
      *
      * @throws MissingResourceException If the indices cannot be accessed
      */

--- a/src/Symfony/Component/Intl/Data/Bundle/Reader/BundleReaderInterface.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Reader/BundleReaderInterface.php
@@ -26,8 +26,8 @@ interface BundleReaderInterface
      * @param string $path   The path to the resource bundle
      * @param string $locale The locale to read
      *
-     * @return mixed Returns an array or {@link \ArrayAccess} instance for
-     *               complex data, a scalar value otherwise.
+     * @return mixed returns an array or {@link \ArrayAccess} instance for
+     *               complex data, a scalar value otherwise
      */
     public function read($path, $locale);
 }

--- a/src/Symfony/Component/Intl/Data/Bundle/Writer/TextBundleWriter.php
+++ b/src/Symfony/Component/Intl/Data/Bundle/Writer/TextBundleWriter.php
@@ -46,8 +46,8 @@ class TextBundleWriter implements BundleWriterInterface
      * @param resource $file       The file handle to write to
      * @param string   $bundleName The name of the bundle
      * @param mixed    $value      The value of the node
-     * @param bool     $fallback   Whether the resource bundle should be merged
-     *                             with the fallback locale.
+     * @param bool     $fallback   whether the resource bundle should be merged
+     *                             with the fallback locale
      *
      * @see http://source.icu-project.org/repos/icu/icuhtml/trunk/design/bnf_rb.txt
      */
@@ -66,8 +66,8 @@ class TextBundleWriter implements BundleWriterInterface
      * @param resource $file          The file handle to write to
      * @param mixed    $value         The value of the node
      * @param int      $indentation   The number of levels to indent
-     * @param bool     $requireBraces Whether to require braces to be printed
-     *                                around the value.
+     * @param bool     $requireBraces whether to require braces to be printed
+     *                                around the value
      *
      * @see http://source.icu-project.org/repos/icu/icuhtml/trunk/design/bnf_rb.txt
      */
@@ -153,8 +153,8 @@ class TextBundleWriter implements BundleWriterInterface
      *
      * @param resource $file          The file handle to write to
      * @param string   $value         The value of the node
-     * @param bool     $requireBraces Whether to require braces to be printed
-     *                                around the value.
+     * @param bool     $requireBraces whether to require braces to be printed
+     *                                around the value
      *
      * @see http://source.icu-project.org/repos/icu/icuhtml/trunk/design/bnf_rb.txt
      */
@@ -199,11 +199,11 @@ class TextBundleWriter implements BundleWriterInterface
      * @param resource           $file        The file handle to write to
      * @param array|\Traversable $value       The value of the node
      * @param int                $indentation The number of levels to indent
-     * @param bool               $fallback    Whether the table should be merged
-     *                                        with the fallback locale.
+     * @param bool               $fallback    whether the table should be merged
+     *                                        with the fallback locale
      *
-     * @throws UnexpectedTypeException When $value is not an array and not a
-     *                                 \Traversable instance.
+     * @throws UnexpectedTypeException when $value is not an array and not a
+     *                                 \Traversable instance
      */
     private function writeTable($file, $value, $indentation, $fallback = true)
     {

--- a/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
+++ b/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php
@@ -167,8 +167,8 @@ class IntlDateFormatter
      * @param int    $datetype Type of date formatting, one of the format type constants
      * @param int    $timetype Type of time formatting, one of the format type constants
      * @param string $timezone Timezone identifier
-     * @param int    $calendar Calendar to use for formatting or parsing; default is Gregorian
-     *                         One of the calendar constants.
+     * @param int    $calendar calendar to use for formatting or parsing; default is Gregorian
+     *                         One of the calendar constants
      * @param string $pattern  Optional pattern to use when formatting
      *
      * @return IntlDateFormatter
@@ -524,9 +524,9 @@ class IntlDateFormatter
     /**
      * Set the formatter's timezone identifier.
      *
-     * @param string $timeZoneId The time zone ID string of the time zone to use
+     * @param string $timeZoneId the time zone ID string of the time zone to use
      *                           If NULL or the empty string, the default time zone for the
-     *                           runtime is used.
+     *                           runtime is used
      *
      * @return bool true on success or false on failure
      *

--- a/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
+++ b/src/Symfony/Component/Intl/NumberFormatter/NumberFormatter.php
@@ -258,9 +258,9 @@ class NumberFormatter
      * Constructor.
      *
      * @param string $locale  The locale code. The only currently supported locale is "en" (or null using the default locale, i.e. "en")
-     * @param int    $style   Style of the formatting, one of the format style constants
+     * @param int    $style   style of the formatting, one of the format style constants
      *                        The only supported styles are NumberFormatter::DECIMAL
-     *                        and NumberFormatter::CURRENCY.
+     *                        and NumberFormatter::CURRENCY
      * @param string $pattern Not supported. A pattern string in case $style is NumberFormat::PATTERN_DECIMAL or
      *                        NumberFormat::PATTERN_RULEBASED. It must conform to  the syntax
      *                        described in the ICU DecimalFormat or ICU RuleBasedNumberFormat documentation
@@ -295,9 +295,9 @@ class NumberFormatter
      * Static constructor.
      *
      * @param string $locale  The locale code. The only supported locale is "en" (or null using the default locale, i.e. "en")
-     * @param int    $style   Style of the formatting, one of the format style constants
+     * @param int    $style   style of the formatting, one of the format style constants
      *                        The only currently supported styles are NumberFormatter::DECIMAL
-     *                        and NumberFormatter::CURRENCY.
+     *                        and NumberFormatter::CURRENCY
      * @param string $pattern Not supported. A pattern string in case $style is NumberFormat::PATTERN_DECIMAL or
      *                        NumberFormat::PATTERN_RULEBASED. It must conform to  the syntax
      *                        described in the ICU DecimalFormat or ICU RuleBasedNumberFormat documentation
@@ -356,8 +356,8 @@ class NumberFormatter
      * Format a number.
      *
      * @param number $value The value to format
-     * @param int    $type  Type of the formatting, one of the format type constants
-     *                      Only type NumberFormatter::TYPE_DEFAULT is currently supported.
+     * @param int    $type  type of the formatting, one of the format type constants
+     *                      Only type NumberFormatter::TYPE_DEFAULT is currently supported
      *
      * @return bool|string The formatted value or false on error
      *
@@ -566,9 +566,9 @@ class NumberFormatter
     /**
      * Set an attribute.
      *
-     * @param int $attr  An attribute specifier, one of the numeric attribute constants
+     * @param int $attr  an attribute specifier, one of the numeric attribute constants
      *                   The only currently supported attributes are NumberFormatter::FRACTION_DIGITS,
-     *                   NumberFormatter::GROUPING_USED and NumberFormatter::ROUNDING_MODE.
+     *                   NumberFormatter::GROUPING_USED and NumberFormatter::ROUNDING_MODE
      * @param int $value The attribute value
      *
      * @return bool true on success or false on failure

--- a/src/Symfony/Component/Intl/Resources/stubs/functions.php
+++ b/src/Symfony/Component/Intl/Resources/stubs/functions.php
@@ -35,8 +35,8 @@ if (!function_exists('intl_is_failure')) {
      *
      * @author Bernhard Schussek <bschussek@gmail.com>
      *
-     * @return bool The error code of the last intl function call or
-     *              IntlGlobals::U_ZERO_ERROR if no error occurred.
+     * @return bool the error code of the last intl function call or
+     *              IntlGlobals::U_ZERO_ERROR if no error occurred
      *
      * @see IntlGlobals::getErrorCode()
      */
@@ -51,8 +51,8 @@ if (!function_exists('intl_is_failure')) {
      *
      * @author Bernhard Schussek <bschussek@gmail.com>
      *
-     * @return bool The error message of the last intl function call or
-     *              "U_ZERO_ERROR" if no error occurred.
+     * @return bool the error message of the last intl function call or
+     *              "U_ZERO_ERROR" if no error occurred
      *
      * @see IntlGlobals::getErrorMessage()
      */

--- a/src/Symfony/Component/Intl/Util/IcuVersion.php
+++ b/src/Symfony/Component/Intl/Util/IcuVersion.php
@@ -84,8 +84,8 @@ class IcuVersion
      * @param int|null $precision The number of components to include. Pass
      *                            NULL to return the version unchanged.
      *
-     * @return string|null The normalized ICU version or NULL if it couldn't be
-     *                     normalized.
+     * @return string|null the normalized ICU version or NULL if it couldn't be
+     *                     normalized
      */
     public static function normalize($version, $precision)
     {

--- a/src/Symfony/Component/Intl/Util/SvnCommit.php
+++ b/src/Symfony/Component/Intl/Util/SvnCommit.php
@@ -26,8 +26,8 @@ class SvnCommit
     /**
      * Creates a commit from the given "svn info" data.
      *
-     * @param \SimpleXMLElement $svnInfo The XML result from the "svn info"
-     *                                   command.
+     * @param \SimpleXMLElement $svnInfo the XML result from the "svn info"
+     *                                   command
      */
     public function __construct(\SimpleXMLElement $svnInfo)
     {

--- a/src/Symfony/Component/Intl/Util/SvnRepository.php
+++ b/src/Symfony/Component/Intl/Util/SvnRepository.php
@@ -44,7 +44,7 @@ class SvnRepository
      *
      * @return SvnRepository The directory where the data is stored
      *
-     * @throws RuntimeException If an error occurs during the download.
+     * @throws RuntimeException if an error occurs during the download
      */
     public static function download($url, $targetDir)
     {
@@ -119,7 +119,7 @@ class SvnRepository
      *
      * @return \SimpleXMLElement The XML result from the "svn info" command
      *
-     * @throws RuntimeException If the "svn info" command failed.
+     * @throws RuntimeException if the "svn info" command failed
      */
     private function getSvnInfo()
     {

--- a/src/Symfony/Component/Intl/Util/Version.php
+++ b/src/Symfony/Component/Intl/Util/Version.php
@@ -67,8 +67,8 @@ class Version
      * @param int|null $precision The number of components to include. Pass
      *                            NULL to return the version unchanged.
      *
-     * @return string|null The normalized version or NULL if it couldn't be
-     *                     normalized.
+     * @return string|null the normalized version or NULL if it couldn't be
+     *                     normalized
      */
     public static function normalize($version, $precision)
     {

--- a/src/Symfony/Component/OptionsResolver/OptionsResolverInterface.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolverInterface.php
@@ -40,8 +40,8 @@ interface OptionsResolverInterface
      *
      * The closures should return the lazily created option value.
      *
-     * @param array $defaultValues A list of option names as keys and default
-     *                             values or closures as values.
+     * @param array $defaultValues a list of option names as keys and default
+     *                             values or closures as values
      *
      * @return OptionsResolverInterface The resolver instance
      */
@@ -55,8 +55,8 @@ interface OptionsResolverInterface
      * performance if the previous default value is calculated by an expensive
      * closure.
      *
-     * @param array $defaultValues A list of option names as keys and default
-     *                             values or closures as values.
+     * @param array $defaultValues a list of option names as keys and default
+     *                             values or closures as values
      *
      * @return OptionsResolverInterface The resolver instance
      */
@@ -92,15 +92,15 @@ interface OptionsResolverInterface
     /**
      * Sets allowed values for a list of options.
      *
-     * @param array $allowedValues A list of option names as keys and arrays
+     * @param array $allowedValues a list of option names as keys and arrays
      *                             with values acceptable for that option as
-     *                             values.
+     *                             values
      *
      * @return OptionsResolverInterface The resolver instance
      *
-     * @throws InvalidOptionsException If an option has not been defined
+     * @throws InvalidOptionsException if an option has not been defined
      *                                 (see {@link isKnown()}) for which
-     *                                 an allowed value is set.
+     *                                 an allowed value is set
      */
     public function setAllowedValues($allowedValues);
 
@@ -109,28 +109,28 @@ interface OptionsResolverInterface
      *
      * The values are merged with the allowed values defined previously.
      *
-     * @param array $allowedValues A list of option names as keys and arrays
+     * @param array $allowedValues a list of option names as keys and arrays
      *                             with values acceptable for that option as
-     *                             values.
+     *                             values
      *
      * @return OptionsResolverInterface The resolver instance
      *
-     * @throws InvalidOptionsException If an option has not been defined
+     * @throws InvalidOptionsException if an option has not been defined
      *                                 (see {@link isKnown()}) for which
-     *                                 an allowed value is set.
+     *                                 an allowed value is set
      */
     public function addAllowedValues($allowedValues);
 
     /**
      * Sets allowed types for a list of options.
      *
-     * @param array $allowedTypes A list of option names as keys and type
-     *                            names passed as string or array as values.
+     * @param array $allowedTypes a list of option names as keys and type
+     *                            names passed as string or array as values
      *
      * @return OptionsResolverInterface The resolver instance
      *
-     * @throws InvalidOptionsException If an option has not been defined for
-     *                                 which an allowed type is set.
+     * @throws InvalidOptionsException if an option has not been defined for
+     *                                 which an allowed type is set
      */
     public function setAllowedTypes($allowedTypes);
 
@@ -139,13 +139,13 @@ interface OptionsResolverInterface
      *
      * The types are merged with the allowed types defined previously.
      *
-     * @param array $allowedTypes A list of option names as keys and type
-     *                            names passed as string or array as values.
+     * @param array $allowedTypes a list of option names as keys and type
+     *                            names passed as string or array as values
      *
      * @return OptionsResolverInterface The resolver instance
      *
-     * @throws InvalidOptionsException If an option has not been defined for
-     *                                 which an allowed type is set.
+     * @throws InvalidOptionsException if an option has not been defined for
+     *                                 which an allowed type is set
      */
     public function addAllowedTypes($allowedTypes);
 
@@ -201,12 +201,12 @@ interface OptionsResolverInterface
      *
      * @return array A list of options and their values
      *
-     * @throws InvalidOptionsException   If any of the passed options has not
+     * @throws InvalidOptionsException   if any of the passed options has not
      *                                   been defined or does not contain an
-     *                                   allowed value.
-     * @throws MissingOptionsException   If a required option is missing.
-     * @throws OptionDefinitionException If a cyclic dependency is detected
-     *                                   between two lazy options.
+     *                                   allowed value
+     * @throws MissingOptionsException   if a required option is missing
+     * @throws OptionDefinitionException if a cyclic dependency is detected
+     *                                   between two lazy options
      */
     public function resolve(array $options = array());
 }

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1480,7 +1480,7 @@ class Process
      *
      * @param string $functionName The function name that was called
      *
-     * @throws LogicException If the process has not run.
+     * @throws LogicException if the process has not run
      */
     private function requireProcessIsStarted($functionName)
     {
@@ -1494,7 +1494,7 @@ class Process
      *
      * @param string $functionName The function name that was called
      *
-     * @throws LogicException If the process is not yet terminated.
+     * @throws LogicException if the process is not yet terminated
      */
     private function requireProcessIsTerminated($functionName)
     {

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -330,7 +330,7 @@ class PropertyAccessor implements PropertyAccessorInterface
      *
      * @return array The values read in the path
      *
-     * @throws UnexpectedTypeException If a value within the path is neither object nor array.
+     * @throws UnexpectedTypeException if a value within the path is neither object nor array
      * @throws NoSuchIndexException    If a non-existing index is accessed
      */
     private function readPropertiesUntil($zval, PropertyPathInterface $propertyPath, $lastIndex, $ignoreInvalidIndices = true)
@@ -448,7 +448,7 @@ class PropertyAccessor implements PropertyAccessorInterface
      *
      * @return array The array containing the value of the property
      *
-     * @throws NoSuchPropertyException If the property does not exist or is not public.
+     * @throws NoSuchPropertyException if the property does not exist or is not public
      */
     private function readProperty($zval, $property)
     {
@@ -590,7 +590,7 @@ class PropertyAccessor implements PropertyAccessorInterface
      * @param string $property The property to write
      * @param mixed  $value    The value to write
      *
-     * @throws NoSuchPropertyException If the property does not exist or is not public.
+     * @throws NoSuchPropertyException if the property does not exist or is not public
      */
     private function writeProperty($zval, $property, $value)
     {

--- a/src/Symfony/Component/PropertyAccess/PropertyPathBuilder.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPathBuilder.php
@@ -45,10 +45,10 @@ class PropertyPathBuilder
      * Appends a (sub-) path to the current path.
      *
      * @param PropertyPathInterface|string $path   The path to append
-     * @param int                          $offset The offset where the appended
-     *                                             piece starts in $path.
-     * @param int                          $length The length of the appended piece
-     *                                             If 0, the full path is appended.
+     * @param int                          $offset the offset where the appended
+     *                                             piece starts in $path
+     * @param int                          $length the length of the appended piece
+     *                                             If 0, the full path is appended
      */
     public function append($path, $offset = 0, $length = 0)
     {
@@ -113,10 +113,10 @@ class PropertyPathBuilder
      * @param int                          $offset     The offset at which to replace
      * @param int                          $length     The length of the piece to replace
      * @param PropertyPathInterface|string $path       The path to insert
-     * @param int                          $pathOffset The offset where the inserted piece
-     *                                                 starts in $path.
-     * @param int                          $pathLength The length of the inserted piece
-     *                                                 If 0, the full path is inserted.
+     * @param int                          $pathOffset the offset where the inserted piece
+     *                                                 starts in $path
+     * @param int                          $pathLength the length of the inserted piece
+     *                                                 If 0, the full path is inserted
      *
      * @throws OutOfBoundsException If the offset is invalid
      */

--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -36,8 +36,8 @@ class XmlFileLoader extends FileLoader
      *
      * @return RouteCollection A RouteCollection instance
      *
-     * @throws \InvalidArgumentException When the file cannot be loaded or when the XML cannot be
-     *                                   parsed because it does not validate against the scheme.
+     * @throws \InvalidArgumentException when the file cannot be loaded or when the XML cannot be
+     *                                   parsed because it does not validate against the scheme
      */
     public function load($file, $type = null)
     {

--- a/src/Symfony/Component/Security/Core/Authorization/AuthorizationChecker.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AuthorizationChecker.php
@@ -49,7 +49,7 @@ class AuthorizationChecker implements AuthorizationCheckerInterface
     /**
      * {@inheritdoc}
      *
-     * @throws AuthenticationCredentialsNotFoundException when the token storage has no authentication token.
+     * @throws AuthenticationCredentialsNotFoundException when the token storage has no authentication token
      */
     final public function isGranted($attributes, $object = null)
     {

--- a/src/Symfony/Component/Security/Core/User/InMemoryUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/InMemoryUserProvider.php
@@ -101,7 +101,7 @@ class InMemoryUserProvider implements UserProviderInterface
      *
      * @return User
      *
-     * @throws UsernameNotFoundException If user whose given username does not exist.
+     * @throws UsernameNotFoundException if user whose given username does not exist
      */
     private function getUser($username)
     {

--- a/src/Symfony/Component/Security/Http/Logout/LogoutUrlGenerator.php
+++ b/src/Symfony/Component/Security/Http/Logout/LogoutUrlGenerator.php
@@ -90,7 +90,7 @@ class LogoutUrlGenerator
      *
      * @return string The logout URL
      *
-     * @throws \InvalidArgumentException if no LogoutListener is registered for the key or the key could not be found automatically.
+     * @throws \InvalidArgumentException if no LogoutListener is registered for the key or the key could not be found automatically
      */
     private function generateLogoutUrl($key, $referenceType)
     {

--- a/src/Symfony/Component/Serializer/Encoder/ChainDecoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/ChainDecoder.php
@@ -59,7 +59,7 @@ class ChainDecoder implements DecoderInterface
      *
      * @return DecoderInterface
      *
-     * @throws RuntimeException If no decoder is found.
+     * @throws RuntimeException if no decoder is found
      */
     private function getDecoder($format)
     {

--- a/src/Symfony/Component/Serializer/Normalizer/NormalizableInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizableInterface.php
@@ -27,10 +27,10 @@ interface NormalizableInterface
      * It is important to understand that the normalize() call should normalize
      * recursively all child objects of the implementor.
      *
-     * @param NormalizerInterface $normalizer The normalizer is given so that you
-     *                                        can use it to normalize objects contained within this object.
-     * @param string|null         $format     The format is optionally given to be able to normalize differently
-     *                                        based on different output formats.
+     * @param NormalizerInterface $normalizer the normalizer is given so that you
+     *                                        can use it to normalize objects contained within this object
+     * @param string|null         $format     the format is optionally given to be able to normalize differently
+     *                                        based on different output formats
      * @param array               $context    Options for normalizing this object
      *
      * @return array|scalar

--- a/src/Symfony/Component/Translation/Loader/MoFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/MoFileLoader.php
@@ -82,7 +82,7 @@ class MoFileLoader extends ArrayLoader
      *
      * @return array
      *
-     * @throws InvalidResourceException If stream content has an invalid format.
+     * @throws InvalidResourceException if stream content has an invalid format
      */
     private function parse($resource)
     {

--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -209,7 +209,7 @@ abstract class Constraint
      *
      * @throws InvalidOptionsException If an invalid option name is given
      *
-     * @internal This method should not be used or overwritten in userland code.
+     * @internal this method should not be used or overwritten in userland code
      */
     public function __get($option)
     {

--- a/src/Symfony/Component/Validator/ConstraintViolationInterface.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationInterface.php
@@ -56,8 +56,8 @@ interface ConstraintViolationInterface
     /**
      * Returns the parameters to be inserted into the raw violation message.
      *
-     * @return array A possibly empty list of parameters indexed by the names
-     *               that appear in the message template.
+     * @return array a possibly empty list of parameters indexed by the names
+     *               that appear in the message template
      *
      * @see getMessageTemplate()
      * @deprecated since version 2.7, to be replaced by getParameters() in 3.0.
@@ -111,8 +111,8 @@ interface ConstraintViolationInterface
     /**
      * Returns the value that caused the violation.
      *
-     * @return mixed The invalid value that caused the validated constraint to
-     *               fail.
+     * @return mixed the invalid value that caused the validated constraint to
+     *               fail
      */
     public function getInvalidValue();
 

--- a/src/Symfony/Component/Validator/ConstraintViolationListInterface.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationListInterface.php
@@ -39,7 +39,7 @@ interface ConstraintViolationListInterface extends \Traversable, \Countable, \Ar
      *
      * @return ConstraintViolationInterface The violation
      *
-     * @throws \OutOfBoundsException If the offset does not exist.
+     * @throws \OutOfBoundsException if the offset does not exist
      */
     public function get($offset);
 

--- a/src/Symfony/Component/Validator/DefaultTranslator.php
+++ b/src/Symfony/Component/Validator/DefaultTranslator.php
@@ -129,8 +129,8 @@ class DefaultTranslator implements TranslatorInterface
      *
      * @return string The translated string
      *
-     * @throws InvalidArgumentException If the message id does not have the format
-     *                                  "singular|plural".
+     * @throws InvalidArgumentException if the message id does not have the format
+     *                                  "singular|plural"
      */
     public function transChoice($id, $number, array $parameters = array(), $domain = null, $locale = null)
     {

--- a/src/Symfony/Component/Validator/ExecutionContextInterface.php
+++ b/src/Symfony/Component/Validator/ExecutionContextInterface.php
@@ -150,10 +150,10 @@ interface ExecutionContextInterface
      * @param null|string|string[] $groups   The groups to validate in. If you don't pass any
      *                                       groups here, the current group of the context
      *                                       will be used.
-     * @param bool                 $traverse Whether to traverse the value if it is an array
-     *                                       or an instance of <tt>\Traversable</tt>.
-     * @param bool                 $deep     Whether to traverse the value recursively if
-     *                                       it is a collection of collections.
+     * @param bool                 $traverse whether to traverse the value if it is an array
+     *                                       or an instance of <tt>\Traversable</tt>
+     * @param bool                 $deep     whether to traverse the value recursively if
+     *                                       it is a collection of collections
      *
      * @deprecated since version 2.5, to be removed in 3.0.
      *             Use {@link Context\ExecutionContextInterface::getValidator()}
@@ -237,8 +237,8 @@ interface ExecutionContextInterface
      * has been called with a plain value and constraint, this method returns
      * null.
      *
-     * @return MetadataInterface|null The metadata of the currently validated
-     *                                value.
+     * @return MetadataInterface|null the metadata of the currently validated
+     *                                value
      */
     public function getMetadata();
 

--- a/src/Symfony/Component/Validator/Validation.php
+++ b/src/Symfony/Component/Validator/Validation.php
@@ -21,7 +21,7 @@ final class Validation
     /**
      * The Validator API provided by Symfony 2.4 and older.
      *
-     * @deprecated use API_VERSION_2_5_BC instead.
+     * @deprecated use API_VERSION_2_5_BC instead
      */
     const API_VERSION_2_4 = 1;
 

--- a/src/Symfony/Component/Validator/ValidationVisitorInterface.php
+++ b/src/Symfony/Component/Validator/ValidationVisitorInterface.php
@@ -62,8 +62,8 @@ interface ValidationVisitorInterface
      * @param bool   $traverse     Whether to traverse the value if it is traversable
      * @param bool   $deep         Whether to traverse nested traversable values recursively
      *
-     * @throws Exception\NoSuchMetadataException If no metadata can be found for
-     *                                           the given value.
+     * @throws Exception\NoSuchMetadataException if no metadata can be found for
+     *                                           the given value
      */
     public function validate($value, $group, $propertyPath, $traverse = false, $deep = false);
 

--- a/src/Symfony/Component/Validator/Validator.php
+++ b/src/Symfony/Component/Validator/Validator.php
@@ -108,7 +108,7 @@ class Validator implements ValidatorInterface, Mapping\Factory\MetadataFactoryIn
     /**
      * {@inheritdoc}
      *
-     * @throws ValidatorException If the metadata for the value does not support properties.
+     * @throws ValidatorException if the metadata for the value does not support properties
      */
     public function validateProperty($containingValue, $property, $groups = null)
     {
@@ -139,7 +139,7 @@ class Validator implements ValidatorInterface, Mapping\Factory\MetadataFactoryIn
     /**
      * {@inheritdoc}
      *
-     * @throws ValidatorException If the metadata for the value does not support properties.
+     * @throws ValidatorException if the metadata for the value does not support properties
      */
     public function validatePropertyValue($containingValue, $property, $value, $groups = null)
     {

--- a/src/Symfony/Component/Validator/ValidatorInterface.php
+++ b/src/Symfony/Component/Validator/ValidatorInterface.php
@@ -64,8 +64,8 @@ interface ValidatorInterface
      *
      * @param mixed      $containingValue The value containing the property
      * @param string     $property        The name of the property to validate
-     * @param string     $value           The value to validate against the
-     *                                    constraints of the property.
+     * @param string     $value           the value to validate against the
+     *                                    constraints of the property
      * @param array|null $groups          The validation groups to validate
      *
      * @return ConstraintViolationListInterface A list of constraint violations. If the


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | 2.7 |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | n/a |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

`phpdoc_annotation_without_dot` rule was requested by Symfony, most cases was adjusted in code, but the rule was a bit problematic to apply it everywhere.
This PR is based on extended implementation of that rule (see https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2247). I think it covers the problematic cases properly, but let us discuss.
Also, for that reason, I decided to put it in independent PR.
