### PR TITLE
Add "ContainerAwareTestCase" as a test base class

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/ContainerAwareTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/ContainerAwareTestCase.php
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class ContainerAwareTestCase extends KernelTestCase
 {
     /**
-     * Returns the service container
+     * Returns the service container.
      *
      * @param array $options Options to pass to the KernelTestCase::createKernel() method. May contain the
      *                       'environment' and 'debug' keys that will be used to create the underlying kernel.

--- a/src/Symfony/Bundle/FrameworkBundle/Test/ContainerAwareTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/ContainerAwareTestCase.php
@@ -45,12 +45,11 @@ class ContainerAwareTestCase extends KernelTestCase
     }
 
     /**
-     * Release container after test
+     * Release container after test.
      */
     protected function tearDown()
     {
         self::$container = null;
         parent::tearDown();
     }
-
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Test/ContainerAwareTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/ContainerAwareTestCase.php
@@ -36,12 +36,12 @@ class ContainerAwareTestCase extends KernelTestCase
      */
     public static function getContainer(array $options = array())
     {
-        if (null === static::$container) {
+        if (null === self::$container) {
             static::bootKernel($options);
-            static::$container = static::$kernel->getContainer();
+            self::$container = static::$kernel->getContainer();
         }
 
-        return static::$container;
+        return self::$container;
     }
 
     /**
@@ -49,7 +49,7 @@ class ContainerAwareTestCase extends KernelTestCase
      */
     protected function tearDown()
     {
-        static::$container = null;
+        self::$container = null;
         parent::tearDown();
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Test/ContainerAwareTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/ContainerAwareTestCase.php
@@ -22,6 +22,11 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class ContainerAwareTestCase extends KernelTestCase
 {
     /**
+     * @var ContainerInterface
+     */
+    private static $container;
+
+    /**
      * Returns the service container.
      *
      * @param array $options Options to pass to the KernelTestCase::createKernel() method. May contain the
@@ -31,8 +36,21 @@ class ContainerAwareTestCase extends KernelTestCase
      */
     public static function getContainer(array $options = array())
     {
-        static::bootKernel($options);
+        if (null === static::$container) {
+            static::bootKernel($options);
+            static::$container = static::$kernel->getContainer();
+        }
 
-        return static::$kernel->getContainer();
+        return static::$container;
     }
+
+    /**
+     * Release container after test
+     */
+    protected function tearDown()
+    {
+        static::$container = null;
+        parent::tearDown();
+    }
+
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Test/ContainerAwareTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/ContainerAwareTestCase.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Test;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * This class can be used as a base class for functional tests that need to
+ * access the service container.
+ *
+ * @author Matthias Pigulla <mp@webfactory.de>
+ */
+class ContainerAwareTestCase extends KernelTestCase
+{
+    /**
+     * Returns the service container
+     *
+     * @param array $options Options to pass to the KernelTestCase::createKernel() method. May contain the
+     *                       'environment' and 'debug' keys that will be used to create the underlying kernel.
+     *
+     * @return ContainerInterface
+     */
+    public static function getContainer(array $options = array())
+    {
+        static::bootKernel($options);
+
+        return static::$kernel->getContainer();
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Test/ContainerAwareTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/ContainerAwareTestCase.php
@@ -22,11 +22,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 abstract class ContainerAwareTestCase extends KernelTestCase
 {
     /**
-     * @var ContainerInterface
-     */
-    private static $container;
-
-    /**
      * Returns the service container.
      *
      * @param array $options Options to pass to the KernelTestCase::createKernel() method. May contain the
@@ -36,20 +31,10 @@ abstract class ContainerAwareTestCase extends KernelTestCase
      */
     public static function getContainer(array $options = array())
     {
-        if (null === self::$container) {
+        if (null === self::$kernel) {
             static::bootKernel($options);
-            self::$container = static::$kernel->getContainer();
         }
 
-        return self::$container;
-    }
-
-    /**
-     * Release container after test.
-     */
-    protected function tearDown()
-    {
-        self::$container = null;
-        parent::tearDown();
+        return self::$kernel->getContainer();
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Test/ContainerAwareTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/ContainerAwareTestCase.php
@@ -22,20 +22,34 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 abstract class ContainerAwareTestCase extends KernelTestCase
 {
     /**
-     * Returns a fresh instance of the service container.
-     *
-     * Note that every invocation of this method will create a fresh container instance and also discard and
-     * reboot the underlying kernel instance in static::$kernel.
+     * @var ContainerInterface
+     */
+    private static $container;
+
+    /**
+     * Returns the service container.
      *
      * @param array $options Options to pass to the KernelTestCase::createKernel() method. May contain the
      *                       'environment' and 'debug' keys that will be used to create the underlying kernel.
      *
      * @return ContainerInterface
      */
-    public static function createContainer(array $options = array())
+    public static function getContainer(array $options = array())
     {
-        static::bootKernel($options);
+        if (null === self::$container) {
+            static::bootKernel($options);
+            self::$container = static::$kernel->getContainer();
+        }
 
-        return static::$kernel->getContainer();
+        return self::$container;
+    }
+
+    /**
+     * Release container after test.
+     */
+    protected function tearDown()
+    {
+        self::$container = null;
+        parent::tearDown();
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Test/ContainerAwareTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/ContainerAwareTestCase.php
@@ -22,34 +22,20 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class ContainerAwareTestCase extends KernelTestCase
 {
     /**
-     * @var ContainerInterface
-     */
-    private static $container;
-
-    /**
-     * Returns the service container.
+     * Returns a fresh instance of the service container.
+     *
+     * Note that every invocation of this method will create a fresh container instance and also discard and
+     * reboot the underlying kernel instance in static::$kernel.
      *
      * @param array $options Options to pass to the KernelTestCase::createKernel() method. May contain the
      *                       'environment' and 'debug' keys that will be used to create the underlying kernel.
      *
      * @return ContainerInterface
      */
-    public static function getContainer(array $options = array())
+    public static function createContainer(array $options = array())
     {
-        if (null === self::$container) {
-            static::bootKernel($options);
-            self::$container = static::$kernel->getContainer();
-        }
+        static::bootKernel($options);
 
-        return self::$container;
-    }
-
-    /**
-     * Release container after test.
-     */
-    protected function tearDown()
-    {
-        self::$container = null;
-        parent::tearDown();
+        return static::$kernel->getContainer();
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Test/ContainerAwareTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/ContainerAwareTestCase.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @author Matthias Pigulla <mp@webfactory.de>
  */
-class ContainerAwareTestCase extends KernelTestCase
+abstract class ContainerAwareTestCase extends KernelTestCase
 {
     /**
      * Returns a fresh instance of the service container.

--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -181,6 +181,7 @@ abstract class KernelTestCase extends \PHPUnit_Framework_TestCase
             if ($container instanceof ResettableContainerInterface) {
                 $container->reset();
             }
+            static::$kernel = null;
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -18,7 +18,7 @@ use Symfony\Bundle\FrameworkBundle\Client;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-abstract class WebTestCase extends KernelTestCase
+abstract class WebTestCase extends ContainerAwareTestCase
 {
     /**
      * Creates a Client.
@@ -30,9 +30,7 @@ abstract class WebTestCase extends KernelTestCase
      */
     protected static function createClient(array $options = array(), array $server = array())
     {
-        static::bootKernel($options);
-
-        $client = static::$kernel->getContainer()->get('test.client');
+        $client = static::getContainer($options)->get('test.client');
         $client->setServerParameters($server);
 
         return $client;

--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -30,7 +30,7 @@ abstract class WebTestCase extends ContainerAwareTestCase
      */
     protected static function createClient(array $options = array(), array $server = array())
     {
-        $client = static::getContainer($options)->get('test.client');
+        $client = static::createContainer($options)->get('test.client');
         $client->setServerParameters($server);
 
         return $client;

--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -30,7 +30,7 @@ abstract class WebTestCase extends ContainerAwareTestCase
      */
     protected static function createClient(array $options = array(), array $server = array())
     {
-        $client = static::createContainer($options)->get('test.client');
+        $client = static::getContainer($options)->get('test.client');
         $client->setServerParameters($server);
 
         return $client;

--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -23,7 +23,7 @@ abstract class WebTestCase extends KernelTestCase
     /**
      * Creates a Client.
      *
-     * @param array $options An array of options to pass to the createKernel class
+     * @param array $options An array of options to pass to the KernelTestCase::createKernel method
      * @param array $server  An array of server parameters
      *
      * @return Client A Client instance

--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -23,6 +23,9 @@ abstract class WebTestCase extends ContainerAwareTestCase
     /**
      * Creates a Client.
      *
+     * Note: When this method is called multiple times to create different client instances,
+     * each client will be using a new, fresh kernel and container instance.
+     *
      * @param array $options An array of options to pass to the KernelTestCase::createKernel method
      * @param array $server  An array of server parameters
      *
@@ -30,7 +33,9 @@ abstract class WebTestCase extends ContainerAwareTestCase
      */
     protected static function createClient(array $options = array(), array $server = array())
     {
-        $client = static::getContainer($options)->get('test.client');
+        static::bootKernel($options);
+
+        $client = static::$kernel->getContainer()->get('test.client');
         $client->setServerParameters($server);
 
         return $client;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AutowiringTypesTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AutowiringTypesTest.php
@@ -20,8 +20,7 @@ class AutowiringTypesTest extends WebTestCase
 {
     public function testAnnotationReaderAutowiring()
     {
-        static::bootKernel(array('root_config' => 'no_annotations_cache.yml', 'environment' => 'no_annotations_cache'));
-        $container = static::$kernel->getContainer();
+        $container = static::getContainer(array('root_config' => 'no_annotations_cache.yml', 'environment' => 'no_annotations_cache'));
 
         $annotationReader = $container->get('test.autowiring_types.autowired_services')->getAnnotationReader();
         $this->assertInstanceOf(AnnotationReader::class, $annotationReader);
@@ -29,8 +28,7 @@ class AutowiringTypesTest extends WebTestCase
 
     public function testCachedAnnotationReaderAutowiring()
     {
-        static::bootKernel();
-        $container = static::$kernel->getContainer();
+        $container = static::getContainer();
 
         $annotationReader = $container->get('test.autowiring_types.autowired_services')->getAnnotationReader();
         $this->assertInstanceOf(CachedReader::class, $annotationReader);
@@ -38,8 +36,7 @@ class AutowiringTypesTest extends WebTestCase
 
     public function testTemplatingAutowiring()
     {
-        static::bootKernel();
-        $container = static::$kernel->getContainer();
+        $container = static::getContainer();
 
         $autowiredServices = $container->get('test.autowiring_types.autowired_services');
         $this->assertInstanceOf(FrameworkBundleEngineInterface::class, $autowiredServices->getFrameworkBundleEngine());

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AutowiringTypesTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AutowiringTypesTest.php
@@ -20,7 +20,7 @@ class AutowiringTypesTest extends WebTestCase
 {
     public function testAnnotationReaderAutowiring()
     {
-        $container = static::getContainer(array('root_config' => 'no_annotations_cache.yml', 'environment' => 'no_annotations_cache'));
+        $container = static::createContainer(array('root_config' => 'no_annotations_cache.yml', 'environment' => 'no_annotations_cache'));
 
         $annotationReader = $container->get('test.autowiring_types.autowired_services')->getAnnotationReader();
         $this->assertInstanceOf(AnnotationReader::class, $annotationReader);
@@ -28,7 +28,7 @@ class AutowiringTypesTest extends WebTestCase
 
     public function testCachedAnnotationReaderAutowiring()
     {
-        $container = static::getContainer();
+        $container = static::createContainer();
 
         $annotationReader = $container->get('test.autowiring_types.autowired_services')->getAnnotationReader();
         $this->assertInstanceOf(CachedReader::class, $annotationReader);
@@ -36,7 +36,7 @@ class AutowiringTypesTest extends WebTestCase
 
     public function testTemplatingAutowiring()
     {
-        $container = static::getContainer();
+        $container = static::createContainer();
 
         $autowiredServices = $container->get('test.autowiring_types.autowired_services');
         $this->assertInstanceOf(FrameworkBundleEngineInterface::class, $autowiredServices->getFrameworkBundleEngine());

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AutowiringTypesTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AutowiringTypesTest.php
@@ -20,7 +20,7 @@ class AutowiringTypesTest extends WebTestCase
 {
     public function testAnnotationReaderAutowiring()
     {
-        $container = static::createContainer(array('root_config' => 'no_annotations_cache.yml', 'environment' => 'no_annotations_cache'));
+        $container = static::getContainer(array('root_config' => 'no_annotations_cache.yml', 'environment' => 'no_annotations_cache'));
 
         $annotationReader = $container->get('test.autowiring_types.autowired_services')->getAnnotationReader();
         $this->assertInstanceOf(AnnotationReader::class, $annotationReader);
@@ -28,7 +28,7 @@ class AutowiringTypesTest extends WebTestCase
 
     public function testCachedAnnotationReaderAutowiring()
     {
-        $container = static::createContainer();
+        $container = static::getContainer();
 
         $annotationReader = $container->get('test.autowiring_types.autowired_services')->getAnnotationReader();
         $this->assertInstanceOf(CachedReader::class, $annotationReader);
@@ -36,7 +36,7 @@ class AutowiringTypesTest extends WebTestCase
 
     public function testTemplatingAutowiring()
     {
-        $container = static::createContainer();
+        $container = static::getContainer();
 
         $autowiredServices = $container->get('test.autowiring_types.autowired_services');
         $this->assertInstanceOf(FrameworkBundleEngineInterface::class, $autowiredServices->getFrameworkBundleEngine());

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
@@ -59,8 +59,7 @@ class CachePoolsTest extends WebTestCase
 
     public function doTestCachePools($options, $adapterClass)
     {
-        static::bootKernel($options);
-        $container = static::$kernel->getContainer();
+        $container = static::getContainer($options);
 
         $pool = $container->get('cache.test');
         $this->assertInstanceOf($adapterClass, $pool);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
@@ -59,7 +59,7 @@ class CachePoolsTest extends WebTestCase
 
     public function doTestCachePools($options, $adapterClass)
     {
-        $container = static::getContainer($options);
+        $container = static::createContainer($options);
 
         $pool = $container->get('cache.test');
         $this->assertInstanceOf($adapterClass, $pool);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
@@ -59,7 +59,7 @@ class CachePoolsTest extends WebTestCase
 
     public function doTestCachePools($options, $adapterClass)
     {
-        $container = static::createContainer($options);
+        $container = static::getContainer($options);
 
         $pool = $container->get('cache.test');
         $this->assertInstanceOf($adapterClass, $pool);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no (according to _the promise_; but adds method with obvious name that might cause regressions)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This is just a tiny "extract class" refactoring. Every now and then, I need to write tests that depend on a service with everything behind it, and every time I wrote these lines again.