### PR TITLE
[SecurityBundle] Fix term width in UserPasswordEncoderCommandTest

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/UserPasswordEncoderCommandTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/UserPasswordEncoderCommandTest.php
@@ -144,7 +144,7 @@ class UserPasswordEncoderCommandTest extends WebTestCase
         $kernel->boot();
 
         $application = new Application($kernel);
-        $application->setTerminalDimensions(120, 80);
+        $application->setTerminalDimensions(119 + strlen(PHP_EOL), 80);
 
         $application->add(new UserPasswordEncoderCommand());
         $passwordEncoderCommand = $application->find('security:encode-password');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

