### PR TITLE
[PhpUnitBridge] Support namespaces that begin with Tests\

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/ClockMock.php
+++ b/src/Symfony/Bridge/PhpUnit/ClockMock.php
@@ -74,8 +74,8 @@ class ClockMock
         $self = get_called_class();
 
         $mockedNs = array(substr($class, 0, strrpos($class, '\\')));
-        if (strpos($class, '\\Tests\\')) {
-            $ns = str_replace('\\Tests\\', '\\', $class);
+        if (preg_match($pattern = '/(^|\\\\)Tests\\\\/', $class)) {
+            $ns = preg_replace($pattern, '$1', $class);
             $mockedNs[] = substr($ns, 0, strrpos($ns, '\\'));
         }
         foreach ($mockedNs as $ns) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes?
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

When registering a test class with `ClockMock`, the namespace of the tested class is resolved by removing `\Test\` from the namespace of the test class. But that does not work if this namespace actually starts with `Test\`.