### PR TITLE
[WebProfilerBundle] Dont use request attributes in RouterController

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
@@ -87,7 +87,7 @@ class RouterController
         $traceRequest = Request::create(
             $request->getPathInfo(),
             $request->getRequestServer()->get('REQUEST_METHOD'),
-            $request->getRequestAttributes()->all(),
+            array(),
             $request->getRequestCookies()->all(),
             array(),
             $request->getRequestServer()->all()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

As spotted in #20621, it makes little sense to use request attributes here, and if it were to have, the current code is broken because the returned values here have already been processed by ValueExporter in RequestDataCollector.