### PR TITLE
Add a --show-arguments flag to the debug:container command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -44,6 +44,7 @@ class ContainerDebugCommand extends ContainerAwareCommand
             ->setDefinition(array(
                 new InputArgument('name', InputArgument::OPTIONAL, 'A service name (foo)'),
                 new InputOption('show-private', null, InputOption::VALUE_NONE, 'Used to show public *and* private services'),
+                new InputOption('show-arguments', null, InputOption::VALUE_NONE, 'Used to show arguments in services'),
                 new InputOption('tag', null, InputOption::VALUE_REQUIRED, 'Shows all services with a specific tag'),
                 new InputOption('tags', null, InputOption::VALUE_NONE, 'Displays tagged services for an application'),
                 new InputOption('parameter', null, InputOption::VALUE_REQUIRED, 'Displays a specific parameter for an application'),
@@ -118,6 +119,7 @@ EOF
 
         $helper = new DescriptorHelper();
         $options['format'] = $input->getOption('format');
+        $options['show_arguments'] = $input->getOption('show-arguments');
         $options['raw_text'] = $input->getOption('raw');
         $options['output'] = $io;
         $helper->describe($output, $object, $options);

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -129,6 +129,7 @@ class MarkdownDescriptor extends Descriptor
 
         $serviceIds = isset($options['tag']) && $options['tag'] ? array_keys($builder->findTaggedServiceIds($options['tag'])) : $builder->getServiceIds();
         $showPrivate = isset($options['show_private']) && $options['show_private'];
+        $showArguments = isset($options['show_arguments']) && $options['show_arguments'];
         $services = array('definitions' => array(), 'aliases' => array(), 'services' => array());
 
         foreach ($this->sortServiceIds($serviceIds) as $serviceId) {
@@ -149,7 +150,7 @@ class MarkdownDescriptor extends Descriptor
             $this->write("\n\nDefinitions\n-----------\n");
             foreach ($services['definitions'] as $id => $service) {
                 $this->write("\n");
-                $this->describeContainerDefinition($service, array('id' => $id));
+                $this->describeContainerDefinition($service, array('id' => $id, 'show_arguments' => $showArguments));
             }
         }
 
@@ -193,6 +194,10 @@ class MarkdownDescriptor extends Descriptor
             foreach ($definition->getAutowiringTypes() as $autowiringType) {
                 $output .= "\n".'- Autowiring Type: `'.$autowiringType.'`';
             }
+        }
+
+        if (isset($options['show_arguments']) && $options['show_arguments']) {
+            $output .= "\n".'- Arguments: '.($definition->getArguments() ? 'yes' : 'no');
         }
 
         if ($definition->getFile()) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTest.php
@@ -197,6 +197,7 @@ abstract class AbstractDescriptorTest extends \PHPUnit_Framework_TestCase
             'public' => array('show_private' => false),
             'tag1' => array('show_private' => true, 'tag' => 'tag1'),
             'tags' => array('group_by' => 'tags', 'show_private' => true),
+            'arguments' => array('show_private' => false, 'show_arguments' => true),
         );
 
         $data = array();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
@@ -105,6 +105,9 @@ class ObjectsProvider
                 ->setSynthetic(false)
                 ->setLazy(true)
                 ->setAbstract(true)
+                ->addArgument(new Reference('definition2'))
+                ->addArgument('%parameter%')
+                ->addArgument(new Definition('inline_service', array('arg1', 'arg2')))
                 ->setFactory(array('Full\\Qualified\\FactoryClass', 'get')),
             'definition_2' => $definition2
                 ->setPublic(false)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.json
@@ -1,0 +1,56 @@
+{
+    "definitions": {
+        "definition_1": {
+            "class": "Full\\Qualified\\Class1",
+            "public": true,
+            "synthetic": false,
+            "lazy": true,
+            "shared": true,
+            "abstract": true,
+            "file": null,
+            "factory_class": "Full\\Qualified\\FactoryClass",
+            "factory_method": "get",
+            "tags": [
+
+            ],
+            "autowire": false,
+            "autowiring_types": [],
+            "arguments": [
+                {
+                    "type": "service",
+                    "id": "definition2"
+                },
+                "%parameter%",
+                {
+                    "class": "inline_service",
+                    "public": true,
+                    "synthetic": false,
+                    "lazy": false,
+                    "shared": true,
+                    "abstract": false,
+                    "autowire": false,
+                    "autowiring_types": [],
+                    "arguments": [
+                        "arg1",
+                        "arg2"
+                    ],
+                    "file": null,
+                    "tags": []
+                }
+            ]
+        }
+    },
+    "aliases": {
+        "alias_1": {
+            "service": "service_1",
+            "public": true
+        },
+        "alias_2": {
+            "service": "service_2",
+            "public": false
+        }
+    },
+    "services": {
+        "service_container": "Symfony\\Component\\DependencyInjection\\ContainerBuilder"
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.md
@@ -1,0 +1,41 @@
+Public services
+===============
+
+Definitions
+-----------
+
+definition_1
+~~~~~~~~~~~~
+
+- Class: `Full\Qualified\Class1`
+- Public: yes
+- Synthetic: no
+- Lazy: yes
+- Shared: yes
+- Abstract: yes
+- Autowired: no
+- Arguments: yes
+- Factory Class: `Full\Qualified\FactoryClass`
+- Factory Method: `get`
+
+
+Aliases
+-------
+
+alias_1
+~~~~~~~
+
+- Service: `service_1`
+- Public: yes
+
+alias_2
+~~~~~~~
+
+- Service: `service_2`
+- Public: no
+
+
+Services
+--------
+
+- `service_container`: `Symfony\Component\DependencyInjection\ContainerBuilder`

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.txt
@@ -1,0 +1,13 @@
+
+[33mSymfony Container Public Services[39m
+[33m=================================[39m
+
+ ------------------- -------------------------------------------------------- 
+ [32m Service ID        [39m [32m Class name                                             [39m 
+ ------------------- -------------------------------------------------------- 
+  alias_1             alias for "service_1"                                   
+  alias_2             alias for "service_2"                                   
+  definition_1        Full\Qualified\Class1                                   
+  service_container   Symfony\Component\DependencyInjection\ContainerBuilder  
+ ------------------- -------------------------------------------------------- 
+

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container>
+  <alias id="alias_1" service="service_1" public="true"/>
+  <alias id="alias_2" service="service_2" public="false"/>
+  <definition id="definition_1" class="Full\Qualified\Class1" public="true" synthetic="false" lazy="true" shared="true" abstract="true" autowired="false" file="">
+    <factory class="Full\Qualified\FactoryClass" method="get"/>
+    <argument type="service" id="definition2"/>
+    <argument>%parameter%</argument>
+    <argument>
+      <definition class="inline_service" public="true" synthetic="false" lazy="false" shared="true" abstract="false" autowired="false" file="">
+        <argument>arg1</argument>
+        <argument>arg2</argument>
+      </definition>
+    </argument>
+  </definition>
+  <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerBuilder"/>
+</container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | not yet

This PR adds a `--show-arguments` flag to the `debug:container` command that shows arguments in the services in the different available formats.

(Ping @dunglas)
