### PR TITLE
Revert "bug #20184 [FrameworkBundle] Convert null prefix to an empty string in translation:update (chalasr)"

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -118,9 +118,8 @@ EOF
         // load any messages from templates
         $extractedCatalogue = new MessageCatalogue($input->getArgument('locale'));
         $output->text('Parsing templates');
-        $prefix = $input->getOption('prefix');
         $extractor = $this->getContainer()->get('translation.extractor');
-        $extractor->setPrefix(null === $prefix ? '' : $prefix);
+        $extractor->setPrefix($input->getOption('prefix'));
         foreach ($transPaths as $path) {
             $path .= 'views';
             if (is_dir($path)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/20184#discussion_r85265689
| License       | MIT
| Doc PR        | n/a

This reverts commit 3f650f8 because the fix is not valid.
It is actually not possible to have an option with value optional given empty to be `empty` if this one has a default value. The default value will always be the one returned, see https://github.com/symfony/symfony/pull/20184#discussion_r85265689 for details.