### PR TITLE
[SecurityBundle] consistent "not authenticated" output in WDT

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -34,7 +34,8 @@
                 </div>
             {% else %}
                 <div class="sf-toolbar-info-piece">
-                    <span>You are not authenticated.</span>
+                    <b>Authenticated</b>
+                    <span class="sf-toolbar-status sf-toolbar-status-red">No</span>
                 </div>
             {% endif %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

This makes the output in the toolbar when no token is present consistent
with what it looks like when there is a token.

**Before**:

<img width="335" alt="before" src="https://cloud.githubusercontent.com/assets/1957048/20016982/0841bde2-a2c2-11e6-8ec2-0bea84290e00.png">

**After**:

<img width="278" alt="after" src="https://cloud.githubusercontent.com/assets/1957048/20016981/083f3fae-a2c2-11e6-9ac0-0ad35b816411.png">