### PR TITLE
[Routing] Allow to override fragment decoded chars

### DIFF
--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -74,6 +74,14 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
         '%2A' => '*',
         '%7C' => '|',
     );
+    
+    /**
+     * This array defines the characters (besides alphanumeric ones) that will not be percent-encoded in the fragment of the generated URL.
+     */
+    protected $decodedFragmentChars = array(
+        '%2F' => '/', 
+        '%3F' => '?',  
+    );
 
     /**
      * Constructor.
@@ -280,7 +288,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
         }
 
         if ('' !== $fragment) {
-            $url .= '#'.strtr(rawurlencode($fragment), array('%2F' => '/', '%3F' => '?'));
+            $url .= '#'.strtr(rawurlencode($fragment), $this->decodedFragmentChars);
         }
 
         return $url;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Like with $decodedChars, it is important to be able to override $decodedChars for fragment, for example to use #page=2 (I know it's not RFC compliant...)

