### PR TITLE
[Workflow] Removed definition builder

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -406,7 +406,7 @@ class FrameworkExtension extends Extension
         foreach ($workflows as $name => $workflow) {
             $type = $workflow['type'];
 
-            $transitions = [];
+            $transitions = array();
             foreach ($workflow['transitions'] as $transitionName => $transition) {
                 if ($type === 'workflow') {
                     $transitions[] = new Definition(Workflow\Transition::class, array($transitionName, $transition['from'], $transition['to']));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master" 
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

As of @xabbuh comment in https://github.com/symfony/symfony/pull/20451#discussion_r87398660

We do not really need the definition builder here. 

