### PR TITLE
[HttpKernel] Fix exception when serializing request attributes

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
@@ -87,7 +87,7 @@ class RouterController
         $traceRequest = Request::create(
             $request->getPathInfo(),
             $request->getRequestServer(true)->get('REQUEST_METHOD'),
-            $request->getRequestAttributes(true)->all(),
+            array(),
             $request->getRequestCookies(true)->all(),
             array(),
             $request->getRequestServer(true)->all()

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -127,7 +127,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
             if ('request_headers' === $key || 'response_headers' === $key) {
                 $value = array_map(function ($v) { return isset($v[1]) ? $v : $v[0]; }, $value);
             }
-            if ('request_server' !== $key && 'request_attributes' !== $key && 'request_cookies' !== $key) {
+            if ('request_server' !== $key && 'request_cookies' !== $key) {
                 $this->data[$key] = array_map(array($this, 'cloneVar'), $value);
             }
         }
@@ -190,9 +190,9 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
         return new ParameterBag($raw ? $this->data['request_cookies'] : array_map(array($this, 'cloneVar'), $this->data['request_cookies']));
     }
 
-    public function getRequestAttributes($raw = false)
+    public function getRequestAttributes()
     {
-        return new ParameterBag($raw ? $this->data['request_attributes'] : array_map(array($this, 'cloneVar'), $this->data['request_attributes']));
+        return new ParameterBag($this->data['request_attributes']);
     }
 
     public function getResponseHeaders()
@@ -271,7 +271,17 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
      */
     public function getRouteParams()
     {
-        return isset($this->data['request_attributes']['_route_params']) ? array_map(array($this, 'cloneVar'), $this->data['request_attributes']['_route_params']) : array();
+        if (!isset($this->data['request_attributes']['_route_params'])) {
+            return array();
+        }
+
+        $data = $this->data['request_attributes']['_route_params'];
+        $params = array();
+        foreach ($data->getRawData()[1] as $k => $v) {
+            $params[$k] = $data->seek($k);
+        }
+
+        return $params;
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
@@ -47,7 +47,7 @@ class RequestDataCollectorTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\ParameterBag', $c->getRequestQuery());
         $this->assertSame('html', $c->getFormat());
         $this->assertEquals('foobar', $c->getRoute());
-        $this->assertEquals(array('name' => $cloner->cloneVar('foo')), $c->getRouteParams());
+        $this->assertEquals(array('name' => $cloner->cloneVar(array('name' => 'foo'))->seek('name')), $c->getRouteParams());
         $this->assertSame(array(), $c->getSessionAttributes());
         $this->assertSame('en', $c->getLocale());
         $this->assertEquals($cloner->cloneVar($request->attributes->get('resource')), $attributes->get('resource'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Serializing request attributes obviously fails easily since once can put anything there (I've just got an "Exception: Serialization of 'Closure' is not allowed").
Yet, we don't need attributes when forging a request to feed the TraceableUrlMatcher in RouterController.
Well, technically one could for sure register a listener before the router to add an attribute to the request, then use that in the url matcher. 
But, it makes no sense. And if it were to have, the profiler is already broken in this respect because in e.g. 3.1, the attribute array that is used here has already been processed by the ValueExporter. So the original values have already been altered.

Let's just handle request attributes as all the other collected data: using var dumper.