### PR TITLE
[FrameworkBundle] Separate controller utils from its base class

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerUtils.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerUtils.php
@@ -1,0 +1,172 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Controller;
+
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Roland Franssen <franssen.roland@gmail.com>
+ */
+class ControllerUtils
+{
+    private $kernel;
+    private $requestStack;
+    private $urlGenerator;
+    private $serializer;
+
+    public function __construct(HttpKernelInterface $kernel, RequestStack $requestStack, UrlGeneratorInterface $urlGenerator = null, SerializerInterface $serializer = null)
+    {
+        $this->kernel = $kernel;
+        $this->requestStack = $requestStack;
+        $this->urlGenerator = $urlGenerator;
+        $this->serializer = $serializer;
+    }
+
+    /**
+     * Generates a URL from the given parameters.
+     *
+     * @param string $route         The name of the route
+     * @param mixed  $parameters    An array of parameters
+     * @param int    $referenceType The type of reference (one of the constants in UrlGeneratorInterface)
+     *
+     * @return string The generated URL
+     *
+     * @throws \LogicException
+     *
+     * @see UrlGeneratorInterface
+     */
+    public function generateUrl($route, $parameters = array(), $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
+    {
+        if (null === $this->urlGenerator) {
+            throw new \LogicException('You can not use the generateUrl method if routing is disabled.');
+        }
+
+        return $this->urlGenerator->generate($route, $parameters, $referenceType);
+    }
+
+    /**
+     * Forwards the request to another controller.
+     *
+     * @param string $controller The controller name (a string like BlogBundle:Post:index)
+     * @param array  $path       An array of path parameters
+     * @param array  $query      An array of query parameters
+     *
+     * @return Response A Response instance
+     */
+    public function forward($controller, array $path = array(), array $query = array())
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        $path['_forwarded'] = $request->attributes;
+        $path['_controller'] = $controller;
+        $subRequest = $request->duplicate($query, null, $path);
+
+        return $this->kernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
+    }
+
+    /**
+     * Returns a RedirectResponse to the given URL.
+     *
+     * @param string $url    The URL to redirect to
+     * @param int    $status The status code to use for the Response
+     *
+     * @return RedirectResponse
+     */
+    public function redirect($url, $status = 302)
+    {
+        return new RedirectResponse($url, $status);
+    }
+
+    /**
+     * Returns a RedirectResponse to the given route with the given parameters.
+     *
+     * @param string $route      The name of the route
+     * @param array  $parameters An array of parameters
+     * @param int    $status     The status code to use for the Response
+     *
+     * @return RedirectResponse
+     */
+    public function redirectToRoute($route, array $parameters = array(), $status = 302)
+    {
+        return $this->redirect($this->generateUrl($route, $parameters), $status);
+    }
+
+    /**
+     * Returns a JsonResponse that uses the serializer component if enabled, or json_encode.
+     *
+     * @param mixed $data    The response data
+     * @param int   $status  The status code to use for the Response
+     * @param array $headers Array of extra headers to add
+     * @param array $context Context to pass to serializer when using serializer component
+     *
+     * @return JsonResponse
+     */
+    public function json($data, $status = 200, $headers = array(), $context = array())
+    {
+        if (null !== $this->serializer) {
+            $json = $this->serializer->serialize($data, 'json', array_merge(array(
+                'json_encode_options' => JsonResponse::DEFAULT_ENCODING_OPTIONS,
+            ), $context));
+
+            return new JsonResponse($json, $status, $headers, true);
+        }
+
+        return new JsonResponse($data, $status, $headers);
+    }
+
+    /**
+     * Returns a BinaryFileResponse object with original or customized file name and disposition header.
+     *
+     * @param \SplFileInfo|string $file        File object or path to file to be sent as response
+     * @param string|null         $fileName    File name to be sent to response or null (will use original file name)
+     * @param string              $disposition Disposition of response ("attachment" is default, other type is "inline")
+     *
+     * @return BinaryFileResponse
+     */
+    public function file($file, $fileName = null, $disposition = ResponseHeaderBag::DISPOSITION_ATTACHMENT)
+    {
+        $response = new BinaryFileResponse($file);
+        $response->setContentDisposition($disposition, $fileName === null ? $response->getFile()->getFileName() : $fileName);
+
+        return $response;
+    }
+
+    /**
+     * Adds a flash message to the current session for type.
+     *
+     * @param string $type    The type
+     * @param string $message The message
+     *
+     * @throws \LogicException
+     */
+    public function addFlash($type, $message)
+    {
+        $session = $this->requestStack->getCurrentRequest()->getSession();
+        if (null === $session) {
+            throw new \LogicException('You can not use the addFlash method if sessions are disabled.');
+        }
+        if (!$session instanceof Session) {
+            throw new \LogicException('You can not use the addFlash method for session implementation other then the default one.');
+        }
+
+        $session->getFlashBag()->add($type, $message);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
@@ -17,6 +17,13 @@
             <argument type="service" id="logger" on-invalid="ignore" />
         </service>
 
+        <service id="controller_utils" class="Symfony\Bundle\FrameworkBundle\Controller\ControllerUtils">
+            <argument type="service" id="http_kernel" />
+            <argument type="service" id="request_stack" />
+            <argument type="service" id="router" on-invalid="ignore" />
+            <argument type="service" id="serializer" on-invalid="ignore" />
+        </service>
+
         <service id="argument_metadata_factory" class="Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadataFactory" public="false" />
 
         <service id="argument_resolver" class="Symfony\Component\HttpKernel\Controller\ArgumentResolver" public="false">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | not yet
| Fixed tickets | #16863
| License       | MIT
| Doc PR        | reference to the documentation PR, if any

My version of decoupling controller utilities from the controller base class.

It's a WIP as not all utils are transferred yet and tests are failing by the way in which mocks are built. (the annoying way).

Goals;
- dont force a controller base class
- dont inject the service container
- dont inject the same services over and over again in each controller to avoid above
- avoid traits to do the above
- allow for reuseabality of those very useful utilities :))
- clean and explicit dependencies

This could deprecate `Controller::generateUrl` in favor of `ControllerUtils::generateUrl` (along with others).

```php
// before
$this->generateUrl();

// after
$this->get('controller_utils')->generateUrl();
```

Idea is to do the same thing for security related utils, so `ControllerUtils` can inject and forward to `SecurityUtils`.