### PR TITLE
Updated the "PHP config" panel in the profiler

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -197,8 +197,8 @@
         </div>
 
         <div class="metric">
-            <span class="value">{{ collector.phplocale }}</span>
-            <span class="label">Locale</span>
+            <span class="value">{{ collector.phpintllocale }}</span>
+            <span class="label">Intl locale</span>
         </div>
 
         <div class="metric">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -214,8 +214,8 @@
         </div>
 
         <div class="metric">
-            <span class="value">{{ include('@WebProfiler/Icon/' ~ (collector.hasapc ? 'yes' : 'no') ~ '.svg') }}</span>
-            <span class="label">APC</span>
+            <span class="value">{{ include('@WebProfiler/Icon/' ~ (collector.hasapcu ? 'yes' : 'no') ~ '.svg') }}</span>
+            <span class="label">APCu</span>
         </div>
 
         <div class="metric">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -192,17 +192,22 @@
         </div>
 
         <div class="metric">
-            <span class="value">{{ include('@WebProfiler/Icon/' ~ (collector.hasaccelerator ? 'yes' : 'no') ~ '.svg') }}</span>
-            <span class="label">PHP acceleration</span>
+            <span class="value">{{ collector.phparchitecture }} <span class="unit">bits</span></span>
+            <span class="label">Architecture</span>
         </div>
 
         <div class="metric">
-            <span class="value">{{ include('@WebProfiler/Icon/' ~ (collector.hasxdebug ? 'yes' : 'no') ~ '.svg') }}</span>
-            <span class="label">Xdebug</span>
+            <span class="value">{{ collector.phplocale }}</span>
+            <span class="label">Locale</span>
+        </div>
+
+        <div class="metric">
+            <span class="value">{{ collector.phptimezone }}</span>
+            <span class="label">Timezone</span>
         </div>
     </div>
 
-    <div class="metrics metrics-horizontal">
+    <div class="metrics">
         <div class="metric">
             <span class="value">{{ include('@WebProfiler/Icon/' ~ (collector.haszendopcache ? 'yes' : 'no') ~ '.svg') }}</span>
             <span class="label">OPcache</span>
@@ -214,13 +219,8 @@
         </div>
 
         <div class="metric">
-            <span class="value">{{ include('@WebProfiler/Icon/' ~ (collector.hasxcache ? 'yes' : 'no') ~ '.svg') }}</span>
-            <span class="label">XCache</span>
-        </div>
-
-        <div class="metric">
-            <span class="value">{{ include('@WebProfiler/Icon/' ~ (collector.haseaccelerator ? 'yes' : 'no') ~ '.svg') }}</span>
-            <span class="label">EAccelerator</span>
+            <span class="value">{{ include('@WebProfiler/Icon/' ~ (collector.hasxdebug ? 'yes' : 'no') ~ '.svg') }}</span>
+            <span class="label">Xdebug</span>
         </div>
     </div>
 

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -71,7 +71,7 @@ class ConfigDataCollector extends DataCollector
             'php_intl_locale' => \Locale::getDefault() ?: 'n/a',
             'php_timezone' => date_default_timezone_get(),
             'xdebug_enabled' => extension_loaded('xdebug'),
-            'apc_enabled' => extension_loaded('apc') && ini_get('apc.enabled'),
+            'apcu_enabled' => extension_loaded('apcu') && ini_get('apc.enabled'),
             'zend_opcache_enabled' => extension_loaded('Zend OPcache') && ini_get('opcache.enable'),
             'bundles' => array(),
             'sapi_name' => PHP_SAPI,
@@ -201,13 +201,13 @@ class ConfigDataCollector extends DataCollector
     }
 
     /**
-     * Returns true if APC is enabled.
+     * Returns true if APCu is enabled.
      *
-     * @return bool true if APC is enabled, false otherwise
+     * @return bool true if APCu is enabled, false otherwise
      */
-    public function hasApc()
+    public function hasApcu()
     {
-        return $this->data['apc_enabled'];
+        return $this->data['apcu_enabled'];
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -67,11 +67,11 @@ class ConfigDataCollector extends DataCollector
             'env' => isset($this->kernel) ? $this->kernel->getEnvironment() : 'n/a',
             'debug' => isset($this->kernel) ? $this->kernel->isDebug() : 'n/a',
             'php_version' => PHP_VERSION,
+            'php_architecture' => PHP_INT_SIZE * 8,
+            'php_locale' => \Locale::getDefault() ?: 'n/a',
+            'php_timezone' => date_default_timezone_get(),
             'xdebug_enabled' => extension_loaded('xdebug'),
-            'eaccel_enabled' => extension_loaded('eaccelerator') && ini_get('eaccelerator.enable'),
             'apc_enabled' => extension_loaded('apc') && ini_get('apc.enabled'),
-            'xcache_enabled' => extension_loaded('xcache') && ini_get('xcache.cacher'),
-            'wincache_enabled' => extension_loaded('wincache') && ini_get('wincache.ocenabled'),
             'zend_opcache_enabled' => extension_loaded('Zend OPcache') && ini_get('opcache.enable'),
             'bundles' => array(),
             'sapi_name' => PHP_SAPI,
@@ -137,6 +137,30 @@ class ConfigDataCollector extends DataCollector
     }
 
     /**
+     * @return int The PHP architecture as number of bits (e.g. 32 or 64)
+     */
+    public function getPhpArchitecture()
+    {
+        return $this->data['php_architecture'];
+    }
+
+    /**
+     * @return string
+     */
+    public function getPhpLocale()
+    {
+        return $this->data['php_locale'];
+    }
+
+    /**
+     * @return string
+     */
+    public function getPhpTimezone()
+    {
+        return $this->data['php_timezone'];
+    }
+
+    /**
      * Gets the application name.
      *
      * @return string The application name
@@ -177,16 +201,6 @@ class ConfigDataCollector extends DataCollector
     }
 
     /**
-     * Returns true if EAccelerator is enabled.
-     *
-     * @return bool true if EAccelerator is enabled, false otherwise
-     */
-    public function hasEAccelerator()
-    {
-        return $this->data['eaccel_enabled'];
-    }
-
-    /**
      * Returns true if APC is enabled.
      *
      * @return bool true if APC is enabled, false otherwise
@@ -204,36 +218,6 @@ class ConfigDataCollector extends DataCollector
     public function hasZendOpcache()
     {
         return $this->data['zend_opcache_enabled'];
-    }
-
-    /**
-     * Returns true if XCache is enabled.
-     *
-     * @return bool true if XCache is enabled, false otherwise
-     */
-    public function hasXCache()
-    {
-        return $this->data['xcache_enabled'];
-    }
-
-    /**
-     * Returns true if WinCache is enabled.
-     *
-     * @return bool true if WinCache is enabled, false otherwise
-     */
-    public function hasWinCache()
-    {
-        return $this->data['wincache_enabled'];
-    }
-
-    /**
-     * Returns true if any accelerator is enabled.
-     *
-     * @return bool true if any accelerator is enabled, false otherwise
-     */
-    public function hasAccelerator()
-    {
-        return $this->hasApc() || $this->hasZendOpcache() || $this->hasEAccelerator() || $this->hasXCache() || $this->hasWinCache();
     }
 
     public function getBundles()

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -68,7 +68,7 @@ class ConfigDataCollector extends DataCollector
             'debug' => isset($this->kernel) ? $this->kernel->isDebug() : 'n/a',
             'php_version' => PHP_VERSION,
             'php_architecture' => PHP_INT_SIZE * 8,
-            'php_locale' => \Locale::getDefault() ?: 'n/a',
+            'php_intl_locale' => \Locale::getDefault() ?: 'n/a',
             'php_timezone' => date_default_timezone_get(),
             'xdebug_enabled' => extension_loaded('xdebug'),
             'apc_enabled' => extension_loaded('apc') && ini_get('apc.enabled'),
@@ -147,9 +147,9 @@ class ConfigDataCollector extends DataCollector
     /**
      * @return string
      */
-    public function getPhpLocale()
+    public function getPhpIntlLocale()
     {
-        return $this->data['php_locale'];
+        return $this->data['php_intl_locale'];
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
@@ -38,7 +38,7 @@ class ConfigDataCollectorTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($c->getToken());
         $this->assertSame(extension_loaded('xdebug'), $c->hasXDebug());
         $this->assertSame(extension_loaded('Zend OPcache') && ini_get('opcache.enable'), $c->hasZendOpcache());
-        $this->assertSame(extension_loaded('apc') && ini_get('apc.enabled'), $c->hasApc());
+        $this->assertSame(extension_loaded('apcu') && ini_get('apc.enabled'), $c->hasApcu());
     }
 }
 

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
@@ -31,30 +31,14 @@ class ConfigDataCollectorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('config', $c->getName());
         $this->assertSame('testkernel', $c->getAppName());
         $this->assertSame(PHP_VERSION, $c->getPhpVersion());
+        $this->assertSame(PHP_INT_SIZE * 8, $c->getPhpArchitecture());
+        $this->assertSame(\Locale::getDefault() ?: 'n/a', $c->getPhpLocale());
+        $this->assertSame(date_default_timezone_get(), $c->getPhpTimezone());
         $this->assertSame(Kernel::VERSION, $c->getSymfonyVersion());
         $this->assertNull($c->getToken());
-
-        // if else clause because we don't know it
-        if (extension_loaded('xdebug')) {
-            $this->assertTrue($c->hasXDebug());
-        } else {
-            $this->assertFalse($c->hasXDebug());
-        }
-
-        // if else clause because we don't know it
-        if (((extension_loaded('eaccelerator') && ini_get('eaccelerator.enable'))
-                ||
-                (extension_loaded('apc') && ini_get('apc.enabled'))
-                ||
-                (extension_loaded('Zend OPcache') && ini_get('opcache.enable'))
-                ||
-                (extension_loaded('xcache') && ini_get('xcache.cacher'))
-                ||
-                (extension_loaded('wincache') && ini_get('wincache.ocenabled')))) {
-            $this->assertTrue($c->hasAccelerator());
-        } else {
-            $this->assertFalse($c->hasAccelerator());
-        }
+        $this->assertSame(extension_loaded('xdebug'), $c->hasXDebug());
+        $this->assertSame(extension_loaded('Zend OPcache') && ini_get('opcache.enable'), $c->hasZendOpcache());
+        $this->assertSame(extension_loaded('apc') && ini_get('apc.enabled'), $c->hasApc());
     }
 }
 

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
@@ -32,7 +32,7 @@ class ConfigDataCollectorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('testkernel', $c->getAppName());
         $this->assertSame(PHP_VERSION, $c->getPhpVersion());
         $this->assertSame(PHP_INT_SIZE * 8, $c->getPhpArchitecture());
-        $this->assertSame(\Locale::getDefault() ?: 'n/a', $c->getPhpLocale());
+        $this->assertSame(\Locale::getDefault() ?: 'n/a', $c->getPhpIntlLocale());
         $this->assertSame(date_default_timezone_get(), $c->getPhpTimezone());
         $this->assertSame(Kernel::VERSION, $c->getSymfonyVersion());
         $this->assertNull($c->getToken());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

I propose to update this panel taking some of the ideas introduced by @ro0NL in #20126:

* Adding more info that helps debugging problems (like 32/64 bits, the locale and the timezone)
* Removing anything related to PHP acceleration that is not OPcache or APC

### Before

![php-config-before](https://cloud.githubusercontent.com/assets/73419/20751739/b557ca9a-b6fd-11e6-98c4-49e80b16d424.png)

### After

![php-config-after](https://cloud.githubusercontent.com/assets/73419/20751740/b7da5c38-b6fd-11e6-8619-3d3b5f477887.png)
