### PR TITLE
[Form] Added FormView::getRoot

### DIFF
--- a/src/Symfony/Component/Form/FormView.php
+++ b/src/Symfony/Component/Form/FormView.php
@@ -153,4 +153,14 @@ class FormView implements \ArrayAccess, \IteratorAggregate, \Countable
     {
         return count($this->children);
     }
+    
+    /**
+     * Get the root view
+     *
+     * @return FormView the root view
+     */
+    public function getRoot()
+    {
+        return null !== $this->parent ? $this->parent->getRoot() : $this;
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch? | "master" |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any |
| License | MIT |
| Doc PR | reference to the documentation PR, if any |

Problem is the _default_ parent options are merged into child options, however those may differ from the _actual_ options, as those are not merged into children. To clarify;

``` php
$form = $this->createFormBuilder(null, ['method' => 'GET'])
  ->add('child', CheckboxType::class)
  ->getForm();
```

``` twig
form.vars.method == 'GET'
form.child.vars.method == 'POST'
```

![image](https://cloud.githubusercontent.com/assets/1047696/19839837/a2410ea2-9ee9-11e6-8027-8815e26dd7de.png)

This allows for consistent access to `form.root.vars.method`.

I believe a BC break can happen if one named a field `root`. There's an issue somewhere regarding this for the `parent` field as well ;-)

edit: https://github.com/symfony/symfony/pull/19492#issuecomment-236421708
