### PR TITLE
Fixed getRouteParams() when no parameters are available

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -276,8 +276,13 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
         }
 
         $data = $this->data['request_attributes']['_route_params'];
+        $rawData = $data->getRawData();
+        if (!isset($rawData[1])) {
+            return array();
+        }
+
         $params = array();
-        foreach ($data->getRawData()[1] as $k => $v) {
+        foreach ($rawData[1] as $k => $v) {
             $params[$k] = $data->seek($k);
         }
 

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
@@ -59,6 +59,16 @@ class RequestDataCollectorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('application/json', $c->getContentType());
     }
 
+    public function testCollectWithoutRouteParams()
+    {
+        $request = $this->createRequest(array());
+
+        $c = new RequestDataCollector();
+        $c->collect($request, $this->createResponse());
+
+        $this->assertEquals(array(), $c->getRouteParams());
+    }
+
     public function testKernelResponseDoesNotStartSession()
     {
         $kernel = $this->getMock(HttpKernelInterface::class);
@@ -197,12 +207,12 @@ class RequestDataCollectorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('n/a', $c->getController());
     }
 
-    protected function createRequest()
+    protected function createRequest($routeParams = array('name' => 'foo'))
     {
         $request = Request::create('http://test.com/foo?bar=baz');
         $request->attributes->set('foo', 'bar');
         $request->attributes->set('_route', 'foobar');
-        $request->attributes->set('_route_params', array('name' => 'foo'));
+        $request->attributes->set('_route_params', $routeParams);
         $request->attributes->set('resource', fopen(__FILE__, 'r'));
         $request->attributes->set('object', new \stdClass());
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20650 
| License       | MIT
| Doc PR        | -

