### PR TITLE
[Console] simplified code

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressIndicator.php
+++ b/src/Symfony/Component/Console/Helper/ProgressIndicator.php
@@ -28,7 +28,6 @@ class ProgressIndicator
     private $indicatorCurrent;
     private $indicatorChangeInterval;
     private $indicatorUpdateTime;
-    private $lastMessagesLength;
     private $started = false;
 
     private static $formatters;
@@ -125,7 +124,6 @@ class ProgressIndicator
 
         $this->message = $message;
         $this->started = true;
-        $this->lastMessagesLength = 0;
         $this->startTime = time();
         $this->indicatorUpdateTime = $this->getCurrentTimeInMilliseconds() + $this->indicatorChangeInterval;
         $this->indicatorCurrent = 0;
@@ -262,26 +260,11 @@ class ProgressIndicator
      */
     private function overwrite($message)
     {
-        // append whitespace to match the line's length
-        if (null !== $this->lastMessagesLength) {
-            if ($this->lastMessagesLength > Helper::strlenWithoutDecoration($this->output->getFormatter(), $message)) {
-                $message = str_pad($message, $this->lastMessagesLength, "\x20", STR_PAD_RIGHT);
-            }
-        }
-
         if ($this->output->isDecorated()) {
-            $this->output->write("\x0D");
+            $this->output->write("\x0D\x1B[2K");
             $this->output->write($message);
         } else {
             $this->output->writeln($message);
-        }
-
-        $this->lastMessagesLength = 0;
-
-        $len = Helper::strlenWithoutDecoration($this->output->getFormatter(), $message);
-
-        if ($len > $this->lastMessagesLength) {
-            $this->lastMessagesLength = $len;
         }
     }
 

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressIndicatorTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressIndicatorTest.php
@@ -44,11 +44,11 @@ class ProgressIndicatorTest extends \PHPUnit_Framework_TestCase
             $this->generateOutput(' \\ Starting...').
             $this->generateOutput(' \\ Advancing...').
             $this->generateOutput(' | Advancing...').
-            $this->generateOutput(' | Done...     ').
+            $this->generateOutput(' | Done...').
             PHP_EOL.
             $this->generateOutput(' - Starting Again...').
             $this->generateOutput(' \\ Starting Again...').
-            $this->generateOutput(' \\ Done Again...    ').
+            $this->generateOutput(' \\ Done Again...').
             PHP_EOL,
             stream_get_contents($output->getStream())
         );
@@ -70,8 +70,8 @@ class ProgressIndicatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(
             ' Starting...'.PHP_EOL.
-            ' Midway...  '.PHP_EOL.
-            ' Done...    '.PHP_EOL.PHP_EOL,
+            ' Midway...'.PHP_EOL.
+            ' Done...'.PHP_EOL.PHP_EOL,
             stream_get_contents($output->getStream())
         );
     }
@@ -177,6 +177,6 @@ class ProgressIndicatorTest extends \PHPUnit_Framework_TestCase
     {
         $count = substr_count($expected, "\n");
 
-        return "\x0D".($count ? sprintf("\033[%dA", $count) : '').$expected;
+        return "\x0D\x1B[2K".($count ? sprintf("\033[%dA", $count) : '').$expected;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | ~no~ yes (even if the output is "better" with this PR)
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Instead of adding blank character for shorter lines and having to keep the max length of messages, I propose to clear the line via an ANSI sequence like done in the progress bar.

Code is cleaner and output is better as currently, then cursor can be "away" from the last character which is unexpected.

Actually, this is a bug fix as the current code does not work well when using styles in the indicator message.
