### PR TITLE
[FrameworkBundle] Cache pool namespace added to configuration

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -680,6 +680,7 @@ class Configuration implements ConfigurationInterface
                                     ->scalarNode('adapter')->defaultValue('cache.app')->end()
                                     ->booleanNode('public')->defaultFalse()->end()
                                     ->integerNode('default_lifetime')->end()
+                                    ->scalarNode('namespace')->end()
                                     ->scalarNode('provider')
                                         ->info('The service name to use as provider when the specified adapter needs one.')
                                     ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -224,6 +224,7 @@
         <xsd:attribute name="adapter" type="xsd:string" />
         <xsd:attribute name="public" type="xsd:boolean" />
         <xsd:attribute name="default-lifetime" type="xsd:integer" />
+        <xsd:attribute name="namespace" type="xsd:string" />
         <xsd:attribute name="provider" type="xsd:string" />
         <xsd:attribute name="clearer" type="xsd:string" />
     </xsd:complexType>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache.php
@@ -6,6 +6,7 @@ $container->loadFromExtension('framework', array(
             'cache.foo' => array(
                 'adapter' => 'cache.adapter.apcu',
                 'default_lifetime' => 30,
+                'namespace' => 'foo_',
             ),
             'cache.bar' => array(
                 'adapter' => 'cache.adapter.doctrine',
@@ -19,6 +20,7 @@ $container->loadFromExtension('framework', array(
             'cache.foobar' => array(
                 'adapter' => 'cache.adapter.psr6',
                 'default_lifetime' => 10,
+                'namespace' => 'foobar_',
                 'provider' => 'app.cache_pool',
             ),
             'cache.def' => array(

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache.xml
@@ -7,10 +7,10 @@
 
     <framework:config>
         <framework:cache>
-            <framework:pool name="cache.foo" adapter="cache.adapter.apcu" default-lifetime="30" />
+            <framework:pool name="cache.foo" adapter="cache.adapter.apcu" default-lifetime="30" namespace="foo_" />
             <framework:pool name="cache.bar" adapter="cache.adapter.doctrine" default-lifetime="5" provider="app.doctrine_cache_provider" />
             <framework:pool name="cache.baz" adapter="cache.adapter.filesystem" default-lifetime="7" />
-            <framework:pool name="cache.foobar" adapter="cache.adapter.psr6" default-lifetime="10" provider="app.cache_pool" />
+            <framework:pool name="cache.foobar" adapter="cache.adapter.psr6" default-lifetime="10" namespace="foobar_" provider="app.cache_pool" />
             <framework:pool name="cache.def" default-lifetime="11" />
         </framework:cache>
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache.yml
@@ -4,6 +4,7 @@ framework:
             cache.foo:
                 adapter: cache.adapter.apcu
                 default_lifetime: 30
+                namespace: 'foo_'
             cache.bar:
                 adapter: cache.adapter.doctrine
                 default_lifetime: 5
@@ -14,6 +15,7 @@ framework:
             cache.foobar:
                 adapter: cache.adapter.psr6
                 default_lifetime: 10
+                namespace: 'foobar_'
                 provider: app.cache_pool
             cache.def:
                 default_lifetime: 11

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -638,10 +638,10 @@ abstract class FrameworkExtensionTest extends TestCase
     {
         $container = $this->createContainerFromFile('cache');
 
-        $this->assertCachePoolServiceDefinitionIsCreated($container, 'cache.foo', 'cache.adapter.apcu', 30);
+        $this->assertCachePoolServiceDefinitionIsCreated($container, 'cache.foo', 'cache.adapter.apcu', 30, 'foo_');
         $this->assertCachePoolServiceDefinitionIsCreated($container, 'cache.bar', 'cache.adapter.doctrine', 5);
         $this->assertCachePoolServiceDefinitionIsCreated($container, 'cache.baz', 'cache.adapter.filesystem', 7);
-        $this->assertCachePoolServiceDefinitionIsCreated($container, 'cache.foobar', 'cache.adapter.psr6', 10);
+        $this->assertCachePoolServiceDefinitionIsCreated($container, 'cache.foobar', 'cache.adapter.psr6', 10, 'foobar_');
         $this->assertCachePoolServiceDefinitionIsCreated($container, 'cache.def', 'cache.app', 11);
     }
 
@@ -717,7 +717,7 @@ abstract class FrameworkExtensionTest extends TestCase
         }
     }
 
-    private function assertCachePoolServiceDefinitionIsCreated(ContainerBuilder $container, $id, $adapter, $defaultLifetime)
+    private function assertCachePoolServiceDefinitionIsCreated(ContainerBuilder $container, $id, $adapter, $defaultLifetime, $namespace = null)
     {
         $this->assertTrue($container->has($id), sprintf('Service definition "%s" for cache pool of type "%s" is registered', $id, $adapter));
 
@@ -731,6 +731,11 @@ abstract class FrameworkExtensionTest extends TestCase
         $tag = $poolDefinition->getTag('cache.pool');
         $this->assertTrue(isset($tag[0]['default_lifetime']), 'The default lifetime is stored as an attribute of the "cache.pool" tag.');
         $this->assertSame($defaultLifetime, $tag[0]['default_lifetime'], 'The default lifetime is stored as an attribute of the "cache.pool" tag.');
+
+        if (null !== $namespace) {
+            $this->assertTrue(isset($tag[0]['namespace']), 'The namespace is stored as an attribute of the "cache.pool" tag.');
+            $this->assertSame($namespace, $tag[0]['namespace'], 'The namespace is stored as an attribute of the "cache.pool" tag.');
+        }
 
         $parentDefinition = $poolDefinition;
         do {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Hey. It's [already checking for namespace at compiler pass](https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/CachePoolPass.php#L58). So I've added an ability to control it via config.

