### PR TITLE
[SecurityBundle] Make FirewallConfig services public

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -114,7 +114,7 @@
             <argument />  <!-- FirewallConfig -->
         </service>
 
-        <service id="security.firewall.config" class="Symfony\Bundle\SecurityBundle\Security\FirewallConfig" abstract="true" public="false">
+        <service id="security.firewall.config" class="Symfony\Bundle\SecurityBundle\Security\FirewallConfig" abstract="true">
             <argument />                   <!-- name -->
             <argument />                   <!-- request_matcher -->
             <argument />                   <!-- user_checker -->


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | no
| New feature?  | not really
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | [20585#issuecomment-262085751](https://github.com/symfony/symfony/pull/20585#issuecomment-262085751)
| License       | MIT
| Doc PR        | N/A

Alternative and pragmatic approach of https://github.com/symfony/symfony/pull/20591 for https://github.com/symfony/symfony/pull/20585 if the only use case is to get the firewall config by firewall name at runtime.
