### PR TITLE
[WebProfilerBundle] add dependency on Twig

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -19,7 +19,8 @@
         "php": ">=5.3.9",
         "symfony/http-kernel": "~2.4",
         "symfony/routing": "~2.2",
-        "symfony/twig-bridge": "~2.7"
+        "symfony/twig-bridge": "~2.7",
+        "twig/twig": "~1.28|~2.0"
     },
     "require-dev": {
         "symfony/config": "~2.2",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20802
| License       | MIT
| Doc PR        | 

Requiring a specific minimum version of the TwigBridge just to be sure
that we end up with the required Twig version does not make much sense
if can simply specify the required version instead (we do in fact depend
on Twig in the WebProfilerBundle).