### PR TITLE
Updated the "Symfony Config" panel in the profiler

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -181,6 +181,31 @@
                 </div>
             {% endif %}
         </div>
+
+        {% set symfony_status = { dev: 'Unstable Version', stable: 'Stable Version', eom: 'Maintenance Ended', eol: 'Version Expired' } %}
+        {% set symfony_status_class = { dev: 'warning', stable: 'success', eom: 'warning', eol: 'error' } %}
+        <table>
+            <thead class="small">
+                <tr>
+                    <th>Symfony Status</th>
+                    <th>Bugs are fixed until</th>
+                    <th>Security issues are fixed until</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td class="font-normal">
+                        <span class="label status-{{ symfony_status_class[collector.symfonystate] }}">{{ symfony_status[collector.symfonystate]|upper }}</span>
+                    </td>
+                    <td class="font-normal">{{ collector.symfonyeom }}</td>
+                    <td class="font-normal">{{ collector.symfonyeol }}</td>
+                    <td class="font-normal">
+                        <a href="//symfony.com/roadmap?version={{ collector.symfonyminorversion }}#checker">View roadmap</a>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
     {% endif %}
 
     <h2>PHP Configuration</h2>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -201,7 +201,7 @@
                     <td class="font-normal">{{ collector.symfonyeom }}</td>
                     <td class="font-normal">{{ collector.symfonyeol }}</td>
                     <td class="font-normal">
-                        <a href="//symfony.com/roadmap?version={{ collector.symfonyminorversion }}#checker">View roadmap</a>
+                        <a href="https://symfony.com/roadmap?version={{ collector.symfonyminorversion }}#checker">View roadmap</a>
                     </td>
                 </tr>
             </tbody>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -188,8 +188,8 @@
             <thead class="small">
                 <tr>
                     <th>Symfony Status</th>
-                    <th>Bugs are fixed until</th>
-                    <th>Security issues are fixed until</th>
+                    <th>Bugs {{ collector.symfonystate in ['eom', 'eol'] ? 'were' : 'are' }} fixed until</th>
+                    <th>Security issues {{ collector.symfonystate == 'eol' ? 'were' : 'are' }} fixed until</th>
                     <th></th>
                 </tr>
             </thead>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -166,6 +166,10 @@ table thead th {
 table thead th.key {
     width: 19%;
 }
+table thead.small th {
+    font-size: 12px;
+    padding: 4px 10px;
+}
 
 table tbody th,
 table tbody td {

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -131,10 +131,9 @@ class ConfigDataCollector extends DataCollector
         return $this->data['symfony_state'];
     }
 
-
     /**
      * Returns the minor Symfony version used (without patch numbers of extra
-     * suffix like "RC", "beta", etc.)
+     * suffix like "RC", "beta", etc.).
      *
      * @return string
      */

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -83,6 +83,11 @@ class ConfigDataCollector extends DataCollector
             }
 
             $this->data['symfony_state'] = $this->determineSymfonyState();
+            $this->data['symfony_minor_version'] = sprintf('%s.%s', Kernel::MAJOR_VERSION, Kernel::MINOR_VERSION);
+            $eom = \DateTime::createFromFormat('m/Y', Kernel::END_OF_MAINTENANCE);
+            $eol = \DateTime::createFromFormat('m/Y', Kernel::END_OF_LIFE);
+            $this->data['symfony_eom'] = $eom->format('F Y');
+            $this->data['symfony_eol'] = $eol->format('F Y');
         }
     }
 
@@ -124,6 +129,40 @@ class ConfigDataCollector extends DataCollector
     public function getSymfonyState()
     {
         return $this->data['symfony_state'];
+    }
+
+
+    /**
+     * Returns the minor Symfony version used (without patch numbers of extra
+     * suffix like "RC", "beta", etc.)
+     *
+     * @return string
+     */
+    public function getSymfonyMinorVersion()
+    {
+        return $this->data['symfony_minor_version'];
+    }
+
+    /**
+     * Returns the human redable date when this Symfony version ends its
+     * maintenance period.
+     *
+     * @return string
+     */
+    public function getSymfonyEom()
+    {
+        return $this->data['symfony_eom'];
+    }
+
+    /**
+     * Returns the human redable date when this Symfony version reaches its
+     * "end of life" and won't receive bugs or security fixes.
+     *
+     * @return string
+     */
+    public function getSymfonyEol()
+    {
+        return $this->data['symfony_eol'];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This adds more information about the status of your Symfony version:

![symfony_config](https://cloud.githubusercontent.com/assets/73419/20830798/8ad42a1c-b882-11e6-9c5f-fac392d3118f.png)

And here some screenshots of the different statuses:

![symfony-dev](https://cloud.githubusercontent.com/assets/73419/20830807/9757aa2a-b882-11e6-8049-c156d9b16c83.png)

![symfony-eom](https://cloud.githubusercontent.com/assets/73419/20830810/9973b330-b882-11e6-8d57-6da3baafc256.png)

![symfony-eol](https://cloud.githubusercontent.com/assets/73419/20830811/9b99c67c-b882-11e6-8ff4-c76c77266e0c.png)


