### PR TITLE
[DependencyInjection] Added Yaml syntax shortcut for name-only tags

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -267,7 +267,7 @@ class YamlFileLoader extends FileLoader
 
             foreach ($service['tags'] as $tag) {
                 if (!is_array($tag)) {
-                    throw new InvalidArgumentException(sprintf('A "tags" entry must be an array for service "%s" in %s. Check your YAML syntax.', $id, $file));
+                    $tag = array('name' => $tag);
                 }
 
                 if (!isset($tag['name'])) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/badtag4.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/badtag4.yml
@@ -1,6 +1,0 @@
-services:
-    foo_service:
-        class:    FooClass
-        tags:
-          # tag is not an array
-          - foo

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/tag_name_only.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/tag_name_only.yml
@@ -1,0 +1,5 @@
+services:
+    foo_service:
+        class: FooClass
+        tags:
+          - foo

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -223,16 +223,6 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
-     * @expectedExceptionMessage A "tags" entry must be an array for service
-     */
-    public function testNonArrayTagThrowsException()
-    {
-        $loader = new YamlFileLoader(new ContainerBuilder(), new FileLocator(self::$fixturesPath.'/yaml'));
-        $loader->load('badtag4.yml');
-    }
-
     public function testTagWithoutNameThrowsException()
     {
         $loader = new YamlFileLoader(new ContainerBuilder(), new FileLocator(self::$fixturesPath.'/yaml'));
@@ -243,6 +233,15 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
             $this->assertInstanceOf('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException', $e, '->load() throws an InvalidArgumentException if a tag is missing the name key');
             $this->assertStringStartsWith('A "tags" entry is missing a "name" key for service ', $e->getMessage(), '->load() throws an InvalidArgumentException if a tag is missing the name key');
         }
+    }
+
+    public function testNameOnlyTagsAreAllowedAsString()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('tag_name_only.yml');
+
+        $this->assertCount(1, $container->getDefinition('foo_service')->getTag('foo'));
     }
 
     public function testTagWithAttributeArrayThrowsException()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | todo

This PR adds a little shorcut for tags without any attributes. There are increasingly more name-only tags in Symfony and having to do `{ name: twig.extension }` for these seems way too verbose to me.

**Before**
```yaml
services:
    app.twig_extension:
        class: AppBundle\Twig\AppExtension
        tags:
            - { name: twig.extension }
```

**After**
```yaml
services:
    app.twig_extension:
        class: AppBundle\Twig\AppExtension
        tags: [twig.extension]
        # or
        #    - twig.extension
```

This of course means we introduce a new format to achieve the same goal. I believe this isn't a big problem as the decision is distinctive and simple: If you configure tag attributes, use the long format, otherwise use the short format.

Backwards compatibility
---

In this PR, an exception was removed to allow this new shortcut format. The BC promise doesn't cover exceptions and I think removing the exception here should cause anything to break:

 * Applications shouldn't rely on exceptions
 * If code was triggering this exception before, it would not cause any behaviour change after this PR: The service just retrieves an unused tag, which is simply ignored by the container.