### PR TITLE
[WebProfilerBundle] Fix deprecated uses of profiler_dump

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
@@ -86,11 +86,11 @@ class RouterController
     {
         $traceRequest = Request::create(
             $request->getPathInfo(),
-            $request->getRequestServer()->get('REQUEST_METHOD'),
-            $request->getRequestAttributes()->all(),
-            $request->getRequestCookies()->all(),
+            $request->getRequestServer(true)->get('REQUEST_METHOD'),
+            $request->getRequestAttributes(true)->all(),
+            $request->getRequestCookies(true)->all(),
             array(),
-            $request->getRequestServer()->all()
+            $request->getRequestServer(true)->all()
         );
 
         $context = $this->matcher->getContext();

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -154,7 +154,7 @@
                 {% endif %}
 
                 <h3>Request Headers</h3>
-                {{ include('@WebProfiler/Profiler/bag.html.twig', { bag: collector.requestheaders, labels: ['Header', 'Value'] }, with_context = false) }}
+                {{ include('@WebProfiler/Profiler/bag.html.twig', { bag: collector.requestheaders, labels: ['Header', 'Value'], maxDepth: 1 }, with_context = false) }}
 
                 <h3>Request Content</h3>
 
@@ -183,7 +183,7 @@
             <div class="tab-content">
                 <h3>Response Headers</h3>
 
-                {{ include('@WebProfiler/Profiler/bag.html.twig', { bag: collector.responseheaders, labels: ['Header', 'Value'] }, with_context = false) }}
+                {{ include('@WebProfiler/Profiler/bag.html.twig', { bag: collector.responseheaders, labels: ['Header', 'Value'], maxDepth: 1 }, with_context = false) }}
             </div>
         </div>
 

--- a/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
@@ -130,7 +130,7 @@ abstract class DataCollector implements DataCollectorInterface, \Serializable
                     return new ClassStub($var);
                 }
             }
-            if (false !== strpos($var, DIRECTORY_SEPARATOR) && false === strpos($var, '://') && file_exists($var)) {
+            if (false !== strpos($var, DIRECTORY_SEPARATOR) && false === strpos($var, '://') && false === strpos($var, "\0") && is_file($var)) {
                 return new LinkStub($var);
             }
         }

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -12,10 +12,8 @@
 namespace Symfony\Component\HttpKernel\DataCollector;
 
 use Symfony\Component\HttpFoundation\ParameterBag;
-use Symfony\Component\HttpFoundation\HeaderBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
@@ -54,14 +52,11 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
         $attributes = array();
         $route = '';
         foreach ($request->attributes->all() as $key => $value) {
-            if ('_route' === $key && is_object($value)) {
-                $attributes[$key] = $this->cloneVar($value->getPath());
-            } else {
-                $attributes[$key] = $this->cloneVar($value);
-            }
-
             if ('_route' === $key) {
                 $route = is_object($value) ? $value->getPath() : $value;
+                $attributes[$key] = $route;
+            } else {
+                $attributes[$key] = $value;
             }
         }
 
@@ -97,8 +92,8 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
             'content_type' => $response->headers->get('Content-Type', 'text/html'),
             'status_text' => isset(Response::$statusTexts[$statusCode]) ? Response::$statusTexts[$statusCode] : '',
             'status_code' => $statusCode,
-            'request_query' => array_map(array($this, 'cloneVar'), $request->query->all()),
-            'request_request' => array_map(array($this, 'cloneVar'), $request->request->all()),
+            'request_query' => $request->query->all(),
+            'request_request' => $request->request->all(),
             'request_headers' => $request->headers->all(),
             'request_server' => $request->server->all(),
             'request_cookies' => $request->cookies->all(),
@@ -123,6 +118,18 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
 
         if (isset($this->data['request_request']['_password'])) {
             $this->data['request_request']['_password'] = '******';
+        }
+
+        foreach ($this->data as $key => $value) {
+            if (!is_array($value)) {
+                continue;
+            }
+            if ('request_headers' === $key || 'response_headers' === $key) {
+                $value = array_map(function ($v) { return isset($v[1]) ? $v : $v[0]; }, $value);
+            }
+            if ('request_server' !== $key && 'request_attributes' !== $key && 'request_cookies' !== $key) {
+                $this->data[$key] = array_map(array($this, 'cloneVar'), $value);
+            }
         }
 
         if (isset($this->controllers[$request])) {
@@ -170,27 +177,27 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
 
     public function getRequestHeaders()
     {
-        return new HeaderBag($this->data['request_headers']);
+        return new ParameterBag($this->data['request_headers']);
     }
 
-    public function getRequestServer()
+    public function getRequestServer($raw = false)
     {
-        return new ParameterBag($this->data['request_server']);
+        return new ParameterBag($raw ? $this->data['request_server'] : array_map(array($this, 'cloneVar'), $this->data['request_server']));
     }
 
-    public function getRequestCookies()
+    public function getRequestCookies($raw = false)
     {
-        return new ParameterBag($this->data['request_cookies']);
+        return new ParameterBag($raw ? $this->data['request_cookies'] : array_map(array($this, 'cloneVar'), $this->data['request_cookies']));
     }
 
-    public function getRequestAttributes()
+    public function getRequestAttributes($raw = false)
     {
-        return new ParameterBag($this->data['request_attributes']);
+        return new ParameterBag($raw ? $this->data['request_attributes'] : array_map(array($this, 'cloneVar'), $this->data['request_attributes']));
     }
 
     public function getResponseHeaders()
     {
-        return new ResponseHeaderBag($this->data['response_headers']);
+        return new ParameterBag($this->data['response_headers']);
     }
 
     public function getSessionMetadata()
@@ -264,7 +271,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
      */
     public function getRouteParams()
     {
-        return isset($this->data['request_attributes']['_route_params']) ? $this->data['request_attributes']['_route_params'] : $this->cloneVar(array());
+        return isset($this->data['request_attributes']['_route_params']) ? array_map(array($this, 'cloneVar'), $this->data['request_attributes']['_route_params']) : array();
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
@@ -39,7 +39,7 @@ class RequestDataCollectorTest extends \PHPUnit_Framework_TestCase
         $attributes = $c->getRequestAttributes();
 
         $this->assertSame('request', $c->getName());
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\HeaderBag', $c->getRequestHeaders());
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\ParameterBag', $c->getRequestHeaders());
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\ParameterBag', $c->getRequestServer());
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\ParameterBag', $c->getRequestCookies());
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\ParameterBag', $attributes);
@@ -47,13 +47,13 @@ class RequestDataCollectorTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\ParameterBag', $c->getRequestQuery());
         $this->assertSame('html', $c->getFormat());
         $this->assertEquals('foobar', $c->getRoute());
-        $this->assertEquals($cloner->cloneVar(array('name' => 'foo')), $c->getRouteParams());
+        $this->assertEquals(array('name' => $cloner->cloneVar('foo')), $c->getRouteParams());
         $this->assertSame(array(), $c->getSessionAttributes());
         $this->assertSame('en', $c->getLocale());
         $this->assertEquals($cloner->cloneVar($request->attributes->get('resource')), $attributes->get('resource'));
         $this->assertEquals($cloner->cloneVar($request->attributes->get('object')), $attributes->get('object'));
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\HeaderBag', $c->getResponseHeaders());
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\ParameterBag', $c->getResponseHeaders());
         $this->assertSame('OK', $c->getStatusText());
         $this->assertSame(200, $c->getStatusCode());
         $this->assertSame('application/json', $c->getContentType());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Replaces #20571 that made me realize that we completely missed updating the "Request / Response" panel that is current triggering a bunch of deprecation notices about profiler_dump. Yet, these notices triggered by the profiler are not displayed anywhere (what, we don't have a profiler for the profiler? :) ). And we missed them.

