### PR TITLE
[FrameworkBundle] Fix unresolved parameters from default configs in debug:config

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
@@ -90,7 +90,7 @@ EOF
             $output->writeln(sprintf('# Current configuration for "%s"', $name));
         }
 
-        $output->writeln(Yaml::dump(array($extension->getAlias() => $config), 10));
+        $output->writeln(Yaml::dump(array($extension->getAlias() => $container->getParameterBag()->resolveValue($config)), 10));
     }
 
     private function compileContainer()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

When using the `debug:config` command, if the dumped configuration is explicitly defined by the user, then parameters are properly resolved in the output. If it is not, and values come from the bundle default configuration directly, they are not.

Steps to reproduce:
- Checkout the symfony demo
- Run `debug:config twig`
- Look at the `debug` key, it is the `kernel.debug` parameter properly resolved: `true` 
- Look at the `cache` key, it is not resolved: `'%kernel.cache_dir%/twig'`

This fixes it by resolving configs once again after processing the configuration.
ping @weaverryan 