### PR TITLE
[FrameworkBundle] Register the ArrayDenormalizer

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.xml
@@ -23,8 +23,13 @@
             <argument type="service" id="serializer.property_accessor" />
             <argument type="service" id="property_info" on-invalid="ignore" />
 
-            <!-- Run after all custom serializers -->
+            <!-- Run after all custom normalizers -->
             <tag name="serializer.normalizer" priority="-1000" />
+        </service>
+
+        <service id="serializer.denormalizer.array" class="Symfony\Component\Serializer\Normalizer\ArrayDenormalizer" public="false">
+            <!-- Run before the object normalizer -->
+            <tag name="serializer.normalizer" priority="-990" />
         </service>
 
         <!-- Loader -->

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SerializerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SerializerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class SerializerTest extends WebTestCase
+{
+    public function testDeserializeArrayOfObject()
+    {
+        static::bootKernel(array('test_case' => 'Serializer'));
+        $container = static::$kernel->getContainer();
+
+        $result = $container->get('serializer')->deserialize('{"bars": [{"id": 1}, {"id": 2}]}', Foo::class, 'json');
+
+        $bar1 = new Bar();
+        $bar1->id = 1;
+        $bar2 = new Bar();
+        $bar2->id = 2;
+
+        $expected = new Foo();
+        $expected->bars = array($bar1, $bar2);
+
+        $this->assertEquals($expected, $result);
+    }
+}
+
+class Foo
+{
+    /**
+     * @var Bar[]
+     */
+    public $bars;
+}
+
+class Bar
+{
+    /**
+     * @var int
+     */
+    public $id;
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SerializerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SerializerTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
+use Symfony\Component\Serializer\Normalizer\DataUriNormalizer;
+
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
@@ -18,6 +20,10 @@ class SerializerTest extends WebTestCase
 {
     public function testDeserializeArrayOfObject()
     {
+        if (!class_exists(DataUriNormalizer::class)) {
+            $this->markTestSkipped('This test is only applicable when using the Symfony Serializer Component version 3.1 or superior.');
+        }
+
         static::bootKernel(array('test_case' => 'Serializer'));
         $container = static::$kernel->getContainer();
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Serializer/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Serializer/bundles.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+
+return array(
+    new FrameworkBundle(),
+);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Serializer/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Serializer/config.yml
@@ -1,0 +1,6 @@
+imports:
+    - { resource: ../config/default.yml }
+
+framework:
+    serializer: { enabled: true }
+    property_info: { enabled: true }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Registers the `ArrayDenormalizer` class in FrameworkBundle.

**Why it's a bug fix?**

Because since 3.1, most normalizers are able to deserialize complex types (e.g.: an object embedded in an object). They use the `Class\Name[]` notation to handle collections.

However, this only works when the `ArrayDenormalizer` has been registered (it is responsible of handling the `[]` notation).
We do it manually in unit tests, but `ArrayDenormalizer` has never been integrated in FrameworkBundle.

See the test case for further details.