### PR TITLE
[WebProfilerBundle] check for <title> instead of </body> for injecting toolbar

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
@@ -25,8 +25,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  *
  * The onKernelResponse method must be connected to the kernel.response event.
  *
- * The WDT is only injected on well-formed HTML (with a proper </body> tag).
- * This means that the WDT is never included in sub-requests or ESI requests.
+ * The WDT is only injected on well-formed HTML (with a proper <title> tag).
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
@@ -117,7 +116,7 @@ class WebDebugToolbarListener implements EventSubscriberInterface
     protected function injectToolbar(Response $response, Request $request, array $nonces)
     {
         $content = $response->getContent();
-        $pos = strripos($content, '</body>');
+        $pos = stripos($content, '<title>');
 
         if (false !== $pos) {
             $toolbar = "\n".str_replace("\n", '', $this->twig->render(

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -1,13 +1,14 @@
-<div id="sfwdt{{ token }}" class="sf-toolbar sf-display-none"></div>
 {{ include('@WebProfiler/Profiler/base_js.html.twig') }}
 <script{% if csp_script_nonce %} nonce={{ csp_script_nonce }}{% endif %}>/*<![CDATA[*/
-    (function () {
+    Sfjs.addEventListener(document, 'DOMContentLoaded', function () {
+        var sfwdt = document.createElement('div');
+        sfwdt.id = 'sfwdt{{ token }}';
+        sfwdt.className = 'sf-toolbar sf-display-none';
+
         {% if 'top' == position %}
-            var sfwdt = document.getElementById('sfwdt{{ token }}');
-            document.body.insertBefore(
-                document.body.removeChild(sfwdt),
-                document.body.firstChild
-            );
+            document.body.insertBefore(sfwdt, document.body.firstChild);
+        {% else %}
+            document.body.appendChild(sfwdt);
         {% endif %}
 
         Sfjs.load(
@@ -97,5 +98,5 @@
             },
             { maxTries: 5 }
         );
-    })();
+    });
 /*]]>*/</script>

--- a/src/Symfony/Bundle/WebProfilerBundle/Twig/WebProfilerExtension.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Twig/WebProfilerExtension.php
@@ -107,7 +107,7 @@ class WebProfilerExtension extends \Twig_Extension_Profiler
     }
 
     /**
-     * @deprecated since 3.2, to be removed in 4.0. Use the dumpData() method instead.
+     * @deprecated since 3.2, to be removed in 4.0. Use the dumpData() method instead
      */
     public function dumpValue($value)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20339 
| License       | MIT

Follow-up of #20343 where it was revealed the bug couldn't be fixed without BC break. Now we check for `<title>` only so BC break is for people who don't have this tag and thus, invalid HTML.