### PR TITLE
Deprecate ClassCollectionLoader and Kernel::loadClassCache

### DIFF
--- a/src/Symfony/Bridge/Twig/Form/TwigRendererEngineInterface.php
+++ b/src/Symfony/Bridge/Twig/Form/TwigRendererEngineInterface.php
@@ -16,7 +16,7 @@ use Symfony\Component\Form\FormRendererEngineInterface;
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @deprecated Deprecated since version 3.2, to be removed in 4.0.
+ * @deprecated since version 3.2, to be removed in 4.0.
  */
 interface TwigRendererEngineInterface extends FormRendererEngineInterface
 {

--- a/src/Symfony/Bridge/Twig/Form/TwigRendererInterface.php
+++ b/src/Symfony/Bridge/Twig/Form/TwigRendererInterface.php
@@ -16,7 +16,7 @@ use Symfony\Component\Form\FormRendererInterface;
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @deprecated Deprecated since version 3.2, to be removed in 4.0.
+ * @deprecated since version 3.2, to be removed in 4.0.
  */
 interface TwigRendererInterface extends FormRendererInterface
 {

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ClassCacheCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ClassCacheCacheWarmer.php
@@ -11,6 +11,10 @@
 
 namespace Symfony\Bundle\FrameworkBundle\CacheWarmer;
 
+if (PHP_VERSION_ID >= 70000) {
+    @trigger_error('The '.__NAMESPACE__.'\ClassCacheCacheWarmer class is deprecated since version 3.3 and will be removed in 4.0.', E_USER_DEPRECATED);
+}
+
 use Symfony\Component\ClassLoader\ClassCollectionLoader;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 
@@ -18,6 +22,8 @@ use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
  * Generates the Class Cache (classes.php) file.
  *
  * @author Tugdual Saunier <tucksaun@gmail.com>
+ *
+ * @deprecated since version 3.3, to be removed in 4.0.
  */
 class ClassCacheCacheWarmer implements CacheWarmerInterface
 {

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -71,6 +71,14 @@ class FrameworkExtension extends Extension
 
         $loader->load('web.xml');
         $loader->load('services.xml');
+
+        if (PHP_VERSION_ID < 70000) {
+            $definition = $container->getDefinition('kernel.class_cache.cache_warmer');
+            $definition->addTag('kernel.cache_warmer');
+            // Ignore deprecation for PHP versions below 7.0
+            $definition->setDeprecated(false);
+        }
+
         $loader->load('fragment_renderer.xml');
 
         // Property access is used by both the Form and the Validator component
@@ -194,47 +202,49 @@ class FrameworkExtension extends Extension
             'Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller',
         ));
 
-        $this->addClassesToCompile(array(
-            'Symfony\\Component\\Config\\ConfigCache',
-            'Symfony\\Component\\Config\\FileLocator',
+        if (PHP_VERSION_ID < 70000) {
+            $this->addClassesToCompile(array(
+                'Symfony\\Component\\Config\\ConfigCache',
+                'Symfony\\Component\\Config\\FileLocator',
 
-            'Symfony\\Component\\Debug\\ErrorHandler',
+                'Symfony\\Component\\Debug\\ErrorHandler',
 
-            'Symfony\\Component\\DependencyInjection\\ContainerAwareInterface',
-            'Symfony\\Component\\DependencyInjection\\Container',
+                'Symfony\\Component\\DependencyInjection\\ContainerAwareInterface',
+                'Symfony\\Component\\DependencyInjection\\Container',
 
-            'Symfony\\Component\\EventDispatcher\\Event',
-            'Symfony\\Component\\EventDispatcher\\ContainerAwareEventDispatcher',
+                'Symfony\\Component\\EventDispatcher\\Event',
+                'Symfony\\Component\\EventDispatcher\\ContainerAwareEventDispatcher',
 
-            'Symfony\\Component\\HttpFoundation\\Response',
-            'Symfony\\Component\\HttpFoundation\\ResponseHeaderBag',
+                'Symfony\\Component\\HttpFoundation\\Response',
+                'Symfony\\Component\\HttpFoundation\\ResponseHeaderBag',
 
-            'Symfony\\Component\\HttpKernel\\EventListener\\ResponseListener',
-            'Symfony\\Component\\HttpKernel\\EventListener\\RouterListener',
-            'Symfony\\Component\\HttpKernel\\Bundle\\Bundle',
-            'Symfony\\Component\\HttpKernel\\Controller\\ControllerResolver',
-            'Symfony\\Component\\HttpKernel\\Controller\\ArgumentResolver',
-            'Symfony\\Component\\HttpKernel\\ControllerMetadata\\ArgumentMetadata',
-            'Symfony\\Component\\HttpKernel\\ControllerMetadata\\ArgumentMetadataFactory',
-            'Symfony\\Component\\HttpKernel\\Event\\KernelEvent',
-            'Symfony\\Component\\HttpKernel\\Event\\FilterControllerEvent',
-            'Symfony\\Component\\HttpKernel\\Event\\FilterResponseEvent',
-            'Symfony\\Component\\HttpKernel\\Event\\GetResponseEvent',
-            'Symfony\\Component\\HttpKernel\\Event\\GetResponseForControllerResultEvent',
-            'Symfony\\Component\\HttpKernel\\Event\\GetResponseForExceptionEvent',
-            'Symfony\\Component\\HttpKernel\\HttpKernel',
-            'Symfony\\Component\\HttpKernel\\KernelEvents',
-            'Symfony\\Component\\HttpKernel\\Config\\FileLocator',
+                'Symfony\\Component\\HttpKernel\\EventListener\\ResponseListener',
+                'Symfony\\Component\\HttpKernel\\EventListener\\RouterListener',
+                'Symfony\\Component\\HttpKernel\\Bundle\\Bundle',
+                'Symfony\\Component\\HttpKernel\\Controller\\ControllerResolver',
+                'Symfony\\Component\\HttpKernel\\Controller\\ArgumentResolver',
+                'Symfony\\Component\\HttpKernel\\ControllerMetadata\\ArgumentMetadata',
+                'Symfony\\Component\\HttpKernel\\ControllerMetadata\\ArgumentMetadataFactory',
+                'Symfony\\Component\\HttpKernel\\Event\\KernelEvent',
+                'Symfony\\Component\\HttpKernel\\Event\\FilterControllerEvent',
+                'Symfony\\Component\\HttpKernel\\Event\\FilterResponseEvent',
+                'Symfony\\Component\\HttpKernel\\Event\\GetResponseEvent',
+                'Symfony\\Component\\HttpKernel\\Event\\GetResponseForControllerResultEvent',
+                'Symfony\\Component\\HttpKernel\\Event\\GetResponseForExceptionEvent',
+                'Symfony\\Component\\HttpKernel\\HttpKernel',
+                'Symfony\\Component\\HttpKernel\\KernelEvents',
+                'Symfony\\Component\\HttpKernel\\Config\\FileLocator',
 
-            'Symfony\\Bundle\\FrameworkBundle\\Controller\\ControllerNameParser',
-            'Symfony\\Bundle\\FrameworkBundle\\Controller\\ControllerResolver',
+                'Symfony\\Bundle\\FrameworkBundle\\Controller\\ControllerNameParser',
+                'Symfony\\Bundle\\FrameworkBundle\\Controller\\ControllerResolver',
 
-            // Cannot be included because annotations will parse the big compiled class file
-            // 'Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller',
+                // Cannot be included because annotations will parse the big compiled class file
+                // 'Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller',
 
-            // cannot be included as commands are discovered based on the path to this class via Reflection
-            // 'Symfony\\Bundle\\FrameworkBundle\\FrameworkBundle',
-        ));
+                // cannot be included as commands are discovered based on the path to this class via Reflection
+                // 'Symfony\\Bundle\\FrameworkBundle\\FrameworkBundle',
+            ));
+        }
     }
 
     /**
@@ -525,13 +535,15 @@ class FrameworkExtension extends Extension
         $container->setParameter('request_listener.http_port', $config['http_port']);
         $container->setParameter('request_listener.https_port', $config['https_port']);
 
-        $this->addClassesToCompile(array(
-            'Symfony\\Component\\Routing\\Generator\\UrlGenerator',
-            'Symfony\\Component\\Routing\\RequestContext',
-            'Symfony\\Component\\Routing\\Router',
-            'Symfony\\Bundle\\FrameworkBundle\\Routing\\RedirectableUrlMatcher',
-            $container->findDefinition('router.default')->getClass(),
-        ));
+        if (PHP_VERSION_ID < 70000) {
+            $this->addClassesToCompile(array(
+                'Symfony\\Component\\Routing\\Generator\\UrlGenerator',
+                'Symfony\\Component\\Routing\\RequestContext',
+                'Symfony\\Component\\Routing\\Router',
+                'Symfony\\Bundle\\FrameworkBundle\\Routing\\RedirectableUrlMatcher',
+                $container->findDefinition('router.default')->getClass(),
+            ));
+        }
     }
 
     /**
@@ -574,20 +586,22 @@ class FrameworkExtension extends Extension
 
         $container->setParameter('session.save_path', $config['save_path']);
 
-        $this->addClassesToCompile(array(
-            'Symfony\\Bundle\\FrameworkBundle\\EventListener\\SessionListener',
-            'Symfony\\Component\\HttpFoundation\\Session\\Storage\\NativeSessionStorage',
-            'Symfony\\Component\\HttpFoundation\\Session\\Storage\\PhpBridgeSessionStorage',
-            'Symfony\\Component\\HttpFoundation\\Session\\Storage\\Handler\\NativeFileSessionHandler',
-            'Symfony\\Component\\HttpFoundation\\Session\\Storage\\Proxy\\AbstractProxy',
-            'Symfony\\Component\\HttpFoundation\\Session\\Storage\\Proxy\\SessionHandlerProxy',
-            $container->getDefinition('session')->getClass(),
-        ));
-
-        if ($container->hasDefinition($config['storage_id'])) {
+        if (PHP_VERSION_ID < 70000) {
             $this->addClassesToCompile(array(
-                $container->findDefinition('session.storage')->getClass(),
+                'Symfony\\Bundle\\FrameworkBundle\\EventListener\\SessionListener',
+                'Symfony\\Component\\HttpFoundation\\Session\\Storage\\NativeSessionStorage',
+                'Symfony\\Component\\HttpFoundation\\Session\\Storage\\PhpBridgeSessionStorage',
+                'Symfony\\Component\\HttpFoundation\\Session\\Storage\\Handler\\NativeFileSessionHandler',
+                'Symfony\\Component\\HttpFoundation\\Session\\Storage\\Proxy\\AbstractProxy',
+                'Symfony\\Component\\HttpFoundation\\Session\\Storage\\Proxy\\SessionHandlerProxy',
+                $container->getDefinition('session')->getClass(),
             ));
+
+            if ($container->hasDefinition($config['storage_id'])) {
+                $this->addClassesToCompile(array(
+                    $container->findDefinition('session.storage')->getClass(),
+                ));
+            }
         }
 
         $container->setParameter('session.metadata.update_threshold', $config['metadata_update_threshold']);
@@ -657,12 +671,14 @@ class FrameworkExtension extends Extension
             $container->setDefinition('templating.loader', $loaderCache);
         }
 
-        $this->addClassesToCompile(array(
-            'Symfony\\Bundle\\FrameworkBundle\\Templating\\GlobalVariables',
-            'Symfony\\Bundle\\FrameworkBundle\\Templating\\TemplateReference',
-            'Symfony\\Bundle\\FrameworkBundle\\Templating\\TemplateNameParser',
-            $container->findDefinition('templating.locator')->getClass(),
-        ));
+        if (PHP_VERSION_ID < 70000) {
+            $this->addClassesToCompile(array(
+                'Symfony\\Bundle\\FrameworkBundle\\Templating\\GlobalVariables',
+                'Symfony\\Bundle\\FrameworkBundle\\Templating\\TemplateReference',
+                'Symfony\\Bundle\\FrameworkBundle\\Templating\\TemplateNameParser',
+                $container->findDefinition('templating.locator')->getClass(),
+            ));
+        }
 
         $container->setParameter('templating.engines', $config['engines']);
         $engines = array_map(function ($engine) { return new Reference('templating.engine.'.$engine); }, $config['engines']);
@@ -695,11 +711,13 @@ class FrameworkExtension extends Extension
                 $container->setAlias('debug.templating.engine.php', 'templating.engine.php');
             }
 
-            $this->addClassesToCompile(array(
-                'Symfony\\Component\\Templating\\Storage\\FileStorage',
-                'Symfony\\Bundle\\FrameworkBundle\\Templating\\PhpEngine',
-                'Symfony\\Bundle\\FrameworkBundle\\Templating\\Loader\\FilesystemLoader',
-            ));
+            if (PHP_VERSION_ID < 70000) {
+                $this->addClassesToCompile(array(
+                    'Symfony\\Component\\Templating\\Storage\\FileStorage',
+                    'Symfony\\Bundle\\FrameworkBundle\\Templating\\PhpEngine',
+                    'Symfony\\Bundle\\FrameworkBundle\\Templating\\Loader\\FilesystemLoader',
+                ));
+            }
 
             if ($container->has('assets.packages')) {
                 $container->getDefinition('templating.helper.assets')->replaceArgument(0, new Reference('assets.packages'));
@@ -1015,10 +1033,12 @@ class FrameworkExtension extends Extension
                 $definition = $container->findDefinition('annotations.cache_warmer');
                 $definition->addTag('kernel.cache_warmer');
 
-                $this->addClassesToCompile(array(
-                    'Symfony\Component\Cache\Adapter\PhpArrayAdapter',
-                    'Symfony\Component\Cache\DoctrineProvider',
-                ));
+                if (PHP_VERSION_ID < 70000) {
+                    $this->addClassesToCompile(array(
+                        'Symfony\Component\Cache\Adapter\PhpArrayAdapter',
+                        'Symfony\Component\Cache\DoctrineProvider',
+                    ));
+                }
             } elseif ('file' === $config['cache']) {
                 $cacheDir = $container->getParameterBag()->resolveValue($config['file_cache_dir']);
 
@@ -1270,11 +1290,13 @@ class FrameworkExtension extends Extension
             $propertyAccessDefinition->addTag('monolog.logger', array('channel' => 'cache'));
         }
 
-        $this->addClassesToCompile(array(
-            'Symfony\Component\Cache\Adapter\ApcuAdapter',
-            'Symfony\Component\Cache\Adapter\FilesystemAdapter',
-            'Symfony\Component\Cache\CacheItem',
-        ));
+        if (PHP_VERSION_ID < 70000) {
+            $this->addClassesToCompile(array(
+                'Symfony\Component\Cache\Adapter\ApcuAdapter',
+                'Symfony\Component\Cache\Adapter\FilesystemAdapter',
+                'Symfony\Component\Cache\CacheItem',
+            ));
+        }
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -25,7 +25,6 @@
         </service>
 
         <service id="kernel.class_cache.cache_warmer" class="Symfony\Bundle\FrameworkBundle\CacheWarmer\ClassCacheCacheWarmer">
-            <tag name="kernel.cache_warmer" />
             <argument type="collection">
                 <argument>Symfony\Component\HttpFoundation\ParameterBag</argument>
                 <argument>Symfony\Component\HttpFoundation\HeaderBag</argument>
@@ -33,8 +32,8 @@
                 <argument>Symfony\Component\HttpFoundation\ServerBag</argument>
                 <argument>Symfony\Component\HttpFoundation\Request</argument>
                 <argument>Symfony\Component\HttpKernel\Kernel</argument>
-                <argument>Symfony\Component\ClassLoader\ClassCollectionLoader</argument>
             </argument>
+            <deprecated>The "%service_id%" option is deprecated since version 3.3, to be removed in 4.0.</deprecated>
         </service>
 
         <service id="cache_clearer" class="Symfony\Component\HttpKernel\CacheClearer\ChainCacheClearer">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ClassCacheCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ClassCacheCacheWarmerTest.php
@@ -16,6 +16,9 @@ use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\DeclaredClass;
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\WarmedClass;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 
+/**
+ * @group legacy
+ */
 class ClassCacheCacheWarmerTest extends TestCase
 {
     public function testWithDeclaredClasses()

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -101,20 +101,22 @@ class SecurityExtension extends Extension
             $this->aclLoad($config['acl'], $container);
         }
 
-        // add some required classes for compilation
-        $this->addClassesToCompile(array(
-            'Symfony\Component\Security\Http\Firewall',
-            'Symfony\Component\Security\Core\User\UserProviderInterface',
-            'Symfony\Component\Security\Core\Authentication\AuthenticationProviderManager',
-            'Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage',
-            'Symfony\Component\Security\Core\Authorization\AccessDecisionManager',
-            'Symfony\Component\Security\Core\Authorization\AuthorizationChecker',
-            'Symfony\Component\Security\Core\Authorization\Voter\VoterInterface',
-            'Symfony\Bundle\SecurityBundle\Security\FirewallConfig',
-            'Symfony\Bundle\SecurityBundle\Security\FirewallMap',
-            'Symfony\Bundle\SecurityBundle\Security\FirewallContext',
-            'Symfony\Component\HttpFoundation\RequestMatcher',
-        ));
+        if (PHP_VERSION_ID < 70000) {
+            // add some required classes for compilation
+            $this->addClassesToCompile(array(
+                'Symfony\Component\Security\Http\Firewall',
+                'Symfony\Component\Security\Core\User\UserProviderInterface',
+                'Symfony\Component\Security\Core\Authentication\AuthenticationProviderManager',
+                'Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage',
+                'Symfony\Component\Security\Core\Authorization\AccessDecisionManager',
+                'Symfony\Component\Security\Core\Authorization\AuthorizationChecker',
+                'Symfony\Component\Security\Core\Authorization\Voter\VoterInterface',
+                'Symfony\Bundle\SecurityBundle\Security\FirewallConfig',
+                'Symfony\Bundle\SecurityBundle\Security\FirewallMap',
+                'Symfony\Bundle\SecurityBundle\Security\FirewallContext',
+                'Symfony\Component\HttpFoundation\RequestMatcher',
+            ));
+        }
     }
 
     private function aclLoad($config, ContainerBuilder $container)
@@ -191,9 +193,11 @@ class SecurityExtension extends Extension
             return;
         }
 
-        $this->addClassesToCompile(array(
-            'Symfony\\Component\\Security\\Http\\AccessMap',
-        ));
+        if (PHP_VERSION_ID < 70000) {
+            $this->addClassesToCompile(array(
+                'Symfony\\Component\\Security\\Http\\AccessMap',
+            ));
+        }
 
         foreach ($config['access_control'] as $access) {
             $matcher = $this->createRequestMatcher(

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -126,16 +126,18 @@ class TwigExtension extends Extension
 
         $container->getDefinition('twig')->replaceArgument(1, $config);
 
-        $this->addClassesToCompile(array(
-            'Twig_Environment',
-            'Twig_Extension',
-            'Twig_Extension_Core',
-            'Twig_Extension_Escaper',
-            'Twig_Extension_Optimizer',
-            'Twig_LoaderInterface',
-            'Twig_Markup',
-            'Twig_Template',
-        ));
+        if (PHP_VERSION_ID < 70000) {
+            $this->addClassesToCompile(array(
+                'Twig_Environment',
+                'Twig_Extension',
+                'Twig_Extension_Core',
+                'Twig_Extension_Escaper',
+                'Twig_Extension_Optimizer',
+                'Twig_LoaderInterface',
+                'Twig_Markup',
+                'Twig_Template',
+            ));
+        }
     }
 
     private function addTwigPath($twigFilesystemLoaderDefinition, $dir, $bundle)

--- a/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
@@ -11,10 +11,16 @@
 
 namespace Symfony\Component\ClassLoader;
 
+if (PHP_VERSION_ID >= 70000) {
+    @trigger_error('The '.__NAMESPACE__.'\ClassCollectionLoader class is deprecated since version 3.3 and will be removed in 4.0.', E_USER_DEPRECATED);
+}
+
 /**
  * ClassCollectionLoader.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since version 3.3, to be removed in 4.0.
  */
 class ClassCollectionLoader
 {

--- a/src/Symfony/Component/ClassLoader/Tests/ClassCollectionLoaderTest.php
+++ b/src/Symfony/Component/ClassLoader/Tests/ClassCollectionLoaderTest.php
@@ -20,6 +20,9 @@ require_once __DIR__.'/Fixtures/ClassesWithParents/CInterface.php';
 require_once __DIR__.'/Fixtures/ClassesWithParents/B.php';
 require_once __DIR__.'/Fixtures/ClassesWithParents/A.php';
 
+/**
+ * @group legacy
+ */
 class ClassCollectionLoaderTest extends \PHPUnit_Framework_TestCase
 {
     public function testTraitDependencies()

--- a/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
@@ -98,7 +98,7 @@ abstract class DataCollector implements DataCollectorInterface, \Serializable
      *
      * @return string The string representation of the variable
      *
-     * @deprecated Deprecated since version 3.2, to be removed in 4.0. Use cloneVar() instead.
+     * @deprecated since version 3.2, to be removed in 4.0. Use cloneVar() instead.
      */
     protected function varToString($var)
     {

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/AddClassesToCachePass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/AddClassesToCachePass.php
@@ -11,6 +11,10 @@
 
 namespace Symfony\Component\HttpKernel\DependencyInjection;
 
+if (PHP_VERSION_ID >= 70000) {
+    @trigger_error('The '.__NAMESPACE__.'\AddClassesToCachePass class is deprecated since version 3.3 and will be removed in 4.0.', E_USER_DEPRECATED);
+}
+
 use Composer\Autoload\ClassLoader;
 use Symfony\Component\Debug\DebugClassLoader;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -21,6 +25,8 @@ use Symfony\Component\HttpKernel\Kernel;
  * Sets the classes to compile in the cache for the container.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since version 3.3, to be removed in 4.0.
  */
 class AddClassesToCachePass implements CompilerPassInterface
 {

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/Extension.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/Extension.php
@@ -47,9 +47,15 @@ abstract class Extension extends BaseExtension
      * Adds classes to the class cache.
      *
      * @param array $classes An array of class patterns
+     *
+     * @deprecated since version 3.3, to be removed in 4.0.
      */
     public function addClassesToCompile(array $classes)
     {
+        if (PHP_VERSION_ID >= 70000) {
+            @trigger_error(__METHOD__.'() is deprecated since version 3.3, to be removed in 4.0.', E_USER_DEPRECATED);
+        }
+
         $this->classes = array_merge($this->classes, $classes);
     }
 

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -321,17 +321,29 @@ abstract class Kernel implements KernelInterface, TerminableInterface
      *
      * @param string $name      The cache name prefix
      * @param string $extension File extension of the resulting file
+     *
+     * @deprecated since version 3.3, to be removed in 4.0.
      */
     public function loadClassCache($name = 'classes', $extension = '.php')
     {
+        if (PHP_VERSION_ID >= 70000) {
+            @trigger_error(__METHOD__.'() is deprecated since version 3.3, to be removed in 4.0.', E_USER_DEPRECATED);
+        }
+
         $this->loadClassCache = array($name, $extension);
     }
 
     /**
      * @internal
+     *
+     * @deprecated since version 3.3, to be removed in 4.0.
      */
     public function setClassCache(array $classes)
     {
+        if (PHP_VERSION_ID >= 70000) {
+            @trigger_error(__METHOD__.'() is deprecated since version 3.3, to be removed in 4.0.', E_USER_DEPRECATED);
+        }
+
         file_put_contents($this->getCacheDir().'/classes.map', sprintf('<?php return %s;', var_export($classes, true)));
     }
 
@@ -375,8 +387,15 @@ abstract class Kernel implements KernelInterface, TerminableInterface
         return 'UTF-8';
     }
 
+    /**
+     * @deprecated since version 3.3, to be removed in 4.0.
+     */
     protected function doLoadClassCache($name, $extension)
     {
+        if (PHP_VERSION_ID >= 70000) {
+            @trigger_error(__METHOD__.'() is deprecated since version 3.3, to be removed in 4.0.', E_USER_DEPRECATED);
+        }
+
         if (!$this->booted && is_file($this->getCacheDir().'/classes.map')) {
             ClassCollectionLoader::load(include($this->getCacheDir().'/classes.map'), $this->getCacheDir(), $name, $this->debug, false, $extension);
         }
@@ -571,7 +590,9 @@ abstract class Kernel implements KernelInterface, TerminableInterface
             $container->merge($cont);
         }
 
-        $container->addCompilerPass(new AddClassesToCachePass($this));
+        if (PHP_VERSION_ID < 70000) {
+            $container->addCompilerPass(new AddClassesToCachePass($this));
+        }
         $container->addResource(new EnvParametersResource('SYMFONY__'));
 
         return $container;

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/AddClassesToCachePassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/AddClassesToCachePassTest.php
@@ -13,6 +13,9 @@ namespace Symfony\Component\HttpKernel\Tests\DependencyInjection;
 
 use Symfony\Component\HttpKernel\DependencyInjection\AddClassesToCachePass;
 
+/**
+ * @group legacy
+ */
 class AddClassesToCachePassTest extends \PHPUnit_Framework_TestCase
 {
     public function testExpandClasses()

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -85,6 +85,9 @@ class KernelTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($kernel->isBooted());
     }
 
+    /**
+     * @group legacy
+     */
     public function testClassCacheIsLoaded()
     {
         $kernel = $this->getKernel(array('initializeBundles', 'initializeContainer', 'doLoadClassCache'));
@@ -105,6 +108,9 @@ class KernelTest extends \PHPUnit_Framework_TestCase
         $kernel->boot();
     }
 
+    /**
+     * @group legacy
+     */
     public function testClassCacheIsNotLoadedWhenKernelIsNotBooted()
     {
         $kernel = $this->getKernel(array('initializeBundles', 'initializeContainer', 'doLoadClassCache'));

--- a/src/Symfony/Component/PropertyAccess/StringUtil.php
+++ b/src/Symfony/Component/PropertyAccess/StringUtil.php
@@ -18,7 +18,7 @@ use Symfony\Component\Inflector\Inflector;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @deprecated Deprecated since version 3.1, to be removed in 4.0. Use {@see Symfony\Component\Inflector\Inflector} instead.
+ * @deprecated since version 3.1, to be removed in 4.0. Use {@see Symfony\Component\Inflector\Inflector} instead.
  */
 class StringUtil
 {
@@ -40,7 +40,7 @@ class StringUtil
      * @return string|array The singular form or an array of possible singular
      *                      forms
      *
-     * @deprecated Deprecated since version 3.1, to be removed in 4.0. Use {@see Symfony\Component\Inflector\Inflector::singularize} instead.
+     * @deprecated since version 3.1, to be removed in 4.0. Use {@see Symfony\Component\Inflector\Inflector::singularize} instead.
      */
     public static function singularify($plural)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #20668
| License       | MIT

As suggested by @nicolas-grekas in #20668 I added deprecation notices to ClassCollectionLoader and Kernel::loadClassCache.