### PR TITLE
[FrameworkBundle] Mark cache.default_*_provider services private

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1045,6 +1045,7 @@ class FrameworkExtension extends Extension
         foreach (array('doctrine', 'psr6', 'redis') as $name) {
             if (isset($config[$name = 'default_'.$name.'_provider'])) {
                 $container->setAlias('cache.'.$name, Compiler\CachePoolPass::getServiceProvider($container, $config[$name]));
+                $container->getAlias('cache.'.$name)->setPublic(false);
             }
         }
         foreach (array('app', 'system') as $name) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20563
| License       | MIT
| Doc PR        | -

I know making a service private has a potential for breaking BC. Yet, these services should not be used directly in controllers/userland code, and I really doubt anyone did. Let's make it private now and fix linked issue (even if it's a false positive from SymfonyServiceDefinitionValidator, it shows we have this service that really isn't meant to be public).