### PR TITLE
[DoctrineBridge] Fix deprecation message/documentation of implementing UserProviderInterface using the entity provider

### DIFF
--- a/UPGRADE-2.8.md
+++ b/UPGRADE-2.8.md
@@ -658,3 +658,8 @@ Routing
    // url generated in @router service
    $router->generate('blog_show', array('slug' => 'my-blog-post'), UrlGeneratorInterface::ABSOLUTE_URL);
    ```
+   
+DoctrineBridge
+--------------
+ * Deprecated using the entity provider with a Doctrine repository implementing `UserProviderInterface`.
+   Make it implement `UserLoaderInterface` instead.

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -202,6 +202,9 @@ UPGRADE FROM 2.x to 3.0
    closures, but the closure is now resolved in the type instead of in the
    loader.
 
+ * Using the entity provider with a Doctrine repository implementing `UserProviderInterface` is not supported anymore.
+   You should make the repository implement `UserLoaderInterface` instead.
+
 ### EventDispatcher
 
  * The interface `Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcherInterface`

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+2.8.0
+-----
+
+ * deprecated using the entity provider with a Doctrine repository implementing UserProviderInterface
+ * added UserLoaderInterface for loading users through Doctrine.
+
 2.7.0
 -----
 

--- a/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
@@ -55,7 +55,7 @@ class EntityUserProvider implements UserProviderInterface
                     throw new \InvalidArgumentException(sprintf('You must either make the "%s" entity Doctrine Repository ("%s") implement "Symfony\Bridge\Doctrine\Security\User\UserLoaderInterface" or set the "property" option in the corresponding entity provider configuration.', $this->classOrAlias, get_class($repository)));
                 }
 
-                @trigger_error('Implementing loadUserByUsername from Symfony\Component\Security\Core\User\UserProviderInterface is deprecated since version 2.8 and will be removed in 3.0. Implement the Symfony\Bridge\Doctrine\Security\User\UserLoaderInterface instead.', E_USER_DEPRECATED);
+                @trigger_error('Implementing Symfony\Component\Security\Core\User\UserProviderInterface in a Doctrine repository when using the entity provider is deprecated since version 2.8 and will not be supported in 3.0. Make the repository implement Symfony\Bridge\Doctrine\Security\User\UserLoaderInterface instead.', E_USER_DEPRECATED);
             }
 
             $user = $repository->loadUserByUsername($username);

--- a/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
@@ -81,6 +81,7 @@ class EntityUserProviderTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @group legacy
+     * @expectedDeprecation Implementing Symfony\Component\Security\Core\User\UserProviderInterface in a Doctrine repository when using the entity provider is deprecated since version 2.8 and will not be supported in 3.0. Make the repository implement Symfony\Bridge\Doctrine\Security\User\UserLoaderInterface instead.
      */
     public function testLoadUserByUsernameWithUserProviderRepositoryAndWithoutProperty()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes (but the behavior doesn't change)
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20514
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/5993 (already merged)