### PR TITLE
[ClassLoader] Fix ClassCollectionLoader inlining with __halt_compiler

### DIFF
--- a/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
@@ -106,6 +106,7 @@ class ClassCollectionLoader
 
         $c = '(?:\s*+(?:(?:#|//)[^\n]*+\n|/\*(?:(?<!\*/).)++)?+)*+';
         $strictTypesRegex = str_replace('.', $c, "'^<\?php\s.declare.\(.strict_types.=.1.\).;'is");
+        $haltCompilerRegex = str_replace('.', $c, "'\b__halt_compiler.\(.\)'is");
 
         $cacheDir = explode(DIRECTORY_SEPARATOR, $cacheDir);
         $files = array();
@@ -118,7 +119,7 @@ class ClassCollectionLoader
             $files[] = $file = $class->getFileName();
             $c = file_get_contents($file);
 
-            if (preg_match($strictTypesRegex, $c)) {
+            if (preg_match($strictTypesRegex, $c) || preg_match($haltCompilerRegex, $c)) {
                 $file = explode(DIRECTORY_SEPARATOR, $file);
 
                 for ($i = 0; isset($file[$i], $cacheDir[$i]); ++$i) {

--- a/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
@@ -104,9 +104,15 @@ class ClassCollectionLoader
             }
         }
 
-        $c = '(?:\s*+(?:(?:#|//)[^\n]*+\n|/\*(?:(?<!\*/).)++)?+)*+';
-        $strictTypesRegex = str_replace('.', $c, "'^<\?php\s.declare.\(.strict_types.=.1.\).;'is");
-        $haltCompilerRegex = str_replace('.', $c, "'\b__halt_compiler.\(.\)'is");
+        $spacesRegex = '(?:\s*+(?:(?:\#|//)[^\n]*+\n|/\*(?:(?<!\*/).)++)?+)*+';
+        $dontInlineRegex = <<<REGEX
+            '(?:
+               ^<\?php\s.declare.\(.strict_types.=.1.\).;
+               | \b__halt_compiler.\(.\)
+               | \b__(?:DIR|FILE)__\b
+            )'isx
+REGEX;
+        $dontInlineRegex = str_replace('.', $spacesRegex, $dontInlineRegex);
 
         $cacheDir = explode(DIRECTORY_SEPARATOR, $cacheDir);
         $files = array();
@@ -119,7 +125,7 @@ class ClassCollectionLoader
             $files[] = $file = $class->getFileName();
             $c = file_get_contents($file);
 
-            if (preg_match($strictTypesRegex, $c) || preg_match($haltCompilerRegex, $c)) {
+            if (preg_match($dontInlineRegex, $c)) {
                 $file = explode(DIRECTORY_SEPARATOR, $file);
 
                 for ($i = 0; isset($file[$i], $cacheDir[$i]); ++$i) {

--- a/src/Symfony/Component/ClassLoader/Tests/ClassCollectionLoaderTest.php
+++ b/src/Symfony/Component/ClassLoader/Tests/ClassCollectionLoaderTest.php
@@ -235,7 +235,7 @@ class ClassCollectionLoaderTest extends \PHPUnit_Framework_TestCase
         $strictTypes = defined('HHVM_VERSION') ? '' : "\nnamespace {require __DIR__.'/Fixtures/Namespaced/WithStrictTypes.php';}";
 
         ClassCollectionLoader::load(
-            array('Namespaced\\WithComments', 'Pearlike_WithComments', 'Namespaced\\WithHaltCompiler', $strictTypes ? 'Namespaced\\WithStrictTypes' : 'Namespaced\\WithComments'),
+            array('Namespaced\\WithComments', 'Pearlike_WithComments', 'Namespaced\\WithDirMagic', 'Namespaced\\WithFileMagic', 'Namespaced\\WithHaltCompiler', $strictTypes ? 'Namespaced\\WithStrictTypes' : 'Namespaced\\WithComments'),
             __DIR__,
             'bar',
             false
@@ -275,6 +275,8 @@ class Pearlike_WithComments
 public static $loaded = true;
 }
 }
+namespace {require __DIR__.'/Fixtures/Namespaced/WithDirMagic.php';}
+namespace {require __DIR__.'/Fixtures/Namespaced/WithFileMagic.php';}
 namespace {require __DIR__.'/Fixtures/Namespaced/WithHaltCompiler.php';}
 EOF
             .$strictTypes,

--- a/src/Symfony/Component/ClassLoader/Tests/ClassCollectionLoaderTest.php
+++ b/src/Symfony/Component/ClassLoader/Tests/ClassCollectionLoaderTest.php
@@ -235,7 +235,7 @@ class ClassCollectionLoaderTest extends \PHPUnit_Framework_TestCase
         $strictTypes = defined('HHVM_VERSION') ? '' : "\nnamespace {require __DIR__.'/Fixtures/Namespaced/WithStrictTypes.php';}";
 
         ClassCollectionLoader::load(
-            array('Namespaced\\WithComments', 'Pearlike_WithComments', $strictTypes ? 'Namespaced\\WithStrictTypes' : 'Namespaced\\WithComments'),
+            array('Namespaced\\WithComments', 'Pearlike_WithComments', 'Namespaced\\WithHaltCompiler', $strictTypes ? 'Namespaced\\WithStrictTypes' : 'Namespaced\\WithComments'),
             __DIR__,
             'bar',
             false
@@ -275,6 +275,7 @@ class Pearlike_WithComments
 public static $loaded = true;
 }
 }
+namespace {require __DIR__.'/Fixtures/Namespaced/WithHaltCompiler.php';}
 EOF
             .$strictTypes,
             str_replace(array("<?php \n", '\\\\'), array('', '/'), file_get_contents($file))

--- a/src/Symfony/Component/ClassLoader/Tests/ClassMapGeneratorTest.php
+++ b/src/Symfony/Component/ClassLoader/Tests/ClassMapGeneratorTest.php
@@ -76,9 +76,9 @@ class ClassMapGeneratorTest extends \PHPUnit_Framework_TestCase
                 'Namespaced\\Foo' => realpath(__DIR__).'/Fixtures/Namespaced/Foo.php',
                 'Namespaced\\Baz' => realpath(__DIR__).'/Fixtures/Namespaced/Baz.php',
                 'Namespaced\\WithComments' => realpath(__DIR__).'/Fixtures/Namespaced/WithComments.php',
-                'Namespaced\WithStrictTypes' => realpath(__DIR__).'/Fixtures/Namespaced/WithStrictTypes.php',
-                ),
-            ),
+                'Namespaced\\WithStrictTypes' => realpath(__DIR__).'/Fixtures/Namespaced/WithStrictTypes.php',
+                'Namespaced\\WithHaltCompiler' => realpath(__DIR__).'/Fixtures/Namespaced/WithHaltCompiler.php',
+            )),
             array(__DIR__.'/Fixtures/beta/NamespaceCollision', array(
                 'NamespaceCollision\\A\\B\\Bar' => realpath(__DIR__).'/Fixtures/beta/NamespaceCollision/A/B/Bar.php',
                 'NamespaceCollision\\A\\B\\Foo' => realpath(__DIR__).'/Fixtures/beta/NamespaceCollision/A/B/Foo.php',

--- a/src/Symfony/Component/ClassLoader/Tests/ClassMapGeneratorTest.php
+++ b/src/Symfony/Component/ClassLoader/Tests/ClassMapGeneratorTest.php
@@ -78,6 +78,8 @@ class ClassMapGeneratorTest extends \PHPUnit_Framework_TestCase
                 'Namespaced\\WithComments' => realpath(__DIR__).'/Fixtures/Namespaced/WithComments.php',
                 'Namespaced\\WithStrictTypes' => realpath(__DIR__).'/Fixtures/Namespaced/WithStrictTypes.php',
                 'Namespaced\\WithHaltCompiler' => realpath(__DIR__).'/Fixtures/Namespaced/WithHaltCompiler.php',
+                'Namespaced\\WithDirMagic' => realpath(__DIR__).'/Fixtures/Namespaced/WithDirMagic.php',
+                'Namespaced\\WithFileMagic' => realpath(__DIR__).'/Fixtures/Namespaced/WithFileMagic.php',
             )),
             array(__DIR__.'/Fixtures/beta/NamespaceCollision', array(
                 'NamespaceCollision\\A\\B\\Bar' => realpath(__DIR__).'/Fixtures/beta/NamespaceCollision/A/B/Bar.php',

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/Namespaced/WithDirMagic.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/Namespaced/WithDirMagic.php
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * foo
+ */
+
+namespace Namespaced;
+
+class WithDirMagic
+{
+    public function getDir()
+    {
+        return __DIR__;
+    }
+}

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/Namespaced/WithFileMagic.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/Namespaced/WithFileMagic.php
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * foo
+ */
+
+namespace Namespaced;
+
+class WithFileMagic
+{
+    public function getFile()
+    {
+        return __FILE__;
+    }
+}

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/Namespaced/WithHaltCompiler.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/Namespaced/WithHaltCompiler.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * foo
+ */
+
+namespace Namespaced;
+
+class WithHaltCompiler
+{
+}
+
+// the end of the script execution
+__halt_compiler(); data
+data
+data
+data
+...


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7+
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | |
| License       | MIT
| Doc PR        | |

I have some PHP classes which ends with an `__halt_compiler` call which fail on production.

This is due to the ClassCollectionLoader inlining the class code (which is followed by random binary data) which breaks PHP parsing of the following classes.

I found this issue while using ZendGuardLoader module, but this apply to whatever php class using this function call.

I've made my fix, based on #19859, and tested it with symfony 2.7 and 2.8
