### PR TITLE
[DI] Allow null as default env value

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
@@ -96,8 +96,8 @@ class EnvPlaceholderParameterBag extends ParameterBag
             }
             if (is_numeric($default = $this->parameters[$name])) {
                 $this->parameters[$name] = (string) $default;
-            } elseif (null !== $default && !is_string($default)) {
-                throw new RuntimeException(sprintf('The default value of env parameter "%s" must be string or null, %s given.', $env, gettype($default)));
+            } elseif (null !== $default && !is_scalar($default)) {
+                throw new RuntimeException(sprintf('The default value of env parameter "%s" must be scalar or null, %s given.', $env, gettype($default)));
             }
         }
     }

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/EnvPlaceholderParameterBag.php
@@ -41,8 +41,8 @@ class EnvPlaceholderParameterBag extends ParameterBag
             if ($this->has($name)) {
                 $defaultValue = parent::get($name);
 
-                if (!is_scalar($defaultValue)) {
-                    throw new RuntimeException(sprintf('The default value of an env() parameter must be scalar, but "%s" given to "%s".', gettype($defaultValue), $name));
+                if (null !== $defaultValue && !is_scalar($defaultValue)) {
+                    throw new RuntimeException(sprintf('The default value of an env() parameter must be scalar or null, but "%s" given to "%s".', gettype($defaultValue), $name));
                 }
             }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
@@ -139,4 +139,26 @@ class EnvPlaceholderParameterBagTest extends \PHPUnit_Framework_TestCase
         $bag->set('env(Array_Var)', array());
         $bag->resolve();
     }
+
+    public function testGetEndAllowsNull()
+    {
+        $bag = new EnvPlaceholderParameterBag();
+        $bag->set('env(NULL_VAR)', null);
+        $bag->get('env(NULL_VAR)');
+        $bag->resolve();
+
+        $this->assertNull($bag->all()['env(null_var)']);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
+     * @expectedExceptionMessage The default value of an env() parameter must be scalar or null, but "array" given to "env(ARRAY_VAR)".
+     */
+    public function testGetThrowsOnBadDefaultValue()
+    {
+        $bag = new EnvPlaceholderParameterBag();
+        $bag->set('env(ARRAY_VAR)', array());
+        $bag->get('env(ARRAY_VAR)');
+        $bag->resolve();
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/EnvPlaceholderParameterBagTest.php
@@ -130,7 +130,7 @@ class EnvPlaceholderParameterBagTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
-     * @expectedExceptionMessage The default value of env parameter "ARRAY_VAR" must be string or null, array given.
+     * @expectedExceptionMessage The default value of env parameter "ARRAY_VAR" must be scalar or null, array given.
      */
     public function testResolveThrowsOnBadDefaultValue()
     {
@@ -140,7 +140,7 @@ class EnvPlaceholderParameterBagTest extends \PHPUnit_Framework_TestCase
         $bag->resolve();
     }
 
-    public function testGetEndAllowsNull()
+    public function testGetEnvAllowsNull()
     {
         $bag = new EnvPlaceholderParameterBag();
         $bag->set('env(NULL_VAR)', null);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ø
| License       | MIT
| Doc PR        | ø

This PR allows the environment variable default value to be null. The way, we can allow optional environment variables, such as in this example:

```yaml
parameters:
    # Default values
    env(DATABASE_HOST): database
    env(DATABASE_PORT): ~
    env(DATABASE_NAME): symfony
    env(DATABASE_USERNAME): root
    env(DATABASE_PASSWORD): ~

    # Database configuration
    database_host:     "%env(DATABASE_HOST)%"
    database_port:     "%env(DATABASE_PORT)%"
    database_name:     "%env(DATABASE_NAME)%"
    database_user:     "%env(DATABASE_USERNAME)%"
    database_password: "%env(DATABASE_PASSWORD)%"
```