### PR TITLE
[Ldap] Always have a valid connection when using the EntryManager

### DIFF
--- a/src/Symfony/Component/Ldap/Adapter/EntryManagerInterface.php
+++ b/src/Symfony/Component/Ldap/Adapter/EntryManagerInterface.php
@@ -12,11 +12,14 @@
 namespace Symfony\Component\Ldap\Adapter;
 
 use Symfony\Component\Ldap\Entry;
+use Symfony\Component\Ldap\Exception\LdapException;
+use Symfony\Component\Ldap\Exception\NotBoundException;
 
 /**
  * Entry manager interface.
  *
  * @author Charles Sarrazin <charles@sarraz.in>
+ * @author Bob van de Vijver <bobvandevijver@hotmail.com>
  */
 interface EntryManagerInterface
 {
@@ -24,6 +27,9 @@ interface EntryManagerInterface
      * Adds a new entry in the Ldap server.
      *
      * @param Entry $entry
+     *
+     * @throws NotBoundException
+     * @throws LdapException
      */
     public function add(Entry $entry);
 
@@ -31,6 +37,9 @@ interface EntryManagerInterface
      * Updates an entry from the Ldap server.
      *
      * @param Entry $entry
+     *
+     * @throws NotBoundException
+     * @throws LdapException
      */
     public function update(Entry $entry);
 
@@ -38,6 +47,9 @@ interface EntryManagerInterface
      * Removes an entry from the Ldap server.
      *
      * @param Entry $entry
+     *
+     * @throws NotBoundException
+     * @throws LdapException
      */
     public function remove(Entry $entry);
 }

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Adapter.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Adapter.php
@@ -50,7 +50,7 @@ class Adapter implements AdapterInterface
     public function getEntryManager()
     {
         if (null === $this->entryManager) {
-            $this->entryManager = new EntryManager($this->connection);
+            $this->entryManager = new EntryManager($this->getConnection());
         }
 
         return $this->entryManager;

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
@@ -13,13 +13,15 @@ namespace Symfony\Component\Ldap\Adapter\ExtLdap;
 
 use Symfony\Component\Ldap\Adapter\AbstractQuery;
 use Symfony\Component\Ldap\Exception\LdapException;
+use Symfony\Component\Ldap\Exception\NotBoundException;
 
 /**
  * @author Charles Sarrazin <charles@sarraz.in>
+ * @author Bob van de Vijver <bobvandevijver@hotmail.com>
  */
 class Query extends AbstractQuery
 {
-    /** @var  Connection */
+    /** @var Connection */
     protected $connection;
 
     /** @var resource */
@@ -53,9 +55,9 @@ class Query extends AbstractQuery
     public function execute()
     {
         if (null === $this->search) {
-            // If the connection is not bound, then we try an anonymous bind.
+            // If the connection is not bound, throw an exception. Users should use an explicit bind call first.
             if (!$this->connection->isBound()) {
-                $this->connection->bind();
+                throw new NotBoundException('Query execution is not possible without binding the connection first.');
             }
 
             $con = $this->connection->getResource();

--- a/src/Symfony/Component/Ldap/Adapter/QueryInterface.php
+++ b/src/Symfony/Component/Ldap/Adapter/QueryInterface.php
@@ -12,9 +12,12 @@
 namespace Symfony\Component\Ldap\Adapter;
 
 use Symfony\Component\Ldap\Entry;
+use Symfony\Component\Ldap\Exception\LdapException;
+use Symfony\Component\Ldap\Exception\NotBoundException;
 
 /**
  * @author Charles Sarrazin <charles@sarraz.in>
+ * @author Bob van de Vijver <bobvandevijver@hotmail.com>
  */
 interface QueryInterface
 {
@@ -27,6 +30,9 @@ interface QueryInterface
      * Executes a query and returns the list of Ldap entries.
      *
      * @return CollectionInterface|Entry[]
+     *
+     * @throws NotBoundException
+     * @throws LdapException
      */
     public function execute();
 }

--- a/src/Symfony/Component/Ldap/Exception/NotBoundException.php
+++ b/src/Symfony/Component/Ldap/Exception/NotBoundException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Ldap\Exception;
+
+/**
+ * NotBoundException is thrown if the connection with the LDAP server is not yet bound.
+ *
+ * @author Bob van de Vijver <bobvandevijver@hotmail.com>
+ */
+class NotBoundException extends \RuntimeException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Ldap\Tests;
 use Symfony\Component\Ldap\Adapter\ExtLdap\Adapter;
 use Symfony\Component\Ldap\Adapter\ExtLdap\Collection;
 use Symfony\Component\Ldap\Entry;
+use Symfony\Component\Ldap\Exception\NotBoundException;
 use Symfony\Component\Ldap\LdapInterface;
 
 /**
@@ -64,5 +65,16 @@ class AdapterTest extends LdapTestCase
         $this->assertInstanceOf(Entry::class, $entry);
         $this->assertEquals(array('Fabien Potencier'), $entry->getAttribute('cn'));
         $this->assertEquals(array('fabpot@symfony.com', 'fabien@potencier.com'), $entry->getAttribute('mail'));
+    }
+
+    /**
+     * @group functional
+     */
+    public function testLdapQueryWithoutBind()
+    {
+        $ldap = new Adapter($this->getLdapConfig());
+        $this->setExpectedException(NotBoundException::class);
+        $query = $ldap->createQuery('dc=symfony,dc=com', '(&(objectclass=person)(ou=Maintainers))', array());
+        $query->execute();
     }
 }

--- a/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/LdapManagerTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/LdapManagerTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\Ldap\Adapter\ExtLdap\Adapter;
 use Symfony\Component\Ldap\Adapter\ExtLdap\Collection;
 use Symfony\Component\Ldap\Entry;
 use Symfony\Component\Ldap\Exception\LdapException;
+use Symfony\Component\Ldap\Exception\NotBoundException;
 
 /**
  * @requires extension ldap
@@ -96,6 +97,39 @@ class LdapManagerTest extends LdapTestCase
         $result = $this->executeSearchQuery(1);
         $entry = $result[0];
         $this->assertNull($entry->getAttribute('email'));
+    }
+
+    /**
+     * @group functional
+     */
+    public function testLdapUnboundAdd()
+    {
+        $this->adapter = new Adapter($this->getLdapConfig());
+        $this->setExpectedException(NotBoundException::class);
+        $em = $this->adapter->getEntryManager();
+        $em->add(new Entry(''));
+    }
+
+    /**
+     * @group functional
+     */
+    public function testLdapUnboundRemove()
+    {
+        $this->adapter = new Adapter($this->getLdapConfig());
+        $this->setExpectedException(NotBoundException::class);
+        $em = $this->adapter->getEntryManager();
+        $em->remove(new Entry(''));
+    }
+
+    /**
+     * @group functional
+     */
+    public function testLdapUnboundUpdate()
+    {
+        $this->adapter = new Adapter($this->getLdapConfig());
+        $this->setExpectedException(NotBoundException::class);
+        $em = $this->adapter->getEntryManager();
+        $em->update(new Entry(''));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | They should
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The connection might be `null` when calling the `getEntryManager` function as it uses the `$this->connection` instead of retrieved it from it's own method which checks (and constructs if necessary) it first.