### PR TITLE
Ignore missing 'debug.file_link_formatter' service in Debug and Twig bundles

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/DebugBundle/Resources/config/services.xml
@@ -14,7 +14,7 @@
         <service id="data_collector.dump" class="Symfony\Component\HttpKernel\DataCollector\DumpDataCollector">
             <tag name="data_collector" id="dump" template="@Debug/Profiler/dump.html.twig" priority="240" />
             <argument type="service" id="debug.stopwatch" on-invalid="ignore" />
-            <argument type="service" id="debug.file_link_formatter"></argument>
+            <argument type="service" id="debug.file_link_formatter" on-invalid="ignore"></argument>
             <argument>%kernel.charset%</argument>
             <argument type="service" id="request_stack" />
             <argument>null</argument><!-- var_dumper.cli_dumper when debug.dump_destination is set -->

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -88,7 +88,7 @@
 
         <service id="twig.extension.code" class="Symfony\Bridge\Twig\Extension\CodeExtension" public="false">
             <tag name="twig.extension" />
-            <argument type="service" id="debug.file_link_formatter" />
+            <argument type="service" id="debug.file_link_formatter" on-invalid="ignore" />
             <argument>%kernel.root_dir%</argument>
             <argument>%kernel.charset%</argument>
         </service>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | TBD
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

The TwigBundle's `twig.extension.code` service and the DebugBundle's `data_collector.dump` service require the new `debug.file_link_formatter` service however this is only available with the FrameworkBundle or WebProfilerBundle 3.2.  The class it refers to was added to the HttpKernel at 3.2 as well.  In the case of the TwigBundle, attempting to upgrade a site's dependencies where you try to install `symfony/twig-bundle ~3.2` with `symfony/framework-bundle <3.2` or `symfony/web-profiler-bundle <3.2` causes a `ServiceNotFoundException` with message 'The service "twig" has a dependency on a non-existent service "debug.file_link_formatter".' to be thrown.