### PR TITLE
[Serializer] Allow to specify a single value in @Groups

### DIFF
--- a/src/Symfony/Component/Serializer/Annotation/Groups.php
+++ b/src/Symfony/Component/Serializer/Annotation/Groups.php
@@ -42,7 +42,7 @@ class Groups
         $value = (array) $data['value'];
         foreach ($value as $group) {
             if (!is_string($group)) {
-                throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" must be an array of strings.', get_class($this)));
+                throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" must be a string or an array of strings.', get_class($this)));
             }
         }
 

--- a/src/Symfony/Component/Serializer/Annotation/Groups.php
+++ b/src/Symfony/Component/Serializer/Annotation/Groups.php
@@ -24,7 +24,7 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 class Groups
 {
     /**
-     * @var array
+     * @var string[]
      */
     private $groups;
 
@@ -39,23 +39,20 @@ class Groups
             throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" cannot be empty.', get_class($this)));
         }
 
-        if (!is_array($data['value'])) {
-            throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" must be an array of strings.', get_class($this)));
-        }
-
-        foreach ($data['value'] as $group) {
+        $value = (array) $data['value'];
+        foreach ($value as $group) {
             if (!is_string($group)) {
                 throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" must be an array of strings.', get_class($this)));
             }
         }
 
-        $this->groups = $data['value'];
+        $this->groups = $value;
     }
 
     /**
      * Gets groups.
      *
-     * @return array
+     * @return string[]
      */
     public function getGroups()
     {

--- a/src/Symfony/Component/Serializer/Tests/Annotation/GroupsTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Annotation/GroupsTest.php
@@ -31,7 +31,7 @@ class GroupsTest extends \PHPUnit_Framework_TestCase
      */
     public function testNotAnArrayGroupsParameter()
     {
-        new Groups(array('value' => 'coopTilleuls'));
+        new Groups(array('value' => 12));
     }
 
     /**
@@ -48,5 +48,11 @@ class GroupsTest extends \PHPUnit_Framework_TestCase
 
         $groups = new Groups(array('value' => $validData));
         $this->assertEquals($validData, $groups->getGroups());
+    }
+
+    public function testSingleGroup()
+    {
+        $groups = new Groups(array('value' => 'a'));
+        $this->assertEquals(array('a'), $groups->getGroups());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/19374#issuecomment-256688002
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/10314

Tiny DX improvement:

Before:

```php
use Symfony\Component\Serializer\Annotation\Groups;

class Product
{
    /**
     * @Groups({"admins"})
     */
    public $itemsSold;
}
```

Now allowed:

```php
use Symfony\Component\Serializer\Annotation\Groups;

class Product
{
    /**
     * @Groups("admins")
     */
    public $itemsSold;
}
```
