### PR TITLE
[Security] Fix context listener misbehaviour

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -166,13 +166,13 @@ class ContextListener implements ListenerInterface
 
                 return $token;
             } catch (UnsupportedUserException $e) {
-                // let's try the next user provider
+                continue;
             } catch (UsernameNotFoundException $e) {
                 if (null !== $this->logger) {
                     $this->logger->warning('Username could not be found in the selected user provider.', array('username' => $e->getUsername(), 'provider' => get_class($provider)));
                 }
 
-                return;
+                continue;
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #4498
| License       | MIT
| Doc PR        | |

The implementation of `ContextListener` is not logical.

Here is the actual difference between the `ContextListener` and the `ChainUserProvider`.
The `ContextListener` will only loop if the provider throws an `UnsupportedUserException`:

```php
foreach ($this->userProviders as $provider) {
    try {
        // …
        return $token;
    } catch (UnsupportedUserException $e) {
        // let's try the next user provider
    } catch (UsernameNotFoundException $e) {
        if (null !== $this->logger) {
            $this->logger->warning('Username could not be found in the selected user provider.', array('username' => $e->getUsername(), 'provider' => get_class($provider)));
        }

        return;
    }
}
```

The `ChainUserProvider` on the other hand, will try to refresh the user with every provider even if the user was not found : 

```php
foreach ($this->providers as $provider) {
    try {
        return $provider->refreshUser($user);
    } catch (UnsupportedUserException $e) {
        // try next one
    } catch (UsernameNotFoundException $e) {
        $supportedUserFound = true;
        // try next one
    }
}
```

This is not only undocumented, it is also very disturbing. This leads to strange behaviours: If you had not set a chain provider, the login is successful but right after the redirection you're anonymous again without form error.

We really need to fix this incoherent behaviour. `ChainProvider` should be necessary only if you want to use multiple providers for **a specific firewall**.