### PR TITLE
[HttpFoundation] Fix Request::preparePathInfo with rewrites

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1280,6 +1280,22 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $request->initialize(array(), array(), array(), array(), array(), $server);
 
         $this->assertEquals('/path%20test/info', $request->getPathInfo());
+
+        $server = array();
+        $server['REQUEST_URI'] = '/path/info';
+        $server['PATH_INFO'] = '/info';
+        $request->initialize(array(), array(), array(), array(), array(), $server);
+
+        $this->assertEquals('/info', $request->getPathInfo());
+
+        $server = array();
+        $server['REQUEST_URI'] = '/app.php/path/info';
+        $server['SCRIPT_FILENAME'] = '/webroot/web/app.php';
+        $server['SCRIPT_NAME'] = '/web/app.php';
+        $server['PHP_SELF'] = '/web/app.php';
+        $request->initialize(array(), array(), array(), array(), array(), $server);
+
+        $this->assertEquals('/path/info', $request->getPathInfo());
     }
 
     public function testGetParameterPrecedence()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #14064
| License       | MIT
| Doc PR        | n/a

preparePathInfo naively strips strlen($baseUrl) characters off the
front of the requestUri. If the request has passed through url
rewriting by the server, this may strip an incorrect amount of
characters off of the PathInfo causing all routes to mismatch

Additionally, the server may set PATH_INFO which would save us
all of this work in the first place, so use that if we've got it.