### PR TITLE
Fix phpDoc for UserInterface getRoles

### DIFF
--- a/src/Symfony/Component/Security/Core/User/UserInterface.php
+++ b/src/Symfony/Component/Security/Core/User/UserInterface.php
@@ -47,7 +47,7 @@ interface UserInterface
      * and populated in any number of different ways when the user object
      * is created.
      *
-     * @return (Role|string)[] The user roles
+     * @return Role[]|string[] The user roles
      */
     public function getRoles();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes?
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Otherwise it is not possible to navigate to Role, thus imported `Symfony\Component\Security\Core\Role\Role` is marked as not used by PhpStorm IDE.
