### PR TITLE
[Console] Disallow inheritance from ProgressBar

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -22,7 +22,7 @@ use Symfony\Component\Console\Terminal;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Chris Jones <leeked@gmail.com>
  */
-class ProgressBar
+final class ProgressBar
 {
     // options
     private $barWidth = 28;

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -353,35 +353,52 @@ class ProgressBarTest extends \PHPUnit_Framework_TestCase
 
     public function testRedrawFrequency()
     {
-        $bar = $this->getMock('Symfony\Component\Console\Helper\ProgressBar', array('display'), array($this->getOutputStream(), 6));
-        $bar->expects($this->exactly(4))->method('display');
-
+        $bar = new ProgressBar($output = $this->getOutputStream(), 6);
         $bar->setRedrawFrequency(2);
         $bar->start();
         $bar->setProgress(1);
         $bar->advance(2);
         $bar->advance(2);
         $bar->advance(1);
+
+        rewind($output->getStream());
+        $this->assertEquals(
+            ' 0/6 [>---------------------------]   0%'.
+            $this->generateOutput(' 3/6 [==============>-------------]  50%').
+            $this->generateOutput(' 5/6 [=======================>----]  83%').
+            $this->generateOutput(' 6/6 [============================] 100%'),
+            stream_get_contents($output->getStream())
+        );
     }
 
     public function testRedrawFrequencyIsAtLeastOneIfZeroGiven()
     {
-        $bar = $this->getMock('Symfony\Component\Console\Helper\ProgressBar', array('display'), array($this->getOutputStream()));
-
-        $bar->expects($this->exactly(2))->method('display');
+        $bar = new ProgressBar($output = $this->getOutputStream());
         $bar->setRedrawFrequency(0);
         $bar->start();
         $bar->advance();
+
+        rewind($output->getStream());
+        $this->assertEquals(
+            '    0 [>---------------------------]'.
+            $this->generateOutput('    1 [->--------------------------]'),
+            stream_get_contents($output->getStream())
+        );
     }
 
     public function testRedrawFrequencyIsAtLeastOneIfSmallerOneGiven()
     {
-        $bar = $this->getMock('Symfony\Component\Console\Helper\ProgressBar', array('display'), array($this->getOutputStream()));
-
-        $bar->expects($this->exactly(2))->method('display');
+        $bar = new ProgressBar($output = $this->getOutputStream());
         $bar->setRedrawFrequency(0.9);
         $bar->start();
         $bar->advance();
+
+        rewind($output->getStream());
+        $this->assertEquals(
+            '    0 [>---------------------------]'.
+            $this->generateOutput('    1 [->--------------------------]'),
+            stream_get_contents($output->getStream())
+        );
     }
 
     public function testMultiByteSupport()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20427
| License       | MIT
| Doc PR        | ~

Changed `ProgressBar` to `final`, fixed tests. 
As explained below, this modification doesn't break BC because inheritance from `ProgressBar` was not possible anyway.
See: https://github.com/symfony/symfony/issues/20427