### PR TITLE
[FrameworkBundle] Added GlobalVariables::getToken()

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.3.0
+-----
+
+ * Added `GlobalVariables::getToken()`
+
 3.2.0
 -----
 

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Templating;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 /**
  * GlobalVariables is the entry point for Symfony global variables in PHP templates.
@@ -33,21 +34,27 @@ class GlobalVariables
     }
 
     /**
-     * Returns the current user.
+     * Returns the current token.
      *
-     * @return mixed
-     *
-     * @see TokenInterface::getUser()
+     * @return TokenInterface|null
      */
-    public function getUser()
+    public function getToken()
     {
         if (!$this->container->has('security.token_storage')) {
             return;
         }
 
-        $tokenStorage = $this->container->get('security.token_storage');
+        return $this->container->get('security.token_storage')->getToken();
+    }
 
-        if (!$token = $tokenStorage->getToken()) {
+    /**
+     * Returns the current user.
+     *
+     * @see TokenInterface::getUser()
+     */
+    public function getUser()
+    {
+        if (!$token = $this->getToken()) {
             return;
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/GlobalVariablesTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/GlobalVariablesTest.php
@@ -26,6 +26,32 @@ class GlobalVariablesTest extends TestCase
         $this->globals = new GlobalVariables($this->container);
     }
 
+    public function testGetTokenNoTokenStorage()
+    {
+        $this->assertNull($this->globals->getToken());
+    }
+
+    public function testGetTokenNoToken()
+    {
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $this->container->set('security.token_storage', $tokenStorage);
+        $this->assertNull($this->globals->getToken());
+    }
+
+    public function testGetToken()
+    {
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+
+        $this->container->set('security.token_storage', $tokenStorage);
+
+        $tokenStorage
+            ->expects($this->once())
+            ->method('getToken')
+            ->will($this->returnValue('token'));
+
+        $this->assertSame('token', $this->globals->getToken());
+    }
+
     public function testGetUserNoTokenStorage()
     {
         $this->assertNull($this->globals->getUser());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony-docs/pull/7191 comments
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/7191

I propose this feature as bug fix in 3.2, since I don't use the PHP templating I forgot to add the method in the `FrameworkBundle`, to keep it align with the `TwigBridge` in https://github.com/symfony/symfony/pull/19991.

Is this acceptable or should it go in master?