### PR TITLE
[HttpFoundation][DX] Add has() method to Request

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -732,6 +732,24 @@ class Request
     }
 
     /**
+     * Returns true if the parameter is defined from any bag.
+     *
+     * This method is mainly useful for libraries that want to provide some flexibility. If you don't need the
+     * flexibility in controllers, it is better to explicitly check request parameters from the appropriate
+     * public property instead (attributes, query, request).
+     *
+     * Order of precedence: PATH (routing placeholders or custom attributes), GET, BODY
+     *
+     * @param string $key the key
+     *
+     * @return bool true if the parameter exists, false otherwise
+     */
+    public function has($key)
+    {
+        return $this->attributes->has($key) || $this->query->has($key) || $this->request->has($key);
+    }
+
+    /**
      * Gets the Session.
      *
      * @return SessionInterface|null The session

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1301,6 +1301,25 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($request->get('foo'));
     }
 
+    public function testHasParameterPrecedence()
+    {
+        $request = new Request();
+        $request->attributes->set('foo', 'attr');
+        $request->query->set('foo', 'query');
+        $request->request->set('foo', 'body');
+
+        $this->assertTrue($request->has('foo'));
+
+        $request->attributes->remove('foo');
+        $this->assertTrue($request->has('foo'));
+
+        $request->query->remove('foo');
+        $this->assertTrue($request->has('foo'));
+
+        $request->request->remove('foo');
+        $this->assertFalse($request->has('foo'));
+    }
+
     public function testGetPreferredLanguage()
     {
         $request = new Request();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

### Check Request Parameters:

| PR's Moment | ``IF`` Statement | Memory Usage | Speed | DX
| ------ | ------ | ----------| ------- | ----
| Before | ``$request->get('foo')`` | Yes | 1x | Regular
| Before | ``$request->attributes->has('foo') || $request->query->has('foo') || $request->request->has('foo')`` | No | 2x | Normal
| **After** | **``$request->has('foo')``** | **No** | **2x** | **Good**

This method is mainly useful for libraries that want to provide some flexibility.