### PR TITLE
[Translation] allows TranslatorInterface::transChoice to accept float numbers

### DIFF
--- a/src/Symfony/Component/Translation/IdentityTranslator.php
+++ b/src/Symfony/Component/Translation/IdentityTranslator.php
@@ -60,6 +60,6 @@ class IdentityTranslator implements TranslatorInterface
      */
     public function transChoice($id, $number, array $parameters = array(), $domain = null, $locale = null)
     {
-        return strtr($this->selector->choose((string) $id, (int) $number, $locale ?: $this->getLocale()), $parameters);
+        return strtr($this->selector->choose((string) $id, $number, $locale ?: $this->getLocale()), $parameters);
     }
 }

--- a/src/Symfony/Component/Translation/Interval.php
+++ b/src/Symfony/Component/Translation/Interval.php
@@ -36,8 +36,8 @@ class Interval
     /**
      * Tests if the given number is in the math interval.
      *
-     * @param int    $number   A number
-     * @param string $interval An interval
+     * @param float|int $number   A number
+     * @param string    $interval An interval
      *
      * @return bool
      *

--- a/src/Symfony/Component/Translation/MessageSelector.php
+++ b/src/Symfony/Component/Translation/MessageSelector.php
@@ -37,9 +37,9 @@ class MessageSelector
      * The two methods can also be mixed:
      *     {0} There are no apples|one: There is one apple|more: There are %count% apples
      *
-     * @param string $message The message being translated
-     * @param int    $number  The number of items represented for the message
-     * @param string $locale  The locale to use for choosing
+     * @param string    $message The message being translated
+     * @param float|int $number  The number of items represented for the message
+     * @param string    $locale  The locale to use for choosing
      *
      * @return string
      *

--- a/src/Symfony/Component/Translation/PluralizationRules.php
+++ b/src/Symfony/Component/Translation/PluralizationRules.php
@@ -30,6 +30,8 @@ class PluralizationRules
      */
     public static function get($number, $locale)
     {
+        $number = (int) $number;
+
         if ('pt_BR' === $locale) {
             // temporary set a locale for brazilian
             $locale = 'xbr';

--- a/src/Symfony/Component/Translation/Tests/IdentityTranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/IdentityTranslatorTest.php
@@ -90,6 +90,10 @@ class IdentityTranslatorTest extends \PHPUnit_Framework_TestCase
             array('There are 10 apples', 'There is 1 apple|There are %count% apples', 10, array('%count%' => 10)),
             // custom validation messages may be coded with a fixed value
             array('There are 2 apples', 'There are 2 apples', 2, array('%count%' => 2)),
+            // tests for float numbers
+            array('There is almost half apple', '[0,0.5[ There is almost half apple |{0.5} There is half apple |]0.5,1] There is more than half apple', 0.2, array()),
+            array('There is half apple', '[0,0.5[ There is almost half apple |{0.5} There is half apple |]0.5,1] There is more than half apple', 0.5, array()),
+            array('There is more than half apple', '[0,0.5[ There is almost half apple |{0.5} There is half apple |]0.5,1] There is more than half apple', 0.8, array()),
         );
     }
 }

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -214,7 +214,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
             }
         }
 
-        return strtr($this->selector->choose($catalogue->get($id, $domain), (int) $number, $locale), $parameters);
+        return strtr($this->selector->choose($catalogue->get($id, $domain), $number, $locale), $parameters);
     }
 
     /**

--- a/src/Symfony/Component/Translation/TranslatorInterface.php
+++ b/src/Symfony/Component/Translation/TranslatorInterface.php
@@ -36,7 +36,7 @@ interface TranslatorInterface
      * Translates the given choice message by choosing a translation according to a number.
      *
      * @param string      $id         The message id (may also be an object that can be cast to string)
-     * @param int         $number     The number to use to find the indice of the message
+     * @param float|int   $number     The number to use to find the indice of the message
      * @param array       $parameters An array of parameters for the message
      * @param string|null $domain     The domain for the message or null to use the default
      * @param string|null $locale     The locale or null to use the default


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Revert the changes made on https://github.com/symfony/symfony/pull/7058.

The `MessageSelector` and `Interval` classes can work fine with float number from https://github.com/symfony/symfony/pull/5890, so there is no need to cast it to int.

(This should fix https://stackoverflow.com/questions/40592490/how-to-deal-with-non-integers-and-symfonys-transchoice)

