### PR TITLE
[Validator] Fix issue 12302 - cache constraints

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/Factory/LazyLoadingMetadataFactory.php
+++ b/src/Symfony/Component/Validator/Mapping/Factory/LazyLoadingMetadataFactory.php
@@ -99,8 +99,11 @@ class LazyLoadingMetadataFactory implements MetadataFactoryInterface
             return $this->loadedClasses[$class];
         }
 
-        if (null !== $this->cache && false !== ($this->loadedClasses[$class] = $this->cache->read($class))) {
-            return $this->loadedClasses[$class];
+        if (null !== $this->cache && false !== ($metadata = $this->cache->read($class))) {
+            // Include constraints from the parent class
+            $this->mergeConstraints($metadata);
+
+            return $this->loadedClasses[$class] = $metadata;
         }
 
         if (!class_exists($class) && !interface_exists($class)) {
@@ -109,6 +112,22 @@ class LazyLoadingMetadataFactory implements MetadataFactoryInterface
 
         $metadata = new ClassMetadata($class);
 
+        if (null !== $this->loader) {
+            $this->loader->loadClassMetadata($metadata);
+        }
+
+        if (null !== $this->cache) {
+            $this->cache->write($metadata);
+        }
+
+        // Include constraints from the parent class
+        $this->mergeConstraints($metadata);
+
+        return $this->loadedClasses[$class] = $metadata;
+    }
+
+    protected function mergeConstraints(ClassMetadata $metadata)
+    {
         // Include constraints from the parent class
         if ($parent = $metadata->getReflectionClass()->getParentClass()) {
             $metadata->mergeConstraints($this->getMetadataFor($parent->name));
@@ -139,16 +158,6 @@ class LazyLoadingMetadataFactory implements MetadataFactoryInterface
             }
             $metadata->mergeConstraints($this->getMetadataFor($interface->name));
         }
-
-        if (null !== $this->loader) {
-            $this->loader->loadClassMetadata($metadata);
-        }
-
-        if (null !== $this->cache) {
-            $this->cache->write($metadata);
-        }
-
-        return $this->loadedClasses[$class] = $metadata;
     }
 
     /**

--- a/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
@@ -140,6 +140,7 @@ class LazyLoadingMetadataFactoryTest extends \PHPUnit_Framework_TestCase
                   if (self::PARENT_CLASS == $name) {
                       return $metadata;
                   }
+
                   return new ClassMetadata(self::INTERFACE_A_CLASS);
               });
 
@@ -162,12 +163,10 @@ class LazyLoadingMetadataFactoryTest extends \PHPUnit_Framework_TestCase
           ->will($this->returnValue(false));
 
         $metadata = $factory->getMetadataFor(self::PARENT_CLASS);
-        $metadata->addConstraint(new Callback(function() {} ));
+        $metadata->addConstraint(new Callback(function () {}));
 
         $metadata = $factory->getMetadataFor(self::CLASS_NAME);
-
     }
-
 }
 
 class TestLoader implements LoaderInterface

--- a/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Mapping\Factory;
 
+use Symfony\Component\Validator\Constraints\Callback;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Factory\LazyLoadingMetadataFactory;
 use Symfony\Component\Validator\Mapping\Loader\LoaderInterface;
@@ -30,8 +31,8 @@ class LazyLoadingMetadataFactoryTest extends \PHPUnit_Framework_TestCase
         $metadata = $factory->getMetadataFor(self::PARENT_CLASS);
 
         $constraints = array(
-            new ConstraintA(array('groups' => array('Default', 'EntityInterfaceA', 'EntityParent'))),
             new ConstraintA(array('groups' => array('Default', 'EntityParent'))),
+            new ConstraintA(array('groups' => array('Default', 'EntityInterfaceA', 'EntityParent'))),
         );
 
         $this->assertEquals($constraints, $metadata->getConstraints());
@@ -43,6 +44,16 @@ class LazyLoadingMetadataFactoryTest extends \PHPUnit_Framework_TestCase
         $metadata = $factory->getMetadataFor(self::CLASS_NAME);
 
         $constraints = array(
+
+            new ConstraintA(array('groups' => array(
+                'Default',
+                'Entity',
+            ))),
+            new ConstraintA(array('groups' => array(
+                'Default',
+                'EntityParent',
+                'Entity',
+            ))),
             new ConstraintA(array('groups' => array(
                 'Default',
                 'EntityInterfaceA',
@@ -51,7 +62,7 @@ class LazyLoadingMetadataFactoryTest extends \PHPUnit_Framework_TestCase
             ))),
             new ConstraintA(array('groups' => array(
                 'Default',
-                'EntityParent',
+                'EntityInterfaceB',
                 'Entity',
             ))),
             new ConstraintA(array('groups' => array(
@@ -60,15 +71,7 @@ class LazyLoadingMetadataFactoryTest extends \PHPUnit_Framework_TestCase
                 'EntityInterfaceB',
                 'Entity',
             ))),
-            new ConstraintA(array('groups' => array(
-                'Default',
-                'EntityInterfaceB',
-                'Entity',
-            ))),
-            new ConstraintA(array('groups' => array(
-                'Default',
-                'Entity',
-            ))),
+
         );
 
         $this->assertEquals($constraints, $metadata->getConstraints());
@@ -80,8 +83,8 @@ class LazyLoadingMetadataFactoryTest extends \PHPUnit_Framework_TestCase
         $factory = new LazyLoadingMetadataFactory(new TestLoader(), $cache);
 
         $parentClassConstraints = array(
-            new ConstraintA(array('groups' => array('Default', 'EntityInterfaceA', 'EntityParent'))),
             new ConstraintA(array('groups' => array('Default', 'EntityParent'))),
+            new ConstraintA(array('groups' => array('Default', 'EntityInterfaceA', 'EntityParent'))),
         );
         $interfaceAConstraints = array(
             new ConstraintA(array('groups' => array('Default', 'EntityInterfaceA'))),
@@ -127,12 +130,44 @@ class LazyLoadingMetadataFactoryTest extends \PHPUnit_Framework_TestCase
 
         $cache->expects($this->never())
               ->method('has');
-        $cache->expects($this->once())
+        $cache->expects($this->exactly(2))
               ->method('read')
-              ->will($this->returnValue($metadata));
+              ->withConsecutive(
+                  array(self::PARENT_CLASS),
+                  array(self::INTERFACE_A_CLASS)
+              )
+              ->willReturnCallback(function ($name) use ($metadata) {
+                  if (self::PARENT_CLASS == $name) {
+                      return $metadata;
+                  }
+                  return new ClassMetadata(self::INTERFACE_A_CLASS);
+              });
 
         $this->assertEquals($metadata, $factory->getMetadataFor(self::PARENT_CLASS));
     }
+
+    public function testMetadataCacheWithRuntimeConstraint()
+    {
+        $cache = $this->getMock('Symfony\Component\Validator\Mapping\Cache\CacheInterface');
+        $factory = new LazyLoadingMetadataFactory(new TestLoader(), $cache);
+
+        $cache
+          ->expects($this->any())
+          ->method('write')
+          ->will($this->returnCallback(function ($metadata) { serialize($metadata);}))
+        ;
+
+        $cache->expects($this->any())
+          ->method('read')
+          ->will($this->returnValue(false));
+
+        $metadata = $factory->getMetadataFor(self::PARENT_CLASS);
+        $metadata->addConstraint(new Callback(function() {} ));
+
+        $metadata = $factory->getMetadataFor(self::CLASS_NAME);
+
+    }
+
 }
 
 class TestLoader implements LoaderInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master" for new features / 2.7, 2.8 or 3.1 for fixes
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12302
| License       | MIT
| Doc PR        | -

This change allows to still cache constraints even when an un-cachable constraint (i.e. Callback)
is added to a parent class at runtime.

This is achieved by caching the constraints that are loaded for the class in question only
and merging parent and interface constraints after reading from cache.