### PR TITLE
[YAML] Allow empty lines before comment and document separator

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -738,7 +738,7 @@ class Parser
         }
 
         // remove start of the document marker (---)
-        $trimmedValue = preg_replace('#^\n*\s*\-\-\-.*?\n#s', '', $value, -1, $count);
+        $trimmedValue = preg_replace('#^\h*\v*---.*?\n#s', '', $value, -1, $count);
         if ($count == 1) {
             // items have been removed, update the offset
             $this->offset += substr_count($value, "\n") - substr_count($trimmedValue, "\n");

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -730,7 +730,7 @@ class Parser
         $this->offset += $count;
 
         // remove leading comments
-        $trimmedValue = preg_replace('#^(\n+)?(\#.*?\n)+#s', '', $value, -1, $count);
+        $trimmedValue = preg_replace('#^\n*\s*(\#.*?\n)+#s', '', $value, -1, $count);
         if ($count == 1) {
             // items have been removed, update the offset
             $this->offset += substr_count($value, "\n") - substr_count($trimmedValue, "\n");
@@ -738,7 +738,7 @@ class Parser
         }
 
         // remove start of the document marker (---)
-        $trimmedValue = preg_replace('#^(\n+)?\-\-\-.*?\n#s', '', $value, -1, $count);
+        $trimmedValue = preg_replace('#^\n*\s*\-\-\-.*?\n#s', '', $value, -1, $count);
         if ($count == 1) {
             // items have been removed, update the offset
             $this->offset += substr_count($value, "\n") - substr_count($trimmedValue, "\n");

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -730,7 +730,7 @@ class Parser
         $this->offset += $count;
 
         // remove leading comments
-        $trimmedValue = preg_replace('#^(\#.*?\n)+#s', '', $value, -1, $count);
+        $trimmedValue = preg_replace('#^(\n+)?(\#.*?\n)+#s', '', $value, -1, $count);
         if ($count == 1) {
             // items have been removed, update the offset
             $this->offset += substr_count($value, "\n") - substr_count($trimmedValue, "\n");
@@ -738,7 +738,7 @@ class Parser
         }
 
         // remove start of the document marker (---)
-        $trimmedValue = preg_replace('#^\-\-\-.*?\n#s', '', $value, -1, $count);
+        $trimmedValue = preg_replace('#^(\n+)?\-\-\-.*?\n#s', '', $value, -1, $count);
         if ($count == 1) {
             // items have been removed, update the offset
             $this->offset += substr_count($value, "\n") - substr_count($trimmedValue, "\n");

--- a/src/Symfony/Component/Yaml/Tests/Fixtures/LineBreaksBeforeDocumentSeparatorAndComment.yml
+++ b/src/Symfony/Component/Yaml/Tests/Fixtures/LineBreaksBeforeDocumentSeparatorAndComment.yml
@@ -1,0 +1,6 @@
+
+
+# Comment.
+
+---
+key2: value2

--- a/src/Symfony/Component/Yaml/Tests/Fixtures/LineBreaksBeforeDocumentSeparatorAndComment.yml
+++ b/src/Symfony/Component/Yaml/Tests/Fixtures/LineBreaksBeforeDocumentSeparatorAndComment.yml
@@ -1,6 +1,0 @@
-
- 
-# Comment.
-   
----
-key2: value2

--- a/src/Symfony/Component/Yaml/Tests/Fixtures/LineBreaksBeforeDocumentSeparatorAndComment.yml
+++ b/src/Symfony/Component/Yaml/Tests/Fixtures/LineBreaksBeforeDocumentSeparatorAndComment.yml
@@ -1,6 +1,6 @@
 
-
+ 
 # Comment.
-
+   
 ---
 key2: value2

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -81,6 +81,22 @@ EOF;
         $this->parser->parse($yaml);
     }
 
+    /**
+     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
+     * @expectedExceptionMessage Unable to parse at line 3 (near "  ---").
+     */
+    public function testSpacesBeforeDocumentSeparator()
+    {
+        $yaml = <<<'EOF'
+   
+
+  ---
+key2: value2
+
+EOF;
+        $this->parser->parse($yaml);
+    }
+
     public function testTabsInYaml()
     {
         // test tabs in YAML

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -66,8 +66,9 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         return $tests;
     }
 
-    public function testLineBreaksBeforeDocumentSeparatorAndComment() {
-      $this->parser->parse(file_get_contents(__DIR__.'/Fixtures/LineBreaksBeforeDocumentSeparatorAndComment.yml'));
+    public function testLineBreaksBeforeDocumentSeparatorAndComment()
+    {
+        $this->parser->parse(file_get_contents(__DIR__.'/Fixtures/LineBreaksBeforeDocumentSeparatorAndComment.yml'));
     }
 
     public function testTabsInYaml()

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -68,20 +68,9 @@ class ParserTest extends \PHPUnit_Framework_TestCase
 
     public function testLineBreaksBeforeDocumentSeparatorAndComment()
     {
-        $yaml = <<<'EOF'
-
- 
-# Two empty lines above (second - with one whitespace) and two below (first - with three whitespaces).
-   
-
----
-key2: value2
-
-EOF;
-
-        // Ensure that user's editor didn't trimmed white spaces in Heredoc.
-        $this->assertSame($yaml, "\n \n# Two empty lines above (second - with one whitespace) and two below (first - with three whitespaces).\n   \n\n---\nkey2: value2\n");
-        $this->parser->parse($yaml);
+        $this->assertSame($this->parser->parse("\n \n# Two empty lines above (second - with one whitespace) and two below (first - with three whitespaces).\n   \n\n---\nkey2: value2\n"), [
+          'key2' => 'value2',
+        ]);
     }
 
     /**
@@ -90,17 +79,7 @@ EOF;
      */
     public function testSpacesBeforeDocumentSeparator()
     {
-        $yaml = <<<'EOF'
-   
-
-  ---
-key2: value2
-
-EOF;
-
-        // Ensure that user's editor didn't trimmed white spaces in Heredoc.
-        $this->assertSame($yaml, "   \n\n  ---\nkey2: value2\n");
-        $this->parser->parse($yaml);
+      $this->parser->parse("   \n\n  ---\nkey2: value2\n");
     }
 
     public function testTabsInYaml()

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -68,7 +68,17 @@ class ParserTest extends \PHPUnit_Framework_TestCase
 
     public function testLineBreaksBeforeDocumentSeparatorAndComment()
     {
-        $this->parser->parse(file_get_contents(__DIR__.'/Fixtures/LineBreaksBeforeDocumentSeparatorAndComment.yml'));
+        $yaml = <<<'EOF'
+
+ 
+# Two empty lines above (second - with one whitespace) and two below (first - with three whitespaces).
+   
+
+---
+key2: value2
+
+EOF;
+        $this->parser->parse($yaml);
     }
 
     public function testTabsInYaml()

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -68,9 +68,9 @@ class ParserTest extends \PHPUnit_Framework_TestCase
 
     public function testLineBreaksBeforeDocumentSeparatorAndComment()
     {
-        $this->assertSame($this->parser->parse("\n \n# Two empty lines above (second - with one whitespace) and two below (first - with three whitespaces).\n   \n\n---\nkey2: value2\n"), [
-          'key2' => 'value2',
-        ]);
+        $this->assertSame($this->parser->parse("\n \n# Two empty lines above (second - with one whitespace) and two below (first - with three whitespaces).\n   \n\n---\nkey2: value2\n"), array(
+            'key2' => 'value2',
+        ));
     }
 
     /**

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -66,6 +66,10 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         return $tests;
     }
 
+    public function testLineBreaksBeforeDocumentSeparatorAndComment() {
+      $this->parser->parse(file_get_contents(__DIR__.'/Fixtures/LineBreaksBeforeDocumentSeparatorAndComment.yml'));
+    }
+
     public function testTabsInYaml()
     {
         // test tabs in YAML

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -79,7 +79,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     public function testSpacesBeforeDocumentSeparator()
     {
-      $this->parser->parse("   \n\n  ---\nkey2: value2\n");
+        $this->parser->parse("   \n\n  ---\nkey2: value2\n");
     }
 
     public function testTabsInYaml()

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -78,6 +78,9 @@ class ParserTest extends \PHPUnit_Framework_TestCase
 key2: value2
 
 EOF;
+
+        // Ensure that user's editor didn't trimmed white spaces in Heredoc.
+        $this->assertSame($yaml, "\n \n# Two empty lines above (second - with one whitespace) and two below (first - with three whitespaces).\n   \n\n---\nkey2: value2\n");
         $this->parser->parse($yaml);
     }
 
@@ -94,6 +97,9 @@ EOF;
 key2: value2
 
 EOF;
+
+        // Ensure that user's editor didn't trimmed white spaces in Heredoc.
+        $this->assertSame($yaml, "   \n\n  ---\nkey2: value2\n");
         $this->parser->parse($yaml);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20659
| License       | MIT

