### PR TITLE
Fix accessDenyUnlessGranted 'bc'

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -192,8 +192,11 @@ abstract class Controller implements ContainerAwareInterface
     {
         if (!$this->isGranted($attributes, $object)) {
             $exception = $this->createAccessDeniedException($message);
-            $exception->setAttributes($attributes);
-            $exception->setSubject($object);
+
+            if ($exception instanceof AccessDeniedException) {
+                $exception->setAttributes($attributes);
+                $exception->setSubject($object);
+            }
 
             throw $exception;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | kind of
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | /
| License       | MIT
| Doc PR        | /

Hi,

I've just upgraded from Symfony 3.1 to 3.2 and my build broke because I overrode the `Controller::createAccessDeniedException()` method to return an `AccessDeniedHttpException` instead of the promised `AccessDeniedException`.

I know this is wrong and hacky but @nicolas-grekas suggested me to open a PR so it could be discussed furthermore.

Yet I think the main problem here is that `denyAccessUnlessGranted` should be allowed to throw any kind of Exception, be it `AccessDeniedException` or `AccessDeniedHttpException`.