### PR TITLE
debug service with one line by tag

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -257,7 +257,7 @@ class TextDescriptor extends Descriptor
 
         $tags = $definition->getTags();
         if (count($tags)) {
-            $tagInformation = '';
+            $tagInformation = array();
             foreach ($tags as $tagName => $tagData) {
                 foreach ($tagData as $tagParameters) {
                     $parameters = array_map(function ($key, $value) {
@@ -266,12 +266,13 @@ class TextDescriptor extends Descriptor
                     $parameters = implode(', ', $parameters);
 
                     if ('' === $parameters) {
-                        $tagInformation .= sprintf('%s', $tagName);
+                        $tagInformation[] = sprintf('%s', $tagName);
                     } else {
-                        $tagInformation .= sprintf('%s (%s)', $tagName, $parameters);
+                        $tagInformation[] = sprintf('%s (%s)', $tagName, $parameters);
                     }
                 }
             }
+            $tagInformation = implode("\n", $tagInformation);
         } else {
             $tagInformation = '-';
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.txt
@@ -6,11 +6,11 @@
   Tags               tag1 ([32mattr1[39m: val1, [32mattr2[39m: val2)  
                      tag1 ([32mattr3[39m: val3)               
                      tag2                             
-  Calls              setMailer                        
+  Scope              container                        
   Public             no                               
   Synthetic          yes                              
   Lazy               no                               
-  Shared             yes                              
+  Synchronized       no                               
   Abstract           no                               
   Autowired          no                               
   Autowiring Types   -                                

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_2.txt
@@ -1,18 +1,21 @@
------------------- ------------------------------------------------------- 
- [32m Option           [39m [32m Value                                                 [39m 
- ------------------ ------------------------------------------------------- 
-  Service ID         -                                                      
-  Class              Full\Qualified\Class2                                  
-  Tags               tag1 ([32mattr1[39m: val1, [32mattr2[39m: val2)tag1 ([32mattr3[39m: val3)tag2  
-  Scope              container                                              
-  Public             no                                                     
-  Synthetic          yes                                                    
-  Lazy               no                                                     
-  Synchronized       no                                                     
-  Abstract           no                                                     
-  Autowired          no                                                     
-  Autowiring Types   -                                                      
-  Required File      /path/to/file                                          
-  Factory Service    factory.service                                        
-  Factory Method     get                                                    
- ------------------ -------------------------------------------------------
+ ------------------ --------------------------------- 
+ [32m Option           [39m [32m Value                           [39m 
+ ------------------ --------------------------------- 
+  Service ID         -                                
+  Class              Full\Qualified\Class2            
+  Tags               tag1 ([32mattr1[39m: val1, [32mattr2[39m: val2)  
+                     tag1 ([32mattr3[39m: val3)               
+                     tag2                             
+  Calls              setMailer                        
+  Public             no                               
+  Synthetic          yes                              
+  Lazy               no                               
+  Shared             yes                              
+  Abstract           no                               
+  Autowired          no                               
+  Autowiring Types   -                                
+  Required File      /path/to/file                    
+  Factory Service    factory.service                  
+  Factory Method     get                              
+ ------------------ --------------------------------- 
+

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/legacy_synchronized_service_definition_2.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/legacy_synchronized_service_definition_2.txt
@@ -1,18 +1,21 @@
------------------- ------------------------------------------------------- 
- [32m Option           [39m [32m Value                                                 [39m 
- ------------------ ------------------------------------------------------- 
-  Service ID         -                                                      
-  Class              Full\Qualified\Class2                                  
-  Tags               tag1 ([32mattr1[39m: val1, [32mattr2[39m: val2)tag1 ([32mattr3[39m: val3)tag2  
-  Scope              container                                              
-  Public             no                                                     
-  Synthetic          yes                                                    
-  Lazy               no                                                     
-  Synchronized       no                                                     
-  Abstract           no                                                     
-  Autowired          no                                                     
-  Autowiring Types   -                                                      
-  Required File      /path/to/file                                          
-  Factory Service    factory.service                                        
-  Factory Method     get                                                    
- ------------------ -------------------------------------------------------
+ ------------------ --------------------------------- 
+ [32m Option           [39m [32m Value                           [39m 
+ ------------------ --------------------------------- 
+  Service ID         -                                
+  Class              Full\Qualified\Class2            
+  Tags               tag1 ([32mattr1[39m: val1, [32mattr2[39m: val2)  
+                     tag1 ([32mattr3[39m: val3)               
+                     tag2                             
+  Scope              container                        
+  Public             no                               
+  Synthetic          yes                              
+  Lazy               no                               
+  Synchronized       no                               
+  Abstract           no                               
+  Autowired          no                               
+  Autowiring Types   -                                
+  Required File      /path/to/file                    
+  Factory Service    factory.service                  
+  Factory Method     get                              
+ ------------------ --------------------------------- 
+


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8, 3.*
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Since the 2.8 branch, the `debug:container` command output service tags in one single line. 
So if the debugged service have many tags, this print an unreadable large table.

This PR solve this issue by printing one line by tag.