### PR TITLE
[VarDumper] fix tests when xdebug is enabled

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
@@ -147,6 +147,10 @@ EOTXT
      */
     public function testGenerator()
     {
+        if (extension_loaded('xdebug')) {
+            $this->markTestSkipped('xdebug is active');
+        }
+
         $g = new GeneratorDemo();
         $g = $g->baz();
         $r = new \ReflectionGenerator($g);

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
@@ -147,7 +147,7 @@ EOTXT
      */
     public function testGenerator()
     {
-        if (extension_loaded('xdebug')) {
+        if (ini_get('xdebug.overload_var_dump') == 2) {
             $this->markTestSkipped('xdebug is active');
         }
 

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
@@ -147,7 +147,7 @@ EOTXT
      */
     public function testGenerator()
     {
-        if (ini_get('xdebug.overload_var_dump') == 2) {
+        if (extension_loaded('xdebug')) {
             $this->markTestSkipped('xdebug is active');
         }
 

--- a/src/Symfony/Component/VarDumper/Tests/VarClonerTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/VarClonerTest.php
@@ -157,6 +157,10 @@ EOTXT;
 
     public function testJsonCast()
     {
+        if (extension_loaded('xdebug')) {
+            $this->markTestSkipped('xdebug is active');
+        }
+
         $data = (array) json_decode('{"1":{}}');
 
         $cloner = new VarCloner();

--- a/src/Symfony/Component/VarDumper/Tests/VarClonerTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/VarClonerTest.php
@@ -157,7 +157,7 @@ EOTXT;
 
     public function testJsonCast()
     {
-        if (extension_loaded('xdebug')) {
+        if (ini_get('xdebug.overload_var_dump') == 2) {
             $this->markTestSkipped('xdebug is active');
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20778
| License       | MIT

- Disabled some test cases when xdebug is enabled, see https://github.com/symfony/symfony/issues/20778

