### PR TITLE
[SecurityBundle] Fix complete config tests

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
@@ -21,7 +21,9 @@ abstract class CompleteConfigurationTest extends \PHPUnit_Framework_TestCase
 {
     private static $containerCache = array();
 
-    abstract protected function loadFromFile(ContainerBuilder $container, $file);
+    abstract protected function getLoader(ContainerBuilder $container);
+
+    abstract protected function getFileExtension();
 
     public function testRolesHierarchy()
     {
@@ -237,6 +239,8 @@ abstract class CompleteConfigurationTest extends \PHPUnit_Framework_TestCase
 
     protected function getContainer($file)
     {
+        $file = $file.'.'.$this->getFileExtension();
+
         if (isset(self::$containerCache[$file])) {
             return self::$containerCache[$file];
         }
@@ -246,7 +250,7 @@ abstract class CompleteConfigurationTest extends \PHPUnit_Framework_TestCase
 
         $bundle = new SecurityBundle();
         $bundle->build($container); // Attach all default factories
-        $this->loadFromFile($container, $file);
+        $this->getLoader($container)->load($file);
 
         $container->getCompilerPassConfig()->setOptimizationPasses(array());
         $container->getCompilerPassConfig()->setRemovingPasses(array());

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/PhpCompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/PhpCompleteConfigurationTest.php
@@ -17,9 +17,13 @@ use Symfony\Component\Config\FileLocator;
 
 class PhpCompleteConfigurationTest extends CompleteConfigurationTest
 {
-    protected function loadFromFile(ContainerBuilder $container, $file)
+    protected function getLoader(ContainerBuilder $container)
     {
-        $loadXml = new PhpFileLoader($container, new FileLocator(__DIR__.'/Fixtures/php'));
-        $loadXml->load($file.'.php');
+        return new PhpFileLoader($container, new FileLocator(__DIR__.'/Fixtures/php'));
+    }
+
+    protected function getFileExtension()
+    {
+        return 'php';
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/XmlCompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/XmlCompleteConfigurationTest.php
@@ -17,9 +17,13 @@ use Symfony\Component\Config\FileLocator;
 
 class XmlCompleteConfigurationTest extends CompleteConfigurationTest
 {
-    protected function loadFromFile(ContainerBuilder $container, $file)
+    protected function getLoader(ContainerBuilder $container)
     {
-        $loadXml = new XmlFileLoader($container, new FileLocator(__DIR__.'/Fixtures/xml'));
-        $loadXml->load($file.'.xml');
+        return new XmlFileLoader($container, new FileLocator(__DIR__.'/Fixtures/xml'));
+    }
+
+    protected function getFileExtension()
+    {
+        return 'xml';
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/YamlCompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/YamlCompleteConfigurationTest.php
@@ -17,9 +17,13 @@ use Symfony\Component\Config\FileLocator;
 
 class YamlCompleteConfigurationTest extends CompleteConfigurationTest
 {
-    protected function loadFromFile(ContainerBuilder $container, $file)
+    protected function getLoader(ContainerBuilder $container)
     {
-        $loadXml = new YamlFileLoader($container, new FileLocator(__DIR__.'/Fixtures/yml'));
-        $loadXml->load($file.'.yml');
+        return new YamlFileLoader($container, new FileLocator(__DIR__.'/Fixtures/yml'));
+    }
+
+    protected function getFileExtension()
+    {
+        return 'yml';
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Fixes a little bug in `*CompleteConfigurationTest`: if a test fails for one format, subsequent tests for other formats will also fail. This is because subsequent tests actually use the container built from the very first tested config, which is PHP if all tests are ran.

This can be reproduced by changing a value in the PHP config fixtures. `PhpCompleteConfigurationTest` will fail as expected but `XmlCompleteConfigurationTest` and `YamlCompleteConfigurationTest` will fail too, which is not expected.