### PR TITLE
[SecurityBundle] Make the FirewallConfig class final

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallConfig.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallConfig.php
@@ -14,7 +14,7 @@ namespace Symfony\Bundle\SecurityBundle\Security;
 /**
  * @author Robin Chalas <robin.chalas@gmail.com>
  */
-class FirewallConfig
+final class FirewallConfig
 {
     private $name;
     private $requestMatcher;

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallContextTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallContextTest.php
@@ -20,10 +20,7 @@ class FirewallContextTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetters()
     {
-        $config = $this
-            ->getMockBuilder(FirewallConfig::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $config = new FirewallConfig('main', 'request_matcher');
 
         $exceptionListener = $this
             ->getMockBuilder(ExceptionListener::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

I suggest to make the `FirewallConfig` class final. This value object is only built by the `SecurityExtension` from the `SecurityBundle` and is not meant to be an extension point.

ping @chalasr 