### PR TITLE
[Config] Fix YamlReferenceDumper extra space

### DIFF
--- a/src/Symfony/Component/Config/Definition/Dumper/YamlReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/YamlReferenceDumper.php
@@ -120,7 +120,7 @@ class YamlReferenceDumper
         $default = (string) $default != '' ? ' '.$default : '';
         $comments = count($comments) ? '# '.implode(', ', $comments) : '';
 
-        $text = rtrim(sprintf('%-20s %s %s', $node->getName().':', $default, $comments), ' ');
+        $text = rtrim(sprintf('%-21s%s %s', $node->getName().':', $default, $comments), ' ');
 
         if ($info = $node->getInfo()) {
             $this->writeLine('');

--- a/src/Symfony/Component/Config/Tests/Definition/Dumper/XmlReferenceDumperTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Dumper/XmlReferenceDumperTest.php
@@ -49,6 +49,7 @@ class XmlReferenceDumperTest extends \PHPUnit_Framework_TestCase
     scalar-array-empty=""
     scalar-array-defaults="elem1,elem2"
     scalar-required=""
+    node-with-a-looong-name=""
     enum-with-default="this"
     enum=""
 >

--- a/src/Symfony/Component/Config/Tests/Definition/Dumper/YamlReferenceDumperTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Dumper/YamlReferenceDumperTest.php
@@ -43,6 +43,7 @@ acme_root:
         - elem1
         - elem2
     scalar_required:      ~ # Required
+    node_with_a_looong_name: ~
     enum_with_default:    this # One of "this"; "that"
     enum:                 ~ # One of "this"; "that"
 

--- a/src/Symfony/Component/Config/Tests/Fixtures/Configuration/ExampleConfiguration.php
+++ b/src/Symfony/Component/Config/Tests/Fixtures/Configuration/ExampleConfiguration.php
@@ -34,6 +34,7 @@ class ExampleConfiguration implements ConfigurationInterface
                 ->scalarNode('scalar_array_empty')->defaultValue(array())->end()
                 ->scalarNode('scalar_array_defaults')->defaultValue(array('elem1', 'elem2'))->end()
                 ->scalarNode('scalar_required')->isRequired()->end()
+                ->scalarNode('node_with_a_looong_name')->end()
                 ->enumNode('enum_with_default')->values(array('this', 'that'))->defaultValue('this')->end()
                 ->enumNode('enum')->values(array('this', 'that'))->end()
                 ->arrayNode('array')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes (minor rendering issue)
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Simply fixes a minor rendering issue when using the `YamlReferenceDumper`.

<details>
<summary>For reference, see the difference with this fix on the framework configuration</summary>

```diff
diff --git a/framework_before.yml b/framework_after.yml
index f28ffd0..0486709 100644
--- a/framework1.txt
+++ b/framework2.txt
@@ -3,7 +3,7 @@ framework:
     secret:               ~
 
     # Set true to enable support for the '_method' request parameter to determine the intended HTTP method on POST requests. Note: When using the HttpCache, you need to call the method in your front controller instead
-    http_method_override:  true
+    http_method_override: true
     trusted_proxies:      []
     ide:                  null
     test:                 ~
@@ -37,7 +37,7 @@ framework:
         enabled:              false
         collect:              true
         only_exceptions:      false
-        only_master_requests:  false
+        only_master_requests: false
         dsn:                  'file:%kernel.cache_dir%/profiler'
         matcher:
             enabled:              false
@@ -97,7 +97,7 @@ framework:
         save_path:            '%kernel.cache_dir%/sessions'
 
         # seconds to wait between 2 session metadata updates, it will also prevent the session handler to write if the session has not changed
-        metadata_update_threshold:  '0'
+        metadata_update_threshold: '0'
 
     # request configuration
     request:
@@ -110,7 +110,7 @@ framework:
     # templating configuration
     templating:
         enabled:              false
-        hinclude_default_template:  null
+        hinclude_default_template: null
         cache:                ~
         form:
             resources:
@@ -180,7 +180,7 @@ framework:
     # Property access configuration
     property_access:
         magic_call:           false
-        throw_exception_on_invalid_index:  false
+        throw_exception_on_invalid_index: false
 
     # Property info configuration
     property_info:
@@ -198,9 +198,9 @@ framework:
         # System related cache pools configuration
         system:               cache.adapter.system
         directory:            '%kernel.cache_dir%/pools'
-        default_doctrine_provider:  ~
-        default_psr6_provider:  ~
-        default_redis_provider:  'redis://localhost'
+        default_doctrine_provider: ~
+        default_psr6_provider: ~
+        default_redis_provider: 'redis://localhost'
         pools:
 
             # Prototype
```
</details>

---

(tests failures are unrelated)