### PR TITLE
[WebProfilerBundle] Fix AJAX panel width for long URLs

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -315,7 +315,7 @@
     padding: 4px;
 }
 .sf-ajax-request-url {
-    max-width: 300px;
+    max-width: 250px;
     line-height: 9px;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

When the AJAX url path is very long, the **profile ``<td>``** token value is not fully displayed.

### Before

![before](https://cloud.githubusercontent.com/assets/2028198/20801819/16949c88-b7b8-11e6-9186-c350cb0f6868.png)

### After

![after](https://cloud.githubusercontent.com/assets/2028198/20804230/1519a7ec-b7c0-11e6-8ebe-f2ebfa5ab08e.png)

### Other Possible Solutions

1. Fix ``max-width`` from ``.sf-toolbar-block:hover .sf-toolbar-info`` class to ``512px``. (same result but the AJAX panel is a bit longer)
2. Fix ``max-width`` from ``.sf-toolbar-block:hover .sf-toolbar-info`` class to ``none`` or remove it. It would avoid future issues (mainly with third bundles) with children width greater than ``480px``. (Promising) ?

//cc @javiereguiluz 