### PR TITLE
[BrowserKit] fix #20306 add a way to unset server parameter

### DIFF
--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -139,6 +139,16 @@ abstract class Client
     }
 
     /**
+     * Unset single server parameter.
+     *
+     * @param string $key A key of the parameter
+     */
+    public function unSetServerParameter($key)
+    {
+        unset($this->server[$key]);
+    }
+
+    /**
      * Gets single server parameter for specified key.
      *
      * @param string $key     A key of the parameter to get

--- a/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
@@ -624,28 +624,14 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     {
         $client = new TestClient();
 
-        $this->assertSame('', $client->getServerParameter('HTTP_HOST'));
-        $this->assertSame('Symfony BrowserKit', $client->getServerParameter('HTTP_USER_AGENT'));
-
-        $client->setServerParameter('HTTP_HOST', 'testhost');
-        $client->unSetServerParameter('HTTP_HOST');
-
-        $this->assertSame('', $client->getServerParameter('HTTP_HOST'));
-
-        $client->setServerParameter('HTTP_USER_AGENT', 'testua');
-        $client->unSetServerParameter('HTTP_USER_AGENT');
-
-        $this->assertSame('', $client->getServerParameter('HTTP_USER_AGENT'));
-
         $client->setServerParameter('HTTP_X-Requested-With', 'XMLHttpRequest');
+
+        $this->assertSame('XMLHttpRequest', $client->getServerParameter('HTTP_X-Requested-With'));
+
         $client->unSetServerParameter('HTTP_X-Requested-With');
-
-        $client->unSetServerParameter('HTTP_X-fefef-With');
-
-        $client->request('GET', 'https://www.example.com/https/www.example.com', array(), array());
+        $client->request('GET', 'https://www.example.com/https/www.example.com');
 
         $this->assertSame('', $client->getServerParameter('HTTP_X-Requested-With'));
-
         $this->assertArrayNotHasKey('HTTP_X-Requested-With', $client->getInternalRequest()->getServer());
     }
 

--- a/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
@@ -620,6 +620,35 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('testua', $client->getServerParameter('HTTP_USER_AGENT'));
     }
 
+    public function testUnSetServerParameter()
+    {
+        $client = new TestClient();
+
+        $this->assertSame('', $client->getServerParameter('HTTP_HOST'));
+        $this->assertSame('Symfony BrowserKit', $client->getServerParameter('HTTP_USER_AGENT'));
+
+        $client->setServerParameter('HTTP_HOST', 'testhost');
+        $client->unSetServerParameter('HTTP_HOST');
+
+        $this->assertSame('', $client->getServerParameter('HTTP_HOST'));
+
+        $client->setServerParameter('HTTP_USER_AGENT', 'testua');
+        $client->unSetServerParameter('HTTP_USER_AGENT');
+
+        $this->assertSame('', $client->getServerParameter('HTTP_USER_AGENT'));
+
+        $client->setServerParameter('HTTP_X-Requested-With', 'XMLHttpRequest');
+        $client->unSetServerParameter('HTTP_X-Requested-With');
+
+        $client->unSetServerParameter('HTTP_X-fefef-With');
+
+        $client->request('GET', 'https://www.example.com/https/www.example.com', array(), array());
+
+        $this->assertSame('', $client->getServerParameter('HTTP_X-Requested-With'));
+
+        $this->assertArrayNotHasKey('HTTP_X-Requested-With', $client->getInternalRequest()->getServer());
+    }
+
     public function testSetServerParameterInRequest()
     {
         $client = new TestClient();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20306
| License       | MIT
| Doc PR        | will need one if validated

