### PR TITLE
Avoid warning in PHP 7.2 because of non-countable data

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -748,7 +748,7 @@ class Form implements \IteratorAggregate, FormInterface
 
         return FormUtil::isEmpty($this->modelData) ||
             // arrays, countables
-            0 === count($this->modelData) ||
+            ((is_array($this->modelData) || $this->modelData instanceof \Countable) && 0 === count($this->modelData)) ||
             // traversables that are not countable
             ($this->modelData instanceof \Traversable && 0 === iterator_count($this->modelData));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Recently, the "[Counting of non-countable objects][1]" RFC was merged in PHP 7.2-dev. This means `count()` now causes a warning when passing anything that's not countable (e.g. `null` or `''`).

As PHP does not lazily execute conditions, `FormUtil::isEmtpy($data) || 0 === count($data)` will cause *both* conditions to be executed. This means `count($data)` errors when `$data` is empty.

Splitting it up in 2 statements avoids the warning being triggered in PHP 7.2.

See https://travis-ci.org/symfony-cmf/content-bundle/jobs/181815895 for a failing test caused by this bug.

 [1]: https://wiki.php.net/rfc/counting_non_countables