### PR TITLE
[FrameworkBundle] Avoid warming up the validator cache for non-existent class

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ValidatorCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ValidatorCacheWarmer.php
@@ -68,7 +68,9 @@ class ValidatorCacheWarmer implements CacheWarmerInterface
 
         foreach ($this->extractSupportedLoaders($loaders) as $loader) {
             foreach ($loader->getMappedClasses() as $mappedClass) {
-                $metadataFactory->getMetadataFor($mappedClass);
+                if ($metadataFactory->hasMetadataFor($mappedClass)) {
+                    $metadataFactory->getMetadataFor($mappedClass);
+                }
             }
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Validation/Resources/person.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Validation/Resources/person.xml
@@ -15,4 +15,15 @@
             </constraint>
         </property>
     </class>
+
+    <class name="Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Validation\NonExistentClass">
+        <property name="gender">
+            <constraint name="Choice">
+                <option name="choices">
+                    <value>other</value>
+                </option>
+                <option name="message">This should be ignored.</option>
+            </constraint>
+        </property>
+    </class>
 </constraint-mapping>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? |no
| Tests pass?   | yes
| License       | MIT

This relates to https://github.com/FriendsOfSymfony/FOSUserBundle/issues/2224 - where basically the cache warmer triggers autoloading of a class that is broken, and it then blows up.

This doesn't fix the problem in itself, loading broken classes will still fail, but it allows us at least to work around it by doing:

```
        "exclude-from-classmap": [
            "vendor/friendsofsymfony/user-bundle/Propel/"
        ]
```

And then `composer dump-autoload -a` to get an authoritative classmap. That way the hasMetadataFor will return false because class_exist() won't try to load the class at all. Without the hasMetadataFor fix though, it calls getMetadataFor which throws an exception in the case the class doesn't exist. I am not sure if that's by design.. that the cache warmer would force you to have classes existing for all your validation definitions.