### PR TITLE
[Console] fixed PHP7 Errors when not using Dispatcher

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -159,8 +159,6 @@ class Application
      * @param OutputInterface $output An Output instance
      *
      * @return int 0 if everything went fine, or an error code
-     *
-     * @throws \Exception when the command being run threw an exception
      */
     public function doRun(InputInterface $input, OutputInterface $output)
     {

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -160,7 +160,7 @@ class Application
      *
      * @return int 0 if everything went fine, or an error code
      *
-     * @throws \Exception propagate the exception from `doRunCommand`
+     * @throws \Exception when the command being run threw an exception
      */
     public function doRun(InputInterface $input, OutputInterface $output)
     {

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -159,6 +159,8 @@ class Application
      * @param OutputInterface $output An Output instance
      *
      * @return int 0 if everything went fine, or an error code
+     *
+     * @throws \Exception propagate the exception from `doRunCommand`
      */
     public function doRun(InputInterface $input, OutputInterface $output)
     {
@@ -843,7 +845,13 @@ class Application
         }
 
         if (null === $this->dispatcher) {
-            return $command->run($input, $output);
+            try {
+                return $command->run($input, $output);
+            } catch (\Exception $e) {
+                throw $e;
+            } catch (\Throwable $e) {
+                throw new FatalThrowableError($e);
+            }
         }
 
         $event = new ConsoleCommandEvent($command, $input, $output);

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -951,6 +951,24 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('before.foo.caught.after.', $tester->getDisplay());
     }
 
+    public function testRunWithError()
+    {
+        $this->setExpectedException('Exception', 'dymerr');
+
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+
+        $application->register('dym')->setCode(function (InputInterface $input, OutputInterface $output) {
+            $output->write('dym.');
+
+            throw new \Error('dymerr');
+        });
+
+        $tester = new ApplicationTester($application);
+        $tester->run(array('command' => 'dym'));
+    }
+
     /**
      * @expectedException        \LogicException
      * @expectedExceptionMessage caught


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #17257, #20110, #20111
| License       | MIT
| Doc PR        | n/a

Original fix, #19813, works only when there is event dispatcher available.
This PR fix the issue also for scenario without event dispatcher.

Closes #20110 issue and #20111 PR connected to it.
Closing #17257 , as everywhere the error is converted to exception and it should be handled
