### PR TITLE
[Workflow] Set the marking then announce enabled transition

### DIFF
--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -126,9 +126,9 @@ class Workflow
 
         $this->enter($subject, $transition, $marking);
 
-        $this->announce($subject, $transition, $marking);
-
         $this->markingStore->setMarking($subject, $marking);
+
+        $this->announce($subject, $transition, $marking);
 
         return $marking;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

It allows to auto-apply some transition from a listener. If we don't do that, the marking is not updated in the listener yet, so the transition is not really enabled.

The feature was asked on [twitter](https://twitter.com/gaetanbuellet/status/796387741420441600) 
And It has been implemented (userland) [here](https://github.com/lyrixx/SFLive-Paris2016-Workflow/commit/9fda92a70572a48a347c69b5eae975fac264d928)
