### PR TITLE
[Bridge/Doctrine] Use cache.prefix.seed parameter for generating cache namespace

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
@@ -384,9 +384,14 @@ abstract class AbstractDoctrineExtension extends Extension
 
         if (!isset($cacheDriver['namespace'])) {
             // generate a unique namespace for the given application
-            $env = $container->getParameter('kernel.root_dir').$container->getParameter('kernel.environment');
-            $hash = hash('sha256', $env);
-            $namespace = 'sf2'.$this->getMappingResourceExtension().'_'.$objectManagerName.'_'.$hash;
+            if ($container->hasParameter('cache.prefix.seed')) {
+                $seed = '.'.$container->getParameterBag()->resolveValue($container->getParameter('cache.prefix.seed'));
+            } else {
+                $seed = '_'.$container->getParameter('kernel.root_dir');
+            }
+            $seed .= '.'.$container->getParameter('kernel.name').'.'.$container->getParameter('kernel.environment').'.'.$container->getParameter('kernel.debug');
+            $hash = hash('sha256', $seed);
+            $namespace = 'sf_'.$this->getMappingResourceExtension().'_'.$objectManagerName.'_'.$hash;
 
             $cacheDriver['namespace'] = $namespace;
         }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/CachePoolClearerPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/CachePoolClearerPass.php
@@ -25,6 +25,8 @@ final class CachePoolClearerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
+        $container->getParameterBag()->remove('cache.prefix.seed');
+
         foreach ($container->findTaggedServiceIds('cache.pool') as $id => $attributes) {
             foreach (array_reverse($attributes) as $attr) {
                 if (isset($attr['clearer'])) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/CachePoolClearerPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/CachePoolClearerPassTest.php
@@ -24,6 +24,10 @@ class CachePoolClearerPassTest extends \PHPUnit_Framework_TestCase
     public function testPoolRefsAreWeak()
     {
         $container = new ContainerBuilder();
+        $container->setParameter('kernel.debug', false);
+        $container->setParameter('kernel.name', 'app');
+        $container->setParameter('kernel.environment', 'prod');
+        $container->setParameter('kernel.root_dir', 'foo');
 
         $publicPool = new Definition();
         $publicPool->addArgument('namespace');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/CachePoolPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/CachePoolPassTest.php
@@ -29,6 +29,10 @@ class CachePoolPassTest extends \PHPUnit_Framework_TestCase
     public function testNamespaceArgumentIsReplaced()
     {
         $container = new ContainerBuilder();
+        $container->setParameter('kernel.debug', false);
+        $container->setParameter('kernel.name', 'app');
+        $container->setParameter('kernel.environment', 'prod');
+        $container->setParameter('kernel.root_dir', 'foo');
         $adapter = new Definition();
         $adapter->setAbstract(true);
         $adapter->addTag('cache.pool');
@@ -41,12 +45,16 @@ class CachePoolPassTest extends \PHPUnit_Framework_TestCase
 
         $this->cachePoolPass->process($container);
 
-        $this->assertSame('kRFqMp5odS', $cachePool->getArgument(0));
+        $this->assertSame('C42Pcl9VBJ', $cachePool->getArgument(0));
     }
 
     public function testArgsAreReplaced()
     {
         $container = new ContainerBuilder();
+        $container->setParameter('kernel.debug', false);
+        $container->setParameter('kernel.name', 'app');
+        $container->setParameter('kernel.environment', 'prod');
+        $container->setParameter('cache.prefix.seed', 'foo');
         $cachePool = new Definition();
         $cachePool->addTag('cache.pool', array(
             'provider' => 'foobar',
@@ -61,7 +69,7 @@ class CachePoolPassTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(Reference::class, $cachePool->getArgument(0));
         $this->assertSame('foobar', (string) $cachePool->getArgument(0));
-        $this->assertSame('kRFqMp5odS', $cachePool->getArgument(1));
+        $this->assertSame('KO3xHaFEZU', $cachePool->getArgument(1));
         $this->assertSame(3, $cachePool->getArgument(2));
     }
 
@@ -72,6 +80,10 @@ class CachePoolPassTest extends \PHPUnit_Framework_TestCase
     public function testThrowsExceptionWhenCachePoolTagHasUnknownAttributes()
     {
         $container = new ContainerBuilder();
+        $container->setParameter('kernel.debug', false);
+        $container->setParameter('kernel.name', 'app');
+        $container->setParameter('kernel.environment', 'prod');
+        $container->setParameter('kernel.root_dir', 'foo');
         $adapter = new Definition();
         $adapter->setAbstract(true);
         $adapter->addTag('cache.pool');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Exactly the same issue as in #20610, but for Doctrine ORM's cache:
> That's a design issue: using root_dir as discriminant doesn't work with blue/green deployment strategies, and doesn't prevent collision when different apps are deployed in the same path while sharing the same cache backend.