### PR TITLE
[Config] Do not skip YamlReferenceDumperTest entirely

### DIFF
--- a/src/Symfony/Component/Config/Tests/Definition/Dumper/YamlReferenceDumperTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Dumper/YamlReferenceDumperTest.php
@@ -22,8 +22,8 @@ class YamlReferenceDumperTest extends \PHPUnit_Framework_TestCase
 
         $dumper = new YamlReferenceDumper();
 
+        $this->assertContains($this->getConfigurationAsString(), $dumper->dump($configuration));
         $this->markTestIncomplete('The Yaml Dumper currently does not support prototyped arrays');
-        $this->assertEquals($this->getConfigurationAsString(), $dumper->dump($configuration));
     }
 
     private function getConfigurationAsString()
@@ -32,7 +32,7 @@ class YamlReferenceDumperTest extends \PHPUnit_Framework_TestCase
 acme_root:
     boolean:              true
     scalar_empty:         ~
-    scalar_null:          ~
+    scalar_null:          null
     scalar_true:          true
     scalar_false:         false
     scalar_default:       default
@@ -59,10 +59,6 @@ acme_root:
 
         # Prototype
         name:                 ~
-    connections:
-        # Prototype
-        - { user: ~, pass: ~ }
-
 EOL;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

The test is now completed in 3.2, but for older branch, any changes in the `YamlReferenceDumper` is not tested on travis and requires to test it manually or comment the `markTestIncomplete` line.

`assertEquals` should still be used on 3.2.