### PR TITLE
[Config] ConfigCache::isFresh() should return false when unserialize() fails

### DIFF
--- a/src/Symfony/Component/Config/Tests/ConfigCacheTest.php
+++ b/src/Symfony/Component/Config/Tests/ConfigCacheTest.php
@@ -93,6 +93,15 @@ class ConfigCacheTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($cache->isFresh());
     }
 
+    public function testCacheIsNotFreshWhenUnserializeFails()
+    {
+        file_put_contents($this->metaFile, str_replace('FileResource', 'ClassNotHere', file_get_contents($this->metaFile)));
+
+        $cache = new ConfigCache($this->cacheFile, true);
+
+        $this->assertFalse($cache->isFresh());
+    }
+
     public function testWriteDumpsFile()
     {
         unlink($this->cacheFile);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20654
| License       | MIT
| Doc PR        | -

Removes some `Warning: Class __PHP_Incomplete_Class has no unserializer` failures when clearing the cache.