### PR TITLE
[Workflow] Allow Transition if subject is in *any one* of the Transition's `from` states

### DIFF
--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -8,6 +8,7 @@ use Symfony\Component\Workflow\Event\GuardEvent;
 use Symfony\Component\Workflow\Marking;
 use Symfony\Component\Workflow\MarkingStore\MarkingStoreInterface;
 use Symfony\Component\Workflow\MarkingStore\MultipleStateMarkingStore;
+use Symfony\Component\Workflow\MarkingStore\SingleStateMarkingStore;
 use Symfony\Component\Workflow\Transition;
 use Symfony\Component\Workflow\Workflow;
 
@@ -149,6 +150,25 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($marking->has('a'));
         $this->assertTrue($marking->has('b'));
         $this->assertTrue($marking->has('c'));
+    }
+
+    public function testApplyUsingTransitionWithMultipleFroms()
+    {
+        $places = ['init', 'draft', 'active'];
+
+        $transitions = array();
+        $transitions[] = new Transition('save', 'init', 'draft');
+        $transitions[] = new Transition('publish', ['init', 'draft'], 'active');
+
+        $definition = new Definition($places, $transitions);
+        $subject = new \stdClass();
+        $subject->marking = null;
+        $workflow = new Workflow($definition, new SingleStateMarkingStore());
+
+        $workflow->apply($subject, 'save');
+        $workflow->apply($subject, 'publish');
+
+        $this->assertEquals('active', $subject->marking);
     }
 
     public function testApplyWithEventDispatcher()

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -287,10 +287,17 @@ class Workflow
     private function getTransitionForSubject($subject, Marking $marking, array $transitions)
     {
         foreach ($transitions as $transition) {
+            $isValidTransition = false;
+
             foreach ($transition->getFroms() as $place) {
-                if (!$marking->has($place)) {
-                    continue 2;
+                if ($marking->has($place)) {
+                    $isValidTransition = true;
+                    break;
                 }
+            }
+
+            if (!$isValidTransition) {
+                continue;
             }
 
             if (true !== $this->guardTransition($subject, $marking, $transition)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | maybe?
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | #20838
| License       | MIT
| Doc PR        | 

---

This breaks the `WorkflowTest::testGetEnabledTransitions` test, but I think that test is actually flawed. Can anyone confirm?

    private function createComplexWorkflowDefinition()
    {
        $places = range('a', 'g');

        $transitions = array();
        $transitions[] = new Transition('t1', 'a', array('b', 'c'));
        $transitions[] = new Transition('t2', array('b', 'c'), 'd');
        $transitions[] = new Transition('t3', 'd', 'e');
        $transitions[] = new Transition('t4', 'd', 'f');
        $transitions[] = new Transition('t5', 'e', 'g');
        $transitions[] = new Transition('t6', 'f', 'g');

        return new Definition($places, $transitions);
    }

    public function testGetEnabledTransitions()
    {
        $definition = $this->createComplexWorkflowDefinition();
        $subject = new \stdClass();
        $subject->marking = null;
        $eventDispatcher = new EventDispatcher();
        $eventDispatcher->addListener('workflow.workflow_name.guard.t1', function (GuardEvent $event) {
            $event->setBlocked(true);
        });
        $workflow = new Workflow($definition, new MultipleStateMarkingStore(), $eventDispatcher, 'workflow_name');

        $this->assertEmpty($workflow->getEnabledTransitions($subject));

        $subject->marking = array('d' => true);
        $transitions = $workflow->getEnabledTransitions($subject);
        $this->assertCount(2, $transitions);
        $this->assertSame('t3', $transitions[0]->getName());
        $this->assertSame('t4', $transitions[1]->getName());

        $subject->marking = array('c' => true, 'e' => true);
        $transitions = $workflow->getEnabledTransitions($subject);
        $this->assertCount(1, $transitions);
        $this->assertSame('t5', $transitions[0]->getName());
    }

It fails at `$this->assertCount(1, $transitions);`. Given `c` and `e` states, I would expect the allowable transitions to be `t2` and `t5`, no? My bugfix makes both `t2` and `t5` allowable, but the current behavior says that only `t5` is.

If I'm correct, I'll fix that test as well.

---

## Late edit

I just realized this *could* not be a bug... please see the bug report for discussion.