### PR TITLE
[VarDumper] Use default color for ellipsed namespaces/paths

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -900,6 +900,7 @@ table.logs .metadata {
 #collector-content .sf-dump-note { color: #6897BB; }
 #collector-content .sf-dump-key { color: #789339; }
 #collector-content .sf-dump-ref { color: #6E6E6E; }
+#collector-content .sf-dump-ellipsis { color: #CC7832; max-width: 100em; }
 
 #collector-content .sf-dump {
     margin: 0;

--- a/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/HtmlDumper.php
@@ -43,6 +43,7 @@ class HtmlDumper extends CliDumper
         'meta' => 'color:#B729D9',
         'key' => 'color:#56DB3A',
         'index' => 'color:#1299DA',
+        'ellipsis' => 'color:#FF8400',
     );
 
     private $displayOptions = array(
@@ -380,7 +381,7 @@ pre.sf-dump .sf-dump-ellipsis {
     display: inline-block;
     overflow: visible;
     text-overflow: ellipsis;
-    width: 5em;
+    max-width: 5em;
     white-space: nowrap;
     overflow: hidden;
     vertical-align: top;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20669
| License       | MIT
| Doc PR        | -

Eases readability by helping the eye to focus more quickly on the class name and less on its namespace.
And let' disable ellipses on the profiler panels, fixing #20669 meanwhile.

![capture du 2016-11-29 11-00-00](https://cloud.githubusercontent.com/assets/243674/20705475/5d512c9a-b623-11e6-881d-04ae58453824.png)
