### PR TITLE
[Debug] Remove GLOBALS from exception context to avoid endless recursion

### DIFF
--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -357,7 +357,7 @@ class ErrorHandler
         $type &= $level | $this->screamedErrors;
 
         if ($type && ($log || $throw)) {
-            if (PHP_VERSION_ID < 50400 && isset($context['GLOBALS']) && ($this->scopedErrors & $type)) {
+            if (isset($context['GLOBALS']) && ($this->scopedErrors & $type)) {
                 $e = $context;                  // Whatever the signature of the method,
                 unset($e['GLOBALS'], $context); // $context is always a reference in 5.3
                 $context = $e;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed ticket | #20347
| License       | MIT

This fixes a endless recursion as seen in https://github.com/felixfbecker/php-language-server/pull/137 - it only happens if you trigger an error in the global context so it's kinda hard to write a test for, but hopefully the fix can be accepted.

