### PR TITLE
[DependencyInjection] Support for parameter injection

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -24,6 +24,9 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class AutowirePass implements CompilerPassInterface
 {
+    /**
+     * @var ContainerBuilder
+     */
     private $container;
     private $reflectionClasses = array();
     private $definedTypes = array();
@@ -40,6 +43,7 @@ class AutowirePass implements CompilerPassInterface
 
         try {
             $this->container = $container;
+
             foreach ($container->getDefinitions() as $id => $definition) {
                 if ($definition->isAutowired()) {
                     $this->completeDefinition($id, $definition);
@@ -104,6 +108,11 @@ class AutowirePass implements CompilerPassInterface
         $arguments = $definition->getArguments();
         foreach ($constructor->getParameters() as $index => $parameter) {
             if (array_key_exists($index, $arguments) && '' !== $arguments[$index]) {
+                continue;
+            }
+
+            if ($this->container->hasParameter($parameter->name)) {
+                $arguments[$index] = $this->container->getParameter($parameter->name);
                 continue;
             }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -476,6 +476,20 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($container->hasDefinition('bar'));
     }
+
+    public function testParameterInjection()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('myParameter', 'SymfonyCon Berlin Hackday!');
+
+        $parameterInjectionDefinition = $container->register(ParameterInjection::class, ParameterInjection::class);
+        $parameterInjectionDefinition->setAutowired(true);
+
+        $pass = new AutowirePass();
+        $pass->process($container);
+
+        $this->assertEquals('SymfonyCon Berlin Hackday!', $parameterInjectionDefinition->getArgument(1));
+    }
 }
 
 class Foo
@@ -651,6 +665,13 @@ class IdenticalClassResource extends ClassForResource
 class ClassChangedConstructorArgs extends ClassForResource
 {
     public function __construct($foo, Bar $bar, $baz)
+    {
+    }
+}
+
+class ParameterInjection
+{
+    public function __construct(Foo $foo, $myParameter)
     {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

It's basically the same idea than request's attributes injection as controller's parameters: if a service is autowired and a container's parameter match, this parameter is injected. Example:

```yaml
# app/config/services.yml

parameters:
    hello: SymfonyCon

services:
    'Foo\Action\Homepage':
        class: 'Foo\Action\Homepage'
        autowire: true
```

```php
// src/Foo/Action/Homepage.php

namespace Foo\Action;

class Homepage
{
    public function __construct($hello/*, Acme $anOtherService*/)
    {
        // $hello value is 'SymfonyCon'
    }
}
```