### PR TITLE
[2.7][HttpKernel] Regression test for missing controller arguments

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -37,6 +37,13 @@ class ControllerResolver implements ControllerResolverInterface
     private $supportsVariadic;
 
     /**
+     * If scalar types exists.
+     *
+     * @var bool
+     */
+    private $supportsScalarTypes;
+
+    /**
      * Constructor.
      *
      * @param LoggerInterface $logger A LoggerInterface instance
@@ -46,6 +53,7 @@ class ControllerResolver implements ControllerResolverInterface
         $this->logger = $logger;
 
         $this->supportsVariadic = method_exists('ReflectionParameter', 'isVariadic');
+        $this->supportsScalarTypes = method_exists('ReflectionParameter', 'getType');
     }
 
     /**
@@ -132,7 +140,7 @@ class ControllerResolver implements ControllerResolverInterface
                 $arguments[] = $request;
             } elseif ($param->isDefaultValueAvailable()) {
                 $arguments[] = $param->getDefaultValue();
-            } elseif ($param->allowsNull()) {
+            } elseif ($this->supportsScalarTypes && $param->hasType() && $param->allowsNull()) {
                 $arguments[] = null;
             } else {
                 if (is_array($controller)) {

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
@@ -224,6 +224,19 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @expectedException \RuntimeException
+     */
+    public function testIfExceptionIsThrownWhenMissingAnArgument()
+    {
+        $resolver = new ControllerResolver();
+        $request = Request::create('/');
+
+        $controller = array($this, 'controllerMethod1');
+
+        $resolver->getArguments($request, $controller);
+    }
+
+    /**
      * @requires PHP 7.1
      */
     public function testGetNullableArguments()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20746
| License       | MIT
| Doc PR        | ~

This fix should ensure that when an action has a mandatory parameter without a type, it will throw the exception instead of inserting null.

This test was missing when adding nullable support in 2.7 and up (probably has to be added to 3.1 as well).

