### PR TITLE
[Cache] Memcached and Memcache Adapters

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/MemcacheAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/MemcacheAdapter.php
@@ -1,0 +1,146 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Adapter;
+
+use Symfony\Component\Cache\Exception\InvalidArgumentException;
+
+/**
+ * @author Rob Frawley 2nd <rmf@src.run>
+ */
+class MemcacheAdapter extends AbstractAdapter
+{
+    use MemcacheAdapterTrait;
+
+    /**
+     * Construct adapter by passing a \Memcache instance and an optional namespace and default cache entry ttl.
+     *
+     * @param \Memcache   $client
+     * @param string|null $namespace
+     * @param int         $defaultLifetime
+     */
+    public function __construct(\Memcache $client, $namespace = '', $defaultLifetime = 0)
+    {
+        parent::__construct($namespace, $defaultLifetime);
+        $this->client = $client;
+    }
+
+    /**
+     * Factory creation method that provides an instance of this adapter with a\Memcache client instantiated and setup.
+     *
+     * Valid DSN values include the following:
+     *  - memcache://localhost                  : Specifies only the host (defaults used for port and weight)
+     *  - memcache://example.com:1234           : Specifies host and port (defaults weight)
+     *  - memcache://example.com:1234?weight=50 : Specifies host, port, and weight (no defaults used)
+     *
+     * @param string|null $dsn
+     *
+     * @return MemcacheAdapter
+     */
+    public static function create($dsn = null)
+    {
+        if (!extension_loaded('memcache') || !version_compare(phpversion('memcache'), '3.0.8', '>')) {
+            throw new InvalidArgumentException('Failed to create memcache client due to missing "memcache" extension or version <3.0.9.');
+        }
+
+        $adapter = new static(new \Memcache());
+        $adapter->setup($dsn ? array($dsn) : array());
+
+        return $adapter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doSave(array $values, $lifetime)
+    {
+        $result = true;
+
+        foreach ($values as $id => $val) {
+            $result = $this->client->set($id, $val, null, $lifetime) && $result;
+        }
+
+        return $result;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doFetch(array $ids)
+    {
+        foreach ($this->client->get($ids) as $id => $val) {
+            yield $id => $val;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doHave($id)
+    {
+        return $this->client->get($id) !== false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doDelete(array $ids)
+    {
+        $remaining = array_filter($ids, function ($id) {
+            return false !== $this->client->get($id) && false === $this->client->delete($id);
+        });
+
+        return 0 === count($remaining);
+    }
+
+    private function getIdsByPrefix($namespace)
+    {
+        $ids = array();
+        foreach ($this->client->getExtendedStats('slabs') as $slabGroup) {
+            foreach ($slabGroup as $slabId => $slabMetadata) {
+                if (!is_array($slabMetadata)) {
+                    continue;
+                }
+                foreach ($this->client->getExtendedStats('cachedump', (int) $slabId, 1000) as $slabIds) {
+                    if (is_array($slabIds)) {
+                        $ids = array_merge($ids, array_keys($slabIds));
+                    }
+                }
+            }
+        }
+
+        return array_filter((array) $ids, function ($id) use ($namespace) {
+            return 0 === strpos($id, $namespace);
+        });
+    }
+
+    private function addServer($dsn)
+    {
+        list($host, $port, $weight) = $this->dsnExtract($dsn);
+
+        return $this->isServerInClientPool($host, $port)
+            || $this->client->addServer($host, $port, false, $weight);
+    }
+
+    private function setOption($opt, $val)
+    {
+        return true;
+    }
+
+    private function isServerInClientPool($host, $port)
+    {
+        $restore = error_reporting(~E_ALL);
+        $srvStat = $this->client->getServerStatus($host, $port);
+        error_reporting($restore);
+
+        return 1 === $srvStat;
+    }
+}

--- a/src/Symfony/Component/Cache/Adapter/MemcacheAdapterTrait.php
+++ b/src/Symfony/Component/Cache/Adapter/MemcacheAdapterTrait.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Adapter;
+
+use Symfony\Component\Cache\Exception\InvalidArgumentException;
+
+/**
+ * @author Rob Frawley 2nd <rmf@src.run>
+ *
+ * @internal
+ */
+trait MemcacheAdapterTrait
+{
+    private static $defaultClientServerValues = array(
+        'host' => '127.0.0.1',
+        'port' => 11211,
+        'weight' => 100,
+    );
+
+    /**
+     * @var \Memcache|\Memcached
+     */
+    private $client;
+
+    /**
+     * Provide ability to reconfigure adapter after construction. See {@see create()} for acceptable DSN formats.
+     *
+     * @param string[] $dsns
+     * @param mixed[]  $opts
+     *
+     * @return bool
+     */
+    public function setup(array $dsns = array(), array $opts = array())
+    {
+        $return = true;
+
+        foreach ($opts as $opt => $val) {
+            $return = $this->setOption($opt, $val) && $return;
+        }
+        foreach ($dsns as $dsn) {
+            $return = $this->addServer($dsn) && $return;
+        }
+
+        return $return;
+    }
+
+    /**
+     * Returns the Memcache client instance.
+     *
+     * @return \Memcache|\Memcached
+     */
+    public function getClient()
+    {
+        return $this->client;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doClear($namespace)
+    {
+        if (!isset($namespace[0]) || false === $ids = $this->getIdsByPrefix($namespace)) {
+            return $this->client->flush();
+        }
+
+        $return = true;
+
+        do {
+            $return = $this->doDelete($ids) && $return;
+        } while ($ids = $this->getIdsByPrefix($namespace));
+
+        return $return;
+    }
+
+    private function dsnExtract($dsn)
+    {
+        $scheme = false !== strpos(static::class, 'Memcached') ? 'memcached' : 'memcache';
+
+        if (false === ($srv = parse_url($dsn)) || $srv['scheme'] !== $scheme || count($srv) > 4) {
+            throw new InvalidArgumentException(sprintf('Invalid %s DSN: %s (expects "%s://example.com[:1234][?weight=<int>]")', $scheme, $dsn, $scheme));
+        }
+
+        if (isset($srv['query']) && 1 === preg_match('{weight=([^&]{1,})}', $srv['query'], $weight)) {
+            $srv['weight'] = (int) $weight[1];
+        }
+
+        return $this->dsnSanitize($srv, $scheme);
+    }
+
+    private function dsnSanitize(array $srv, $scheme)
+    {
+        $srv += self::$defaultClientServerValues;
+
+        if (false === ($host = filter_var($srv['host'], FILTER_VALIDATE_IP)) ||
+            false === ($host = filter_var($srv['host'], FILTER_SANITIZE_URL))) {
+            throw new InvalidArgumentException(sprintf('Invalid %s DSN host: %s (expects resolvable IP or hostname)', $scheme, $srv['host']));
+        }
+
+        if (false === ($weight = filter_var($srv['weight'], FILTER_VALIDATE_INT, array('options' => array('min_range' => 1, 'max_range' => 100))))) {
+            throw new InvalidArgumentException(sprintf('Invalid %s DSN weight: %s (expects int >=1 and <= 100)', $scheme, $srv['weight']));
+        }
+
+        return array($host, $srv['port'], $weight);
+    }
+}

--- a/src/Symfony/Component/Cache/Adapter/MemcachedAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/MemcachedAdapter.php
@@ -1,0 +1,172 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Adapter;
+
+use Symfony\Component\Cache\Exception\InvalidArgumentException;
+
+/**
+ * @author Rob Frawley 2nd <rmf@src.run>
+ */
+class MemcachedAdapter extends AbstractAdapter
+{
+    use MemcacheAdapterTrait;
+
+    /**
+     * Construct adapter by passing a \Memcached instance and an optional namespace and default cache entry ttl.
+     *
+     * @param \Memcached  $client
+     * @param string|null $namespace
+     * @param int         $defaultLifetime
+     */
+    public function __construct(\Memcached $client, $namespace = '', $defaultLifetime = 0)
+    {
+        parent::__construct($namespace, $defaultLifetime);
+        $this->client = $client;
+    }
+
+    /**
+     * Factory creation method that provides an instance of this adapter with a\Memcached client instantiated and setup.
+     *
+     * Valid DSN values include the following:
+     *  - memcached://localhost                  : Specifies only the host (defaults used for port and weight)
+     *  - memcached://example.com:1234           : Specifies host and port (defaults weight)
+     *  - memcached://example.com:1234?weight=50 : Specifies host, port, and weight (no defaults used)
+     *
+     * Valid options include any client constants, as described in the PHP manual:
+     *  - http://php.net/manual/en/memcached.constants.php
+     *
+     * Options are expected to be passed as an associative array with indexes of the option type with coorosponding
+     * values as the option assignment.
+     *
+     * @param string|null $dsn
+     * @param array       $opts
+     * @param string|null $persistentId
+     *
+     * @return MemcachedAdapter
+     */
+    public static function create($dsn = null, array $opts = array(), $persistentId = null)
+    {
+        if (!extension_loaded('memcached')) {
+            throw new InvalidArgumentException('Failed to create Memcache client due to missing "memcached" extension.');
+        }
+
+        $adapter = new static(new \Memcached($persistentId));
+        $adapter->setup($dsn ? array($dsn) : array(), $opts);
+
+        return $adapter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doSave(array $values, $lifetime)
+    {
+        return $this->client->setMulti($values, $lifetime)
+            && $this->isPreviousClientActionSuccessful();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doFetch(array $ids)
+    {
+        foreach ($this->client->getMulti($ids) as $id => $val) {
+            yield $id => $val;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doHave($id)
+    {
+        return $this->client->get($id) !== false
+            && $this->client->getResultCode() !== \Memcached::RES_NOTFOUND;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doDelete(array $ids)
+    {
+        $toDelete = count($ids);
+        foreach ((array) $this->client->deleteMulti($ids) as $result) {
+            if (true === $result || \Memcached::RES_NOTFOUND === $result) {
+                --$toDelete;
+            }
+        }
+
+        return 0 === $toDelete;
+    }
+
+    private function addServer($dsn)
+    {
+        list($host, $port, $weight) = $this->dsnExtract($dsn);
+
+        return $this->isServerInClientPool($host, $port)
+            || ($this->client->addServer($host, $port, $weight)
+                && $this->isPreviousClientActionSuccessful());
+    }
+
+    private function setOption($opt, $val)
+    {
+        list($opt, $val) = $this->optionSanitize($opt, $val);
+
+        $restore = error_reporting(~E_ALL);
+        $success = $this->client->setOption($opt, $val);
+        error_reporting($restore);
+
+        return $success && $this->isPreviousClientActionSuccessful();
+    }
+
+    private function getIdsByPrefix($namespace)
+    {
+        if (false === $ids = $this->client->getAllKeys()) {
+            return false;
+        }
+
+        return array_filter((array) $ids, function ($id) use ($namespace) {
+            return 0 === strpos($id, $namespace);
+        });
+    }
+
+    private function optionSanitize($opt, $val)
+    {
+        if (false === filter_var($opt = $this->optionResolve($opt), FILTER_VALIDATE_INT)) {
+            throw new InvalidArgumentException(sprintf('Invalid memcached option type: %s (expects an int or a resolvable client constant)', $opt));
+        }
+
+        if (false === filter_var($val = $this->optionResolve($val), FILTER_VALIDATE_INT) &&
+            null  === filter_var($val, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)) {
+            throw new InvalidArgumentException(sprintf('Invalid memcached option value: %s (expects an int, a bool, or a resolvable client constant)', $val));
+        }
+
+        return array($opt, $val);
+    }
+
+    private function optionResolve($val)
+    {
+        return defined($constant = '\Memcached::'.strtoupper($val)) ? constant($constant) : $val;
+    }
+
+    private function isPreviousClientActionSuccessful()
+    {
+        return $this->client->getResultCode() === \Memcached::RES_SUCCESS;
+    }
+
+    protected function isServerInClientPool($host, $port)
+    {
+        return (bool) array_filter($this->client->getServerList(), function ($srv) use ($host, $port) {
+            return $host === array_shift($srv) && $port === array_shift($srv);
+        });
+    }
+}

--- a/src/Symfony/Component/Cache/Tests/Adapter/AbstractMemcacheAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AbstractMemcacheAdapterTest.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Adapter;
+
+use Symfony\Component\Cache\Adapter\MemcacheAdapter;
+
+abstract class AbstractMemcacheAdapterTest extends AdapterTestCase
+{
+    protected $skippedTests = array(
+        //'testExpiration' => 'Testing expiration slows down the test suite',
+        //'testHasItemReturnsFalseWhenDeferredItemIsExpired' => 'Testing expiration slows down the test suite',
+        //'testDefaultLifeTime' => 'Testing expiration slows down the test suite',
+    );
+
+    /**
+     * @var \Memcache|\Memcached
+     */
+    protected static $client;
+
+    /**
+     * "memcached" or "memcache".
+     */
+    protected static $extension;
+
+    protected static function defaultConnectionServer()
+    {
+        return sprintf(
+            '%s://%s:%d',
+            static::$extension,
+            getenv('MEMCACHED_HOST') ?: '127.0.0.1',
+            getenv('MEMCACHED_PORT') ?: 11211
+        );
+    }
+
+    public static function setupBeforeClass()
+    {
+        if (!extension_loaded(static::$extension)) {
+            self::markTestSkipped(sprintf('Extension %s required.', static::$extension));
+        }
+
+        parent::setupBeforeClass();
+    }
+
+    public static function tearDownAfterClass()
+    {
+        self::$client->flush();
+        self::$client = null;
+    }
+
+    /**
+     * @group memcacheAdapter
+     * @group memcacheAdapterWithValidDsn
+     */
+    public function provideValidServerConfigData()
+    {
+        $data = array(
+            array(sprintf('%s:', static::$extension)),
+            array(sprintf('%s:?weight=50', static::$extension)),
+            array(sprintf('%s://127.0.0.1', static::$extension)),
+            array(sprintf('%s://127.0.0.1:11211', static::$extension)),
+            array(sprintf('%s://127.0.0.1?weight=50', static::$extension)),
+            array(sprintf('%s://127.0.0.1:11211?weight=50', static::$extension)),
+            array(sprintf('%s://127.0.0.1:11211?weight=50&extra-query=is-ignored', static::$extension)),
+        );
+
+        for ($i = 100; $i <= 65535; $i = $i + random_int(500, 1000)) {
+            $data[] = array(sprintf('%s://127.0.0.1:%d', static::$extension, $i));
+            $data[] = array(sprintf('%s://127.0.0.1:11211?weight=%d', static::$extension, max(floor(100 * $i / 65535), 1)));
+        }
+
+        return $data;
+    }
+
+    public function provideInvalidConnectionDsnSchema()
+    {
+        $data = array(
+            array('http://google.com/?query=this+wont+work'),
+            array('redis://secret@example.com/13'),
+        );
+
+        for ($i = 1; $i <= 10; ++$i) {
+            $data[] = array(sprintf('http://%d.%d.%d.%d', random_int(255, 2550), random_int(255, 2550), random_int(255, 2550), random_int(255, 2550)));
+            $data[] = array(sprintf('http://%d.%d.%d.%d', random_int(-2550, 0), random_int(-2550, 0), random_int(-2550, 0), random_int(-2550, -1)));
+            $data[] = array(sprintf('%s://127.0.0.1', str_repeat(chr(random_int(97, 122)), random_int(1, 10))));
+        }
+
+        return $data;
+    }
+
+    public function provideInvalidConnectionDsnHostOrPort()
+    {
+        $data = array(
+            array(sprintf('%s://invalid-host', static::$extension)),
+            array(sprintf('%s://127.0.0.1:6553500', static::$extension)),
+            array(sprintf('%s://127.0.0.1:-100', static::$extension)),
+        );
+
+        for ($i = 65536; $i < 65535 * 2; $i = $i + random_int(1000, 2000)) {
+            $data[] = array(sprintf('%s://127.0.0.1:%d', static::$extension, $i));
+        }
+
+        return $data;
+    }
+
+    public function provideInvalidConnectionDsnQueryWeight()
+    {
+        $data = array(
+            array(sprintf('%s://127.0.0.1?weight=200000', static::$extension)),
+            array(sprintf('%s://127.0.0.1:11211?weight=foo-bar', static::$extension)),
+            array(sprintf('%s://127.0.0.1?weight=0', static::$extension)),
+            array(sprintf('%s://127.0.0.1:11211?weight=-100', static::$extension)),
+        );
+
+        for ($i = -101; $i > -1000; $i = $i - random_int(40, 60)) {
+            $data[] = array(sprintf('%s://127.0.0.1?weight=%d', static::$extension, $i));
+            $data[] = array(sprintf('%s://127.0.0.1?weight=%d', static::$extension, abs($i)));
+        }
+
+        return $data;
+    }
+}

--- a/src/Symfony/Component/Cache/Tests/Adapter/MemcacheAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MemcacheAdapterTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Adapter;
+
+use Symfony\Component\Cache\Adapter\MemcacheAdapter;
+
+class MemcacheAdapterTest extends AbstractMemcacheAdapterTest
+{
+    protected static $extension = 'memcache';
+
+    public static function setupBeforeClass()
+    {
+        parent::setupBeforeClass();
+
+        if (!version_compare(phpversion('memcache'), '3.0.8', '>')) {
+            self::markTestSkipped(sprintf('Extension %s required must be > 3.0.8.', static::$extension));
+        }
+
+        self::$client = MemcacheAdapter::create(static::defaultConnectionServer())->getClient();
+    }
+
+    public function createCachePool($defaultLifetime = 0)
+    {
+        return new MemcacheAdapter(self::$client, str_replace('\\', '.', __CLASS__), $defaultLifetime);
+    }
+
+    /**
+     * @group memcacheAdapter
+     */
+    public function testCreateAdaptor()
+    {
+        $adapter = MemcacheAdapter::create();
+        $memcache = $adapter->getClient();
+
+        $this->assertInstanceOf(MemcacheAdapter::class, $adapter,
+            'Adapter created should be instance of MemcacheAdapter.');
+
+        $this->assertInstanceOf(\Memcache::class, $memcache,
+            'Client created should be instance of Memcache.');
+
+        $this->assertTrue($adapter->setup(array(static::defaultConnectionServer())),
+            'Expects true return when no server/option errors.');
+
+        $this->assertSame(1, $memcache->getServerStatus('127.0.0.1', 11211),
+            'A single registered servers should exist with Memcache client.');
+    }
+
+    /**
+     * @group memcacheAdapter
+     * @dataProvider provideValidServerConfigData
+     */
+    public function testCreateAdaptorPassingServerConfig($dsn)
+    {
+        $adapter = MemcacheAdapter::create($dsn);
+        $params = parse_url($dsn);
+
+        $this->assertSame(1, $adapter->getClient()->getServerStatus(
+                isset($params['host']) ? $params['host'] : '127.0.0.1',
+                isset($params['port']) ? $params['port'] : 11211)
+        );
+    }
+
+    /**
+     * @group memcacheAdapter
+     * @dataProvider provideInvalidConnectionDsnSchema
+     * @expectedException \Symfony\Component\Cache\Exception\InvalidArgumentException
+     * @expectedExceptionMessageRegExp {Invalid memcache DSN:}
+     */
+    public function testInvalidConnectionDsnSchema($dsn)
+    {
+        MemcacheAdapter::create($dsn);
+    }
+
+    /**
+     * @group memcacheAdapter
+     * @dataProvider provideInvalidConnectionDsnHostOrPort
+     * @expectedException \Symfony\Component\Cache\Exception\InvalidArgumentException
+     * @expectedExceptionMessageRegExp {Invalid memcache DSN( host)?:}
+     */
+    public function testInvalidConnectionDsnHostOrPort($dsn)
+    {
+        MemcacheAdapter::create($dsn);
+    }
+
+    /**
+     * @group memcacheAdapter
+     * @dataProvider provideInvalidConnectionDsnQueryWeight
+     * @expectedException \Symfony\Component\Cache\Exception\InvalidArgumentException
+     * @expectedExceptionMessageRegExp {Invalid memcache DSN weight:}
+     */
+    public function testInvalidConnectionDsnQueryWeight($dsn)
+    {
+        MemcacheAdapter::create($dsn);
+    }
+}

--- a/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
@@ -1,0 +1,183 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Adapter;
+
+use Symfony\Component\Cache\Adapter\MemcachedAdapter;
+
+class MemcachedAdapterTest extends AbstractMemcacheAdapterTest
+{
+    protected static $extension = 'memcached';
+
+    private static function defaultConnectionOptions()
+    {
+        return array(
+            'OPT_DISTRIBUTION' => 'DISTRIBUTION_CONSISTENT',
+            'OPT_LIBKETAMA_COMPATIBLE' => true,
+            'OPT_COMPRESSION' => true,
+        );
+    }
+
+    public static function setupBeforeClass()
+    {
+        parent::setupBeforeClass();
+
+        if (!version_compare(phpversion('memcached'), '2.1.0', '>')) {
+            self::markTestSkipped('Extension memcached >2.1.0 required.');
+        }
+
+        self::$client = MemcachedAdapter::create(static::defaultConnectionServer(), static::defaultConnectionOptions())->getClient();
+    }
+
+    public function createCachePool($defaultLifetime = 0)
+    {
+        return new MemcachedAdapter(self::$client, str_replace('\\', '.', __CLASS__), $defaultLifetime);
+    }
+
+    /**
+     * @group memcachedAdapter
+     */
+    public function testCreateAdaptor()
+    {
+        $adapter = MemcachedAdapter::create();
+        $memcache = $adapter->getClient();
+
+        $this->assertInstanceOf(MemcachedAdapter::class, $adapter,
+            'Adapter created should be instance of MemcachedAdapter.');
+
+        $this->assertInstanceOf(\Memcached::class, $memcache,
+            'Client created should be instance of Memcached.');
+
+        $this->assertCount(0, $memcache->getServerList(),
+            'No registered servers should exist with Memcached client.');
+
+        $this->assertTrue($adapter->setup(array(static::defaultConnectionServer())),
+            'Expects true return when no server/option errors.');
+
+        $this->assertCount(1, $memcache->getServerList(),
+            'A single registered servers should exist with Memcached client.');
+
+        $this->assertTrue($adapter->setup(array(static::defaultConnectionServer()), static::defaultConnectionOptions()),
+            'Expects true return when no server/option errors.');
+
+        $this->assertTrue($memcache->getOption(\Memcached::OPT_COMPRESSION),
+            'Ensure out configured option has been applied to Memcached client.');
+
+        $this->assertSame(1, $memcache->getOption(\Memcached::OPT_LIBKETAMA_COMPATIBLE),
+            'Ensure out configured option has been applied to Memcached client.');
+    }
+
+    /**
+     * @group memcachedAdapter
+     */
+    public function testDuplicateServersAreNotRegistered()
+    {
+        $adapter = MemcachedAdapter::create();
+        $memcache = $adapter->getClient();
+
+        $this->assertCount(0, $memcache->getServerList(),
+            'No registered servers should exist with \Memcached client.');
+
+        for ($i = 0; $i < 10; ++$i) {
+            $this->assertTrue($adapter->setup(array(static::defaultConnectionServer())),
+                'Expects true return when no server/option errors.');
+
+            $this->assertCount(1, $memcache->getServerList(),
+                'A single registered server should exist with \Memcached client when same server added multiple times.');
+        }
+    }
+
+    /**
+     * @group memcachedAdapter
+     * @dataProvider provideValidServerConfigData
+     */
+    public function testCreateAdaptorPassingServerConfig($dsn)
+    {
+        $adapter = MemcachedAdapter::create($dsn);
+        $servers = $adapter->getClient()->getServerList();
+
+        $this->assertCount(1, $servers,
+            'A single registered server should exist with \Memcached client.');
+
+        $params = parse_url($dsn);
+        $server = array_shift($servers);
+
+        $this->assertSame($server['host'], isset($params['host']) ? $params['host'] : '127.0.0.1',
+            'Registered server host with \Memcached client should match expectation.');
+
+        $this->assertSame($server['port'], isset($params['port']) ? $params['port'] : 11211,
+            'Registered server port with \Memcached client should match expectation.');
+    }
+
+    /**
+     * @group memcachedAdapter
+     * @dataProvider provideInvalidConnectionDsnSchema
+     * @expectedException \Symfony\Component\Cache\Exception\InvalidArgumentException
+     * @expectedExceptionMessageRegExp {Invalid memcached DSN:}
+     */
+    public function testInvalidConnectionDsnSchema($dsn)
+    {
+        MemcachedAdapter::create($dsn);
+    }
+
+    /**
+     * @group memcachedAdapter
+     * @dataProvider provideInvalidConnectionDsnQueryWeight
+     * @expectedException \Symfony\Component\Cache\Exception\InvalidArgumentException
+     * @expectedExceptionMessageRegExp {Invalid memcached DSN weight:}
+     */
+    public function testInvalidConnectionDsnQueryWeight($dsn)
+    {
+        MemcachedAdapter::create($dsn);
+    }
+
+    /**
+     * @group memcachedAdapter
+     * @dataProvider provideInvalidServerOptionsData
+     * @expectedException \Symfony\Component\Cache\Exception\InvalidArgumentException
+     * @expectedExceptionMessageRegExp {Invalid memcached option (type|value):([^(]+) \(expects an int(, a bool,)? or a resolvable client constant\)}
+     */
+    public function testInvalidServerOptions(array $options)
+    {
+        MemcachedAdapter::create(null, $options);
+    }
+
+    public function provideInvalidServerOptionsData()
+    {
+        return array(
+            array(array('OPT_DOES_NOT_EXIST' => 'DISTRIBUTION_CONSISTENT')),
+            array(array('OPT_DISTRIBUTION' => 'DISTRIBUTION_DOES_NOT_EXIST')),
+            array(array(-1000000 => 'BAD_OPT')),
+        );
+    }
+
+    /**
+     * @group memcachedAdapter
+     * @dataProvider provideInvalidServerOptionCombinationsData
+     */
+    public function testInvalidServerOptionCombinations(array $options)
+    {
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('HHVM ext for Memcached does not object to invalid option values (silently ignores)');
+        }
+
+        $this->assertFalse(MemcachedAdapter::create(static::defaultConnectionServer())->setup(array(), $options),
+            'Expects false return when server/option errors encountered.');
+    }
+
+    public function provideInvalidServerOptionCombinationsData()
+    {
+        return array(
+            array(array(-10000000 => 'OPT_DISTRIBUTION')),
+            array(array('OPT_SERIALIZER' => 'OPT_DISTRIBUTION')),
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

Provides cache adapters for `memcached` and `memcache` extensions. Included unit tests cover entire code addition. Based heavily on existing Redis tests.