### PR TITLE
Fix annotation type for $context

### DIFF
--- a/src/Symfony/Component/Validator/ConstraintValidator.php
+++ b/src/Symfony/Component/Validator/ConstraintValidator.php
@@ -38,7 +38,7 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
     const OBJECT_TO_STRING = 2;
 
     /**
-     * @var ExecutionContextInterface
+     * @var ExecutionContextInterface2Dot5
      */
     protected $context;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Previous type ExecutionContextInterface was referring to a non declared namespace. Replacing it by ExecutionContextInterface2Dot5 fixes autocomplete.