### PR TITLE
[Console] increased Command test code coverage + minor improvements

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -436,16 +436,6 @@ class Command
     }
 
     /**
-     * Returns the process title of the command.
-     *
-     * @return string The command name
-     */
-    public function getProcessTitle()
-    {
-        return $this->processTitle;
-    }
-
-    /**
      * Returns the command name.
      *
      * @return string The command name

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -436,6 +436,16 @@ class Command
     }
 
     /**
+     * Returns the process title of the command.
+     *
+     * @return string The command name
+     */
+    public function getProcessTitle()
+    {
+        return $this->processTitle;
+    }
+
+    /**
      * Returns the command name.
      *
      * @return string The command name

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Console\Tests\Command;
 
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -54,6 +55,14 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $command = new \TestCommand();
         $command->setApplication($application);
         $this->assertEquals($application, $command->getApplication(), '->setApplication() sets the current application');
+        $this->assertEquals($application->getHelperSet(), $command->getHelperSet());
+    }
+
+    public function testSetApplicationNull()
+    {
+        $command = new \TestCommand();
+        $command->setApplication(null);
+        $this->assertNull($command->getHelperSet());
     }
 
     public function testSetGetDefinition()
@@ -82,6 +91,20 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $ret = $command->addOption('foo');
         $this->assertEquals($command, $ret, '->addOption() implements a fluent interface');
         $this->assertTrue($command->getDefinition()->hasOption('foo'), '->addOption() adds an option to the command');
+    }
+
+    public function testSetProcessTitle()
+    {
+        $command = new \TestCommand();
+        $command->setProcessTitle('foo');
+        $this->assertEquals('foo', $command->getProcessTitle());
+    }
+
+    public function testSetHidden()
+    {
+        $command = new \TestCommand();
+        $command->setHidden(true);
+        $this->assertTrue($command->isHidden());
     }
 
     public function testGetNamespaceGetNameSetName()
@@ -156,12 +179,28 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('name1'), $command->getAliases(), '->setAliases() sets the aliases');
     }
 
+    public function testSetAliasesNull()
+    {
+        $command = new \TestCommand();
+        $this->expectException(InvalidArgumentException::class);
+        $command->setAliases(null);
+    }
+
     public function testGetSynopsis()
     {
         $command = new \TestCommand();
         $command->addOption('foo');
         $command->addArgument('bar');
         $this->assertEquals('namespace:name [--foo] [--] [<bar>]', $command->getSynopsis(), '->getSynopsis() returns the synopsis');
+    }
+
+    public function testAddGetUsages()
+    {
+        $command = new \TestCommand();
+        $command->addUsage('foo1');
+        $command->addUsage('foo2');
+        $this->assertContains('namespace:name foo1', $command->getUsages());
+        $this->assertContains('namespace:name foo2', $command->getUsages());
     }
 
     public function testGetHelper()
@@ -294,6 +333,14 @@ class CommandTest extends \PHPUnit_Framework_TestCase
     {
         $command = new \TestCommand();
 
+        $this->assertSame(0, $command->run(new StringInput(''), new NullOutput()));
+    }
+
+    public function testRunWithProcessTitle()
+    {
+        $command = new \TestCommand();
+        $command->setApplication(new Application());
+        $command->setProcessTitle('foo');
         $this->assertSame(0, $command->run(new StringInput(''), new NullOutput()));
     }
 

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -93,13 +93,6 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($command->getDefinition()->hasOption('foo'), '->addOption() adds an option to the command');
     }
 
-    public function testSetProcessTitle()
-    {
-        $command = new \TestCommand();
-        $command->setProcessTitle('foo');
-        $this->assertEquals('foo', $command->getProcessTitle());
-    }
-
     public function testSetHidden()
     {
         $command = new \TestCommand();
@@ -342,6 +335,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $command->setApplication(new Application());
         $command->setProcessTitle('foo');
         $this->assertSame(0, $command->run(new StringInput(''), new NullOutput()));
+        $this->assertEquals('foo', cli_get_process_title());
     }
 
     public function testSetCode()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

- added 6 test cases to ``CommandTest.php`` and improved an existing one
- added getter method for ``$processTitle`` in ``Command.php``

The code coverage of the Command class has been improved from 86.32% to 96.61%

before:
![before](https://cloud.githubusercontent.com/assets/75517/20927772/54be90cc-bbc3-11e6-869a-65b288579bff.png)

after:
![after](https://cloud.githubusercontent.com/assets/75517/20927777/58ac47e2-bbc3-11e6-907f-75d0115e8907.png)

