### PR TITLE
[Console] fixed BC issue with static closures

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -283,8 +283,15 @@ class Command
         if (PHP_VERSION_ID >= 50400 && $code instanceof \Closure) {
             $r = new \ReflectionFunction($code);
             if (null === $r->getClosureThis()) {
-                // Cannot bind static closures for PHP<7.0 so it may fail
-                $code = @\Closure::bind($code, $this);
+                if (PHP_VERSION_ID < 70000) {
+                    // Bug in PHP5: https://bugs.php.net/bug.php?id=64761
+                    // This means that we cannot bind static closures and therefore we must
+                    // ignore any errors here.  There is no way to test if the closure is
+                    // bindable.
+                    $code = @\Closure::bind($code, $this);
+                } else {
+                    $code = \Closure::bind($code, $this);
+                }
             }
         }
 

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -283,7 +283,8 @@ class Command
         if (PHP_VERSION_ID >= 50400 && $code instanceof \Closure) {
             $r = new \ReflectionFunction($code);
             if (null === $r->getClosureThis()) {
-                $code = \Closure::bind($code, $this);
+                // Cannot bind static closures for PHP<7.0 so it may fail
+                $code = @\Closure::bind($code, $this);
             }
         }
 

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -335,6 +335,29 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('interact called'.PHP_EOL.$expected.PHP_EOL, $tester->getDisplay());
     }
 
+    public function testSetCodeWithStaticClosure()
+    {
+        $command = new \TestCommand();
+        $command->setCode(self::createClosure());
+        $tester = new CommandTester($command);
+        $tester->execute(array());
+
+        if (version_compare(phpversion(), '7.0.0', '<')) {
+            // Cannot bind static closures in PHP 5
+            $this->assertEquals('interact called'.PHP_EOL.'not bound'.PHP_EOL, $tester->getDisplay());
+        } else {
+            // Can bind static closures in PHP 7
+            $this->assertEquals('interact called'.PHP_EOL.'bound'.PHP_EOL, $tester->getDisplay());
+        }
+    }
+
+    private static function createClosure()
+    {
+        return function (InputInterface $input, OutputInterface $output) {
+            $output->writeln(isset($this) ? 'bound' : 'not bound');
+        };
+    }
+
     public function testSetCodeWithNonClosureCallable()
     {
         $command = new \TestCommand();

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -342,7 +342,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $tester = new CommandTester($command);
         $tester->execute(array());
 
-        if (version_compare(phpversion(), '7.0.0', '<')) {
+        if (PHP_VERSION_ID < 70000) {
             // Cannot bind static closures in PHP 5
             $this->assertEquals('interact called'.PHP_EOL.'not bound'.PHP_EOL, $tester->getDisplay());
         } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20845
| License       | MIT
| Doc PR        | n/a

Static closures were unable to be used in Command::setCode since #14431.  This change fixes the BC break and ensures static closures can still be used.

Edit: It seems the inability to bind static closures was considered a feature in PHP5 but was considered a bug by PHP7.  As such, the tests need to work around this fact - but the code can remain the same.  This code change can be tidied/removed once Symfony is PHP7+ only.

Discussion here:
https://bugs.php.net/bug.php?id=64761
https://bugs.php.net/bug.php?id=68792