### PR TITLE
[Serializer][XmlEncoder] Allow removing empty tags in generated XML

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -393,7 +393,9 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
                 } elseif (is_numeric($key) || !$this->isElementNameValid($key)) {
                     $append = $this->appendNode($parentNode, $data, 'item', $key);
                 } else {
-                    $append = $this->appendNode($parentNode, $data, $key);
+                    if ($data !== null || !isset($this->context['remove_empty_tags']) || $this->context['remove_empty_tags'] === false) {
+                        $append = $this->appendNode($parentNode, $data, $key);
+                    }
                 }
             }
 

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -392,10 +392,8 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
                     }
                 } elseif (is_numeric($key) || !$this->isElementNameValid($key)) {
                     $append = $this->appendNode($parentNode, $data, 'item', $key);
-                } else {
-                    if ($data !== null || !isset($this->context['remove_empty_tags']) || $this->context['remove_empty_tags'] === false) {
-                        $append = $this->appendNode($parentNode, $data, $key);
-                    }
+                } elseif (null !== $data || !isset($this->context['remove_empty_tags']) || false === $this->context['remove_empty_tags']) {
+                    $append = $this->appendNode($parentNode, $data, $key);
                 }
             }
 

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -152,6 +152,16 @@ class XmlEncoderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expected, $this->encoder->encode($array, 'xml', $context));
     }
 
+    public function testEncodeNotRemovingEmptyTags()
+    {
+        $array = array('person' => array('firstname' => 'Peter', 'lastname' => null));
+
+        $expected = '<?xml version="1.0"?>'."\n".
+            '<response><person><firstname>Peter</firstname><lastname/></person></response>'."\n";
+
+        $this->assertSame($expected, $this->encoder->encode($array, 'xml'));
+    }
+
     public function testContext()
     {
         $array = array('person' => array('name' => 'George Abitbol'));

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -146,7 +146,7 @@ class XmlEncoderTest extends \PHPUnit_Framework_TestCase
             '<response><person><firstname>Peter</firstname></person></response>'."\n";
 
         $context = array(
-            'remove_empty_tags' => true
+            'remove_empty_tags' => true,
         );
 
         $this->assertSame($expected, $this->encoder->encode($array, 'xml', $context));

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -138,6 +138,21 @@ class XmlEncoderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expected, $this->encoder->encode($array, 'xml', $context));
     }
 
+    public function testEncodeRemovingEmptyTags()
+    {
+        $xml = simplexml_load_string('<firstname>Peter</firstname><lastname/>');
+        $array = array('person' => $xml);
+
+        $expected = '<?xml version="1.0"?>'."\n".
+            '<response><person><firstname>Peter</firstname></person></response>'."\n";
+
+        $context = array(
+            'remove_empty_tags' => true
+        );
+
+        $this->assertSame($expected, $this->encoder->encode($array, 'xml', $context));
+    }
+
     public function testContext()
     {
         $array = array('person' => array('name' => 'George Abitbol'));

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -145,9 +145,7 @@ class XmlEncoderTest extends \PHPUnit_Framework_TestCase
         $expected = '<?xml version="1.0"?>'."\n".
             '<response><person><firstname>Peter</firstname></person></response>'."\n";
 
-        $context = array(
-            'remove_empty_tags' => true,
-        );
+        $context = array('remove_empty_tags' => true);
 
         $this->assertSame($expected, $this->encoder->encode($array, 'xml', $context));
     }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -140,8 +140,7 @@ class XmlEncoderTest extends \PHPUnit_Framework_TestCase
 
     public function testEncodeRemovingEmptyTags()
     {
-        $xml = simplexml_load_string('<firstname>Peter</firstname><lastname/>');
-        $array = array('person' => $xml);
+        $array = array('person' => array('firstname' => 'Peter', 'lastname' => null));
 
         $expected = '<?xml version="1.0"?>'."\n".
             '<response><person><firstname>Peter</firstname></person></response>'."\n";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20398 
| License       | MIT
| Doc PR        | ~

Allow a new option in $context of XmlEncoder.php to remove empty tags if $context['remove_empty_tags'] setted to true, changing this : 

```xml
    <node>
         <subnode>Value</subnode>
         <emptysubnode/>
    </node>
```

To this :

```xml
    <node>
         <subnode>Value</subnode>
    </node>
```