### PR TITLE
[SecurityBundle] Fix FirewallConfig nullable arguments

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -267,6 +267,7 @@ class SecurityExtension extends Extension
     {
         $config = $container->setDefinition($configId, new DefinitionDecorator('security.firewall.config'));
         $config->replaceArgument(0, $id);
+        $config->replaceArgument(1, $firewall['user_checker']);
 
         // Matcher
         $matcher = null;
@@ -279,8 +280,7 @@ class SecurityExtension extends Extension
             $matcher = $this->createRequestMatcher($container, $pattern, $host, $methods);
         }
 
-        $config->replaceArgument(1, (string) $matcher);
-        $config->replaceArgument(2, $firewall['user_checker']);
+        $config->replaceArgument(2, $matcher ? (string) $matcher : null);
         $config->replaceArgument(3, $firewall['security']);
 
         // Security disabled?
@@ -306,6 +306,7 @@ class SecurityExtension extends Extension
         // Channel listener
         $listeners[] = new Reference('security.channel_listener');
 
+        $contextKey = null;
         // Context serializer listener
         if (false === $firewall['stateless']) {
             $contextKey = $id;
@@ -313,10 +314,10 @@ class SecurityExtension extends Extension
                 $contextKey = $firewall['context'];
             }
 
-            $config->replaceArgument(6, $contextKey);
-
             $listeners[] = new Reference($this->createContextListener($container, $contextKey));
         }
+
+        $config->replaceArgument(6, $contextKey);
 
         // Logout listener
         if (isset($firewall['logout'])) {
@@ -399,12 +400,8 @@ class SecurityExtension extends Extension
         // Exception listener
         $exceptionListener = new Reference($this->createExceptionListener($container, $firewall, $id, $configuredEntryPoint ?: $defaultEntryPoint, $firewall['stateless']));
 
-        if (isset($firewall['access_denied_handler'])) {
-            $config->replaceArgument(8, $firewall['access_denied_handler']);
-        }
-        if (isset($firewall['access_denied_url'])) {
-            $config->replaceArgument(9, $firewall['access_denied_url']);
-        }
+        $config->replaceArgument(8, isset($firewall['access_denied_handler']) ? $firewall['access_denied_handler'] : null);
+        $config->replaceArgument(9, isset($firewall['access_denied_url']) ? $firewall['access_denied_url'] : null);
 
         $container->setAlias(new Alias('security.user_checker.'.$id, false), $firewall['user_checker']);
 

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -116,8 +116,8 @@
 
         <service id="security.firewall.config" class="Symfony\Bundle\SecurityBundle\Security\FirewallConfig" abstract="true" public="false">
             <argument />                   <!-- name -->
-            <argument />                   <!-- request_matcher -->
             <argument />                   <!-- user_checker -->
+            <argument />                   <!-- request_matcher -->
             <argument />                   <!-- security enabled -->
             <argument />                   <!-- stateless -->
             <argument />                   <!-- provider -->

--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallConfig.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallConfig.php
@@ -17,8 +17,8 @@ namespace Symfony\Bundle\SecurityBundle\Security;
 final class FirewallConfig
 {
     private $name;
-    private $requestMatcher;
     private $userChecker;
+    private $requestMatcher;
     private $securityEnabled;
     private $stateless;
     private $provider;
@@ -30,8 +30,8 @@ final class FirewallConfig
 
     /**
      * @param string      $name
-     * @param string      $requestMatcher
      * @param string      $userChecker
+     * @param string|null $requestMatcher
      * @param bool        $securityEnabled
      * @param bool        $stateless
      * @param string|null $provider
@@ -41,11 +41,11 @@ final class FirewallConfig
      * @param string|null $accessDeniedUrl
      * @param string[]    $listeners
      */
-    public function __construct($name, $requestMatcher, $userChecker, $securityEnabled = true, $stateless = false, $provider = null, $context = null, $entryPoint = null, $accessDeniedHandler = null, $accessDeniedUrl = null, $listeners = array())
+    public function __construct($name, $userChecker, $requestMatcher = null, $securityEnabled = true, $stateless = false, $provider = null, $context = null, $entryPoint = null, $accessDeniedHandler = null, $accessDeniedUrl = null, $listeners = array())
     {
         $this->name = $name;
-        $this->requestMatcher = $requestMatcher;
         $this->userChecker = $userChecker;
+        $this->requestMatcher = $requestMatcher;
         $this->securityEnabled = $securityEnabled;
         $this->stateless = $stateless;
         $this->provider = $provider;
@@ -62,7 +62,8 @@ final class FirewallConfig
     }
 
     /**
-     * @return string The request matcher service id
+     * @return string|null The request matcher service id or null if neither the request matcher, pattern or host
+     *                     options were provided
      */
     public function getRequestMatcher()
     {

--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallContext.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallContext.php
@@ -27,10 +27,6 @@ class FirewallContext
 
     public function __construct(array $listeners, ExceptionListener $exceptionListener = null, FirewallConfig $config = null)
     {
-        if (null === $config) {
-            @trigger_error(sprintf('"%s()" expects an instance of "%s" as third argument since version 3.2 and will trigger an error in 4.0 if not provided.', __METHOD__, FirewallConfig::class), E_USER_DEPRECATED);
-        }
-
         $this->listeners = $listeners;
         $this->exceptionListener = $exceptionListener;
         $this->config = $config;

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
@@ -78,18 +78,21 @@ abstract class CompleteConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(
             array(
                 'simple',
-                'security.request_matcher.707b20193d4cb9f2718114abcbebb32af48f948484fc166a03482f49bf14f25e271f72c7',
                 'security.user_checker',
+                'security.request_matcher.707b20193d4cb9f2718114abcbebb32af48f948484fc166a03482f49bf14f25e271f72c7',
                 false,
             ),
             array(
                 'secure',
-                '',
                 'security.user_checker',
+                null,
                 true,
                 true,
                 'security.user.provider.concrete.default',
+                null,
                 'security.authentication.form_entry_point.secure',
+                null,
+                null,
                 array(
                     'logout',
                     'switch_user',
@@ -104,13 +107,15 @@ abstract class CompleteConfigurationTest extends \PHPUnit_Framework_TestCase
             ),
             array(
                 'host',
-                'security.request_matcher.dda8b565689ad8509623ee68fb2c639cd81cd4cb339d60edbaf7d67d30e6aa09bd8c63c3',
                 'security.user_checker',
+                'security.request_matcher.dda8b565689ad8509623ee68fb2c639cd81cd4cb339d60edbaf7d67d30e6aa09bd8c63c3',
                 true,
                 false,
                 'security.user.provider.concrete.default',
                 'host',
                 'security.authentication.basic_entry_point.host',
+                null,
+                null,
                 array(
                     'http_basic',
                     'anonymous',
@@ -118,13 +123,15 @@ abstract class CompleteConfigurationTest extends \PHPUnit_Framework_TestCase
             ),
             array(
                 'with_user_checker',
-                '',
                 'app.user_checker',
+                null,
                 true,
                 false,
                 'security.user.provider.concrete.default',
                 'with_user_checker',
                 'security.authentication.basic_entry_point.with_user_checker',
+                null,
+                null,
                 array(
                     'http_basic',
                     'anonymous',

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallConfigTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallConfigTest.php
@@ -32,8 +32,8 @@ class FirewallConfigTest extends \PHPUnit_Framework_TestCase
 
         $config = new FirewallConfig(
             'foo_firewall',
-            $options['request_matcher'],
             $options['user_checker'],
+            $options['request_matcher'],
             $options['security'],
             $options['stateless'],
             $options['provider'],

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallContextTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallContextTest.php
@@ -20,7 +20,7 @@ class FirewallContextTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetters()
     {
-        $config = new FirewallConfig('main', 'request_matcher', 'user_checker');
+        $config = new FirewallConfig('main', 'user_checker', 'request_matcher');
 
         $exceptionListener = $this
             ->getMockBuilder(ExceptionListener::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no, but removes one
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Nullable arguments were replaced by empty strings by the DIC config if values weren't replaced in the extension.

Another solution (looking safer to me) is to apply the following changes in the DIC configuration:

```diff
diff --git a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
index 54e5734..499dd5e 100644
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -116,15 +116,15 @@
 
         <service id="security.firewall.config" class="Symfony\Bundle\SecurityBundle\Security\FirewallConfig" abstract="true" public="false">
             <argument />                   <!-- name -->
-            <argument />                   <!-- user_checker -->
-            <argument />                   <!-- request_matcher -->
-            <argument />                   <!-- security enabled -->
-            <argument />                   <!-- stateless -->
-            <argument />                   <!-- provider -->
-            <argument />                   <!-- context -->
-            <argument />                   <!-- entry_point -->
-            <argument />                   <!-- access_denied_handler -->
-            <argument />                   <!-- access_denied_url -->
+            <argument>null</argument>      <!-- user_checker -->
+            <argument>null</argument>      <!-- request_matcher -->
+            <argument>true</argument>      <!-- security enabled -->
+            <argument>false</argument>     <!-- stateless -->
+            <argument>null</argument>      <!-- provider -->
+            <argument>null</argument>      <!-- context -->
+            <argument>null</argument>      <!-- entry_point -->
+            <argument>null</argument>      <!-- access_denied_handler -->
+            <argument>null</argument>      <!-- access_denied_url -->
             <argument type="collection" /> <!-- listeners -->
         </service>
```

But it doesn't seem to be the way we deal with arguments meant to be replaced by extensions in the Symfony core.

cc @chalasr 

This PR also removes the FirewallContext mandatory `FirewallConfig` argument deprecation for reasons expressed in https://github.com/symfony/symfony/pull/20591#issuecomment-262525029