### PR TITLE
[FrameworkBundle] Alias cache.app_clearer to cache.global_clearer

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.xml
@@ -98,7 +98,7 @@
         </service>
 
         <service id="cache.global_clearer" parent="cache.default_clearer" />
-        <service id="cache.app_clearer" alias="cache.default_clearer" />
+        <service id="cache.app_clearer" alias="cache.global_clearer" />
 
     </services>
 </container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Suggested by @ogizanagi.
So calling `@cache.app_clearer->clear()` clear all the pools of the application, including ones which have a custom clearer. I think it makes sense, though I'm not sure of the drawbacks it could have