### PR TITLE
[HttpKernel] Fix override bundle config files

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -676,7 +676,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
      */
     protected function getContainerLoader(ContainerInterface $container)
     {
-        $locator = new FileLocator($this);
+        $locator = new FileLocator($this, $this->rootDir.'/Resources');
         $resolver = new LoaderResolver(array(
             new XmlFileLoader($container, $locator),
             new YamlFileLoader($container, $locator),

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/BaseBundle/Resources/config/bar.yml
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/BaseBundle/Resources/config/bar.yml
@@ -1,0 +1,2 @@
+parameters:
+    bar: bar

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/BaseBundle/Resources/config/config.yml
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/BaseBundle/Resources/config/config.yml
@@ -1,0 +1,3 @@
+imports:
+    - { resource: "@BaseBundle/Resources/config/bar.yml" }
+    - { resource: "@BaseBundle/Resources/config/foo/foo.yml" }

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/BaseBundle/Resources/config/foo/foo.yml
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/BaseBundle/Resources/config/foo/foo.yml
@@ -1,0 +1,2 @@
+parameters:
+    foo: foo

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelForOverrideConfig.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelForOverrideConfig.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures;
+
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Config\Loader\LoaderInterface;
+
+class KernelForOverrideConfig extends Kernel
+{
+    public function registerBundles()
+    {
+        return array();
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load($this->rootDir.'/config/config.yml');
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/Resources/BaseBundle/config/bar.yml
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/Resources/BaseBundle/config/bar.yml
@@ -1,0 +1,2 @@
+parameters:
+    bar: override-bar

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/Resources/BaseBundle/config/foo/foo.yml
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/Resources/BaseBundle/config/foo/foo.yml
@@ -1,0 +1,2 @@
+parameters:
+    foo: override-foo

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/config/config.yml
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/config/config.yml
@@ -1,0 +1,2 @@
+imports:
+    - { resource: "@BaseBundle/Resources/config/config.yml" }

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -21,7 +21,6 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest;
 use Symfony\Component\HttpKernel\Tests\Fixtures\KernelForOverrideName;
 use Symfony\Component\HttpKernel\Tests\Fixtures\FooBarBundle;
-use Symfony\Component\HttpKernel\Tests\HttpCache\HttpCacheTestCase;
 
 class KernelTest extends \PHPUnit_Framework_TestCase
 {

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -580,7 +580,7 @@ EOF;
 
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Tests\Fixtures\KernelForOverrideConfig')
             ->setConstructorArgs(array('test', false))
-            ->setMethods(array('getBundle'))
+            ->setMethods(array('getBundle', 'getContainerClass'))
             ->getMock();
 
         $p = new \ReflectionProperty($kernel, 'rootDir');
@@ -593,7 +593,11 @@ EOF;
             ->will($this->returnValue(array($bundle)))
         ;
 
-        HttpCacheTestCase::clearDirectory($kernel->getCacheDir());
+        $kernel
+            ->expects($this->any())
+            ->method('getContainerClass')
+            ->will($this->returnValue('OverrideTestProjectContainer'))
+        ;
 
         $kernel->boot();
 

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -37,7 +37,8 @@
         "symfony/stopwatch": "~2.3",
         "symfony/templating": "~2.2",
         "symfony/translation": "~2.0,>=2.0.5",
-        "symfony/var-dumper": "~2.6"
+        "symfony/var-dumper": "~2.6",
+        "symfony/yaml": "~2.2"
     },
     "conflict": {
         "symfony/config": "<2.7"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

`FileLocator` wasn't looking for the config file in `app/Resources/NameBundle/config` because not have the specified path in the arguments.



