### PR TITLE
[TwigBridge] fix FormExtension::$renderer bc break

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -23,7 +23,10 @@ use Symfony\Component\Form\ChoiceList\View\ChoiceView;
  */
 class FormExtension extends \Twig_Extension implements \Twig_Extension_InitRuntimeInterface
 {
-    private $renderer;
+    /**
+     * Make this property private in 4.0.
+     */
+    public $renderer;
 
     public function __construct(TwigRendererInterface $renderer = null)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes?
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Before b515702, the `FormExtension::$renderer` property was not declared but initialized in `FormExtension::__construct()`. This makes the property visibility to public. In b515702, the property was declared but with a private visibility. This broke the backward compatibility of the
`FormExtension` class.