### PR TITLE
DoctrineDataCollector: taught sanitizeParam to support classes with __toString implemented.

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
+++ b/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
@@ -159,7 +159,9 @@ class DoctrineDataCollector extends DataCollector
     private function sanitizeParam($var)
     {
         if (is_object($var)) {
-            return array(sprintf('Object(%s)', get_class($var)), false);
+            return method_exists($var, '__toString') ?
+                array($var->__toString(), false) :
+                array(sprintf('Object(%s)', get_class($var)), false,);
         }
 
         if (is_array($var)) {

--- a/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
+++ b/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
@@ -160,6 +160,7 @@ class DoctrineDataCollector extends DataCollector
     {
         if (is_object($var)) {
             $className = get_class($var);
+
             return method_exists($var, '__toString') ?
                 array(sprintf('Object(%s): "%s"', $className, $var->__toString()), false) :
                 array(sprintf('Object(%s)', $className), false);

--- a/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
+++ b/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
@@ -161,7 +161,7 @@ class DoctrineDataCollector extends DataCollector
         if (is_object($var)) {
             return method_exists($var, '__toString') ?
                 array($var->__toString(), false) :
-                array(sprintf('Object(%s)', get_class($var)), false,);
+                array(sprintf('Object(%s)', get_class($var)), false);
         }
 
         if (is_array($var)) {

--- a/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
+++ b/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
@@ -159,9 +159,10 @@ class DoctrineDataCollector extends DataCollector
     private function sanitizeParam($var)
     {
         if (is_object($var)) {
+            $className = get_class($var);
             return method_exists($var, '__toString') ?
-                array($var->__toString(), false) :
-                array(sprintf('Object(%s)', get_class($var)), false);
+                array(sprintf('Object(%s): "%s"', $className, $var->__toString()), false) :
+                array(sprintf('Object(%s)', $className), false);
         }
 
         if (is_array($var)) {

--- a/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
@@ -127,7 +127,7 @@ class DoctrineDataCollectorTest extends TestCase
             array(null, array(), null, true),
             array(new \DateTime('2011-09-11'), array('date'), '2011-09-11', true),
             array(fopen(__FILE__, 'r'), array(), 'Resource(stream)', false),
-            array(new \stdClass, array(), 'Object(stdClass)', false),
+            array(new \stdClass(), array(), 'Object(stdClass)', false),
             array(new StringRepresentableClass('presentation test'), array(), 'presentation test', false),
         );
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
@@ -127,7 +127,8 @@ class DoctrineDataCollectorTest extends TestCase
             array(null, array(), null, true),
             array(new \DateTime('2011-09-11'), array('date'), '2011-09-11', true),
             array(fopen(__FILE__, 'r'), array(), 'Resource(stream)', false),
-            array(new \SplFileInfo(__FILE__), array(), 'Object(SplFileInfo)', false),
+            array(new \stdClass, array(), 'Object(stdClass)', false),
+            array(new StringRepresentableClass('presentation test'), array(), 'presentation test', false),
         );
     }
 

--- a/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DataCollector/DoctrineDataCollectorTest.php
@@ -128,7 +128,12 @@ class DoctrineDataCollectorTest extends TestCase
             array(new \DateTime('2011-09-11'), array('date'), '2011-09-11', true),
             array(fopen(__FILE__, 'r'), array(), 'Resource(stream)', false),
             array(new \stdClass(), array(), 'Object(stdClass)', false),
-            array(new StringRepresentableClass('presentation test'), array(), 'presentation test', false),
+            array(
+                new StringRepresentableClass('presentation test'),
+                array(),
+                'Object(Symfony\Bridge\Doctrine\Tests\DataCollector\StringRepresentableClass): "presentation test"',
+                false,
+            ),
         );
     }
 

--- a/src/Symfony/Bridge/Doctrine/Tests/DataCollector/StringRepresentableClass.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DataCollector/StringRepresentableClass.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Symfony\Bridge\Doctrine\Tests\DataCollector;
+
+/**
+ * A class for testing __toString method behaviour. It's __toString returns a value, that was passed into constructor.
+ *
+ * @package Symfony\Bridge\Doctrine\Tests\DataCollector
+ */
+class StringRepresentableClass
+{
+	/**
+	 * @var string
+	 */
+	private $representation;
+
+	/**
+	 * CustomStringableClass constructor.
+	 *
+	 * @param string $representation
+	 */
+	public function __construct($representation)
+	{
+		$this->representation = $representation;
+	}
+
+	public function __toString()
+	{
+		return $this->representation;
+	}
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/DataCollector/StringRepresentableClass.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DataCollector/StringRepresentableClass.php
@@ -4,28 +4,26 @@ namespace Symfony\Bridge\Doctrine\Tests\DataCollector;
 
 /**
  * A class for testing __toString method behaviour. It's __toString returns a value, that was passed into constructor.
- *
- * @package Symfony\Bridge\Doctrine\Tests\DataCollector
  */
 class StringRepresentableClass
 {
-	/**
-	 * @var string
-	 */
-	private $representation;
+    /**
+     * @var string
+     */
+    private $representation;
 
-	/**
-	 * CustomStringableClass constructor.
-	 *
-	 * @param string $representation
-	 */
-	public function __construct($representation)
-	{
-		$this->representation = $representation;
-	}
+    /**
+     * CustomStringableClass constructor.
+     *
+     * @param string $representation
+     */
+    public function __construct($representation)
+    {
+        $this->representation = $representation;
+    }
 
-	public function __toString()
-	{
-		return $this->representation;
-	}
+    public function __toString()
+    {
+        return $this->representation;
+    }
 }


### PR DESCRIPTION
This PR teaches \Symfony\Bridge\Doctrine\DataCollector\DoctrineDataCollector::sanitizeParam support objects, which implement __toString and therefore can be represented as a string with more sense, than "(object) ClassName". It also includes test for the feature.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | [20673](https://github.com/symfony/symfony/issues/20673)
| License       | MIT
| Doc PR        | no