### PR TITLE
[SecurityBundle] Rename FirewallContext#getContext()

### DIFF
--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -12,3 +12,9 @@ Security
 
  * The `RoleInterface` has been deprecated. Extend the `Symfony\Component\Security\Core\Role\Role`
    class in your custom role implementations instead.
+
+SecurityBundle
+--------------
+
+ * The `FirewallContext::getContext()` method has been deprecated and will be removed in 4.0.
+   Use the `getListeners()` method instead.

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -134,6 +134,11 @@ FrameworkBundle
    `serializer.mapping.cache.apc` and `serializer.mapping.cache.doctrine.apc`
    have been removed. APCu should now be automatically used when available.
 
+SecurityBundle
+--------------
+
+ * The `FirewallContext::getContext()` method has been removed, use the `getListeners()` method instead.
+
 HttpFoundation
 ---------------
 

--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallContext.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallContext.php
@@ -37,7 +37,17 @@ class FirewallContext
         return $this->config;
     }
 
+    /**
+     * @deprecated since version 3.3, will be removed in 4.0. Use {@link getListeners()} instead.
+     */
     public function getContext()
+    {
+        @trigger_error(sprintf('Method %s() is deprecated since version 3.3 and will be removed in 4.0. Use %s::getListeners() instead.', __METHOD__, __CLASS__), E_USER_DEPRECATED);
+
+        return $this->getListeners();
+    }
+
+    public function getListeners()
     {
         return array($this->listeners, $this->exceptionListener);
     }

--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
@@ -46,7 +46,7 @@ class FirewallMap implements FirewallMapInterface
             return array(array(), null);
         }
 
-        return $context->getContext();
+        return $context->getListeners();
     }
 
     /**

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallContextTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallContextTest.php
@@ -21,12 +21,7 @@ class FirewallContextTest extends \PHPUnit_Framework_TestCase
     public function testGetters()
     {
         $config = new FirewallConfig('main', 'user_checker', 'request_matcher');
-
-        $exceptionListener = $this
-            ->getMockBuilder(ExceptionListener::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $exceptionListener = $this->getExceptionListenerMock();
         $listeners = array(
             $this
                 ->getMockBuilder(ListenerInterface::class)
@@ -36,7 +31,25 @@ class FirewallContextTest extends \PHPUnit_Framework_TestCase
 
         $context = new FirewallContext($listeners, $exceptionListener, $config);
 
-        $this->assertEquals(array($listeners, $exceptionListener), $context->getContext());
+        $this->assertEquals(array($listeners, $exceptionListener), $context->getListeners());
         $this->assertEquals($config, $context->getConfig());
+    }
+
+    /**
+     * @expectedDeprecation Method Symfony\Bundle\SecurityBundle\Security\FirewallContext::getContext() is deprecated since version 3.3 and will be removed in 4.0. Use Symfony\Bundle\SecurityBundle\Security\FirewallContext::getListeners() instead.
+     * @group legacy
+     */
+    public function testGetContextTriggersDeprecation()
+    {
+        (new FirewallContext(array(), $this->getExceptionListenerMock(), new FirewallConfig('main', 'request_matcher', 'user_checker')))
+            ->getContext();
+    }
+
+    private function getExceptionListenerMock()
+    {
+        return $this
+            ->getMockBuilder(ExceptionListener::class)
+            ->disableOriginalConstructor()
+            ->getMock();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

As pointed out in https://github.com/symfony/symfony/pull/19398#r86254648, the name of this method is misleading. 
Because a public service using this class is created for each defined firewall, I suggest to change it to `FirewallContext#getListeners()`, deprecating the current `getContext()` for removing it in 4.0.