### PR TITLE
Fix constraint violation mapping when using a view transformer

### DIFF
--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -20,6 +20,27 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
  */
 interface FormInterface extends \ArrayAccess, \Traversable, \Countable
 {
+	/**
+	 * Constant for view layer
+	 * 
+	 * @var string LAYER_VIEW
+	 */
+	const LAYER_VIEW  = 'view';
+	
+	/**
+	 * Constant for norm layer
+	 *
+	 * @var string LAYER_NORM
+	 */
+	const LAYER_NORM  = 'norm';
+	
+	/**
+	 * Constant for model layer
+	 *
+	 * @var string LAYER_MODEL
+	 */
+	const LAYER_MODEL = 'model';
+	
     /**
      * Sets the parent form.
      *
@@ -176,6 +197,16 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
      * @return \Symfony\Component\PropertyAccess\PropertyPathInterface The property path
      */
     public function getPropertyPath();
+    
+    /*
+     * Returns the property path that the form is mapped in a layer.
+     * 
+     * @return string $layer Layer for property path
+     * @return \Symfony\Component\PropertyAccess\PropertyPathInterface The property path
+     * 
+     * @since 4.0.0
+     */
+    //public function getPropertyPathForLayer($layer);
 
     /**
      * Adds an error to this form.

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/DataTransformer/ViewObjectTransformer.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/DataTransformer/ViewObjectTransformer.php
@@ -1,0 +1,59 @@
+<?php
+namespace Symfony\Component\Form\Tests\Extension\Validator\DataTransformer;
+
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
+/**
+* Transforms Object to array for view
+*
+* @author Charles J. C. Elling <charles@denumeris.com>
+*/
+class ViewObjectTransformer implements DataTransformerInterface {
+	
+	/**
+	 * Expected class of object
+	 * @var string $dataClass
+	 **/
+	protected $dataClass;
+
+	public function __construct($dataClass) {
+		$this->dataClass = $dataClass;
+	}
+
+	public function transform($object) {
+		if($object === null) {
+			return null;
+		}else if(is_a($object, $this->dataClass)) {
+			return (array)$object;
+		}else {
+			if(is_object($object)) {
+				$type = get_class($object);
+			}else {
+				$type = gettype($object);
+			}
+			throw new TransformationFailedException("Expected an {$this->dataClass} got {$type}");
+		}
+	}
+
+	public function reverseTransform($viewData) {
+		if ($viewData === null) {
+			$viewData = array();
+		}
+		if(is_array($viewData) || $viewData instanceof \Traversable) {
+			$dataClass = $this->dataClass;
+			$object = new $dataClass();
+			foreach ($viewData as $name => $value) {
+				$object->{$name} = $value;
+			}
+			return $object;
+		} else {
+			if (is_object($viewData)) {
+				$type = get_class($viewData);
+			} else {
+				$type = gettype($viewData);
+			}
+			throw new TransformationFailedException("Expected an array got {$type}");
+		}
+	}
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Model/ValidatedObject.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Model/ValidatedObject.php
@@ -1,0 +1,34 @@
+<?php
+namespace Symfony\Component\Form\Tests\Extension\Validator\Model;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Test object for validation
+ * @author Charles J. C. Elling <charles@denumeris.com>
+ **/
+class ValidatedObject{
+
+	/**
+	 * @var string $property1
+	 * @Assert\NotBlank()
+	 **/
+	public $property1;
+
+	/**
+	 * @var string $property2
+	 * @Assert\NotBlank()
+	 **/
+	public $property2;
+
+	/**
+	 * @var ValidatedObject
+	 * @Assert\Valid()
+	 **/
+	public $childObject;
+
+	public function __construct(ValidatedObject $childObject = null){
+		$this->childObject = $childObject;
+	}
+
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20624
| License       | MIT


Check when not configured property path and parent data class is NULL
and parent data is object then map constraint violation if child name
equal to path chunk.