### PR TITLE
Add teapot library to handle specific RFCs and provide mouseover expl…

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -16,71 +16,8 @@ namespace Symfony\Component\HttpFoundation;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class Response
+class Response implements ResponseStatusCode
 {
-    const HTTP_CONTINUE = 100;
-    const HTTP_SWITCHING_PROTOCOLS = 101;
-    const HTTP_PROCESSING = 102;            // RFC2518
-    const HTTP_OK = 200;
-    const HTTP_CREATED = 201;
-    const HTTP_ACCEPTED = 202;
-    const HTTP_NON_AUTHORITATIVE_INFORMATION = 203;
-    const HTTP_NO_CONTENT = 204;
-    const HTTP_RESET_CONTENT = 205;
-    const HTTP_PARTIAL_CONTENT = 206;
-    const HTTP_MULTI_STATUS = 207;          // RFC4918
-    const HTTP_ALREADY_REPORTED = 208;      // RFC5842
-    const HTTP_IM_USED = 226;               // RFC3229
-    const HTTP_MULTIPLE_CHOICES = 300;
-    const HTTP_MOVED_PERMANENTLY = 301;
-    const HTTP_FOUND = 302;
-    const HTTP_SEE_OTHER = 303;
-    const HTTP_NOT_MODIFIED = 304;
-    const HTTP_USE_PROXY = 305;
-    const HTTP_RESERVED = 306;
-    const HTTP_TEMPORARY_REDIRECT = 307;
-    const HTTP_PERMANENTLY_REDIRECT = 308;  // RFC7238
-    const HTTP_BAD_REQUEST = 400;
-    const HTTP_UNAUTHORIZED = 401;
-    const HTTP_PAYMENT_REQUIRED = 402;
-    const HTTP_FORBIDDEN = 403;
-    const HTTP_NOT_FOUND = 404;
-    const HTTP_METHOD_NOT_ALLOWED = 405;
-    const HTTP_NOT_ACCEPTABLE = 406;
-    const HTTP_PROXY_AUTHENTICATION_REQUIRED = 407;
-    const HTTP_REQUEST_TIMEOUT = 408;
-    const HTTP_CONFLICT = 409;
-    const HTTP_GONE = 410;
-    const HTTP_LENGTH_REQUIRED = 411;
-    const HTTP_PRECONDITION_FAILED = 412;
-    const HTTP_REQUEST_ENTITY_TOO_LARGE = 413;
-    const HTTP_REQUEST_URI_TOO_LONG = 414;
-    const HTTP_UNSUPPORTED_MEDIA_TYPE = 415;
-    const HTTP_REQUESTED_RANGE_NOT_SATISFIABLE = 416;
-    const HTTP_EXPECTATION_FAILED = 417;
-    const HTTP_I_AM_A_TEAPOT = 418;                                               // RFC2324
-    const HTTP_MISDIRECTED_REQUEST = 421;                                         // RFC7540
-    const HTTP_UNPROCESSABLE_ENTITY = 422;                                        // RFC4918
-    const HTTP_LOCKED = 423;                                                      // RFC4918
-    const HTTP_FAILED_DEPENDENCY = 424;                                           // RFC4918
-    const HTTP_RESERVED_FOR_WEBDAV_ADVANCED_COLLECTIONS_EXPIRED_PROPOSAL = 425;   // RFC2817
-    const HTTP_UPGRADE_REQUIRED = 426;                                            // RFC2817
-    const HTTP_PRECONDITION_REQUIRED = 428;                                       // RFC6585
-    const HTTP_TOO_MANY_REQUESTS = 429;                                           // RFC6585
-    const HTTP_REQUEST_HEADER_FIELDS_TOO_LARGE = 431;                             // RFC6585
-    const HTTP_UNAVAILABLE_FOR_LEGAL_REASONS = 451;
-    const HTTP_INTERNAL_SERVER_ERROR = 500;
-    const HTTP_NOT_IMPLEMENTED = 501;
-    const HTTP_BAD_GATEWAY = 502;
-    const HTTP_SERVICE_UNAVAILABLE = 503;
-    const HTTP_GATEWAY_TIMEOUT = 504;
-    const HTTP_VERSION_NOT_SUPPORTED = 505;
-    const HTTP_VARIANT_ALSO_NEGOTIATES_EXPERIMENTAL = 506;                        // RFC2295
-    const HTTP_INSUFFICIENT_STORAGE = 507;                                        // RFC4918
-    const HTTP_LOOP_DETECTED = 508;                                               // RFC5842
-    const HTTP_NOT_EXTENDED = 510;                                                // RFC2774
-    const HTTP_NETWORK_AUTHENTICATION_REQUIRED = 511;                             // RFC6585
-
     /**
      * @var \Symfony\Component\HttpFoundation\ResponseHeaderBag
      */

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -60,67 +60,68 @@ class Response implements ResponseStatusCode
      * @var array
      */
     public static $statusTexts = array(
-        100 => 'Continue',
-        101 => 'Switching Protocols',
-        102 => 'Processing',            // RFC2518
-        200 => 'OK',
-        201 => 'Created',
-        202 => 'Accepted',
-        203 => 'Non-Authoritative Information',
-        204 => 'No Content',
-        205 => 'Reset Content',
-        206 => 'Partial Content',
-        207 => 'Multi-Status',          // RFC4918
-        208 => 'Already Reported',      // RFC5842
-        226 => 'IM Used',               // RFC3229
-        300 => 'Multiple Choices',
-        301 => 'Moved Permanently',
-        302 => 'Found',
-        303 => 'See Other',
-        304 => 'Not Modified',
-        305 => 'Use Proxy',
-        307 => 'Temporary Redirect',
-        308 => 'Permanent Redirect',    // RFC7238
-        400 => 'Bad Request',
-        401 => 'Unauthorized',
-        402 => 'Payment Required',
-        403 => 'Forbidden',
-        404 => 'Not Found',
-        405 => 'Method Not Allowed',
-        406 => 'Not Acceptable',
-        407 => 'Proxy Authentication Required',
-        408 => 'Request Timeout',
-        409 => 'Conflict',
-        410 => 'Gone',
-        411 => 'Length Required',
-        412 => 'Precondition Failed',
-        413 => 'Payload Too Large',
-        414 => 'URI Too Long',
-        415 => 'Unsupported Media Type',
-        416 => 'Range Not Satisfiable',
-        417 => 'Expectation Failed',
-        418 => 'I\'m a teapot',                                               // RFC2324
-        421 => 'Misdirected Request',                                         // RFC7540
-        422 => 'Unprocessable Entity',                                        // RFC4918
-        423 => 'Locked',                                                      // RFC4918
-        424 => 'Failed Dependency',                                           // RFC4918
-        425 => 'Reserved for WebDAV advanced collections expired proposal',   // RFC2817
-        426 => 'Upgrade Required',                                            // RFC2817
-        428 => 'Precondition Required',                                       // RFC6585
-        429 => 'Too Many Requests',                                           // RFC6585
-        431 => 'Request Header Fields Too Large',                             // RFC6585
-        451 => 'Unavailable For Legal Reasons',                               // RFC7725
-        500 => 'Internal Server Error',
-        501 => 'Not Implemented',
-        502 => 'Bad Gateway',
-        503 => 'Service Unavailable',
-        504 => 'Gateway Timeout',
-        505 => 'HTTP Version Not Supported',
-        506 => 'Variant Also Negotiates (Experimental)',                      // RFC2295
-        507 => 'Insufficient Storage',                                        // RFC4918
-        508 => 'Loop Detected',                                               // RFC5842
-        510 => 'Not Extended',                                                // RFC2774
-        511 => 'Network Authentication Required',                             // RFC6585
+        self::HTTP_CONTINUE => 'Continue',
+        self::HTTP_SWITCHING_PROTOCOLS => 'Switching Protocols',
+        self::HTTP_PROCESSING => 'Processing',            // RFC2518
+        self::HTTP_OK => 'OK',
+        self::HTTP_CREATED => 'Created',
+        self::HTTP_ACCEPTED => 'Accepted',
+        self::HTTP_NON_AUTHORITATIVE_INFORMATION => 'Non-Authoritative Information',
+        self::HTTP_NO_CONTENT => 'No Content',
+        self::HTTP_RESET_CONTENT => 'Reset Content',
+        self::HTTP_PARTIAL_CONTENT => 'Partial Content',
+        self::HTTP_MULTI_STATUS => 'Multi-Status',          // RFC4918
+        self::HTTP_ALREADY_REPORTED => 'Already Reported',      // RFC5842
+        self::HTTP_IM_USED => 'IM Used',               // RFC3229
+        self::HTTP_MULTIPLE_CHOICES => 'Multiple Choices',
+        self::HTTP_MOVED_PERMANENTLY => 'Moved Permanently',
+        self::HTTP_FOUND => 'Found',
+        self::HTTP_SEE_OTHER => 'See Other',
+        self::HTTP_NOT_MODIFIED => 'Not Modified',
+        self::HTTP_USE_PROXY => 'Use Proxy',
+        self::HTTP_TEMPORARY_REDIRECT => 'Temporary Redirect',
+        self::HTTP_PERMANENTLY_REDIRECT => 'Permanent Redirect',    // RFC7238
+        self::HTTP_BAD_REQUEST => 'Bad Request',
+        self::HTTP_UNAUTHORIZED => 'Unauthorized',
+        self::HTTP_PAYMENT_REQUIRED => 'Payment Required',
+        self::HTTP_FORBIDDEN => 'Forbidden',
+        self::HTTP_NOT_FOUND => 'Not Found',
+        self::HTTP_METHOD_NOT_ALLOWED => 'Method Not Allowed',
+        self::HTTP_NOT_ACCEPTABLE => 'Not Acceptable',
+        self::HTTP_PROXY_AUTHENTICATION_REQUIRED => 'Proxy Authentication Required',
+        self::HTTP_REQUEST_TIMEOUT => 'Request Timeout',
+        self::HTTP_CONFLICT => 'Conflict',
+        self::HTTP_GONE => 'Gone',
+        self::HTTP_LENGTH_REQUIRED => 'Length Required',
+        self::HTTP_PRECONDITION_FAILED => 'Precondition Failed',
+        self::HTTP_REQUEST_ENTITY_TOO_LARGE => 'Payload Too Large',
+        self::HTTP_REQUEST_URI_TOO_LONG => 'URI Too Long',
+        self::HTTP_UNSUPPORTED_MEDIA_TYPE => 'Unsupported Media Type',
+        self::HTTP_REQUESTED_RANGE_NOT_SATISFIABLE => 'Range Not Satisfiable',
+        self::HTTP_EXPECTATION_FAILED => 'Expectation Failed',
+        self::HTTP_I_AM_A_TEAPOT => 'I\'m a teapot',
+        self::HTTP_MISDIRECTED_REQUEST => 'Misdirected Request',
+        self::HTTP_UNPROCESSABLE_ENTITY => 'Unprocessable Entity',
+        self::HTTP_LOCKED => 'Locked',
+        self::HTTP_FAILED_DEPENDENCY => 'Failed Dependency',
+        self::HTTP_RESERVED_FOR_WEBDAV_ADVANCED_COLLECTIONS_EXPIRED_PROPOSAL =>
+            'Reserved for WebDAV advanced collections expired proposal',
+        self::HTTP_UPGRADE_REQUIRED => 'Upgrade Required',
+        self::HTTP_PRECONDITION_FAILED => 'Precondition Required',
+        self::HTTP_TOO_MANY_REQUESTS => 'Too Many Requests',
+        self::HTTP_REQUEST_HEADER_FIELDS_TOO_LARGE => 'Request Header Fields Too Large',
+        self::HTTP_UNAVAILABLE_FOR_LEGAL_REASONS => 'Unavailable For Legal Reasons',
+        self::HTTP_INTERNAL_SERVER_ERROR => 'Internal Server Error',
+        self::HTTP_NOT_IMPLEMENTED => 'Not Implemented',
+        self::HTTP_BAD_GATEWAY => 'Bad Gateway',
+        self::HTTP_SERVICE_UNAVAILABLE => 'Service Unavailable',
+        self::HTTP_GATEWAY_TIMEOUT => 'Gateway Timeout',
+        self::HTTP_VERSION_NOT_SUPPORTED => 'HTTP Version Not Supported',
+        self::HTTP_VARIANT_ALSO_NEGOTIATES_EXPERIMENTAL => 'Variant Also Negotiates (Experimental)',
+        self::HTTP_INSUFFICIENT_STORAGE => 'Insufficient Storage',
+        self::HTTP_LOOP_DETECTED => 'Loop Detected',
+        self::HTTP_NOT_EXTENDED => 'Not Extended',
+        self::HTTP_NETWORK_AUTHENTICATION_REQUIRED => 'Network Authentication Required',
     );
 
     private static $deprecatedMethods = array(
@@ -504,7 +505,15 @@ class Response implements ResponseStatusCode
      */
     public function isCacheable()
     {
-        if (!in_array($this->statusCode, array(200, 203, 300, 301, 302, 404, 410))) {
+        if (!in_array($this->statusCode, array(
+            self::HTTP_OK,
+            self::HTTP_NON_AUTHORITATIVE_INFORMATION,
+            self::HTTP_MULTIPLE_CHOICES,
+            self::HTTP_MOVED_PERMANENTLY,
+            self::HTTP_FOUND,
+            self::HTTP_NOT_FOUND,
+            self::HTTP_GONE
+        ))) {
             return false;
         }
 
@@ -1078,7 +1087,7 @@ class Response implements ResponseStatusCode
      */
     public function isOk()
     {
-        return 200 === $this->statusCode;
+        return self::HTTP_OK === $this->statusCode;
     }
 
     /**
@@ -1088,7 +1097,7 @@ class Response implements ResponseStatusCode
      */
     public function isForbidden()
     {
-        return 403 === $this->statusCode;
+        return self::HTTP_FORBIDDEN === $this->statusCode;
     }
 
     /**
@@ -1098,7 +1107,7 @@ class Response implements ResponseStatusCode
      */
     public function isNotFound()
     {
-        return 404 === $this->statusCode;
+        return self::HTTP_NOT_FOUND === $this->statusCode;
     }
 
     /**
@@ -1110,7 +1119,14 @@ class Response implements ResponseStatusCode
      */
     public function isRedirect($location = null)
     {
-        return in_array($this->statusCode, array(201, 301, 302, 303, 307, 308)) && (null === $location ?: $location == $this->headers->get('Location'));
+        return in_array($this->statusCode, array(
+            self::HTTP_CREATED,
+            self::HTTP_MOVED_PERMANENTLY,
+            self::HTTP_FOUND,
+            self::HTTP_SEE_OTHER,
+            self::HTTP_TEMPORARY_REDIRECT,
+            self::HTTP_PERMANENTLY_REDIRECT
+        )) && (null === $location ?: $location == $this->headers->get('Location'));
     }
 
     /**
@@ -1120,7 +1136,7 @@ class Response implements ResponseStatusCode
      */
     public function isEmpty()
     {
-        return in_array($this->statusCode, array(204, 304));
+        return in_array($this->statusCode, array(self::HTTP_NO_CONTENT, self::HTTP_NOT_MODIFIED));
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/ResponseStatusCode.php
+++ b/src/Symfony/Component/HttpFoundation/ResponseStatusCode.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation;
+
+use Teapot\StatusCode\RFC\RFC2295;
+use Teapot\StatusCode\RFC\RFC2324;
+use Teapot\StatusCode\RFC\RFC2518;
+use Teapot\StatusCode\RFC\RFC2774;
+use Teapot\StatusCode\RFC\RFC2817;
+use Teapot\StatusCode\RFC\RFC3229;
+use Teapot\StatusCode\RFC\RFC3648;
+use Teapot\StatusCode\RFC\RFC4918;
+use Teapot\StatusCode\RFC\RFC5842;
+use Teapot\StatusCode\RFC\RFC6585;
+use Teapot\StatusCode\RFC\RFC7231;
+use Teapot\StatusCode\RFC\RFC7232;
+use Teapot\StatusCode\RFC\RFC7233;
+use Teapot\StatusCode\RFC\RFC7235;
+use Teapot\StatusCode\RFC\RFC7538;
+use Teapot\StatusCode\RFC\RFC7540;
+use Teapot\StatusCode\RFC\RFC7725;
+
+interface ResponseStatusCode
+{
+    const HTTP_CONTINUE                                                  = RFC7231::CONTINUING;
+    const HTTP_SWITCHING_PROTOCOLS                                       = RFC7231::SWITCHING_PROTOCOLS;
+    const HTTP_PROCESSING                                                = RFC2518::PROCESSING;
+    const HTTP_OK                                                        = RFC7231::OK;
+    const HTTP_CREATED                                                   = RFC7231::CREATED;
+    const HTTP_ACCEPTED                                                  = RFC7231::ACCEPTED;
+    const HTTP_NON_AUTHORITATIVE_INFORMATION                             = RFC7231::NON_AUTHORATIVE_INFORMATION;
+    const HTTP_NO_CONTENT                                                = RFC7231::NO_CONTENT;
+    const HTTP_RESET_CONTENT                                             = RFC7231::RESET_CONTENT;
+    const HTTP_PARTIAL_CONTENT                                           = RFC7233::PARTIAL_CONTENT;
+    const HTTP_MULTI_STATUS                                              = RFC4918::MULTI_STATUS;
+    const HTTP_ALREADY_REPORTED                                          = RFC5842::ALREADY_REPORTED;
+    const HTTP_IM_USED                                                   = RFC3229::IM_USED;
+    const HTTP_MULTIPLE_CHOICES                                          = RFC7231::MULTIPLE_CHOICES;
+    const HTTP_MOVED_PERMANENTLY                                         = RFC7231::MOVED_PERMANENTLY;
+    const HTTP_FOUND                                                     = RFC7231::FOUND;
+    const HTTP_SEE_OTHER                                                 = RFC7231::SEE_OTHER;
+    const HTTP_NOT_MODIFIED                                              = RFC7232::NOT_MODIFIED;
+    const HTTP_USE_PROXY                                                 = RFC7231::USE_PROXY;
+    const HTTP_RESERVED                                                  = RFC7231::UNUSED;
+    const HTTP_TEMPORARY_REDIRECT                                        = RFC7231::TEMPORARY_REDIRECT;
+    const HTTP_PERMANENTLY_REDIRECT                                      = RFC7538::PERMANENT_REDIRECT;
+    const HTTP_BAD_REQUEST                                               = RFC7231::BAD_REQUEST;
+    const HTTP_UNAUTHORIZED                                              = RFC7235::UNAUTHORIZED;
+    const HTTP_PAYMENT_REQUIRED                                          = RFC7231::PAYMENT_REQUIRED;
+    const HTTP_FORBIDDEN                                                 = RFC7231::FORBIDDEN;
+    const HTTP_NOT_FOUND                                                 = RFC7231::NOT_FOUND;
+    const HTTP_METHOD_NOT_ALLOWED                                        = RFC7231::METHOD_NOT_ALLOWED;
+    const HTTP_NOT_ACCEPTABLE                                            = RFC7231::NOT_ACCEPTABLE;
+    const HTTP_PROXY_AUTHENTICATION_REQUIRED                             = RFC7235::PROXY_AUTHENTICATION_REQUIRED;
+    const HTTP_REQUEST_TIMEOUT                                           = RFC7231::REQUEST_TIMEOUT;
+    const HTTP_CONFLICT                                                  = RFC7231::CONFLICT;
+    const HTTP_GONE                                                      = RFC7231::GONE;
+    const HTTP_LENGTH_REQUIRED                                           = RFC7231::LENGTH_REQUIRED;
+    const HTTP_PRECONDITION_FAILED                                       = RFC7232::PRECONDITION_FAILED;
+    const HTTP_REQUEST_ENTITY_TOO_LARGE                                  = RFC7231::PAYLOAD_TOO_LARGE;
+    const HTTP_REQUEST_URI_TOO_LONG                                      = RFC7231::URI_TOO_LONG;
+    const HTTP_UNSUPPORTED_MEDIA_TYPE                                    = RFC7231::UNSUPPORTED_MEDIA_TYPE;
+    const HTTP_REQUESTED_RANGE_NOT_SATISFIABLE                           = RFC7233::RANGE_NOT_SATISFIABLE;
+    const HTTP_EXPECTATION_FAILED                                        = RFC7231::EXPECTATION_FAILED;
+    const HTTP_I_AM_A_TEAPOT                                             = RFC2324::I_AM_A_TEAPOT;
+    const HTTP_MISDIRECTED_REQUEST                                       = RFC7540::MISDIRECTED_REQUEST;
+    const HTTP_UNPROCESSABLE_ENTITY                                      = RFC4918::UNPROCESSABLE_ENTITY;
+    const HTTP_LOCKED                                                    = RFC4918::ENTITY_LOCKED;
+    const HTTP_FAILED_DEPENDENCY                                         = RFC4918::FAILED_DEPENDENCY;
+    const HTTP_RESERVED_FOR_WEBDAV_ADVANCED_COLLECTIONS_EXPIRED_PROPOSAL = RFC3648::UNORDERED_COLLECTION;
+    const HTTP_UPGRADE_REQUIRED                                          = RFC2817::UPDATE_REQUIRED;
+    const HTTP_PRECONDITION_REQUIRED                                     = RFC6585::PRECONDITION_REQUIRED;
+    const HTTP_TOO_MANY_REQUESTS                                         = RFC6585::TOO_MANY_REQUESTS;
+    const HTTP_REQUEST_HEADER_FIELDS_TOO_LARGE                           = RFC6585::REQUEST_HEADER_FIELDS_TOO_LARGE;
+    const HTTP_UNAVAILABLE_FOR_LEGAL_REASONS                             = RFC7725::UNAVAILABLE_FOR_LEGAL_REASONS;
+    const HTTP_INTERNAL_SERVER_ERROR                                     = RFC7231::INTERNAL_SERVER_ERROR;
+    const HTTP_NOT_IMPLEMENTED                                           = RFC7231::NOT_IMPLEMENTED;
+    const HTTP_BAD_GATEWAY                                               = RFC7231::BAD_GATEWAY;
+    const HTTP_SERVICE_UNAVAILABLE                                       = RFC7231::SERVICE_UNAVAILABLE;
+    const HTTP_GATEWAY_TIMEOUT                                           = RFC7231::GATEWAY_TIMEOUT;
+    const HTTP_VERSION_NOT_SUPPORTED                                     = RFC7231::HTTP_VERSION_NOT_SUPPORTED;
+    const HTTP_VARIANT_ALSO_NEGOTIATES_EXPERIMENTAL                      = RFC2295::VARIANT_ALSO_NEGOTIATES;
+    const HTTP_INSUFFICIENT_STORAGE                                      = RFC4918::INSUFFICIENT_STORAGE;
+    const HTTP_LOOP_DETECTED                                             = RFC5842::LOOP_DETECTED;
+    const HTTP_NOT_EXTENDED                                              = RFC2774::NOT_EXTENDED;
+    const HTTP_NETWORK_AUTHENTICATION_REQUIRED                           = RFC6585::NETWORK_AUTHENTICATION_REQUIRED;
+}

--- a/src/Symfony/Component/HttpFoundation/ResponseStatusCode.php
+++ b/src/Symfony/Component/HttpFoundation/ResponseStatusCode.php
@@ -31,66 +31,252 @@ use Teapot\StatusCode\RFC\RFC7725;
 
 interface ResponseStatusCode
 {
+    /**
+     * @see RFC7231::CONTINUING
+     */
     const HTTP_CONTINUE                                                  = RFC7231::CONTINUING;
+    /**
+     * @see RFC7231::SWITCHING_PROTOCOLS;
+     */
     const HTTP_SWITCHING_PROTOCOLS                                       = RFC7231::SWITCHING_PROTOCOLS;
+    /**
+     * @see RFC2518::PROCESSING
+     */
     const HTTP_PROCESSING                                                = RFC2518::PROCESSING;
+    /**
+     * @see RFC7231::OK
+     */
     const HTTP_OK                                                        = RFC7231::OK;
+    /**
+     * @see RFC7231::CREATED
+     */
     const HTTP_CREATED                                                   = RFC7231::CREATED;
+    /**
+     * @see RFC7231::ACCEPTED
+     */
     const HTTP_ACCEPTED                                                  = RFC7231::ACCEPTED;
+    /**
+     * @see RFC7231::NON_AUTHORATIVE_INFORMATION
+     */
     const HTTP_NON_AUTHORITATIVE_INFORMATION                             = RFC7231::NON_AUTHORATIVE_INFORMATION;
+    /**
+     * @see RFC7231::NO_CONTENT
+     */
     const HTTP_NO_CONTENT                                                = RFC7231::NO_CONTENT;
+    /**
+     * @see RFC7231::RESET_CONTENT
+     */
     const HTTP_RESET_CONTENT                                             = RFC7231::RESET_CONTENT;
+    /**
+     * @see RFC7233::PARTIAL_CONTENT
+     */
     const HTTP_PARTIAL_CONTENT                                           = RFC7233::PARTIAL_CONTENT;
+    /**
+     * @see RFC4918::MULTI_STATUS
+     */
     const HTTP_MULTI_STATUS                                              = RFC4918::MULTI_STATUS;
+    /**
+     * @see RFC5842::ALREADY_REPORTED
+     */
     const HTTP_ALREADY_REPORTED                                          = RFC5842::ALREADY_REPORTED;
+    /**
+     * @see RFC3229::IM_USED
+     */
     const HTTP_IM_USED                                                   = RFC3229::IM_USED;
+    /**
+     * @see RFC7231::MULTIPLE_CHOICES
+     */
     const HTTP_MULTIPLE_CHOICES                                          = RFC7231::MULTIPLE_CHOICES;
+    /**
+     * @see RFC7231::MOVED_PERMANENTLY
+     */
     const HTTP_MOVED_PERMANENTLY                                         = RFC7231::MOVED_PERMANENTLY;
+    /**
+     * @see RFC7231::FOUND
+     */
     const HTTP_FOUND                                                     = RFC7231::FOUND;
+    /**
+     * @see RFC7231::SEE_OTHER
+     */
     const HTTP_SEE_OTHER                                                 = RFC7231::SEE_OTHER;
+    /**
+     * @see RFC7232::NOT_MODIFIED
+     */
     const HTTP_NOT_MODIFIED                                              = RFC7232::NOT_MODIFIED;
+    /**
+     * @see RFC7231::USE_PROXY
+     */
     const HTTP_USE_PROXY                                                 = RFC7231::USE_PROXY;
+    /**
+     * @see RFC7231::UNUSED
+     */
     const HTTP_RESERVED                                                  = RFC7231::UNUSED;
+    /**
+     * @see RFC7231::TEMPORARY_REDIRECT
+     */
     const HTTP_TEMPORARY_REDIRECT                                        = RFC7231::TEMPORARY_REDIRECT;
+    /**
+     * @see RFC7538::PERMANENT_REDIRECT
+     */
     const HTTP_PERMANENTLY_REDIRECT                                      = RFC7538::PERMANENT_REDIRECT;
+    /**
+     * @see RFC7231::BAD_REQUEST
+     */
     const HTTP_BAD_REQUEST                                               = RFC7231::BAD_REQUEST;
+    /**
+     * @see RFC7235::UNAUTHORIZED
+     */
     const HTTP_UNAUTHORIZED                                              = RFC7235::UNAUTHORIZED;
+    /**
+     * @see RFC7231::PAYMENT_REQUIRED;
+     */
     const HTTP_PAYMENT_REQUIRED                                          = RFC7231::PAYMENT_REQUIRED;
+    /**
+     * @see RFC7231::FORBIDDEN
+     */
     const HTTP_FORBIDDEN                                                 = RFC7231::FORBIDDEN;
+    /**
+     * @see RFC7231::NOT_FOUND
+     */
     const HTTP_NOT_FOUND                                                 = RFC7231::NOT_FOUND;
+    /**
+     * @see RFC7231::METHOD_NOT_ALLOWED
+     */
     const HTTP_METHOD_NOT_ALLOWED                                        = RFC7231::METHOD_NOT_ALLOWED;
+    /**
+     * @see RFC7231::NOT_ACCEPTABLE
+     */
     const HTTP_NOT_ACCEPTABLE                                            = RFC7231::NOT_ACCEPTABLE;
+    /**
+     * @see RFC7235::PROXY_AUTHENTICATION_REQUIRED
+     */
     const HTTP_PROXY_AUTHENTICATION_REQUIRED                             = RFC7235::PROXY_AUTHENTICATION_REQUIRED;
+    /**
+     * @see RFC7231::REQUEST_TIMEOUT
+     */
     const HTTP_REQUEST_TIMEOUT                                           = RFC7231::REQUEST_TIMEOUT;
+    /**
+     * @see RFC7231::CONFLICT
+     */
     const HTTP_CONFLICT                                                  = RFC7231::CONFLICT;
+    /**
+     * @see RFC7231::GONE
+     */
     const HTTP_GONE                                                      = RFC7231::GONE;
+    /**
+     * @see RFC7231::LENGTH_REQUIRED
+     */
     const HTTP_LENGTH_REQUIRED                                           = RFC7231::LENGTH_REQUIRED;
+    /**
+     * @see RFC7232::PRECONDITION_FAILED
+     */
     const HTTP_PRECONDITION_FAILED                                       = RFC7232::PRECONDITION_FAILED;
+    /**
+     * @see RFC7231::PAYLOAD_TOO_LARGE
+     */
     const HTTP_REQUEST_ENTITY_TOO_LARGE                                  = RFC7231::PAYLOAD_TOO_LARGE;
+    /**
+     * @see RFC7231::URI_TOO_LONG
+     */
     const HTTP_REQUEST_URI_TOO_LONG                                      = RFC7231::URI_TOO_LONG;
+    /**
+     * @see RFC7231::UNSUPPORTED_MEDIA_TYPE
+     */
     const HTTP_UNSUPPORTED_MEDIA_TYPE                                    = RFC7231::UNSUPPORTED_MEDIA_TYPE;
+    /**
+     * @see RFC7233::RANGE_NOT_SATISFIABLE
+     */
     const HTTP_REQUESTED_RANGE_NOT_SATISFIABLE                           = RFC7233::RANGE_NOT_SATISFIABLE;
+    /**
+     * @see RFC7231::EXPECTATION_FAILED
+     */
     const HTTP_EXPECTATION_FAILED                                        = RFC7231::EXPECTATION_FAILED;
+    /**
+     * @see RFC2324::I_AM_A_TEAPOT
+     */
     const HTTP_I_AM_A_TEAPOT                                             = RFC2324::I_AM_A_TEAPOT;
+    /**
+     * @see RFC7540::MISDIRECTED_REQUEST
+     */
     const HTTP_MISDIRECTED_REQUEST                                       = RFC7540::MISDIRECTED_REQUEST;
+    /**
+     * @see RFC4918::UNPROCESSABLE_ENTITY
+     */
     const HTTP_UNPROCESSABLE_ENTITY                                      = RFC4918::UNPROCESSABLE_ENTITY;
+    /**
+     * @see RFC4918::ENTITY_LOCKED
+     */
     const HTTP_LOCKED                                                    = RFC4918::ENTITY_LOCKED;
+    /**
+     * @see RFC4918::FAILED_DEPENDENCY
+     */
     const HTTP_FAILED_DEPENDENCY                                         = RFC4918::FAILED_DEPENDENCY;
+    /**
+     * @see RFC3648::UNORDERED_COLLECTION
+     */
     const HTTP_RESERVED_FOR_WEBDAV_ADVANCED_COLLECTIONS_EXPIRED_PROPOSAL = RFC3648::UNORDERED_COLLECTION;
+    /**
+     * @see RFC2817::UPDATE_REQUIRED
+     */
     const HTTP_UPGRADE_REQUIRED                                          = RFC2817::UPDATE_REQUIRED;
+    /**
+     * @see RFC6585::PRECONDITION_REQUIRED
+     */
     const HTTP_PRECONDITION_REQUIRED                                     = RFC6585::PRECONDITION_REQUIRED;
+    /**
+     * @see RFC6585::TOO_MANY_REQUESTS
+     */
     const HTTP_TOO_MANY_REQUESTS                                         = RFC6585::TOO_MANY_REQUESTS;
+    /**
+     * @see RFC6585::REQUEST_HEADER_FIELDS_TOO_LARGE
+     */
     const HTTP_REQUEST_HEADER_FIELDS_TOO_LARGE                           = RFC6585::REQUEST_HEADER_FIELDS_TOO_LARGE;
+    /**
+     * @see RFC7725::UNAVAILABLE_FOR_LEGAL_REASONS
+     */
     const HTTP_UNAVAILABLE_FOR_LEGAL_REASONS                             = RFC7725::UNAVAILABLE_FOR_LEGAL_REASONS;
+    /**
+     * @see RFC7231::INTERNAL_SERVER_ERROR
+     */
     const HTTP_INTERNAL_SERVER_ERROR                                     = RFC7231::INTERNAL_SERVER_ERROR;
+    /**
+     * @see RFC7231::NOT_IMPLEMENTED
+     */
     const HTTP_NOT_IMPLEMENTED                                           = RFC7231::NOT_IMPLEMENTED;
+    /**
+     * @see RFC7231::BAD_GATEWAY
+     */
     const HTTP_BAD_GATEWAY                                               = RFC7231::BAD_GATEWAY;
+    /**
+     * @see RFC7231::SERVICE_UNAVAILABLE
+     */
     const HTTP_SERVICE_UNAVAILABLE                                       = RFC7231::SERVICE_UNAVAILABLE;
+    /**
+     * @see RFC7231::GATEWAY_TIMEOUT
+     */
     const HTTP_GATEWAY_TIMEOUT                                           = RFC7231::GATEWAY_TIMEOUT;
+    /**
+     * @see RFC7231::HTTP_VERSION_NOT_SUPPORTED
+     */
     const HTTP_VERSION_NOT_SUPPORTED                                     = RFC7231::HTTP_VERSION_NOT_SUPPORTED;
+    /**
+     * @see RFC2295::VARIANT_ALSO_NEGOTIATES
+     */
     const HTTP_VARIANT_ALSO_NEGOTIATES_EXPERIMENTAL                      = RFC2295::VARIANT_ALSO_NEGOTIATES;
+    /**
+     * @see RFC4918::INSUFFICIENT_STORAGE
+     */
     const HTTP_INSUFFICIENT_STORAGE                                      = RFC4918::INSUFFICIENT_STORAGE;
+    /**
+     * @see RFC5842::LOOP_DETECTED
+     */
     const HTTP_LOOP_DETECTED                                             = RFC5842::LOOP_DETECTED;
+    /**
+     * @see RFC2774::NOT_EXTENDED
+     */
     const HTTP_NOT_EXTENDED                                              = RFC2774::NOT_EXTENDED;
+    /**
+     * @see RFC6585::NETWORK_AUTHENTICATION_REQUIRED
+     */
     const HTTP_NETWORK_AUTHENTICATION_REQUIRED                           = RFC6585::NETWORK_AUTHENTICATION_REQUIRED;
 }

--- a/src/Symfony/Component/HttpFoundation/composer.json
+++ b/src/Symfony/Component/HttpFoundation/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "symfony/polyfill-mbstring": "~1.1"
+        "symfony/polyfill-mbstring": "~1.1",
+        "teapot/status-code": "~1.0"
     },
     "require-dev": {
         "symfony/expression-language": "~2.8|~3.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes (There are deprecated HTTP status codes currently in use which will still be honoured)
| Tests pass?   | no, I get a segmentation fault when trying to run phpunit from brew against php 7, so I am relying on the build server.
| Fixed tickets | None
| License       | MIT
| Doc PR        | reference to the documentation PR, if any

The Symfony Response component uses a number of constants representing HTTP status codes, against a variety of different RFCs (both active and deprecated). While comments point to the RFC in question (in some cases, incorrectly), it gives no context or definition for the code, because it it outside of the scope of the Response class to do so.

The [teapot] library's sole responsibility is hunting down official RFCs, putting the status code definition in an IDE-friendly code block in an interface that defines the RFC in question, and linking to the official IETF/W3C documentation.

This PR remaps the `HTTP_` constants in the `Response` class to the various RFCx interfaces within Teapot, as well as replacing the hardcoded integer-based keys in the status classes array (and other tests against individual integers) with the same constants to ensure no discrepancies. 

[teapot]: https://github.com/shrikeh/teapot