### PR TITLE
[HttpKernel] Fix invalid Container class name

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -479,7 +479,13 @@ abstract class Kernel implements KernelInterface, TerminableInterface
      */
     protected function getContainerClass()
     {
-        return $this->name.ucfirst($this->environment).($this->debug ? 'Debug' : '').'ProjectContainer';
+        $class = $this->name.ucfirst($this->environment).($this->debug ? 'Debug' : '').'ProjectContainer';
+
+        if (!preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $class)) {
+            $class = '_'.$class;
+        }
+
+        return $class;
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -114,6 +114,21 @@ class KernelTest extends \PHPUnit_Framework_TestCase
             ->method('doLoadClassCache');
     }
 
+    public function testInvalidContainerClassName()
+    {
+        $kernel = new KernelForTest('test', true);
+
+        $p = new \ReflectionProperty($kernel, 'name');
+        $p->setAccessible(true);
+        $p->setValue($kernel, '123foobar');
+
+        $reflection = new \ReflectionClass(get_class($kernel));
+        $method = $reflection->getMethod('getContainerClass');
+        $method->setAccessible(true);
+
+        $this->assertSame('_123foobarTestDebugProjectContainer', $method->invoke($kernel));
+    }
+
     public function testEnvParametersResourceIsAdded()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Steps to reproduce this bug (based on [Building your own Framework with the MicroKernelTrait][1]):

1. ``$ git clone https://github.com/yceruto/micro-kernel 123foobar``
2. ``$ cd 123foobar``
3. ``$ composer update``
4. ``$ php index.php``

Result:

> Parse error: syntax error, unexpected '123' (T_LNUMBER), expecting identifier (T_STRING) in /var/www/vhost/123foobar/cache/dev/123foobarDevDebugProjectContainer.php on line 16

  [1]: http://symfony.com/doc/current/configuration/micro_kernel_trait.html

The solution was taken from http://php.net/manual/en/language.oop5.basic.php:

> A valid class name starts with a letter or underscore, followed by any number of letters, numbers, or underscores. As a regular expression, it would be expressed thus: ^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$.