### PR TITLE
[Workflow] Added DefinitionInterface

### DIFF
--- a/src/Symfony/Component/Workflow/Definition.php
+++ b/src/Symfony/Component/Workflow/Definition.php
@@ -18,7 +18,7 @@ use Symfony\Component\Workflow\Exception\LogicException;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  */
-class Definition
+class Definition implements DefinitionInterface
 {
     private $places = array();
     private $transitions = array();

--- a/src/Symfony/Component/Workflow/DefinitionInterface.php
+++ b/src/Symfony/Component/Workflow/DefinitionInterface.php
@@ -1,0 +1,28 @@
+<?php
+namespace Symfony\Component\Workflow;
+
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+interface DefinitionInterface
+{
+    /**
+     * Get the initial place
+     *
+     * @return string
+     */
+    public function getInitialPlace();
+
+    /**
+     * Get all the places
+     *
+     * @return string[]
+     */
+    public function getPlaces();
+
+    /**
+     * @return Transition[]
+     */
+    public function getTransitions();
+}

--- a/src/Symfony/Component/Workflow/DefinitionInterface.php
+++ b/src/Symfony/Component/Workflow/DefinitionInterface.php
@@ -1,6 +1,15 @@
 <?php
-namespace Symfony\Component\Workflow;
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Workflow;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
@@ -8,14 +17,14 @@ namespace Symfony\Component\Workflow;
 interface DefinitionInterface
 {
     /**
-     * Get the initial place
+     * Get the initial place.
      *
      * @return string
      */
     public function getInitialPlace();
 
     /**
-     * Get all the places
+     * Get all the places.
      *
      * @return string[]
      */

--- a/src/Symfony/Component/Workflow/Dumper/DumperInterface.php
+++ b/src/Symfony/Component/Workflow/Dumper/DumperInterface.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Workflow\Dumper;
 
-use Symfony\Component\Workflow\Definition;
+use Symfony\Component\Workflow\DefinitionInterface;
 use Symfony\Component\Workflow\Marking;
 
 /**
@@ -25,11 +25,11 @@ interface DumperInterface
     /**
      * Dumps a workflow definition.
      *
-     * @param Definition   $definition A Definition instance
-     * @param Marking|null $marking    A Marking instance
-     * @param array        $options    An array of options
+     * @param DefinitionInterface $definition A Definition instance
+     * @param Marking|null $marking A Marking instance
+     * @param array $options An array of options
      *
      * @return string The representation of the workflow
      */
-    public function dump(Definition $definition, Marking $marking = null, array $options = array());
+    public function dump(DefinitionInterface $definition, Marking $marking = null, array $options = array());
 }

--- a/src/Symfony/Component/Workflow/Dumper/DumperInterface.php
+++ b/src/Symfony/Component/Workflow/Dumper/DumperInterface.php
@@ -26,8 +26,8 @@ interface DumperInterface
      * Dumps a workflow definition.
      *
      * @param DefinitionInterface $definition A Definition instance
-     * @param Marking|null $marking A Marking instance
-     * @param array $options An array of options
+     * @param Marking|null        $marking    A Marking instance
+     * @param array               $options    An array of options
      *
      * @return string The representation of the workflow
      */

--- a/src/Symfony/Component/Workflow/Dumper/GraphvizDumper.php
+++ b/src/Symfony/Component/Workflow/Dumper/GraphvizDumper.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Workflow\Dumper;
 
-use Symfony\Component\Workflow\Definition;
+use Symfony\Component\Workflow\DefinitionInterface;
 use Symfony\Component\Workflow\Marking;
 
 /**
@@ -43,7 +43,7 @@ class GraphvizDumper implements DumperInterface
      *  * node: The default options for nodes (places + transitions)
      *  * edge: The default options for edges
      */
-    public function dump(Definition $definition, Marking $marking = null, array $options = array())
+    public function dump(DefinitionInterface $definition, Marking $marking = null, array $options = array())
     {
         $places = $this->findPlaces($definition, $marking);
         $transitions = $this->findTransitions($definition);
@@ -58,7 +58,7 @@ class GraphvizDumper implements DumperInterface
             .$this->endDot();
     }
 
-    private function findPlaces(Definition $definition, Marking $marking = null)
+    private function findPlaces(DefinitionInterface $definition, Marking $marking = null)
     {
         $places = array();
 
@@ -79,7 +79,7 @@ class GraphvizDumper implements DumperInterface
         return $places;
     }
 
-    private function findTransitions(Definition $definition)
+    private function findTransitions(DefinitionInterface $definition)
     {
         $transitions = array();
 
@@ -123,7 +123,7 @@ class GraphvizDumper implements DumperInterface
         return $code;
     }
 
-    private function findEdges(Definition $definition)
+    private function findEdges(DefinitionInterface $definition)
     {
         $dotEdges = array();
 

--- a/src/Symfony/Component/Workflow/StateMachine.php
+++ b/src/Symfony/Component/Workflow/StateMachine.php
@@ -11,7 +11,7 @@ use Symfony\Component\Workflow\MarkingStore\ScalarMarkingStore;
  */
 class StateMachine extends Workflow
 {
-    public function __construct(Definition $definition, MarkingStoreInterface $markingStore = null, EventDispatcherInterface $dispatcher = null, $name = 'unnamed')
+    public function __construct(DefinitionInterface $definition, MarkingStoreInterface $markingStore = null, EventDispatcherInterface $dispatcher = null, $name = 'unnamed')
     {
         parent::__construct($definition, $markingStore ?: new ScalarMarkingStore(), $dispatcher, $name);
     }

--- a/src/Symfony/Component/Workflow/Validator/DefinitionValidatorInterface.php
+++ b/src/Symfony/Component/Workflow/Validator/DefinitionValidatorInterface.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Workflow\Validator;
 
 use Symfony\Component\Workflow\Definition;
+use Symfony\Component\Workflow\DefinitionInterface;
 use Symfony\Component\Workflow\Exception\InvalidDefinitionException;
 
 /**
@@ -20,12 +21,12 @@ use Symfony\Component\Workflow\Exception\InvalidDefinitionException;
 interface DefinitionValidatorInterface
 {
     /**
-     * @param Definition $definition
+     * @param DefinitionInterface $definition
      * @param string     $name
      *
      * @return bool
      *
      * @throws InvalidDefinitionException on invalid definition
      */
-    public function validate(Definition $definition, $name);
+    public function validate(DefinitionInterface $definition, $name);
 }

--- a/src/Symfony/Component/Workflow/Validator/DefinitionValidatorInterface.php
+++ b/src/Symfony/Component/Workflow/Validator/DefinitionValidatorInterface.php
@@ -22,7 +22,7 @@ interface DefinitionValidatorInterface
 {
     /**
      * @param DefinitionInterface $definition
-     * @param string     $name
+     * @param string              $name
      *
      * @return bool
      *

--- a/src/Symfony/Component/Workflow/Validator/SinglePlaceWorkflowValidator.php
+++ b/src/Symfony/Component/Workflow/Validator/SinglePlaceWorkflowValidator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Workflow\Validator;
 
-use Symfony\Component\Workflow\Definition;
 use Symfony\Component\Workflow\DefinitionInterface;
 use Symfony\Component\Workflow\Exception\InvalidDefinitionException;
 

--- a/src/Symfony/Component/Workflow/Validator/SinglePlaceWorkflowValidator.php
+++ b/src/Symfony/Component/Workflow/Validator/SinglePlaceWorkflowValidator.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Workflow\Validator;
 
 use Symfony\Component\Workflow\Definition;
+use Symfony\Component\Workflow\DefinitionInterface;
 use Symfony\Component\Workflow\Exception\InvalidDefinitionException;
 
 /**
@@ -21,7 +22,7 @@ use Symfony\Component\Workflow\Exception\InvalidDefinitionException;
  */
 class SinglePlaceWorkflowValidator extends WorkflowValidator
 {
-    public function validate(Definition $definition, $name)
+    public function validate(DefinitionInterface $definition, $name)
     {
         foreach ($definition->getTransitions() as $transition) {
             if (1 < count($transition->getTos())) {

--- a/src/Symfony/Component/Workflow/Validator/StateMachineValidator.php
+++ b/src/Symfony/Component/Workflow/Validator/StateMachineValidator.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Workflow\Validator;
 
 use Symfony\Component\Workflow\Definition;
+use Symfony\Component\Workflow\DefinitionInterface;
 use Symfony\Component\Workflow\Exception\InvalidDefinitionException;
 
 /**
@@ -19,7 +20,7 @@ use Symfony\Component\Workflow\Exception\InvalidDefinitionException;
  */
 class StateMachineValidator implements DefinitionValidatorInterface
 {
-    public function validate(Definition $definition, $name)
+    public function validate(DefinitionInterface $definition, $name)
     {
         $transitionFromNames = array();
         foreach ($definition->getTransitions() as $transition) {

--- a/src/Symfony/Component/Workflow/Validator/StateMachineValidator.php
+++ b/src/Symfony/Component/Workflow/Validator/StateMachineValidator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Workflow\Validator;
 
-use Symfony\Component\Workflow\Definition;
 use Symfony\Component\Workflow\DefinitionInterface;
 use Symfony\Component\Workflow\Exception\InvalidDefinitionException;
 

--- a/src/Symfony/Component/Workflow/Validator/WorkflowValidator.php
+++ b/src/Symfony/Component/Workflow/Validator/WorkflowValidator.php
@@ -12,13 +12,14 @@
 namespace Symfony\Component\Workflow\Validator;
 
 use Symfony\Component\Workflow\Definition;
+use Symfony\Component\Workflow\DefinitionInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
 class WorkflowValidator implements DefinitionValidatorInterface
 {
-    public function validate(Definition $definition, $name)
+    public function validate(DefinitionInterface $definition, $name)
     {
     }
 }

--- a/src/Symfony/Component/Workflow/Validator/WorkflowValidator.php
+++ b/src/Symfony/Component/Workflow/Validator/WorkflowValidator.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Workflow\Validator;
 
-use Symfony\Component\Workflow\Definition;
 use Symfony\Component\Workflow\DefinitionInterface;
 
 /**

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -30,7 +30,7 @@ class Workflow
     private $dispatcher;
     private $name;
 
-    public function __construct(Definition $definition, MarkingStoreInterface $markingStore = null, EventDispatcherInterface $dispatcher = null, $name = 'unnamed')
+    public function __construct(DefinitionInterface $definition, MarkingStoreInterface $markingStore = null, EventDispatcherInterface $dispatcher = null, $name = 'unnamed')
     {
         $this->definition = $definition;
         $this->markingStore = $markingStore ?: new PropertyAccessorMarkingStore();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This PR adds an interface for the `Definition`. Following up on the discussions here: https://github.com/symfony/symfony/pull/19629#discussion_r86739886

The Definition of a Workflow should not be changed after the workflow has been created. That means we should always consider the Definition as immutable after this point. By introducing this interface, we have the possibility create an `ImmutableDefinition` and make the `workflow.[name].definition` service public. 

Ping @lyrixx 
