### PR TITLE
Routing - Object __tostring()

### DIFF
--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -670,6 +670,14 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/app.php/testing#fragment', $url);
     }
 
+    public function testQueryStringParametersCanBeObjectsWithToString()
+    {
+        $routes = $this->getRoutes('test', new Route('/{name}'));
+        $url = $this->getGenerator($routes, array())->generate('test', array('name' => new MyObject(), 'query' => new MyObject()));
+
+        $this->assertSame('/app.php/string?query=string', $url);
+    }
+
     protected function getGenerator(RouteCollection $routes, array $parameters = array(), $logger = null)
     {
         $context = new RequestContext('/app.php');
@@ -687,5 +695,13 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $routes->add($name, $route);
 
         return $routes;
+    }
+}
+
+class MyObject
+{
+    public function __tostring()
+    {
+        return 'string';
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

I've noticed some inconsistent behaviour with the routing component when using values that are objects implementing `__tostring`. If the parameter is part of the resource then it is included correctly, otherwise it is not included as a query string parameter.

Is this expected behaviour?  If not what would be the best resolution - to fix the problem with these objects being included in the query string?  disallow objects as route parameters? raise an exception/warning?

I've included a test to demonstrate, you can see the `name` parameter is included, but the `query` one isn't.

*Note:* This has caused a number of bugs in production for us where Uuid objects were silently dropped from query strings.