### PR TITLE
[FrameworkBundle] Resolve env params in debug:config command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
@@ -80,7 +80,7 @@ EOF
 
         $this->validateConfiguration($extension, $configuration);
 
-        $configs = $container->getParameterBag()->resolveValue($configs);
+        $configs = $container->resolveEnvPlaceholders($container->getParameterBag()->resolveValue($configs));
 
         $processor = new Processor();
         $config = $processor->processConfiguration($configuration, $configs);

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\Config\FileLocator;
 
 /**
@@ -96,7 +97,11 @@ EOF
         $object = $this->getContainerBuilder();
 
         if ($input->getOption('parameters')) {
-            $object = $object->getParameterBag();
+            $parameters = array();
+            foreach ($object->getParameterBag()->all() as $k => $v) {
+                $parameters[$k] = $object->resolveEnvPlaceholders($v);
+            }
+            $object = new ParameterBag($parameters);
             $options = array();
         } elseif ($parameter = $input->getOption('parameter')) {
             $options = array('parameter' => $parameter);

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -57,7 +57,7 @@ abstract class Descriptor implements DescriptorInterface
                 $this->describeContainerService($this->resolveServiceDefinition($object, $options['id']), $options);
                 break;
             case $object instanceof ContainerBuilder && isset($options['parameter']):
-                $this->describeContainerParameter($object->getParameter($options['parameter']), $options);
+                $this->describeContainerParameter($object->resolveEnvPlaceholders($object->getParameter($options['parameter'])), $options);
                 break;
             case $object instanceof ContainerBuilder:
                 $this->describeContainerServices($object, $options);

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -495,7 +495,7 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $bag = new EnvPlaceholderParameterBag();
         $bag->get('env(Foo)');
         $config = new ContainerBuilder($bag);
-        $config->resolveEnvPlaceholders($bag->get('env(Bar)'));
+        $this->assertSame(array('%env(Bar)%'), $config->resolveEnvPlaceholders(array($bag->get('env(Bar)'))));
         $container->merge($config);
         $this->assertEquals(array('Foo' => 0, 'Bar' => 1), $container->getEnvCounters());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20696
| License       | MIT
| Doc PR        | -

Displays e.g. `url: '%env(DATABASE_URL)%'`
instead of `url: env_DATABASE_URL_b188317b1d181eca5f0be35aefdae9c4`
when doing `bin/console debug:config doctrine`