### PR TITLE
[Console] Fix wrong handling of multiline arg/opt descriptions

### DIFF
--- a/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
@@ -38,13 +38,13 @@ class TextDescriptor extends Descriptor
         }
 
         $totalWidth = isset($options['total_width']) ? $options['total_width'] : strlen($argument->getName());
-        $spacingWidth = $totalWidth - strlen($argument->getName()) + 2;
+        $spacingWidth = $totalWidth - strlen($argument->getName());
 
-        $this->writeText(sprintf('  <info>%s</info>%s%s%s',
+        $this->writeText(sprintf('  <info>%s</info>  %s%s%s',
             $argument->getName(),
             str_repeat(' ', $spacingWidth),
-            // + 17 = 2 spaces + <info> + </info> + 2 spaces
-            preg_replace('/\s*[\r\n]\s*/', "\n".str_repeat(' ', $totalWidth + 17), $argument->getDescription()),
+            // + 4 = 2 spaces before <info>, 2 spaces after </info>
+            preg_replace('/\s*[\r\n]\s*/', "\n".str_repeat(' ', $totalWidth + 4), $argument->getDescription()),
             $default
         ), $options);
     }
@@ -75,13 +75,13 @@ class TextDescriptor extends Descriptor
             sprintf('--%s%s', $option->getName(), $value)
         );
 
-        $spacingWidth = $totalWidth - strlen($synopsis) + 2;
+        $spacingWidth = $totalWidth - strlen($synopsis);
 
-        $this->writeText(sprintf('  <info>%s</info>%s%s%s%s',
+        $this->writeText(sprintf('  <info>%s</info>  %s%s%s%s',
             $synopsis,
             str_repeat(' ', $spacingWidth),
-            // + 17 = 2 spaces + <info> + </info> + 2 spaces
-            preg_replace('/\s*[\r\n]\s*/', "\n".str_repeat(' ', $totalWidth + 17), $option->getDescription()),
+            // + 4 = 2 spaces before <info>, 2 spaces after </info>
+            preg_replace('/\s*[\r\n]\s*/', "\n".str_repeat(' ', $totalWidth + 4), $option->getDescription()),
             $default,
             $option->isArray() ? '<comment> (multiple values allowed)</comment>' : ''
         ), $options);

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_argument_4.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_argument_4.txt
@@ -1,2 +1,2 @@
   <info>argument_name</info>  multiline
-                              argument description
+                 argument description

--- a/src/Symfony/Component/Console/Tests/Fixtures/input_option_5.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/input_option_5.txt
@@ -1,2 +1,2 @@
   <info>-o, --option_name=OPTION_NAME</info>  multiline
-                                              option description
+                                 option description


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20237, https://github.com/symfony/symfony/pull/13220#discussion_r84281248
| License       | MIT
| Doc PR        | N/A

### Before

<img width="1072" alt="screenshot 2016-11-30 a 19 23 17" src="https://cloud.githubusercontent.com/assets/2211145/20765428/8b622304-b732-11e6-911b-b169e9aed5fd.PNG">

### After

<img width="1074" alt="screenshot 2016-11-30 a 19 23 46" src="https://cloud.githubusercontent.com/assets/2211145/20765432/9159a53e-b732-11e6-909f-ec8107c78fed.PNG">

@rquadling and @leofeyer deserve the credit for reporting the issue and suggesting the proper fix. I've only executed it.

---

<details>
<summary>Show code to reproduce:</summary>

```php
<?php

use Symfony\Component\Console\Application;
use Symfony\Component\Console\Command\Command;
use Symfony\Component\Console\Input\ArgvInput;
use Symfony\Component\Console\Input\InputArgument;
use Symfony\Component\Console\Input\InputOption;

require __DIR__.'/../vendor/autoload.php';

(new Application())
    ->add(new class extends Command {
        protected function configure()
        {
            $description = "One of:" . array_reduce(['purge', 'truncate', 'delete', 'insert', 'select'], function ($value, $previous = '') {
                    return "$value\n- $previous";
            });

            $this
                ->setName('execute')
                ->addArgument('action', InputArgument::REQUIRED, $description)
                ->addOption('another-one', 'a', InputOption::VALUE_OPTIONAL, $description)
            ;
        }
    })
    ->getApplication()
    ->run(new ArgvInput())
;
```
</details>