### PR TITLE
[Routing] Fail properly when a route parameter name cannot be used as a PCRE subpattern name

### DIFF
--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -29,11 +29,19 @@ class RouteCompiler implements RouteCompilerInterface
     const SEPARATORS = '/,;.:-_~+*=@|';
 
     /**
+     * The maximum supported length of a PCRE subpattern name
+     * http://pcre.org/current/doc/html/pcre2pattern.html#SEC16
+     *
+     * @var int
+     */
+    const VARIABLE_MAXIMUM_LENGTH = 32;
+
+    /**
      * {@inheritdoc}
      *
      * @throws \LogicException  If a variable is referenced more than once
-     * @throws \DomainException If a variable name is numeric because PHP raises an error for such
-     *                          subpatterns in PCRE and thus would break matching, e.g. "(?P<123>.+)".
+     * @throws \DomainException If a variable name starts with a digit or if it is too long to be successfully used as
+     *                           a PCRE subpattern.
      */
     public static function compile(Route $route)
     {
@@ -95,11 +103,17 @@ class RouteCompiler implements RouteCompilerInterface
             $precedingChar = strlen($precedingText) > 0 ? substr($precedingText, -1) : '';
             $isSeparator = '' !== $precedingChar && false !== strpos(static::SEPARATORS, $precedingChar);
 
-            if (is_numeric($varName)) {
-                throw new \DomainException(sprintf('Variable name "%s" cannot be numeric in route pattern "%s". Please use a different name.', $varName, $pattern));
+            // A PCRE subpattern name must start with a non-digit. Also a PHP variable cannot start a digit so the
+            // variable would not be usable as a Controller action argument.
+            if (preg_match('/^\d/', $varName)) {
+                throw new \DomainException(sprintf('Variable name "%s" cannot start with a digit in route pattern "%s". Please use a different name.', $varName, $pattern));
             }
             if (in_array($varName, $variables)) {
                 throw new \LogicException(sprintf('Route pattern "%s" cannot reference variable name "%s" more than once.', $pattern, $varName));
+            }
+
+            if (strlen($varName) > self::VARIABLE_MAXIMUM_LENGTH) {
+                throw new \DomainException(sprintf('Variable name "%s" cannot be longer than %s characters in route pattern "%s". Please use a shorter name.', $varName, self::VARIABLE_MAXIMUM_LENGTH, $pattern));
             }
 
             if ($isSeparator && strlen($precedingText) > 1) {

--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -103,7 +103,7 @@ class RouteCompiler implements RouteCompilerInterface
             $precedingChar = strlen($precedingText) > 0 ? substr($precedingText, -1) : '';
             $isSeparator = '' !== $precedingChar && false !== strpos(static::SEPARATORS, $precedingChar);
 
-            // A PCRE subpattern name must start with a non-digit. Also a PHP variable cannot start a digit so the
+            // A PCRE subpattern name must start with a non-digit. Also a PHP variable cannot start with a digit so the
             // variable would not be usable as a Controller action argument.
             if (preg_match('/^\d/', $varName)) {
                 throw new \DomainException(sprintf('Variable name "%s" cannot start with a digit in route pattern "%s". Please use a different name.', $varName, $pattern));

--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -30,7 +30,7 @@ class RouteCompiler implements RouteCompilerInterface
 
     /**
      * The maximum supported length of a PCRE subpattern name
-     * http://pcre.org/current/doc/html/pcre2pattern.html#SEC16
+     * http://pcre.org/current/doc/html/pcre2pattern.html#SEC16.
      *
      * @var int
      */
@@ -41,7 +41,7 @@ class RouteCompiler implements RouteCompilerInterface
      *
      * @throws \LogicException  If a variable is referenced more than once
      * @throws \DomainException If a variable name starts with a digit or if it is too long to be successfully used as
-     *                           a PCRE subpattern.
+     *                          a PCRE subpattern.
      */
     public static function compile(Route $route)
     {

--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -33,6 +33,8 @@ class RouteCompiler implements RouteCompilerInterface
      * http://pcre.org/current/doc/html/pcre2pattern.html#SEC16.
      *
      * @var int
+     *
+     * @internal
      */
     const VARIABLE_MAXIMUM_LENGTH = 32;
 

--- a/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Routing\Tests;
 
 use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCompiler;
 
 class RouteCompilerTest extends \PHPUnit_Framework_TestCase
 {
@@ -176,16 +177,16 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider getNumericVariableNames
+     * @dataProvider getVariableNamesStartingWithADigit
      * @expectedException \DomainException
      */
-    public function testRouteWithNumericVariableName($name)
+    public function testRouteWithVariableNameStartingWithADigit($name)
     {
         $route = new Route('/{'.$name.'}');
         $route->compile();
     }
 
-    public function getNumericVariableNames()
+    public function getVariableNamesStartingWithADigit()
     {
         return array(
            array('09'),
@@ -263,5 +264,14 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
                 ),
             ),
         );
+    }
+
+    /**
+     * @expectedException \DomainException
+     */
+    public function testRouteWithTooLongVariableName()
+    {
+        $route = new Route(sprintf('/{%s}', str_repeat('a', RouteCompiler::VARIABLE_MAXIMUM_LENGTH + 1)));
+        $route->compile();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/7139

This is a follow up PR to https://github.com/symfony/symfony/pull/20327.

I also decided to improve the current `is_numeric()` check that is done by a truer one. The current limitation is that a PCRE subpattern name must not start with a digit which is different.