### PR TITLE
[DX][SecurityBundle] UserPasswordEncoderCommand: ask user class choice question

### DIFF
--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -96,6 +96,14 @@ SecurityBundle
 
  * The `FirewallMap::$map` and `$container` properties have been deprecated and will be removed in 4.0.
 
+ * The `UserPasswordEncoderCommand` command expects to be registered as a service and its
+   constructor arguments fully provided.
+   Registering by convention the command or commands extending it is deprecated and will
+   not be allowed anymore in 4.0.
+ 
+ * `UserPasswordEncoderCommand::getContainer()` is deprecated, and this class won't 
+    extend `ContainerAwareCommand` nor implement `ContainerAwareInterface` anymore in 4.0.
+
 TwigBridge
 ----------
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -437,6 +437,13 @@ Ldap
 
  * The `RenameEntryInterface` has been deprecated, and merged with `EntryManagerInterface`
 
+SecurityBundle
+--------------
+
+ * The `UserPasswordEncoderCommand` class does not allow `null` as the first argument anymore.
+ 
+ * `UserPasswordEncoderCommand` does not implement `ContainerAwareInterface` anymore.
+
 Workflow
 --------
 

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -4,6 +4,10 @@ CHANGELOG
 3.3.0
 -----
 
+ * Deprecated instantiating `UserPasswordEncoderCommand` without its constructor
+   arguments fully provided.
+ * Deprecated `UserPasswordEncoderCommand::getContainer()` and relying on the
+  `ContainerAwareInterface` interface for this command.
  * Deprecated the `FirewallMap::$map` and `$container` properties.
 
 3.2.0

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\SecurityBundle\DependencyInjection;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\SecurityFactoryInterface;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\UserProviderFactoryInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
@@ -96,6 +97,11 @@ class SecurityExtension extends Extension
 
         if ($config['encoders']) {
             $this->createEncoders($config['encoders'], $container);
+
+            if (class_exists(Application::class)) {
+                $loader->load('console.xml');
+                $container->getDefinition('security.console.user_password_encoder_command')->replaceArgument(1, array_keys($config['encoders']));
+            }
         }
 
         // load ACL

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/console.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/console.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="security.console.user_password_encoder_command" class="Symfony\Bundle\SecurityBundle\Command\UserPasswordEncoderCommand" public="false">
+            <argument type="service" id="security.encoder_factory"/>
+            <argument type="collection" /> <!-- encoders' user classes -->
+            <tag name="console.command" />
+        </service>
+    </services>
+</container>

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -25,7 +25,7 @@
     "require-dev": {
         "symfony/asset": "~2.8|~3.0",
         "symfony/browser-kit": "~2.8|~3.0",
-        "symfony/console": "~2.8|~3.0",
+        "symfony/console": "~3.2",
         "symfony/css-selector": "~2.8|~3.0",
         "symfony/dom-crawler": "~2.8|~3.0",
         "symfony/form": "~2.8|~3.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Typing the user class is quite annoying so I'd suggest to ask the user to select it using a choice question.

This changes however requires to inject configured encoders' user classes. Making the command a service and providing it in the constructor from the extension is probably the cleanest way, but it deprecates:

-  registering the command by convention (registered as a service now, so potential commands extending this one should do the same)
-  relying on the fact the command extends `ContainerAwareCommand` and implements `ContainerAwareInterface` (will not extends/implements it anymore in 4.0 because it's not required anymore)