### PR TITLE
[3.1][HttpKernel] Regression test for missing controller arguments

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/DefaultValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/DefaultValueResolver.php
@@ -27,7 +27,7 @@ final class DefaultValueResolver implements ArgumentValueResolverInterface
      */
     public function supports(Request $request, ArgumentMetadata $argument)
     {
-        return $argument->hasDefaultValue() || ($argument->isNullable() && !$argument->isVariadic());
+        return $argument->hasDefaultValue() || (null !== $argument->getType() && $argument->isNullable() && !$argument->isVariadic());
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverTest.php
@@ -204,6 +204,17 @@ class ArgumentResolverTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @expectedException \RuntimeException
+     */
+    public function testIfExceptionIsThrownWhenMissingAnArgument()
+    {
+        $request = Request::create('/');
+        $controller = array($this, 'controllerWithFoo');
+
+        self::$resolver->getArguments($request, $controller);
+    }
+
+    /**
      * @requires PHP 7.1
      */
     public function testGetNullableArguments()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20746
| License       | MIT
| Doc PR        | ~

Same fix as #20755 but for 3.1 and up as the new feature was hit by the same bug.

ping @fabpot 