### PR TITLE
[Security] fix the docblock in regard to the role argument

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -33,7 +33,7 @@ abstract class AbstractToken implements TokenInterface
     /**
      * Constructor.
      *
-     * @param RoleInterface[]|string[] $roles An array of roles
+     * @param (RoleInterface|string)[] $roles An array of roles
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Symfony/Component/Security/Core/Authentication/Token/PreAuthenticatedToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/PreAuthenticatedToken.php
@@ -29,7 +29,7 @@ class PreAuthenticatedToken extends AbstractToken
      * @param string|object            $user        The user can be a UserInterface instance, or an object implementing a __toString method or the username as a regular string
      * @param mixed                    $credentials The user credentials
      * @param string                   $providerKey The provider key
-     * @param RoleInterface[]|string[] $roles       An array of roles
+     * @param (RoleInterface|string)[] $roles       An array of roles
      */
     public function __construct($user, $credentials, $providerKey, array $roles = array())
     {

--- a/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
@@ -29,7 +29,7 @@ class UsernamePasswordToken extends AbstractToken
      * @param string|object            $user        The username (like a nickname, email address, etc.), or a UserInterface instance or an object implementing a __toString method
      * @param string                   $credentials This usually is the password of the user
      * @param string                   $providerKey The provider key
-     * @param RoleInterface[]|string[] $roles       An array of roles
+     * @param (RoleInterface|string)[] $roles       An array of roles
      *
      * @throws \InvalidArgumentException
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Makes the docblocks consistent with the `UserInterface` since #17525.