### PR TITLE
[Validator] Bring egulias/email-validator ~2.0 to parity with ~1.2

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Validator\Constraints;
 
 use Egulias\EmailValidator\Validation\EmailValidation;
-use Egulias\EmailValidator\Validation\RFCValidation;
+use Egulias\EmailValidator\Validation\NoRFCWarningsValidation;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\RuntimeException;
@@ -63,7 +63,7 @@ class EmailValidator extends ConstraintValidator
 
             $strictValidator = new \Egulias\EmailValidator\EmailValidator();
 
-            if (interface_exists(EmailValidation::class) && !$strictValidator->isValid($value, new RFCValidation())) {
+            if (interface_exists(EmailValidation::class) && !$strictValidator->isValid($value, new NoRFCWarningsValidation())) {
                 $this->context->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
                     ->setCode(Email::INVALID_FORMAT_ERROR)

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
@@ -174,6 +174,7 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
             array('test@email>'),
             array('test@email<'),
             array('test@email{'),
+            array(str_repeat('x', 254).'@example.com'), //email with warnings
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | could be ?
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

When using egulias/email-validator ~1.2, we make a strict check of the email, which means that emails with RFC warnings will fail validation.
Currently with egulias/email-validator ~2.0, emails with warnings are considerate valids.

This pull request make EmailValidator with egulias/email-validator ~2.0 behave as with egulias/email-validator ~1.2.