### PR TITLE
Don't use the "app" global variable in the profiler

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
@@ -39,7 +39,7 @@
                                     {%- else -%}
                                             {{ redirect_route }}
                                     {%- endif %}
-                                    (<a href="{{ path('_profiler', { token: redirect.token, panel: app.request.query.get('panel', 'request') }) }}">{{ redirect.token }}</a>)
+                                    (<a href="{{ path('_profiler', { token: redirect.token, panel: request.query.get('panel', 'request') }) }}">{{ redirect.token }}</a>)
                                 </dd>
                             </dl>
                         {%- endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

The use of the `app` variable makes this incompatible with projects like Silex (as pointed by @stof in https://github.com/symfony/symfony/pull/20646#discussion_r91080514)