### PR TITLE
[3.2][HttpKernel] Fix rendering route params in WDT

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -93,7 +93,6 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
                 foreach ($session->all() as $key => $value) {
                     $sessionAttributes[$key] = $this->cloneVar($value);
                 }
-                $sessionAttributes = $session->all();
                 $flashes = $session->getFlashBag()->peekAll();
             }
         }

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -90,7 +90,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
                 $sessionMetadata['Created'] = date(DATE_RFC822, $session->getMetadataBag()->getCreated());
                 $sessionMetadata['Last used'] = date(DATE_RFC822, $session->getMetadataBag()->getLastUsed());
                 $sessionMetadata['Lifetime'] = $session->getMetadataBag()->getLifetime();
-                foreach ($sessionAttributes as $key => $value) {
+                foreach ($session->all() as $key => $value) {
                     $sessionAttributes[$key] = $this->cloneVar($value);
                 }
                 $sessionAttributes = $session->all();

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -53,6 +53,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
         // attributes are serialized and as they can be anything, they need to be converted to strings.
         $attributes = array();
         $route = '';
+        $routeParams = array();
         foreach ($request->attributes->all() as $key => $value) {
             if ('_route' === $key && is_object($value)) {
                 $attributes[$key] = $this->cloneVar($value->getPath());
@@ -62,6 +63,10 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
 
             if ('_route' === $key) {
                 $route = is_object($value) ? $value->getPath() : $value;
+            }
+
+            if ('_route_params' === $key && is_array($value)) {
+                $routeParams = $value;
             }
         }
 
@@ -104,6 +109,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
             'request_cookies' => $request->cookies->all(),
             'request_attributes' => $attributes,
             'route' => $route,
+            'route_params' => $routeParams,
             'response_headers' => $responseHeaders,
             'session_metadata' => $sessionMetadata,
             'session_attributes' => $sessionAttributes,
@@ -264,7 +270,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
      */
     public function getRouteParams()
     {
-        return isset($this->data['request_attributes']['_route_params']) ? $this->data['request_attributes']['_route_params'] : $this->cloneVar(array());
+        return $this->data['route_params'];
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -66,7 +66,9 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
             }
 
             if ('_route_params' === $key && is_array($value)) {
-                $routeParams = $value;
+                foreach ($value as $k => $v) {
+                    $routeParams[$k] = $this->cloneVar($v);
+                }
             }
         }
 
@@ -88,6 +90,9 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
                 $sessionMetadata['Created'] = date(DATE_RFC822, $session->getMetadataBag()->getCreated());
                 $sessionMetadata['Last used'] = date(DATE_RFC822, $session->getMetadataBag()->getLastUsed());
                 $sessionMetadata['Lifetime'] = $session->getMetadataBag()->getLifetime();
+                foreach ($sessionAttributes as $key => $value) {
+                    $sessionAttributes[$key] = $this->cloneVar($value);
+                }
                 $sessionAttributes = $session->all();
                 $flashes = $session->getFlashBag()->peekAll();
             }

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
@@ -47,7 +47,7 @@ class RequestDataCollectorTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\ParameterBag', $c->getRequestQuery());
         $this->assertSame('html', $c->getFormat());
         $this->assertEquals('foobar', $c->getRoute());
-        $this->assertEquals($cloner->cloneVar(array('name' => 'foo')), $c->getRouteParams());
+        $this->assertEquals(array('name' => 'foo'), $c->getRouteParams());
         $this->assertSame(array(), $c->getSessionAttributes());
         $this->assertSame('en', $c->getLocale());
         $this->assertEquals($cloner->cloneVar($request->attributes->get('resource')), $attributes->get('resource'));

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
@@ -47,7 +47,7 @@ class RequestDataCollectorTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\ParameterBag', $c->getRequestQuery());
         $this->assertSame('html', $c->getFormat());
         $this->assertEquals('foobar', $c->getRoute());
-        $this->assertEquals(array('name' => 'foo'), $c->getRouteParams());
+        $this->assertEquals(array('name' => $cloner->cloneVar('foo')), $c->getRouteParams());
         $this->assertSame(array(), $c->getSessionAttributes());
         $this->assertSame('en', $c->getLocale());
         $this->assertEquals($cloner->cloneVar($request->attributes->get('resource')), $attributes->get('resource'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any
| License       | MIT
| Doc PR        | reference to the documentation PR, if any

The route parameters are not rendered in 3.2 in the WDT (routing panel) as `is empty` in twig fails on a `Data` object. This preserves the array type.

![image](https://cloud.githubusercontent.com/assets/1047696/20463595/2b5ef0d4-af37-11e6-8daf-d8974cb72898.png)

With or without params.

See also https://github.com/symfony/symfony/pull/19614/files#diff-e8f5b14fbfbbeac60fc9f3abe310c3b0L59