### PR TITLE
[DI] Allow for service ID prefix in file loaders

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -147,8 +147,10 @@ class YamlFileLoader extends FileLoader
             throw new InvalidArgumentException(sprintf('The "services" key should contain an array in %s. Check your YAML syntax.', $file));
         }
 
+        $idPrefix = isset($content['service_id_prefix']) ? $content['service_id_prefix'] : '';
+
         foreach ($content['services'] as $id => $service) {
-            $this->parseDefinition($id, $service, $file);
+            $this->parseDefinition($idPrefix.$id, $service, $file);
         }
     }
 
@@ -489,7 +491,7 @@ class YamlFileLoader extends FileLoader
     private function loadFromExtensions($content)
     {
         foreach ($content as $namespace => $values) {
-            if (in_array($namespace, array('imports', 'parameters', 'services'))) {
+            if (in_array($namespace, array('imports', 'parameters', 'services', 'service_id_prefix'))) {
                 continue;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no-ish
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any
| License       | MIT
| Doc PR        | reference to the documentation PR, if any

Quick POC to do the following;

```yml
# bar_services.yml
service_id_prefix: bars.
services:
   a: { class: Bar\A }
   b: { class: Bar\B }
```

Giving `bars.a` and `bars.b`

Im not sure yet how useful this would be, so feedback is welcome :) We could definitely use it for prefixes like `controllers.`, `validators.`, `repositories.`, etc. But it heavily depends how you organize services into files..