### PR TITLE
[TwigBridge] [Form] Allow consistent parameters in form_label method

### DIFF
--- a/src/Symfony/Bridge/Twig/Node/SearchAndRenderBlockNode.php
+++ b/src/Symfony/Bridge/Twig/Node/SearchAndRenderBlockNode.php
@@ -33,10 +33,17 @@ class SearchAndRenderBlockNode extends \Twig_Node_Expression_Function
 
             if (isset($arguments[1])) {
                 if ('label' === $blockNameSuffix) {
-                    // The "label" function expects the label in the second and
+                    // The "label" function can have the label in the second and
                     // the variables in the third argument
                     $label = $arguments[1];
                     $variables = isset($arguments[2]) ? $arguments[2] : null;
+
+                    if ($label instanceof \Twig_Node_Expression_Array) {
+                        // The "variables" were passed as the second argument
+                        $variables = $arguments[1];
+                        $label = new \Twig_Node_Expression_Constant(null, 0);
+                    }
+
                     $lineno = $label->getTemplateLine();
 
                     if ($label instanceof \Twig_Node_Expression_Constant) {

--- a/src/Symfony/Bridge/Twig/Tests/Node/SearchAndRenderBlockNodeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/SearchAndRenderBlockNodeTest.php
@@ -261,6 +261,29 @@ class SearchAndRenderBlockNodeTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testCompileLabelWithVariablesAsSecondArgument()
+    {
+        $arguments = new \Twig_Node(array(
+            new \Twig_Node_Expression_Name('form', 0),
+            new \Twig_Node_Expression_Array(array(
+                new \Twig_Node_Expression_Constant('label', 0),
+                new \Twig_Node_Expression_Constant('my own label', 0),
+            ), 0),
+        ));
+
+        $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
+
+        $compiler = new \Twig_Compiler(new \Twig_Environment($this->getMock('Twig_LoaderInterface')));
+
+        $this->assertEquals(
+            sprintf(
+                '$this->env->getRuntime(\'Symfony\Bridge\Twig\Form\TwigRenderer\')->searchAndRenderBlock(%s, \'label\', array("label" => "my own label"))',
+                $this->getVariableGetter('form')
+            ),
+            trim($compiler->compile($node)->getSource())
+        );
+    }
+
     protected function getVariableGetter($name)
     {
         if (PHP_VERSION_ID >= 70000) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20188
| License       | MIT
| Doc PR        | -

As posted in #20188 there is inconsistency in calling Twig functions. With this change it is now possible to call `form_label(view, variables)` exactly like other Twig methods. If called this way the compiler will take label value from the variables. The change is BC, so you can still call `form_label(view, label, variables)`.

If the change is ok I can update relevant CHANGELOG files and documentation.