### PR TITLE
[Validator] Fix caching of constraints derived from non-serializable parents

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
@@ -123,6 +123,8 @@ class LazyLoadingMetadataFactoryTest extends \PHPUnit_Framework_TestCase
         $metadata = new ClassMetadata(self::PARENT_CLASS);
         $metadata->addConstraint(new ConstraintA());
 
+        $parentClass = self::PARENT_CLASS;
+
         $loader->expects($this->never())
                ->method('loadClassMetadata');
 
@@ -134,8 +136,8 @@ class LazyLoadingMetadataFactoryTest extends \PHPUnit_Framework_TestCase
                   array(self::PARENT_CLASS),
                   array(self::INTERFACE_A_CLASS)
               )
-              ->willReturnCallback(function ($name) use ($metadata) {
-                  if (self::PARENT_CLASS == $name) {
+              ->willReturnCallback(function ($name) use ($metadata, $parentClass) {
+                  if ($parentClass == $name) {
                       return $metadata;
                   }
 

--- a/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
@@ -124,6 +124,7 @@ class LazyLoadingMetadataFactoryTest extends \PHPUnit_Framework_TestCase
         $metadata->addConstraint(new ConstraintA());
 
         $parentClass = self::PARENT_CLASS;
+        $interfaceClass = self::INTERFACE_A_CLASS;
 
         $loader->expects($this->never())
                ->method('loadClassMetadata');
@@ -136,12 +137,12 @@ class LazyLoadingMetadataFactoryTest extends \PHPUnit_Framework_TestCase
                   array(self::PARENT_CLASS),
                   array(self::INTERFACE_A_CLASS)
               )
-              ->willReturnCallback(function ($name) use ($metadata, $parentClass) {
+              ->willReturnCallback(function ($name) use ($metadata, $parentClass, $interfaceClass) {
                   if ($parentClass == $name) {
                       return $metadata;
                   }
 
-                  return new ClassMetadata(self::INTERFACE_A_CLASS);
+                  return new ClassMetadata($interfaceClass);
               });
 
         $this->assertEquals($metadata, $factory->getMetadataFor(self::PARENT_CLASS));

--- a/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Mapping\Factory;
 
+use Symfony\Component\Validator\Constraints\Callback;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Factory\LazyLoadingMetadataFactory;
 use Symfony\Component\Validator\Mapping\Loader\LoaderInterface;
@@ -30,8 +31,8 @@ class LazyLoadingMetadataFactoryTest extends \PHPUnit_Framework_TestCase
         $metadata = $factory->getMetadataFor(self::PARENT_CLASS);
 
         $constraints = array(
-            new ConstraintA(array('groups' => array('Default', 'EntityInterfaceA', 'EntityParent'))),
             new ConstraintA(array('groups' => array('Default', 'EntityParent'))),
+            new ConstraintA(array('groups' => array('Default', 'EntityInterfaceA', 'EntityParent'))),
         );
 
         $this->assertEquals($constraints, $metadata->getConstraints());
@@ -45,28 +46,28 @@ class LazyLoadingMetadataFactoryTest extends \PHPUnit_Framework_TestCase
         $constraints = array(
             new ConstraintA(array('groups' => array(
                 'Default',
+                'Entity',
+            ))),
+            new ConstraintA(array('groups' => array(
+                'Default',
+                'EntityParent',
+                'Entity',
+            ))),
+            new ConstraintA(array('groups' => array(
+                'Default',
                 'EntityInterfaceA',
                 'EntityParent',
                 'Entity',
             ))),
             new ConstraintA(array('groups' => array(
                 'Default',
-                'EntityParent',
+                'EntityInterfaceB',
                 'Entity',
             ))),
             new ConstraintA(array('groups' => array(
                 'Default',
                 'EntityParentInterface',
                 'EntityInterfaceB',
-                'Entity',
-            ))),
-            new ConstraintA(array('groups' => array(
-                'Default',
-                'EntityInterfaceB',
-                'Entity',
-            ))),
-            new ConstraintA(array('groups' => array(
-                'Default',
                 'Entity',
             ))),
         );
@@ -80,8 +81,8 @@ class LazyLoadingMetadataFactoryTest extends \PHPUnit_Framework_TestCase
         $factory = new LazyLoadingMetadataFactory(new TestLoader(), $cache);
 
         $parentClassConstraints = array(
-            new ConstraintA(array('groups' => array('Default', 'EntityInterfaceA', 'EntityParent'))),
             new ConstraintA(array('groups' => array('Default', 'EntityParent'))),
+            new ConstraintA(array('groups' => array('Default', 'EntityInterfaceA', 'EntityParent'))),
         );
         $interfaceAConstraints = array(
             new ConstraintA(array('groups' => array('Default', 'EntityInterfaceA'))),
@@ -127,11 +128,42 @@ class LazyLoadingMetadataFactoryTest extends \PHPUnit_Framework_TestCase
 
         $cache->expects($this->never())
               ->method('has');
-        $cache->expects($this->once())
+        $cache->expects($this->exactly(2))
               ->method('read')
-              ->will($this->returnValue($metadata));
+              ->withConsecutive(
+                  array(self::PARENT_CLASS),
+                  array(self::INTERFACE_A_CLASS)
+              )
+              ->willReturnCallback(function ($name) use ($metadata) {
+                  if (self::PARENT_CLASS == $name) {
+                      return $metadata;
+                  }
+
+                  return new ClassMetadata(self::INTERFACE_A_CLASS);
+              });
 
         $this->assertEquals($metadata, $factory->getMetadataFor(self::PARENT_CLASS));
+    }
+
+    public function testMetadataCacheWithRuntimeConstraint()
+    {
+        $cache = $this->getMock('Symfony\Component\Validator\Mapping\Cache\CacheInterface');
+        $factory = new LazyLoadingMetadataFactory(new TestLoader(), $cache);
+
+        $cache
+            ->expects($this->any())
+            ->method('write')
+            ->will($this->returnCallback(function ($metadata) { serialize($metadata);}))
+        ;
+
+        $cache->expects($this->any())
+            ->method('read')
+            ->will($this->returnValue(false));
+
+        $metadata = $factory->getMetadataFor(self::PARENT_CLASS);
+        $metadata->addConstraint(new Callback(function () {}));
+
+        $metadata = $factory->getMetadataFor(self::CLASS_NAME);
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #12302
| License       | MIT
| Doc PR        | -

This change allows to still cache constraints even when an uncachable constraint (i.e. Callback)
is added to a parent class at runtime.

This is achived by caching only the constraints that are loaded for the class in question only
and merging parent and interface constraints after reading from cache.