### PR TITLE
[Finder] Refine phpdoc about argument for NumberComparator

### DIFF
--- a/src/Symfony/Component/Finder/Comparator/NumberComparator.php
+++ b/src/Symfony/Component/Finder/Comparator/NumberComparator.php
@@ -37,7 +37,7 @@ class NumberComparator extends Comparator
     /**
      * Constructor.
      *
-     * @param string $test A comparison string
+     * @param string|int $test A comparison string or an integer
      *
      * @throws \InvalidArgumentException If the test is not understood
      */

--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -200,7 +200,7 @@ class Finder implements \IteratorAggregate, \Countable
      *   $finder->depth('> 1') // the Finder will start matching at level 1.
      *   $finder->depth('< 3') // the Finder will descend at most 3 levels of directories below the starting point.
      *
-     * @param int $level The depth level expression
+     * @param string|int $level The depth level expression
      *
      * @return Finder|SplFileInfo[] The current Finder instance
      *
@@ -372,7 +372,7 @@ class Finder implements \IteratorAggregate, \Countable
      * $finder->size('<= 1Ki');
      * $finder->size(4);
      *
-     * @param string $size A size range string
+     * @param string|int $size A size range string or an integer
      *
      * @return Finder|SplFileInfo[] The current Finder instance
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

The most important being the addition of "string" to `Finder::depth()`.