### PR TITLE
Tag the FormFieldRegistry as being internal

### DIFF
--- a/src/Symfony/Component/DomCrawler/FormFieldRegistry.php
+++ b/src/Symfony/Component/DomCrawler/FormFieldRegistry.php
@@ -15,6 +15,8 @@ use Symfony\Component\DomCrawler\Field\FormField;
 
 /**
  * This is an internal class that must not be used directly.
+ *
+ * @internal
  */
 class FormFieldRegistry
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

The phpdoc already describes it as being internal (since it was introduced). This adds the proper tag to mark it as internal in our standard way.

