### PR TITLE
[Console] improved code coverage of Command class

### DIFF
--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -167,7 +167,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
     public function testSetAliasesNull()
     {
         $command = new \TestCommand();
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException('InvalidArgumentException');
         $command->setAliases(null);
     }
 

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -327,7 +327,9 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $command->setApplication(new Application());
         $command->setProcessTitle('foo');
         $this->assertSame(0, $command->run(new StringInput(''), new NullOutput()));
-        $this->assertEquals('foo', cli_get_process_title());
+        if (function_exists('cli_set_process_title')) {
+            $this->assertEquals('foo', cli_get_process_title());
+        }
     }
 
     public function testSetCode()

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -167,7 +167,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
     public function testSetAliasesNull()
     {
         $command = new \TestCommand();
-        $this->expectException('InvalidArgumentException');
+        $this->setExpectedException('InvalidArgumentException');
         $command->setAliases(null);
     }
 

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -54,6 +54,14 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $command = new \TestCommand();
         $command->setApplication($application);
         $this->assertEquals($application, $command->getApplication(), '->setApplication() sets the current application');
+        $this->assertEquals($application->getHelperSet(), $command->getHelperSet());
+    }
+
+    public function testSetApplicationNull()
+    {
+        $command = new \TestCommand();
+        $command->setApplication(null);
+        $this->assertNull($command->getHelperSet());
     }
 
     public function testSetGetDefinition()
@@ -156,12 +164,28 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('name1'), $command->getAliases(), '->setAliases() sets the aliases');
     }
 
+    public function testSetAliasesNull()
+    {
+        $command = new \TestCommand();
+        $this->expectException(\InvalidArgumentException::class);
+        $command->setAliases(null);
+    }
+
     public function testGetSynopsis()
     {
         $command = new \TestCommand();
         $command->addOption('foo');
         $command->addArgument('bar');
         $this->assertEquals('namespace:name [--foo] [--] [<bar>]', $command->getSynopsis(), '->getSynopsis() returns the synopsis');
+    }
+
+    public function testAddGetUsages()
+    {
+        $command = new \TestCommand();
+        $command->addUsage('foo1');
+        $command->addUsage('foo2');
+        $this->assertContains('namespace:name foo1', $command->getUsages());
+        $this->assertContains('namespace:name foo2', $command->getUsages());
     }
 
     public function testGetHelper()
@@ -275,8 +299,8 @@ class CommandTest extends \PHPUnit_Framework_TestCase
 
         $command = $this->getMock('TestCommand', array('execute'));
         $command->expects($this->once())
-             ->method('execute')
-             ->will($this->returnValue('2.3'));
+            ->method('execute')
+            ->will($this->returnValue('2.3'));
         $exitCode = $command->run(new StringInput(''), new NullOutput());
         $this->assertSame(2, $exitCode, '->run() returns integer exit code (casts numeric to int)');
     }
@@ -295,6 +319,15 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $command = new \TestCommand();
 
         $this->assertSame(0, $command->run(new StringInput(''), new NullOutput()));
+    }
+
+    public function testRunWithProcessTitle()
+    {
+        $command = new \TestCommand();
+        $command->setApplication(new Application());
+        $command->setProcessTitle('foo');
+        $this->assertSame(0, $command->run(new StringInput(''), new NullOutput()));
+        $this->assertEquals('foo', cli_get_process_title());
     }
 
     public function testSetCode()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

This PR increases the code coverage of the Command class from ``86.82%`` to ``96.90%`` of 2.7 branch.

After also https://github.com/symfony/symfony/pull/21067 was merged, thecode coverage of the Command class has been improved from 86.32% to 96.61% of master branch.

before:
![before](https://cloud.githubusercontent.com/assets/75517/20927772/54be90cc-bbc3-11e6-869a-65b288579bff.png)

after:
![after](https://cloud.githubusercontent.com/assets/75517/20927777/58ac47e2-bbc3-11e6-907f-75d0115e8907.png)
