### PR TITLE
[DomCrawler] Add support for formaction and formmethod attributes

### DIFF
--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -211,6 +211,11 @@ class Form extends Link implements \ArrayAccess
 
     protected function getRawUri()
     {
+        // If the form was created from a button rather than the form node, check for HTML5 action overrides
+        if ($this->button !== $this->node && $this->button->getAttribute('formaction')) {
+            return $this->button->getAttribute('formaction');
+        }
+
         return $this->node->getAttribute('action');
     }
 
@@ -225,6 +230,11 @@ class Form extends Link implements \ArrayAccess
     {
         if (null !== $this->method) {
             return $this->method;
+        }
+
+        // If the form was created from a button rather than the form node, check for HTML5 method override
+        if ($this->button !== $this->node && $this->button->getAttribute('formmethod')) {
+            return strtoupper($this->button->getAttribute('formmethod'));
         }
 
         return $this->node->getAttribute('method') ? strtoupper($this->node->getAttribute('method')) : 'GET';

--- a/src/Symfony/Component/DomCrawler/Tests/FormTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/FormTest.php
@@ -320,6 +320,12 @@ class FormTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('PATCH', $form->getMethod(), '->getMethod() returns the method defined in the constructor if provided');
     }
 
+    public function testGetMethodWithOverride()
+    {
+        $form = $this->createForm('<form method="get"><input type="submit" formmethod="post" /></form>');
+        $this->assertEquals('POST', $form->getMethod(), '->getMethod() returns the method attribute value of the form');
+    }
+
     public function testGetSetValue()
     {
         $form = $this->createForm('<form><input type="text" name="foo" value="foo" /><input type="submit" /></form>');
@@ -525,6 +531,12 @@ class FormTest extends \PHPUnit_Framework_TestCase
     {
         $form = $this->createForm('<form><input type="submit" /></form>', null, 'http://localhost/foo/bar');
         $this->assertEquals('http://localhost/foo/bar', $form->getUri(), '->getUri() returns path if no action defined');
+    }
+
+    public function testGetUriWithActionOverride()
+    {
+        $form = $this->createForm('<form action="/foo"><button type="submit" formaction="/bar" /></form>', null, 'http://localhost/foo/');
+        $this->assertEquals('http://localhost/bar', $form->getUri(), '->getUri() returns absolute URIs');
     }
 
     public function provideGetUriValues()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

This adds supports for the ``formaction`` and ``formmethod`` of submit elements, which override the values defined on the ``<form>`` element.
This works only when you call ``$crawler->form()`` on a Crawler containing a button, not when it contains the ``<form>`` itself of course (as the button override is applied only when using this button to submit, not when using another way).

Other button-level overrides are not implemented:
- ``formtarget`` is useless as we don't implement ``target`` either (the Crawler does not deal with frame-based pages anyway)
- ``formnovalidate`` is ignored, as we don't automatically disable the form validation on ``novalidate`` either, but we require an explicit disabling instead (this might be subject to a separate PR though, as it could make sense)
- ``formenctype`` is ignored as we also ignore ``enctype`` (we always submit file fields, even when missing the proper enctype)