### PR TITLE
[DI] Fix unresolved env parameters values

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -413,12 +413,7 @@ class Container implements ResettableContainerInterface
         if (isset($this->envCache[$name]) || array_key_exists($name, $this->envCache)) {
             return $this->envCache[$name];
         }
-        if (isset($_ENV[$name])) {
-            return $this->envCache[$name] = $_ENV[$name];
-        }
-        if (false !== $env = getenv($name)) {
-            return $this->envCache[$name] = $env;
-        }
+
         if (!$this->hasParameter("env($name)")) {
             throw new EnvNotFoundException($name);
         }

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1026,7 +1026,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     }
 
     /**
-     * Resolves env parameter placeholders in a string.
+     * Resolves env parameter placeholders in a string or an array..
      *
      * @param string      $string    The string to resolve
      * @param string|null $format    A sprintf() format to use as replacement for env placeholders or null to use the default parameter format


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | not yet
| Fixed tickets | #20684 
| License       | MIT
| Doc PR        | n/a

This is a poc to make env parameters values resolved as any parameter when using `EnvPlaceholderParametereBag::resolveValue()`, moving the logic of fetching env values from the container to the parameter bag. This needs work, concerns should be separated to don't mix placeholders resolution and values resolution (i.e. `EnvParameterBag`). It makes the `debug:config` command dumps configuration with the actual values of env parameters (default value is used if not defined as env var) and is probably useful for the large number of use cases where parameters need to be resolved.

Is it something viable? I'm looking for inputs. 
ping @nicolas-grekas 

