### PR TITLE
Add a RoleType that allows to select roles among the ones in the hierarchy

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Form/Type/RoleType.php
+++ b/src/Symfony/Bundle/SecurityBundle/Form/Type/RoleType.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class RoleType extends AbstractType
+{
+    private $roleHierarchy;
+
+    public function __construct(array $roleHierarchy)
+    {
+        $this->roleHierarchy = $roleHierarchy;
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'choices' => $this->getKnownRoles(),
+            'multiple' => true,
+            'expanded' => true,
+        ));
+    }
+
+    public function getKnownRoles()
+    {
+        $roles = array();
+
+        foreach ($this->roleHierarchy as $parent => $children) {
+            $roles[$parent] = $parent;
+
+            foreach ($children as $child) {
+                $roles[$child] = $child;
+            }
+        }
+
+        return $roles;
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'role';
+    }
+
+    public function getParent()
+    {
+        return ChoiceType::class;
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -156,6 +156,11 @@
             <argument type="service" id="router" on-invalid="null" />
         </service>
 
+        <!-- Form -->
+        <service id="form.type.role" class="Symfony\Bundle\SecurityBundle\Form\Type\RoleType">
+            <tag name="form.type" />
+            <argument>%security.role_hierarchy.roles%</argument>
+        </service>
 
         <!-- Validator -->
         <service id="security.validator.user_password" class="Symfony\Component\Security\Core\Validator\Constraints\UserPasswordValidator">

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Form/Type/RoleTypeTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Form/Type/RoleTypeTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Form\Type;
+
+use Symfony\Bundle\SecurityBundle\Form\Type\RoleType;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+class RoleTypeTest extends TypeTestCase
+{
+    protected function getExtensions()
+    {
+        $roleHierarchy = array(
+            'ROLE_SUPER_ADMIN' => array('ROLE_ADMIN', 'ROLE_ALLOWED_TO_SWITCH'),
+            'ROLE_ADMIN' => array('ROLE_USER'),
+        );
+
+        return array(
+            new PreloadedExtension(array(new RoleType($roleHierarchy)), array()),
+        );
+    }
+
+    public function testAllRolesAreShown()
+    {
+        $form = $this->factory->create(RoleType::class);
+
+        $this->assertCount(4, $form, 'Each role should be shown');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/10212
| License       | MIT
| Doc PR        | Not yet

This PR adds a `RoleType` to the security bundle that extends the existing `ChoiceType` in order to select roles for a user.

This can be used for instance in an admin backend to edit permissions.