### PR TITLE
[WebProfilerBundle] Fix dump block is unfairly restrained

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -356,10 +356,12 @@
     border-color: #777;
     border-radius: 0;
     margin: 6px 0 12px 0;
-    width: 200px;
 }
 .sf-toolbar-block-dump pre.sf-dump:last-child {
     margin-bottom: 0;
+}
+.sf-toolbar-block-dump .sf-toolbar-info-piece {
+    display: block;
 }
 .sf-toolbar-block-dump .sf-toolbar-info-piece .sf-toolbar-file-line {
     color: #AAA;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

The `display: table-row` rule does not suit well for such blocks and prevent from containing them properly in the parent container (thus the reason why the width was set to `200px` I guess).

### Before

<img width="539" alt="screenshot 2016-12-01 a 20 21 49" src="https://cloud.githubusercontent.com/assets/2211145/20808878/8af6faa2-b804-11e6-8656-8ebd710b4acb.PNG">

### After

<img width="524" alt="screenshot 2016-12-01 a 20 21 14" src="https://cloud.githubusercontent.com/assets/2211145/20808885/9106b0cc-b804-11e6-9ddc-0cc09a546274.PNG">

(max width is still fixed to `480px` by `.sf-toolbar-block:hover .sf-toolbar-info`)