### PR TITLE
[HttpFoundation][Session] Fix memcache session handler

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcacheSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MemcacheSessionHandler.php
@@ -71,7 +71,7 @@ class MemcacheSessionHandler implements \SessionHandlerInterface
      */
     public function close()
     {
-        return $this->memcache->close();
+        return true;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcacheSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcacheSessionHandlerTest.php
@@ -56,12 +56,6 @@ class MemcacheSessionHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testCloseSession()
     {
-        $this->memcache
-            ->expects($this->once())
-            ->method('close')
-            ->will($this->returnValue(true))
-        ;
-
         $this->assertTrue($this->storage->close());
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 3.0, 3.1, master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Commit 0216e056051a6304cab01defc107fb583f3f5efa removed the opening of connection to memcached server on call to `open()`, because it's assumed that connection is already opened. However, `close()` still closes the connection. As a result no more read/write calls can be made if session got closed, as the connection does not get reestablished. 

Basically MemcacheSessionHandler should follow same logic as Memcache**d**SessionHandler, which is exactly what this MR acomplishes.
