### PR TITLE
[Debug] Trigger deprecation on `@final` annotation in DebugClassLoader - prepare making some classes final

### DIFF
--- a/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
@@ -267,6 +267,28 @@ class DebugClassLoaderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($xError, $lastError);
     }
+
+    public function testExtendedFinalClass()
+    {
+        set_error_handler(function () { return false; });
+        $e = error_reporting(0);
+        trigger_error('', E_USER_NOTICE);
+
+        class_exists('Test\\'.__NAMESPACE__.'\\ExtendsFinalClass', true);
+
+        error_reporting($e);
+        restore_error_handler();
+
+        $lastError = error_get_last();
+        unset($lastError['file'], $lastError['line']);
+
+        $xError = array(
+            'type' => E_USER_DEPRECATED,
+            'message' => 'The Symfony\Component\Debug\Tests\Fixtures\FinalClass class is considered final since version 3.3. It may change without further notice as of its next major version. You should not extend it from Test\Symfony\Component\Debug\Tests\ExtendsFinalClass.',
+        );
+
+        $this->assertSame($xError, $lastError);
+    }
 }
 
 class ClassLoader
@@ -300,6 +322,8 @@ class ClassLoader
             return $fixtureDir.'notPsr0Bis.php';
         } elseif (__NAMESPACE__.'\Fixtures\DeprecatedInterface' === $class) {
             return $fixtureDir.'DeprecatedInterface.php';
+        } elseif (__NAMESPACE__.'\Fixtures\FinalClass' === $class) {
+            return $fixtureDir.'FinalClass.php';
         } elseif ('Symfony\Bridge\Debug\Tests\Fixtures\ExtendsDeprecatedParent' === $class) {
             eval('namespace Symfony\Bridge\Debug\Tests\Fixtures; class ExtendsDeprecatedParent extends \\'.__NAMESPACE__.'\Fixtures\DeprecatedClass {}');
         } elseif ('Test\\'.__NAMESPACE__.'\DeprecatedParentClass' === $class) {
@@ -310,6 +334,8 @@ class ClassLoader
             eval('namespace Test\\'.__NAMESPACE__.'; class NonDeprecatedInterfaceClass implements \\'.__NAMESPACE__.'\Fixtures\NonDeprecatedInterface {}');
         } elseif ('Test\\'.__NAMESPACE__.'\Float' === $class) {
             eval('namespace Test\\'.__NAMESPACE__.'; class Float {}');
+        } elseif ('Test\\'.__NAMESPACE__.'\ExtendsFinalClass' === $class) {
+            eval('namespace Test\\'.__NAMESPACE__.'; class ExtendsFinalClass extends \\'.__NAMESPACE__.'\Fixtures\FinalClass {}');
         }
     }
 }

--- a/src/Symfony/Component/Debug/Tests/Fixtures/FinalClass.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/FinalClass.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\Debug\Tests\Fixtures;
+
+/**
+ * @final since version 3.3.
+ */
+class FinalClass
+{
+}

--- a/src/Symfony/Component/Serializer/Encoder/ChainDecoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/ChainDecoder.php
@@ -19,6 +19,8 @@ use Symfony\Component\Serializer\Exception\RuntimeException;
  * @author Jordi Boggiano <j.boggiano@seld.be>
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  * @author Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * @final since version 3.3.
  */
 class ChainDecoder implements DecoderInterface
 {

--- a/src/Symfony/Component/Serializer/Encoder/ChainEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/ChainEncoder.php
@@ -19,6 +19,8 @@ use Symfony\Component\Serializer\Exception\RuntimeException;
  * @author Jordi Boggiano <j.boggiano@seld.be>
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  * @author Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * @final since version 3.3.
  */
 class ChainEncoder implements EncoderInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | follows https://github.com/symfony/symfony/pull/19734
| License       | MIT
| Doc PR        |  |

BC promises become quickly huge but making classes `final` can limit these promises.
At the same time, many classes of the symfony codebase are not meant to be extended and could be  `final`; that's the goal of this PR: prepare making them final in 4.0 by triggering deprecations in their constructor:
```php
public function __construct()
{
    if (__CLASS__ !== get_class($this)) {
        @trigger_error(sprintf('Extending %s is deprecated since 3.3 and won\'t be supported in 4.0 as it will be final.', __CLASS__), E_USER_DEPRECATED);
    }
}
```

I updated two classes for now but we can do much more if you like it.