### PR TITLE
[FrameworkBundle] Removed kernel.debug from the cache pool namespace seed

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/CachePoolPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/CachePoolPass.php
@@ -30,7 +30,7 @@ class CachePoolPass implements CompilerPassInterface
     {
         $namespaceSuffix = '';
 
-        foreach (array('name', 'root_dir', 'environment', 'debug') as $key) {
+        foreach (array('name', 'root_dir', 'environment') as $key) {
             if ($container->hasParameter('kernel.'.$key)) {
                 $namespaceSuffix .= '.'.$container->getParameter('kernel.'.$key);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/20780
| License       | MIT
| Doc PR        |