### PR TITLE
[SecurityBundle] Method to retrieve firewall config by name

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
@@ -63,6 +63,24 @@ class FirewallMap implements FirewallMapInterface
         return $context->getConfig();
     }
 
+    /**
+     * @param string $name
+     *
+     * @throws \OutOfBoundsException
+     *
+     * @return FirewallConfig
+     */
+    public function getFirewallConfigByName($name)
+    {
+        $contextId = 'security.firewall.map.context.'.$name;
+
+        if (!array_key_exists($contextId, $this->map)) {
+            throw new \OutOfBoundsException(sprintf('The firewall "%s" does not exist.', $name));
+        }
+
+        return $this->container->get($contextId)->getConfig();
+    }
+
     private function getFirewallContext(Request $request)
     {
         if ($this->contexts->contains($request)) {

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallMapTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallMapTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Security;
+
+use Symfony\Bundle\SecurityBundle\Security\FirewallConfig;
+use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
+
+class FirewallMapTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetFirewallConfigByName()
+    {
+        $config = new FirewallConfig('foo', 'bar', 'baz');
+
+        $context = $this->getMockBuilder('Symfony\Bundle\SecurityBundle\Security\FirewallContext')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $context
+            ->expects($this->once())
+            ->method('getConfig')
+            ->will($this->returnValue($config))
+        ;
+
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('security.firewall.map.context.foo'))
+            ->will($this->returnValue($context))
+        ;
+
+        $map = new FirewallMap($container, array(
+            'security.firewall.map.context.foo' => $this->getMock('Symfony\Component\HttpFoundation\RequestMatcher'),
+            'security.firewall.map.context.bar' => $this->getMock('Symfony\Component\HttpFoundation\RequestMatcher'),
+        ));
+
+        $this->assertSame($config, $map->getFirewallConfigByName('foo'));
+    }
+
+    /**
+     * @expectedException \OutOfBoundsException
+     */
+    public function testGetFirewallConfigByNameWithUnknownName()
+    {
+        $map = new FirewallMap(
+            $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface'),
+            array()
+        );
+
+        $map->getFirewallConfigByName('foo');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

The `FirewallMap` class allows to retrieve the config for the firewall that matches a given request only. This PR adds a method to retrieve the config of any firewall by its name.