### PR TITLE
[WebProfilerBundle] Fix a web profiler form issue with fields added to the form after the form was built

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
@@ -457,7 +457,7 @@
     {% import _self as tree %}
     <div class="tree-details{% if not show|default(false) %} hidden{% endif %}" {% if data.id is defined %}id="{{ data.id }}-details"{% endif %}>
         <h2 class="dump-inline">
-            {{ name|default('(no name)') }} ({{ profiler_dump(data.type_class) }})
+            {{ name|default('(no name)') }} {% if data.type_class is defined %}({{ profiler_dump(data.type_class) }}){% endif %}
         </h2>
 
         {% if data.errors is defined and data.errors|length > 0 %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20823
| License       | MIT
| Doc PR        | -

I discovered a bug in 3.2 in the web profiler and this PR fixes it. This issue has been fixed in the past by https://github.com/symfony/symfony/pull/13166 and probably reintroduced by the refactoring we did in the WebProfiler in 3.2. I simply applied the fix to these changes.

To reproduce the original problem, simply clone the current standard edition, create a Form with a Type and add a field after its creation. Once done, try to access the Webprofiler: it will fails with the following error:

> Key "type_class" for array with keys "id, name, view_vars, children" does not exist in @WebProfiler/Collector/form.html.twig at line 460.