### PR TITLE
[HttpKernel] HttpKernel Don't allow installing HttpKernel 3.2 with WebProfilerBundle 3.1

### DIFF
--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -40,7 +40,8 @@
         "symfony/var-dumper": "~3.2"
     },
     "conflict": {
-        "symfony/config": "<2.8"
+        "symfony/config": "<2.8",
+        "symfony/web-profiler-bundle": "<3.2"
     },
     "suggest": {
         "symfony/browser-kit": "",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

The data collection in HttpKernel 3.2 is not compatible with WebProfilerBundle 3.1, probably due to the changes of #19614. At least in my environment, PHP errors like deprecations don't show up in the logs view of the profiler.

My suggestion would be to disallow installing those incompatible versions together.