### PR TITLE
Write an exception message in a one heading line

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/exception.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/exception.html.twig
@@ -8,9 +8,7 @@
                 <img alt="" src="data:image/gif;base64,R0lGODlhHAAWAMQQANra2+bl5s3Mzevr6/Pz8+jo6O3t7fHx8c/Oz+Pj49PS093d3djX2NXV1eDf4MrJyvb29gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAEAABAALAAAAAAcABYAQAWWICSOEDE4AamqRuAsT5yu6hA/wNrcfNysjl5PBOAJAAUDDRLoNRKDndAHnN6k058qaH2QuNelqCAYIm45MfGmIJCkAvUIPNB1td/uAyvEz/UqB0VUagQOZTEjgzx+Kk1CEAU8DAdqB4gPCHVjNwhucphKbzefamAFdlaNEGBZd1V3r1t6fE6wqrJ5XS4Ovb69MyQnv8QhADs=" />
             </div>
 
-            <h1>
-                {{ exception.message|nl2br|format_file_from_text }}
-            </h1>
+            <h1>{{ exception.message|nl2br|format_file_from_text }}</h1>
 
             <div>
                 <strong>{{ status_code }}</strong> {{ status_text }} - {{ exception.class|abbr_class }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

It allows quickly `grep`-ing exception messages in console, for example:

```bash
curl localhost/any-path-which-throws-uncaught-exception | grep '<h1>'
```

But it's impossible to use `grep` filter when exception message goes on the next line after `<h1>` tag.