### PR TITLE
[Config] Allow nonexistent file resources

### DIFF
--- a/src/Symfony/Component/Config/Resource/FileExistenceResource.php
+++ b/src/Symfony/Component/Config/Resource/FileExistenceResource.php
@@ -21,9 +21,9 @@ namespace Symfony\Component\Config\Resource;
  */
 class FileExistenceResource implements SelfCheckingResourceInterface, \Serializable
 {
-    private $resource;
+    protected $resource;
 
-    private $exists;
+    protected $exists;
 
     /**
      * Constructor.

--- a/src/Symfony/Component/Config/Tests/Resource/FileResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/FileResourceTest.php
@@ -52,15 +52,6 @@ class FileResourceTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(realpath($this->file), (string) $this->resource);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /The file ".*" does not exist./
-     */
-    public function testResourceDoesNotExist()
-    {
-        $resource = new FileResource('/____foo/foobar'.mt_rand(1, 999999));
-    }
-
     public function testIsFresh()
     {
         $this->assertTrue($this->resource->isFresh($this->time), '->isFresh() returns true if the resource has not changed in same second');
@@ -68,11 +59,21 @@ class FileResourceTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->resource->isFresh($this->time - 86400), '->isFresh() returns false if the resource has been updated');
     }
 
+    public function testIsFreshForCreatedResources()
+    {
+        unlink($this->file);
+
+        $this->resource = new FileResource($this->file);
+        touch($this->file, $this->time);
+
+        $this->assertFalse($this->resource->isFresh($this->time), '->isFresh() returns false if the resource is created');
+    }
+
     public function testIsFreshForDeletedResources()
     {
         unlink($this->file);
 
-        $this->assertFalse($this->resource->isFresh($this->time), '->isFresh() returns false if the resource does not exist');
+        $this->assertFalse($this->resource->isFresh($this->time), '->isFresh() returns false if the resource is deleted');
     }
 
     public function testSerializeUnserialize()

--- a/src/Symfony/Component/Config/Tests/Resource/FileResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/FileResourceTest.php
@@ -79,6 +79,6 @@ class FileResourceTest extends \PHPUnit_Framework_TestCase
     {
         $unserialized = unserialize(serialize($this->resource));
 
-        $this->assertSame(realpath($this->file), $this->resource->getResource());
+        $this->assertSame(realpath($this->file), $unserialized->getResource());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes?
| New feature?  | yes?
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Updates `FileResource` to also evaluate freshness against file existence.

Currently, `FileResource` assumes that the file always exists. I have a use case where this is not necessarily true: for tests purposes, I create a `TestKernel` class that uses `MicroKernelTrait` to define all the configs directly, except some values that are defined in `phpunit.xml` and `phpunit.xml.dist` files. Since the tests can pass with the default values from `phpunit.xml.dist`, creating the `phpunit.xml` file is not required. So in `TestKernel` I have to do this:
```php
if (file_exists('phpunit.xml')) {
    $container->addResource(new FileResource('phpunit.xml'));
} else {
    $container->addResource(new FileExistenceResource('phpunit.xml'));
}
```

Maybe it should be a new class instead, WDYT?