### PR TITLE
[DoctrineBridge] Resolve parameters in entity listener "connection" tag attribute

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php
@@ -127,7 +127,7 @@ class RegisterEventListenersAndSubscribersPass implements CompilerPassInterface
                     }
                 }
 
-                $cons = isset($instance['connection']) ? array($instance['connection']) : $allCons;
+                $cons = isset($instance['connection']) ? array($this->container->getParameterBag()->resolveValue($instance['connection'])) : $allCons;
                 foreach ($cons as $con) {
                     if (!isset($grouped[$con])) {
                         throw new RuntimeException(sprintf('The Doctrine connection "%s" referenced in service "%s" does not exist. Available connections names: %s', $con, $id, implode(', ', array_keys($this->connections))));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes, in case someone named a connection `%something%`
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #16239
| License       | MIT
| Doc PR        | N/A