### PR TITLE
[Serializer] Remove AbstractObjectNormalizer::isAttributeToNormalize

### DIFF
--- a/UPGRADE-3.1.md
+++ b/UPGRADE-3.1.md
@@ -111,6 +111,10 @@ Serializer
    deprecated and will not be supported in Symfony 4.0. You should use the
    `CacheClassMetadataFactory` class instead.
 
+ * The `AbstractObjectNormalizer::isAttributeToNormalize()` method has been removed
+   because it was initially added by mistake, has never been used and is not tested
+   nor documented.
+
 Translation
 -----------
 

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -209,20 +209,6 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
     abstract protected function setAttributeValue($object, $attribute, $value, $format = null, array $context = array());
 
     /**
-     * Should this attribute be normalized?
-     *
-     * @param mixed  $object
-     * @param string $attributeName
-     * @param array  $context
-     *
-     * @return bool
-     */
-    protected function isAttributeToNormalize($object, $attributeName, &$context)
-    {
-        return !in_array($attributeName, $this->ignoredAttributes) && !$this->isMaxDepthReached(get_class($object), $attributeName, $context);
-    }
-
-    /**
      * Validates the submitted data and denormalizes it.
      *
      * @param string      $currentClass


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | unclear
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

I've introduced this method by error in #17113. It has been forgotten during a refactoring. It has always been unused, is not covered by our test suite and has never been documented.

Technically it's a BC break (because this is a protected method), but I think that it's better to remove it has it has never be intended to be used, it's just a miss. An alternative is to deprecate it and remove it in v4.