### PR TITLE
[VarDumper][HttpKernel] Enhance perf of ExceptionCaster & DataCollector

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
@@ -42,6 +42,8 @@ abstract class DataCollector implements DataCollectorInterface, \Serializable
      */
     private $cloner;
 
+    private static $stubsCache = array();
+
     public function serialize()
     {
         return serialize($this->data);
@@ -124,14 +126,17 @@ abstract class DataCollector implements DataCollectorInterface, \Serializable
             return $var;
         }
         if (is_string($var)) {
+            if (isset(self::$stubsCache[$var])) {
+                return self::$stubsCache[$var];
+            }
             if (false !== strpos($var, '\\')) {
                 $c = (false !== $i = strpos($var, '::')) ? substr($var, 0, $i) : $var;
                 if (class_exists($c, false) || interface_exists($c, false) || trait_exists($c, false)) {
-                    return new ClassStub($var);
+                    return self::$stubsCache[$var] = new ClassStub($var);
                 }
             }
             if (false !== strpos($var, DIRECTORY_SEPARATOR) && false === strpos($var, '://') && false === strpos($var, "\0") && is_file($var)) {
-                return new LinkStub($var);
+                return self::$stubsCache[$var] = new LinkStub($var);
             }
         }
 

--- a/src/Symfony/Component/VarDumper/Caster/Caster.php
+++ b/src/Symfony/Component/VarDumper/Caster/Caster.php
@@ -57,15 +57,20 @@ class Caster
         }
 
         if ($a) {
+            $combine = false;
             $p = array_keys($a);
             foreach ($p as $i => $k) {
                 if (isset($k[0]) && "\0" !== $k[0] && !$reflector->hasProperty($k)) {
+                    $combine = true;
                     $p[$i] = self::PREFIX_DYNAMIC.$k;
                 } elseif (isset($k[16]) && "\0" === $k[16] && 0 === strpos($k, "\0class@anonymous\0")) {
+                    $combine = true;
                     $p[$i] = "\0".$reflector->getParentClass().'@anonymous'.strrchr($k, "\0");
                 }
             }
-            $a = array_combine($p, $a);
+            if ($combine) {
+                $a = array_combine($p, $a);
+            }
         }
 
         return $a;

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -252,14 +252,15 @@ abstract class AbstractCloner implements ClonerInterface
                 new \ReflectionClass($class),
                 array_reverse(array($class => $class) + class_parents($class) + class_implements($class) + array('*' => '*')),
             );
+            $classInfo[1] = array_map('strtolower', $classInfo[1]);
 
             $this->classInfo[$class] = $classInfo;
         }
 
-        $a = $this->callCaster('Symfony\Component\VarDumper\Caster\Caster::castObject', $obj, $classInfo[0], null, $isNested);
+        $a = Caster::castObject($obj, $classInfo[0]);
 
         foreach ($classInfo[1] as $p) {
-            if (!empty($this->casters[$p = strtolower($p)])) {
+            if (!empty($this->casters[$p])) {
                 foreach ($this->casters[$p] as $p) {
                     $a = $this->callCaster($p, $obj, $a, $stub, $isNested);
                 }

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php
@@ -179,14 +179,14 @@ EODUMP;
         $f = array(
             new FrameStub(array(
                 'file' => dirname(__DIR__).'/Fixtures/Twig.php',
-                'line' => 21,
+                'line' => 20,
                 'class' => '__TwigTemplate_VarDumperFixture_u75a09',
             )),
             new FrameStub(array(
                 'file' => dirname(__DIR__).'/Fixtures/Twig.php',
                 'line' => 21,
                 'class' => '__TwigTemplate_VarDumperFixture_u75a09',
-                'object' => new \__TwigTemplate_VarDumperFixture_u75a09(null, false),
+                'object' => new \__TwigTemplate_VarDumperFixture_u75a09(null, __FILE__),
             )),
         );
 
@@ -195,10 +195,10 @@ array:2 [
   0 => {
     class: "__TwigTemplate_VarDumperFixture_u75a09"
     src: {
-      bar.twig:2: {
+      %sTwig.php:1: {
+        : 
         : foo bar
         :   twig source
-        : 
       }
     }
   }
@@ -208,7 +208,7 @@ array:2 [
     %A
     }
     src: {
-      foo.twig:2: {
+      %sExceptionCasterTest.php:2: {
         : foo bar
         :   twig source
         : 

--- a/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/CliDumperTest.php
@@ -271,7 +271,7 @@ stream resource {@{$ref}
   ⚠: Symfony\Component\VarDumper\Exception\ThrowingCasterException {{$r}
     #message: "Unexpected Exception thrown from a caster: Foobar"
     -trace: {
-      bar.twig:%d: {
+      %sTwig.php:2: {
         : foo bar
         :   twig source
         : 

--- a/src/Symfony/Component/VarDumper/Tests/Fixtures/Twig.php
+++ b/src/Symfony/Component/VarDumper/Tests/Fixtures/Twig.php
@@ -3,16 +3,16 @@
 /* foo.twig */
 class __TwigTemplate_VarDumperFixture_u75a09 extends Twig_Template
 {
-    private $filename;
+    private $path;
 
-    public function __construct(Twig_Environment $env = null, $filename = null)
+    public function __construct(Twig_Environment $env = null, $path = null)
     {
         if (null !== $env) {
             parent::__construct($env);
         }
         $this->parent = false;
         $this->blocks = array();
-        $this->filename = $filename;
+        $this->path = $path;
     }
 
     protected function doDisplay(array $context, array $blocks = array())
@@ -28,11 +28,11 @@ class __TwigTemplate_VarDumperFixture_u75a09 extends Twig_Template
 
     public function getDebugInfo()
     {
-        return array(21 => 2);
+        return array(20 => 1, 21 => 2);
     }
 
     public function getSourceContext()
     {
-        return new Twig_Source("   foo bar\n     twig source\n\n", 'foo.twig', false === $this->filename ? null : ($this->filename ?: 'bar.twig'));
+        return new Twig_Source("   foo bar\n     twig source\n\n", 'foo.twig', $this->path ?: __FILE__);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

In **dev** on 3.2 , serializing collectors' data is slow because VarDumper is called so many times.
Here is a PR to make it a bit faster, with its Blackfire profile:
https://blackfire.io/profiles/compare/6f0fdc7a-9157-4dad-bee4-4c98a96184b2/graph

Note that it is possible to make things fast again by replacing these multiple calls by a single one juste before serializing the data. Yet, it's not trivial and VarDumper misses a few features to allow dealing with an unserialized Data object and make it look like a real data structure to other code. I'll look at it for 3.3.