### PR TITLE
[FrameworkBundle] Allowed symlinks when searching for translation, searialization and validation files

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -713,6 +713,7 @@ class FrameworkExtension extends Extension
 
             $files = array();
             $finder = Finder::create()
+                ->followLinks()
                 ->files()
                 ->filter(function (\SplFileInfo $file) {
                     return 2 === substr_count($file->getBasename(), '.') && preg_match('/\.\w+$/', $file->getBasename());

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -822,10 +822,10 @@ class FrameworkExtension extends Extension
             }
 
             if (is_dir($dir = $dirname.'/Resources/config/validation')) {
-                foreach (Finder::create()->files()->in($dir)->name('*.xml') as $file) {
+                foreach (Finder::create()->followLinks()->files()->in($dir)->name('*.xml') as $file) {
                     $files[0][] = $file->getPathname();
                 }
-                foreach (Finder::create()->files()->in($dir)->name('*.yml') as $file) {
+                foreach (Finder::create()->followLinks()->files()->in($dir)->name('*.yml') as $file) {
                     $files[1][] = $file->getPathname();
                 }
 
@@ -943,13 +943,13 @@ class FrameworkExtension extends Extension
             }
 
             if (is_dir($dir = $dirname.'/Resources/config/serialization')) {
-                foreach (Finder::create()->files()->in($dir)->name('*.xml') as $file) {
+                foreach (Finder::create()->followLinks()->files()->in($dir)->name('*.xml') as $file) {
                     $definition = new Definition('Symfony\Component\Serializer\Mapping\Loader\XmlFileLoader', array($file->getPathname()));
                     $definition->setPublic(false);
 
                     $serializerLoaders[] = $definition;
                 }
-                foreach (Finder::create()->files()->in($dir)->name('*.yml') as $file) {
+                foreach (Finder::create()->followLinks()->files()->in($dir)->name('*.yml') as $file) {
                     $definition = new Definition('Symfony\Component\Serializer\Mapping\Loader\YamlFileLoader', array($file->getPathname()));
                     $definition->setPublic(false);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

When we have a symlink folder in app/Resources/translations, files inside this symlink are not handled.