### PR TITLE
[Workflow] Fixed some tests and cs

### DIFF
--- a/src/Symfony/Component/Workflow/Exception/InvalidDefinitionException.php
+++ b/src/Symfony/Component/Workflow/Exception/InvalidDefinitionException.php
@@ -16,6 +16,6 @@ namespace Symfony\Component\Workflow\Exception;
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class InvalidDefinitionException extends \LogicException implements ExceptionInterface
+class InvalidDefinitionException extends LogicException
 {
 }

--- a/src/Symfony/Component/Workflow/Tests/Validator/SinglePlaceWorkflowValidatorTest.php
+++ b/src/Symfony/Component/Workflow/Tests/Validator/SinglePlaceWorkflowValidatorTest.php
@@ -9,7 +9,7 @@ use Symfony\Component\Workflow\Transition;
 use Symfony\Component\Workflow\Validator\SinglePlaceWorkflowValidator;
 use Symfony\Component\Workflow\Workflow;
 
-class SinglePlaceWorkflowValidatorTest extends WorkflowTest
+class SinglePlaceWorkflowValidatorTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @expectedException \Symfony\Component\Workflow\Exception\InvalidDefinitionException
@@ -17,7 +17,7 @@ class SinglePlaceWorkflowValidatorTest extends WorkflowTest
      */
     public function testSinglePlaceWorkflowValidatorAndComplexWorkflow()
     {
-        $definition = $this->createComplexWorkflow();
+        $definition = WorkflowTest::createComplexWorkflow();
 
         (new SinglePlaceWorkflowValidator())->validate($definition, 'foo');
     }

--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -210,7 +210,7 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('t5', $transitions[0]->getName());
     }
 
-    protected function createComplexWorkflow()
+    public static function createComplexWorkflow()
     {
         $builder = new DefinitionBuilder();
 

--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -47,7 +47,6 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
     public function testGetMarkingWithImpossiblePlace()
     {
         $subject = new \stdClass();
-        $subject->marking = null;
         $subject->marking = array('nope' => true);
         $workflow = new Workflow(new Definition(array(), array()), new MultipleStateMarkingStore());
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ~
| License       | MIT
| Doc PR        | ~


Some tests are run twice because the `SinglePlaceWorkflowValidatorTest` extends the `WorkflowTest`, let's use a static function instead.