### PR TITLE
[HttpFoundation] Create cookie from string + synchronize response cookies

### DIFF
--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -40,14 +40,14 @@ class HeaderBag implements \IteratorAggregate, \Countable
      */
     public function __toString()
     {
-        if (!$this->headers) {
+        if (!$headers = $this->all()) {
             return '';
         }
 
-        $max = max(array_map('strlen', array_keys($this->headers))) + 1;
+        ksort($headers);
+        $max = max(array_map('strlen', array_keys($headers))) + 1;
         $content = '';
-        ksort($this->headers);
-        foreach ($this->headers as $name => $values) {
+        foreach ($headers as $name => $values) {
             $name = implode('-', array_map('ucfirst', explode('-', $name)));
             foreach ($values as $value) {
                 $content .= sprintf("%-{$max}s %s\r\n", $name.':', $value);
@@ -74,7 +74,7 @@ class HeaderBag implements \IteratorAggregate, \Countable
      */
     public function keys()
     {
-        return array_keys($this->headers);
+        return array_keys($this->all());
     }
 
     /**
@@ -112,8 +112,9 @@ class HeaderBag implements \IteratorAggregate, \Countable
     public function get($key, $default = null, $first = true)
     {
         $key = str_replace('_', '-', strtolower($key));
+        $headers = $this->all();
 
-        if (!array_key_exists($key, $this->headers)) {
+        if (!array_key_exists($key, $headers)) {
             if (null === $default) {
                 return $first ? null : array();
             }
@@ -122,10 +123,10 @@ class HeaderBag implements \IteratorAggregate, \Countable
         }
 
         if ($first) {
-            return count($this->headers[$key]) ? $this->headers[$key][0] : $default;
+            return count($headers[$key]) ? $headers[$key][0] : $default;
         }
 
-        return $this->headers[$key];
+        return $headers[$key];
     }
 
     /**
@@ -161,7 +162,7 @@ class HeaderBag implements \IteratorAggregate, \Countable
      */
     public function has($key)
     {
-        return array_key_exists(str_replace('_', '-', strtolower($key)), $this->headers);
+        return array_key_exists(str_replace('_', '-', strtolower($key)), $this->all());
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -375,7 +375,7 @@ class Response
         }
 
         // headers
-        foreach ($this->headers->allPreserveCase() as $name => $values) {
+        foreach ($this->headers->allPreserveCaseWithoutCookies() as $name => $values) {
             foreach ($values as $value) {
                 header($name.': '.$value, false, $this->statusCode);
             }

--- a/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
@@ -54,28 +54,28 @@ class ResponseHeaderBag extends HeaderBag
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function __toString()
-    {
-        $cookies = '';
-        foreach ($this->getCookies() as $cookie) {
-            $cookies .= 'Set-Cookie: '.$cookie."\r\n";
-        }
-
-        ksort($this->headerNames);
-
-        return parent::__toString().$cookies;
-    }
-
-    /**
      * Returns the headers, with original capitalizations.
      *
      * @return array An array of headers
      */
     public function allPreserveCase()
     {
-        return array_combine($this->headerNames, $this->headers);
+        $headers = array();
+        foreach ($this->all() as $name => $value) {
+            $headers[isset($this->headerNames[$name]) ? $this->headerNames[$name] : $name] = $value;
+        }
+
+        return $headers;
+    }
+
+    public function allPreserveCaseWithoutCookies()
+    {
+        $headers = $this->allPreserveCase();
+        if (isset($this->headerNames['set-cookie'])) {
+            unset($headers[$this->headerNames['set-cookie']]);
+        }
+
+        return $headers;
     }
 
     /**
@@ -95,12 +95,38 @@ class ResponseHeaderBag extends HeaderBag
     /**
      * {@inheritdoc}
      */
+    public function all()
+    {
+        $headers = parent::all();
+        foreach ($this->getCookies() as $cookie) {
+            $headers['set-cookie'][] = (string) $cookie;
+        }
+
+        return $headers;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function set($key, $values, $replace = true)
     {
-        parent::set($key, $values, $replace);
-
         $uniqueKey = str_replace('_', '-', strtolower($key));
+
+        if ('set-cookie' === $uniqueKey) {
+            if ($replace) {
+                $this->cookies = array();
+            }
+            foreach ((array) $values as $cookie) {
+                $this->setCookie(Cookie::fromString($cookie));
+            }
+            $this->headerNames[$uniqueKey] = $key;
+
+            return;
+        }
+
         $this->headerNames[$uniqueKey] = $key;
+
+        parent::set($key, $values, $replace);
 
         // ensure the cache-control header has sensible defaults
         if (in_array($uniqueKey, array('cache-control', 'etag', 'last-modified', 'expires'))) {
@@ -116,10 +142,16 @@ class ResponseHeaderBag extends HeaderBag
      */
     public function remove($key)
     {
-        parent::remove($key);
-
         $uniqueKey = str_replace('_', '-', strtolower($key));
         unset($this->headerNames[$uniqueKey]);
+
+        if ('set-cookie' === $uniqueKey) {
+            $this->cookies = array();
+
+            return;
+        }
+
+        parent::remove($key);
 
         if ('cache-control' === $uniqueKey) {
             $this->computedCacheControl = array();
@@ -150,6 +182,7 @@ class ResponseHeaderBag extends HeaderBag
     public function setCookie(Cookie $cookie)
     {
         $this->cookies[$cookie->getDomain()][$cookie->getPath()][$cookie->getName()] = $cookie;
+        $this->headerNames['set-cookie'] = 'Set-Cookie';
     }
 
     /**
@@ -173,6 +206,10 @@ class ResponseHeaderBag extends HeaderBag
             if (empty($this->cookies[$domain])) {
                 unset($this->cookies[$domain]);
             }
+        }
+
+        if (empty($this->cookies)) {
+            unset($this->headerNames['set-cookie']);
         }
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
@@ -178,4 +178,13 @@ class CookieTest extends \PHPUnit_Framework_TestCase
         $cookie = new Cookie('foo', 'bar', $expire = time() - 100);
         $this->assertEquals($expire - time(), $cookie->getMaxAge());
     }
+
+    public function testFromString()
+    {
+        $cookie = Cookie::fromString('foo=bar; expires=Fri, 20-May-2011 15:25:52 GMT; path=/; domain=.myfoodomain.com; secure; httponly');
+        $this->assertEquals(new Cookie('foo', 'bar', strtotime('Fri, 20-May-2011 15:25:52 GMT'), '/', '.myfoodomain.com', true, true, true), $cookie);
+
+        $cookie = Cookie::fromString('foo=bar', true);
+        $this->assertEquals(new Cookie('foo', 'bar'), $cookie);
+    }
 }

--- a/src/Symfony/Component/HttpKernel/Client.php
+++ b/src/Symfony/Component/HttpKernel/Client.php
@@ -207,20 +207,11 @@ EOF;
      */
     protected function filterResponse($response)
     {
-        $headers = $response->headers->all();
-        if ($response->headers->getCookies()) {
-            $cookies = array();
-            foreach ($response->headers->getCookies() as $cookie) {
-                $cookies[] = new DomCookie($cookie->getName(), $cookie->getValue(), $cookie->getExpiresTime(), $cookie->getPath(), $cookie->getDomain(), $cookie->isSecure(), $cookie->isHttpOnly());
-            }
-            $headers['Set-Cookie'] = $cookies;
-        }
-
         // this is needed to support StreamedResponse
         ob_start();
         $response->sendContent();
         $content = ob_get_clean();
 
-        return new DomResponse($content, $response->getStatusCode(), $headers);
+        return new DomResponse($content, $response->getStatusCode(), $response->headers->all());
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/ClientTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/ClientTest.php
@@ -57,8 +57,8 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $m->setAccessible(true);
 
         $expected = array(
-            'foo=bar; expires=Sun, 15 Feb 2009 20:00:00 GMT; domain=http://example.com; path=/foo; secure; httponly',
-            'foo1=bar1; expires=Sun, 15 Feb 2009 20:00:00 GMT; domain=http://example.com; path=/foo; secure; httponly',
+            'foo=bar; expires=Sun, 15-Feb-2009 20:00:00 GMT; max-age='.(strtotime('Sun, 15-Feb-2009 20:00:00 GMT') - time()).'; path=/foo; domain=http://example.com; secure; httponly',
+            'foo1=bar1; expires=Sun, 15-Feb-2009 20:00:00 GMT; max-age='.(strtotime('Sun, 15-Feb-2009 20:00:00 GMT') - time()).'; path=/foo; domain=http://example.com; secure; httponly',
         );
 
         $response = new Response();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no-ish
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any
| License       | MIT
| Doc PR        | reference to the documentation PR, if any

Fixes the conversion/synchroniczation of cookies between the object API and string API, ie;

```php
$headers->setCookie(new Cookie('foo', 'bar'));
$headers->has('set-cookie'); // true

$headers->set('set-cookie', 'foo2=bar2', false);
count($headers->getCookies()); // 2
```

With an additional feature `Cookie::fromString($cookie)`

The BC break happens in terms you cannot set a custom `Set-Cookie` header anymore, all cookies are set via `set(raw)cookie` by PHP.

We could go one step further by tracking misc. attributes (`Cookie::getAttributes()`) and populate accordingly from `Cookie::fromString`. If the cookie has attributes we should bypass `setcookie` and write a header instead, but im not sure it's worth it.