### PR TITLE
[WebProfiler] added missing event parameter to click handler

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -66,7 +66,7 @@
                         }
                     };
                 }
-                Sfjs.addEventListener(document.getElementById('sfToolbarHideButton-{{ token }}'), 'click', function () {
+                Sfjs.addEventListener(document.getElementById('sfToolbarHideButton-{{ token }}'), 'click', function (event) {
                     event.preventDefault();
 
                     var p = this.parentNode;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

After updating to symfony 3.2 i realized that the debug toolbar does not get closed any more, throwing an error on javascript console: "event" not defined.
This fixes it.
