### PR TITLE
[Bridge\Twig] Trigger deprecation when using FormExtension::$renderer

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\Twig\Extension;
 
 use Symfony\Bridge\Twig\TokenParser\FormThemeTokenParser;
 use Symfony\Bridge\Twig\Form\TwigRendererInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 
 /**
@@ -23,12 +24,17 @@ use Symfony\Component\Form\ChoiceList\View\ChoiceView;
  */
 class FormExtension extends \Twig_Extension implements \Twig_Extension_InitRuntimeInterface
 {
+    /**
+     * @deprecated since version 3.2, to be removed in 4.0 alongside with magic methods below
+     */
     private $renderer;
 
-    public function __construct(TwigRendererInterface $renderer = null)
+    public function __construct($renderer = null)
     {
-        if (null !== $this->renderer) {
+        if ($this->renderer instanceof TwigRendererInterface) {
             @trigger_error(sprintf('Passing a Twig Form Renderer to the "%s" constructor is deprecated since version 3.2 and won\'t be possible in 4.0. Pass the Twig_Environment to the TwigRendererEngine constructor instead.', static::class), E_USER_DEPRECATED);
+        } elseif (null !== $renderer && !(is_array($renderer) && isset($renderer[0], $renderer[1]) && $renderer[0] instanceof ContainerInterface)) {
+            throw new \InvalidArgumentException(sprintf('Passing any arguments the constructor of %s is reserved for internal use.', __CLASS__));
         }
         $this->renderer = $renderer;
     }
@@ -40,8 +46,10 @@ class FormExtension extends \Twig_Extension implements \Twig_Extension_InitRunti
      */
     public function initRuntime(\Twig_Environment $environment)
     {
-        if (null !== $this->renderer) {
+        if ($this->renderer instanceof TwigRendererInterface) {
             $this->renderer->setEnvironment($environment);
+        } elseif (null !== $this->renderer) {
+            $this->renderer[2] = $environment;
         }
     }
 
@@ -92,6 +100,62 @@ class FormExtension extends \Twig_Extension implements \Twig_Extension_InitRunti
         return array(
             new \Twig_SimpleTest('selectedchoice', 'Symfony\Bridge\Twig\Extension\twig_is_selected_choice'),
         );
+    }
+
+    /**
+     * @internal
+     */
+    public function __get($name)
+    {
+        if ('renderer' === $name) {
+            @trigger_error(sprintf('Using the "%s::$renderer" property is deprecated since version 3.2 as it will be removed in 4.0.', __CLASS__), E_USER_DEPRECATED);
+
+            if (is_array($this->renderer)) {
+                $renderer = $this->renderer[0]->get($this->renderer[1]);
+                if (isset($this->renderer[2])) {
+                    $renderer->setEnvironment($this->renderer[2]);
+                }
+                $this->renderer = $renderer;
+            }
+        }
+
+        return $this->$name;
+    }
+
+    /**
+     * @internal
+     */
+    public function __set($name, $value)
+    {
+        if ('renderer' === $name) {
+            @trigger_error(sprintf('Using the "%s::$renderer" property is deprecated since version 3.2 as it will be removed in 4.0.', __CLASS__), E_USER_DEPRECATED);
+        }
+
+        $this->$name = $value;
+    }
+
+    /**
+     * @internal
+     */
+    public function __isset($name)
+    {
+        if ('renderer' === $name) {
+            @trigger_error(sprintf('Using the "%s::$renderer" property is deprecated since version 3.2 as it will be removed in 4.0.', __CLASS__), E_USER_DEPRECATED);
+        }
+
+        return isset($this->$name);
+    }
+
+    /**
+     * @internal
+     */
+    public function __unset($name)
+    {
+        if ('renderer' === $name) {
+            @trigger_error(sprintf('Using the "%s::$renderer" property is deprecated since version 3.2 as it will be removed in 4.0.', __CLASS__), E_USER_DEPRECATED);
+        }
+
+        unset($this->$name);
     }
 
     /**

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -118,7 +118,12 @@
             <argument type="service" id="router.request_context" on-invalid="ignore" />
         </service>
 
-        <service id="twig.extension.form" class="Symfony\Bridge\Twig\Extension\FormExtension" public="false" />
+        <service id="twig.extension.form" class="Symfony\Bridge\Twig\Extension\FormExtension" public="false">
+            <argument type="collection">
+                <argument type="service" id="service_container" />
+                <argument>twig.form.renderer</argument>
+            </argument>
+        </service>
 
         <service id="twig.extension.debug" class="Twig_Extension_Debug" public="false" />
 

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "symfony/twig-bridge": "~3.2",
+        "symfony/twig-bridge": "^3.2.1",
         "symfony/http-foundation": "~2.8|~3.0",
         "symfony/http-kernel": "~2.8|~3.0",
         "twig/twig": "~1.28|~2.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes (instead of a BC break)
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

As spotted in #20710 and https://github.com/sonata-project/SonataAdminBundle/pull/4216.
Note that this simple implementation is fine because neither the class nor its parent have any private/protected properties.