### PR TITLE
[TwigBundle] Fix twig loader registered twice

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\TwigBundle\DependencyInjection\Compiler;
 
+use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -73,7 +74,7 @@ class ExtensionPass implements CompilerPassInterface
             $loader->addTag('twig.loader');
             $loader->setMethodCalls($container->getDefinition('twig.loader.filesystem')->getMethodCalls());
 
-            $container->setDefinition('twig.loader.filesystem', $loader);
+            $container->setAlias('twig.loader.filesystem', new Alias('twig.loader.native_filesystem', false));
         }
 
         if ($container->has('assets.packages')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/20665
| License       | MIT
| Doc PR        | N/A

Generated code:

### Before

```php
    protected function getTwig_LoaderService()
    {
        $a = new \Twig_Loader_Filesystem(array(), $this->targetDirs[3]);
        
        $a->addPath(...);
        // ...

        $this->services['twig.loader'] = $instance = new \Twig_Loader_Chain();

        $instance->addLoader($a);
        $instance->addLoader($a);

        return $instance;
    }
```

### After

```php
    protected function getTwig_LoaderService()
    {
        $this->services['twig.loader'] = $instance = new \Twig_Loader_Filesystem(array(), $this->targetDirs[3]);

        $instance->addPath(...);
        // ...

        return $instance;
    }
```

~~Another solution is to simply create a private alias. But I don't know if we should care or not about the case people may rely on the fact both services exist as definition, and not as an alias, in a compiler pass.~~ (Has been preferred over of using a child definition)

For reference, this issue was introduced in https://github.com/symfony/symfony/pull/13354.