### PR TITLE
[Workflow] added a TransitionsCollectionBuilder so DefinitionBuilder doesn't need Transition objects

### DIFF
--- a/src/Symfony/Component/Workflow/DefinitionBuilder.php
+++ b/src/Symfony/Component/Workflow/DefinitionBuilder.php
@@ -82,12 +82,13 @@ class DefinitionBuilder
     public function addTransitions(array $transitions)
     {
         foreach ($transitions as $transition) {
-            $this->addTransition($transition);
+            list($name, $froms, $tos) = $transition;
+            $this->addTransition($name, $froms, $tos);
         }
     }
 
-    public function addTransition(Transition $transition)
+    public function addTransition($name, $froms, $tos)
     {
-        $this->transitions[] = $transition;
+        $this->transitions[] = new Transition($name, (array) $froms, (array) $tos);
     }
 }

--- a/src/Symfony/Component/Workflow/DefinitionBuilder.php
+++ b/src/Symfony/Component/Workflow/DefinitionBuilder.php
@@ -23,7 +23,7 @@ use Symfony\Component\Workflow\Exception\InvalidArgumentException;
 class DefinitionBuilder
 {
     private $places = array();
-    private $transitions = array();
+    private $transitionsCollection;
     private $initialPlace;
 
     /**
@@ -35,7 +35,8 @@ class DefinitionBuilder
     public function __construct(array $places = array(), array $transitions = array())
     {
         $this->addPlaces($places);
-        $this->addTransitions($transitions);
+        $this->transitionsCollection = new TransitionsCollectionBuilder();
+        $this->transitionsCollection->addTransitions($transitions);
     }
 
     /**
@@ -43,7 +44,7 @@ class DefinitionBuilder
      */
     public function build()
     {
-        return new Definition($this->places, $this->transitions, $this->initialPlace);
+        return new Definition($this->places, $this->transitionsCollection->getTransitions(), $this->initialPlace);
     }
 
     /**
@@ -52,7 +53,7 @@ class DefinitionBuilder
     public function reset()
     {
         $this->places = array();
-        $this->transitions = array();
+        $this->transitionsCollection->reset();
         $this->initialPlace = null;
     }
 
@@ -88,14 +89,7 @@ class DefinitionBuilder
      */
     public function addTransitions(array $transitions)
     {
-        foreach ($transitions as $transition) {
-            if ($transition instanceof Transition) {
-                $this->addTransition($transition);
-            } else {
-                list($name, $froms, $tos) = $transition;
-                $this->addTransition($name, $froms, $tos);
-            }
-        }
+        $this->transitionsCollection->addTransitions($transitions);
     }
 
     /**
@@ -105,10 +99,6 @@ class DefinitionBuilder
      */
     public function addTransition($transition, $froms = null, $tos = null)
     {
-        if ($transition instanceof Transition) {
-            $this->transitions[] = $transition;
-        } else {
-            $this->transitions[] = new Transition($transition, $froms, $tos);
-        }
+        $this->transitionsCollection->addTransition($transition, $froms, $tos);
     }
 }

--- a/src/Symfony/Component/Workflow/DefinitionBuilder.php
+++ b/src/Symfony/Component/Workflow/DefinitionBuilder.php
@@ -27,8 +27,10 @@ class DefinitionBuilder
     private $initialPlace;
 
     /**
-     * @param string[]     $places
-     * @param Transition[] $transitions
+     * @param string[]             $places
+     * @param (Transition|array)[] $transitions Nested values can be either instances of Transition or
+     *                                          arrays with three values: the transition name, and two
+     *                                          to pass string or arrays of string for froms and todos
      */
     public function __construct(array $places = array(), array $transitions = array())
     {
@@ -79,16 +81,34 @@ class DefinitionBuilder
         }
     }
 
+    /**
+     * @param (Transition|array)[] $transitions Nested values can be either instances of Transition or
+     *                                          arrays with three values: the transition name, and two
+     *                                          to pass string or arrays of string for froms and todos
+     */
     public function addTransitions(array $transitions)
     {
         foreach ($transitions as $transition) {
-            list($name, $froms, $tos) = $transition;
-            $this->addTransition($name, $froms, $tos);
+            if ($transition instanceof Transition) {
+                $this->addTransition($transition);
+            } else {
+                list($name, $froms, $tos) = $transition;
+                $this->addTransition($name, $froms, $tos);
+            }
         }
     }
 
-    public function addTransition($name, $froms, $tos)
+    /**
+     * @param Transition|string    $transition
+     * @param string[]|string|null $froms
+     * @param string[]|string|null $tos
+     */
+    public function addTransition($transition, $froms = null, $tos = null)
     {
-        $this->transitions[] = new Transition($name, (array) $froms, (array) $tos);
+        if ($transition instanceof Transition) {
+            $this->transitions[] = $transition;
+        } else {
+            $this->transitions[] = new Transition($transition, $froms, $tos);
+        }
     }
 }

--- a/src/Symfony/Component/Workflow/Tests/DefinitionBuilderTest.php
+++ b/src/Symfony/Component/Workflow/Tests/DefinitionBuilderTest.php
@@ -26,18 +26,20 @@ class DefinitionBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testAddTransition()
     {
+        $name0 = 'name0';
+        $name1 = 'name1';
         $places = range('a', 'b');
 
-        $transition0 = new Transition('name0', $places[0], $places[1]);
-        $transition1 = new Transition('name1', $places[0], $places[1]);
+        $transition0 = array($name0, $places[0], $places[1]);
         $builder = new DefinitionBuilder($places, array($transition0));
-        $builder->addTransition($transition1);
+
+        $builder->addTransition($name1, $places[0], $places[1]);
 
         $definition = $builder->build();
 
         $this->assertCount(2, $definition->getTransitions());
-        $this->assertSame($transition0, $definition->getTransitions()[0]);
-        $this->assertSame($transition1, $definition->getTransitions()[1]);
+        $this->assertEquals(new Transition($name0, $places[0], $places[1]), $definition->getTransitions()[0]);
+        $this->assertEquals(new Transition($name1, $places[0], $places[1]), $definition->getTransitions()[1]);
     }
 
     public function testAddPlace()

--- a/src/Symfony/Component/Workflow/Tests/DefinitionBuilderTest.php
+++ b/src/Symfony/Component/Workflow/Tests/DefinitionBuilderTest.php
@@ -24,22 +24,44 @@ class DefinitionBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('b', $definition->getInitialPlace());
     }
 
-    public function testAddTransition()
+    public function testAddTransitions()
     {
-        $name0 = 'name0';
-        $name1 = 'name1';
         $places = range('a', 'b');
+        $transition0 = new Transition('name0', $places[0], $places[1]);
+        $transition1 = new Transition('name1', $places[0], $places[1]);
 
-        $transition0 = array($name0, $places[0], $places[1]);
         $builder = new DefinitionBuilder($places, array($transition0));
 
-        $builder->addTransition($name1, $places[0], $places[1]);
+        $builder->addTransitions(array(
+            $transition1,
+        ));
 
         $definition = $builder->build();
 
         $this->assertCount(2, $definition->getTransitions());
+        $this->assertSame($transition0, $definition->getTransitions()[0]);
+        $this->assertSame($transition1, $definition->getTransitions()[1]);
+    }
+
+    public function testAddTransition()
+    {
+        $name0 = 'name0';
+        $name2 = 'name2';
+        $places = range('a', 'c');
+
+        $transition0 = array($name0, $places[0], $places[1]);
+        $transition1 = new Transition('name1', $places[0], $places[1]);
+        $builder = new DefinitionBuilder($places, array($transition0));
+
+        $builder->addTransition($transition1);
+        $builder->addTransition($name2, $places[1], $places[2]);
+
+        $definition = $builder->build();
+
+        $this->assertCount(3, $definition->getTransitions());
         $this->assertEquals(new Transition($name0, $places[0], $places[1]), $definition->getTransitions()[0]);
-        $this->assertEquals(new Transition($name1, $places[0], $places[1]), $definition->getTransitions()[1]);
+        $this->assertSame($transition1, $definition->getTransitions()[1]);
+        $this->assertEquals(new Transition($name2, $places[1], $places[2]), $definition->getTransitions()[2]);
     }
 
     public function testAddPlace()

--- a/src/Symfony/Component/Workflow/Tests/Dumper/GraphvizDumperTest.php
+++ b/src/Symfony/Component/Workflow/Tests/Dumper/GraphvizDumperTest.php
@@ -63,12 +63,12 @@ class GraphvizDumperTest extends \PHPUnit_Framework_TestCase
 
         $builder->addPlaces(range('a', 'g'));
 
-        $builder->addTransition(new Transition('t1', 'a', array('b', 'c')));
-        $builder->addTransition(new Transition('t2', array('b', 'c'), 'd'));
-        $builder->addTransition(new Transition('t3', 'd', 'e'));
-        $builder->addTransition(new Transition('t4', 'd', 'f'));
-        $builder->addTransition(new Transition('t5', 'e', 'g'));
-        $builder->addTransition(new Transition('t6', 'f', 'g'));
+        $builder->addTransition('t1', 'a', array('b', 'c'));
+        $builder->addTransition('t2', array('b', 'c'), 'd');
+        $builder->addTransition('t3', 'd', 'e');
+        $builder->addTransition('t4', 'd', 'f');
+        $builder->addTransition('t5', 'e', 'g');
+        $builder->addTransition('t6', 'f', 'g');
 
         return $builder->build();
     }
@@ -79,8 +79,8 @@ class GraphvizDumperTest extends \PHPUnit_Framework_TestCase
 
         $builder->addPlaces(range('a', 'c'));
 
-        $builder->addTransition(new Transition('t1', 'a', 'b'));
-        $builder->addTransition(new Transition('t2', 'b', 'c'));
+        $builder->addTransition('t1', 'a', 'b');
+        $builder->addTransition('t2', 'b', 'c');
 
         return $builder->build();
     }

--- a/src/Symfony/Component/Workflow/Tests/Dumper/GraphvizDumperTest.php
+++ b/src/Symfony/Component/Workflow/Tests/Dumper/GraphvizDumperTest.php
@@ -5,7 +5,6 @@ namespace Symfony\Component\Workflow\Tests\Dumper;
 use Symfony\Component\Workflow\DefinitionBuilder;
 use Symfony\Component\Workflow\Dumper\GraphvizDumper;
 use Symfony\Component\Workflow\Marking;
-use Symfony\Component\Workflow\Transition;
 
 class GraphvizDumperTest extends \PHPUnit_Framework_TestCase
 {
@@ -63,12 +62,14 @@ class GraphvizDumperTest extends \PHPUnit_Framework_TestCase
 
         $builder->addPlaces(range('a', 'g'));
 
-        $builder->addTransition('t1', 'a', array('b', 'c'));
-        $builder->addTransition('t2', array('b', 'c'), 'd');
-        $builder->addTransition('t3', 'd', 'e');
-        $builder->addTransition('t4', 'd', 'f');
-        $builder->addTransition('t5', 'e', 'g');
-        $builder->addTransition('t6', 'f', 'g');
+        $builder->addTransitions(array(
+            array('t1', 'a', array('b', 'c')),
+            array('t2', array('b', 'c'), 'd'),
+            array('t3', 'd', 'e'),
+            array('t4', 'd', 'f'),
+            array('t5', 'e', 'g'),
+            array('t6', 'f', 'g'),
+        ));
 
         return $builder->build();
     }
@@ -79,8 +80,10 @@ class GraphvizDumperTest extends \PHPUnit_Framework_TestCase
 
         $builder->addPlaces(range('a', 'c'));
 
-        $builder->addTransition('t1', 'a', 'b');
-        $builder->addTransition('t2', 'b', 'c');
+        $builder->addTransitions(array(
+            array('t1', 'a', 'b'),
+            array('t2', 'b', 'c'),
+        ));
 
         return $builder->build();
     }

--- a/src/Symfony/Component/Workflow/Tests/Dumper/GraphvizDumperTest.php
+++ b/src/Symfony/Component/Workflow/Tests/Dumper/GraphvizDumperTest.php
@@ -62,14 +62,12 @@ class GraphvizDumperTest extends \PHPUnit_Framework_TestCase
 
         $builder->addPlaces(range('a', 'g'));
 
-        $builder->addTransitions(array(
-            array('t1', 'a', array('b', 'c')),
-            array('t2', array('b', 'c'), 'd'),
-            array('t3', 'd', 'e'),
-            array('t4', 'd', 'f'),
-            array('t5', 'e', 'g'),
-            array('t6', 'f', 'g'),
-        ));
+        $builder->addTransition('t1', 'a', array('b', 'c'));
+        $builder->addTransition('t2', array('b', 'c'), 'd');
+        $builder->addTransition('t3', 'd', 'e');
+        $builder->addTransition('t4', 'd', 'f');
+        $builder->addTransition('t5', 'e', 'g');
+        $builder->addTransition('t6', 'f', 'g');
 
         return $builder->build();
     }
@@ -80,10 +78,8 @@ class GraphvizDumperTest extends \PHPUnit_Framework_TestCase
 
         $builder->addPlaces(range('a', 'c'));
 
-        $builder->addTransitions(array(
-            array('t1', 'a', 'b'),
-            array('t2', 'b', 'c'),
-        ));
+        $builder->addTransition('t1', 'a', 'b');
+        $builder->addTransition('t2', 'b', 'c');
 
         return $builder->build();
     }

--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -216,12 +216,12 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
 
         $builder->addPlaces(range('a', 'g'));
 
-        $builder->addTransition(new Transition('t1', 'a', array('b', 'c')));
-        $builder->addTransition(new Transition('t2', array('b', 'c'), 'd'));
-        $builder->addTransition(new Transition('t3', 'd', 'e'));
-        $builder->addTransition(new Transition('t4', 'd', 'f'));
-        $builder->addTransition(new Transition('t5', 'e', 'g'));
-        $builder->addTransition(new Transition('t6', 'f', 'g'));
+        $builder->addTransition('t1', 'a', array('b', 'c'));
+        $builder->addTransition('t2', array('b', 'c'), 'd');
+        $builder->addTransition('t3', 'd', 'e');
+        $builder->addTransition('t4', 'd', 'f');
+        $builder->addTransition('t5', 'e', 'g');
+        $builder->addTransition('t6', 'f', 'g');
 
         return $builder->build();
 

--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -216,14 +216,12 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
 
         $builder->addPlaces(range('a', 'g'));
 
-        $builder->addTransitions(array(
-            array('t1', 'a', array('b', 'c')),
-            array('t2', array('b', 'c'), 'd'),
-            array('t3', 'd', 'e'),
-            array('t4', 'd', 'f'),
-            array('t5', 'e', 'g'),
-            array('t6', 'f', 'g'),
-        ));
+        $builder->addTransition('t1', 'a', array('b', 'c'));
+        $builder->addTransition('t2', array('b', 'c'), 'd');
+        $builder->addTransition('t3', 'd', 'e');
+        $builder->addTransition('t4', 'd', 'f');
+        $builder->addTransition('t5', 'e', 'g');
+        $builder->addTransition('t6', 'f', 'g');
 
         return $builder->build();
 

--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -216,12 +216,14 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
 
         $builder->addPlaces(range('a', 'g'));
 
-        $builder->addTransition('t1', 'a', array('b', 'c'));
-        $builder->addTransition('t2', array('b', 'c'), 'd');
-        $builder->addTransition('t3', 'd', 'e');
-        $builder->addTransition('t4', 'd', 'f');
-        $builder->addTransition('t5', 'e', 'g');
-        $builder->addTransition('t6', 'f', 'g');
+        $builder->addTransitions(array(
+            array('t1', 'a', array('b', 'c')),
+            array('t2', array('b', 'c'), 'd'),
+            array('t3', 'd', 'e'),
+            array('t4', 'd', 'f'),
+            array('t5', 'e', 'g'),
+            array('t6', 'f', 'g'),
+        ));
 
         return $builder->build();
 

--- a/src/Symfony/Component/Workflow/TransitionsCollectionBuilder.php
+++ b/src/Symfony/Component/Workflow/TransitionsCollectionBuilder.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Workflow;
+
+use Symfony\Component\Workflow\Exception\InvalidArgumentException;
+use Symfony\Component\Workflow\Exception\LogicException;
+
+/**
+ * TransitionsCollectionBuilder.
+ *
+ * @author Jules Pietri <jules@heahprod.com>
+ */
+class TransitionsCollectionBuilder
+{
+    /**
+     * @var Transition[]
+     */
+    private $transitions = array();
+
+    /**
+     * @param Transition|string   $transition
+     * @param string[]string|null $froms
+     * @param string[]string|null $tos
+     */
+    public function addTransition($transition, $froms = null, $tos = null)
+    {
+        if ($transition instanceof Transition) {
+            $this->add($transition);
+
+            return;
+        }
+
+        $this->createTransition($transition, $froms, $tos);
+    }
+
+    /**
+     * @param array[] $transitions An array of arrays of three arguments to pass to "addTransition"
+     */
+    public function addTransitions(array $transitions)
+    {
+        foreach ($transitions as $transition) {
+            if ($transition instanceof Transition) {
+                $this->add($transition);
+
+                continue;
+            }
+
+            if (!is_array($transition) || 3 !== count($transition)) {
+                throw new InvalidArgumentException(sprintf(
+                    'Calling "%s" expected each entry to be an instance of "%s" or an array of three arguments to create a transition instance%s: "name", "froms", and "tos", but got %s.',
+                    __METHOD__,
+                    Transition::class,
+                    isset($transition[0]) ? ' named "'.$transition[0].'"' : '',
+                    is_array($transition) ? ' an array with '.count($transition).' entries' : gettype($transition)));
+            }
+            list($name, $froms, $tos) = $transition;
+            $this->addTransition($name, $froms, $tos);
+        }
+    }
+
+    public function getTransitions()
+    {
+        return $this->transitions;
+    }
+
+    public function reset()
+    {
+        return $this->transitions = array();
+    }
+
+    private function createTransition($name, $froms, $tos)
+    {
+        $this->add(new Transition($name, $froms, $tos));
+
+    }
+
+    private function add(Transition $newTransition) {
+        foreach ($this->transitions as $transition) {
+            if ($newTransition == $transition) {
+                throw new InvalidArgumentException(sprintf('The transition named "%s" has already been added.', $transition->getName()));
+            }
+        }
+        $this->transitions[] = $newTransition;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20451
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/6871

I suggest to not construct `Transition` object repeatedly in user land code, ortherwise we can just create our own `Definition`, let's abstract it in the builder.

ping @lyrixx @Nyholm