### PR TITLE
[DependencyInjection] Added an option to define file header in PhpDumper

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -106,6 +106,7 @@ class PhpDumper extends Dumper
     {
         $this->targetDirRegex = null;
         $options = array_merge(array(
+            'file_header' => '',
             'class' => 'ProjectServiceContainer',
             'base_class' => 'Container',
             'namespace' => '',
@@ -141,7 +142,7 @@ class PhpDumper extends Dumper
             }
         }
 
-        $code = $this->startClass($options['class'], $options['base_class'], $options['namespace']);
+        $code = $this->startClass($options['file_header'], $options['class'], $options['base_class'], $options['namespace']);
 
         if ($this->container->isFrozen()) {
             $code .= $this->addFrozenConstructor();
@@ -763,20 +764,22 @@ EOF;
     /**
      * Adds the class headers.
      *
-     * @param string $class     Class name
-     * @param string $baseClass The name of the base class
-     * @param string $namespace The class namespace
+     * @param string $fileHeader Text to place just after php tag
+     * @param string $class      Class name
+     * @param string $baseClass  The name of the base class
+     * @param string $namespace  The class namespace
      *
      * @return string
      */
-    private function startClass($class, $baseClass, $namespace)
+    private function startClass($fileHeader, $class, $baseClass, $namespace)
     {
         $bagClass = $this->container->isFrozen() ? 'use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;' : 'use Symfony\Component\DependencyInjection\ParameterBag\\ParameterBag;';
+        $fileHeaderLine = $fileHeader ? "$fileHeader\n\n" : '';
         $namespaceLine = $namespace ? "namespace $namespace;\n" : '';
 
         return <<<EOF
 <?php
-$namespaceLine
+$fileHeaderLine$namespaceLine
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -92,9 +92,10 @@ class PhpDumper extends Dumper
      *
      * Available options:
      *
-     *  * class:      The class name
-     *  * base_class: The base class name
-     *  * namespace:  The class namespace
+     *  * file_header: Text to place in a php docblock at the start of the file to serve as a header
+     *  * class:       The class name
+     *  * base_class:  The base class name
+     *  * namespace:   The class namespace
      *
      * @param array $options An array of options
      *
@@ -773,13 +774,19 @@ EOF;
      */
     private function startClass($fileHeader, $class, $baseClass, $namespace)
     {
-        $bagClass = $this->container->isFrozen() ? 'use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;' : 'use Symfony\Component\DependencyInjection\ParameterBag\\ParameterBag;';
-        $fileHeaderLine = $fileHeader ? "$fileHeader\n\n" : '';
+        $bagClass = $this->container->isFrozen( ) ? 'use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;' : 'use Symfony\Component\DependencyInjection\ParameterBag\\ParameterBag;';
+        $fileHeader = str_replace("\n", "\n * ", $fileHeader);
+        if (false !== strpos($fileHeader, '*/')) {
+            throw new InvalidArgumentException(
+                'file_header should not contain "*/" character sequence for security reasons'
+            );
+        }
+        $fileHeader = $fileHeader ? "/**\n * ".$fileHeader."\n */\n\n" : '';
         $namespaceLine = $namespace ? "namespace $namespace;\n" : '';
 
         return <<<EOF
 <?php
-$fileHeaderLine$namespaceLine
+$fileHeader$namespaceLine
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -774,7 +774,7 @@ EOF;
      */
     private function startClass($fileHeader, $class, $baseClass, $namespace)
     {
-        $bagClass = $this->container->isFrozen( ) ? 'use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;' : 'use Symfony\Component\DependencyInjection\ParameterBag\\ParameterBag;';
+        $bagClass = $this->container->isFrozen() ? 'use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;' : 'use Symfony\Component\DependencyInjection\ParameterBag\\ParameterBag;';
         $fileHeader = str_replace("\n", "\n * ", $fileHeader);
         if (false !== strpos($fileHeader, '*/')) {
             throw new InvalidArgumentException(

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -48,7 +48,7 @@ class PhpDumperTest extends \PHPUnit_Framework_TestCase
     {
         $dumper = new PhpDumper($container = new ContainerBuilder());
         $this->expectException(InvalidArgumentException::class);
-        $dumper->dump( array( 'class' => 'Container', 'base_class' => 'AbstractContainer', 'namespace' => 'Symfony\Component\DependencyInjection\Dump', 'file_header' => "Test file header */ echo '123';") );
+        $dumper->dump(array('class' => 'Container', 'base_class' => 'AbstractContainer', 'namespace' => 'Symfony\Component\DependencyInjection\Dump', 'file_header' => "Test file header */ echo '123';"));
     }
 
     public function testDumpOptimizationString()

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -44,10 +44,12 @@ class PhpDumperTest extends \PHPUnit_Framework_TestCase
         new PhpDumper($container);
     }
 
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
+     */
     public function testDumpFileHeaderSecurityException()
     {
         $dumper = new PhpDumper($container = new ContainerBuilder());
-        $this->expectException(InvalidArgumentException::class);
         $dumper->dump(array('class' => 'Container', 'base_class' => 'AbstractContainer', 'namespace' => 'Symfony\Component\DependencyInjection\Dump', 'file_header' => "Test file header */ echo '123';"));
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection\Tests\Dumper;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Definition;
@@ -36,10 +37,18 @@ class PhpDumperTest extends \PHPUnit_Framework_TestCase
 
         $this->assertStringEqualsFile(self::$fixturesPath.'/php/services1.php', $dumper->dump(), '->dump() dumps an empty container as an empty PHP class');
         $this->assertStringEqualsFile(self::$fixturesPath.'/php/services1-1.php', $dumper->dump(array('class' => 'Container', 'base_class' => 'AbstractContainer', 'namespace' => 'Symfony\Component\DependencyInjection\Dump')), '->dump() takes a class and a base_class options');
-        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services1-2.php', $dumper->dump(array('class' => 'Container', 'base_class' => 'AbstractContainer', 'namespace' => 'Symfony\Component\DependencyInjection\Dump', 'file_header' => '/* Test file header */')), '->dump() takes a file_header, class and a base_class options');
+        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services1-2.php', $dumper->dump(array('class' => 'Container', 'base_class' => 'AbstractContainer', 'namespace' => 'Symfony\Component\DependencyInjection\Dump', 'file_header' => 'Test file header')), '->dump() takes a file_header, class and a base_class options');
+        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services1-3.php', $dumper->dump(array('class' => 'Container', 'base_class' => 'AbstractContainer', 'namespace' => 'Symfony\Component\DependencyInjection\Dump', 'file_header' => "Test file header\nMulti line one")), '->dump() takes a multiline file_header, class and a base_class options');
 
         $container = new ContainerBuilder();
         new PhpDumper($container);
+    }
+
+    public function testDumpFileHeaderSecurityException()
+    {
+        $dumper = new PhpDumper($container = new ContainerBuilder());
+        $this->expectException(InvalidArgumentException::class);
+        $dumper->dump( array( 'class' => 'Container', 'base_class' => 'AbstractContainer', 'namespace' => 'Symfony\Component\DependencyInjection\Dump', 'file_header' => "Test file header */ echo '123';") );
     }
 
     public function testDumpOptimizationString()

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -36,6 +36,7 @@ class PhpDumperTest extends \PHPUnit_Framework_TestCase
 
         $this->assertStringEqualsFile(self::$fixturesPath.'/php/services1.php', $dumper->dump(), '->dump() dumps an empty container as an empty PHP class');
         $this->assertStringEqualsFile(self::$fixturesPath.'/php/services1-1.php', $dumper->dump(array('class' => 'Container', 'base_class' => 'AbstractContainer', 'namespace' => 'Symfony\Component\DependencyInjection\Dump')), '->dump() takes a class and a base_class options');
+        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services1-2.php', $dumper->dump(array('class' => 'Container', 'base_class' => 'AbstractContainer', 'namespace' => 'Symfony\Component\DependencyInjection\Dump', 'file_header' => '/* Test file header */')), '->dump() takes a file_header, class and a base_class options');
 
         $container = new ContainerBuilder();
         new PhpDumper($container);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services1-2.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services1-2.php
@@ -1,0 +1,31 @@
+<?php
+/* Test file header */
+
+namespace Symfony\Component\DependencyInjection\Dump;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+
+/**
+ * Container.
+ *
+ * This class has been auto-generated
+ * by the Symfony Dependency Injection Component.
+ */
+class Container extends AbstractContainer
+{
+    private $parameters;
+    private $targetDirs = array();
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services1-3.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services1-3.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * Test file header
+ * Multi line one
  */
 
 namespace Symfony\Component\DependencyInjection\Dump;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | [20124](https://github.com/symfony/symfony/issues/20124)
| License       | MIT
| Doc PR        | no

Useful for example, to document something in PHP docblocks like generation version, build time, etc