### PR TITLE
[BC Break][Validation] Revert #19388

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -308,7 +308,6 @@ class ClassMetadata extends GenericMetadata implements ClassMetadataInterface
                 $member = clone $member;
 
                 foreach ($member->getConstraints() as $constraint) {
-                    $member->constraintsByGroup[$this->getDefaultGroup()][] = $constraint;
                     $constraint->addImplicitGroupName($this->getDefaultGroup());
                 }
 

--- a/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
@@ -153,26 +153,11 @@ class ClassMetadataTest extends \PHPUnit_Framework_TestCase
             $constraintA2,
         );
 
-        $constraintsByGroup = array(
-            'Default' => array(
-                $constraintA1,
-                $constraintA2,
-            ),
-            'EntityParent' => array(
-                $constraintA1,
-            ),
-            'Entity' => array(
-                $constraintA1,
-                $constraintA2,
-            ),
-        );
-
         $members = $this->metadata->getPropertyMetadata('firstName');
 
         $this->assertCount(1, $members);
         $this->assertEquals(self::PARENTCLASS, $members[0]->getClassName());
         $this->assertEquals($constraints, $members[0]->getConstraints());
-        $this->assertEquals($constraintsByGroup, $members[0]->constraintsByGroup);
     }
 
     public function testMemberMetadatas()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20853
| License       | MIT
| Doc PR        | -

I recommend to revert #19388 in order to fix a BC break introduced therefore. 

Looking at #19387 it looks like there might be a misunderstanding of the validation groups.

I had a intense discussion with Bernhard here https://github.com/symfony/symfony/issues/11880 about the validation groups. Also I proposed a dynamic validation solution here https://github.com/symfony/symfony/pull/16984.

I think in order to solve #19387 only this might be needed:

````
/**
 * @Assert\ParentClassConstraint()
 */
class Parent
{
    /**
    * @Assert\NotNull()
    */
    protected $property;
}

/**
 * @Assert\ChildClassConstraint()
 * @Assert\GroupSequence({"Parent", "Child", "Extra"})
 */
class Child extends Parent
{
   /**
    * @Assert\NotNull(groups={"Extra"})
    */
    private $anotherProperty;
}
````

Also it looks like a good use case for my Dynamic Validation Group as I think in many cases you do not want a sequential validation you want to see the validation result of all groups right away.

For more information about validation groups see https://symfony.com/doc/current/validation/groups.html