### PR TITLE
[FrameworkBundle] Add project directory default for installing assets

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
@@ -82,7 +82,13 @@ EOT
         $targetArg = rtrim($input->getArgument('target'), '/');
 
         if (!is_dir($targetArg)) {
-            throw new \InvalidArgumentException(sprintf('The target directory "%s" does not exist.', $input->getArgument('target')));
+            $appRoot = $this->getContainer()->getParameter('kernel.root_dir').'/..';
+
+            $targetArg = $appRoot.'/'.$targetArg;
+
+            if (!is_dir($targetArg)) {
+                throw new \InvalidArgumentException(sprintf('The target directory "%s" does not exist.', $input->getArgument('target')));
+            }
         }
 
         $this->filesystem = $this->getContainer()->get('filesystem');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20337 
| License       | MIT
| Doc PR        | 

This allows the `assets:install` console command to have a fallback default of the project root directory.

Current behavior is to install assets only in the `target` of the current working directory.