### PR TITLE
Minor fixes for 3.2

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/WorkflowDumpCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/WorkflowDumpCommand.php
@@ -17,7 +17,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Workflow\Dumper\GraphvizDumper;
 use Symfony\Component\Workflow\Dumper\StateMachineGraphvizDumper;
 use Symfony\Component\Workflow\Marking;
-use Symfony\Component\Workflow\Workflow;
 
 /**
  * @author Grégoire Pineau <lyrixx@lyrixx.info>

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -137,7 +137,7 @@ abstract class Controller implements ContainerAwareInterface
     protected function file($file, $fileName = null, $disposition = ResponseHeaderBag::DISPOSITION_ATTACHMENT)
     {
         $response = new BinaryFileResponse($file);
-        $response->setContentDisposition($disposition, $fileName === null ? $response->getFile()->getFileName() : $fileName);
+        $response->setContentDisposition($disposition, $fileName === null ? $response->getFile()->getFilename() : $fileName);
 
         return $response;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -20,7 +20,6 @@ use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\ProxyAdapter;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Loader\ClosureLoader;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;

--- a/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
@@ -30,7 +30,7 @@ class TagAwareAdapterTest extends AdapterTestCase
     }
 
     /**
-     * @expectedException Psr\Cache\InvalidArgumentException
+     * @expectedException \Psr\Cache\InvalidArgumentException
      */
     public function testInvalidTag()
     {

--- a/src/Symfony/Component/Cache/Tests/CacheItemTest.php
+++ b/src/Symfony/Component/Cache/Tests/CacheItemTest.php
@@ -65,7 +65,7 @@ class CacheItemTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider provideInvalidKey
-     * @expectedException Symfony\Component\Cache\Exception\InvalidArgumentException
+     * @expectedException \Symfony\Component\Cache\Exception\InvalidArgumentException
      * @expectedExceptionMessage Cache tag
      */
     public function testInvalidTag($tag)

--- a/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Console\Tests\Style;
 
 use PHPUnit_Framework_TestCase;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class SymfonyStyleTest extends PHPUnit_Framework_TestCase

--- a/src/Symfony/Component/Serializer/Encoder/YamlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/YamlEncoder.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Serializer\Encoder;
 
 use Symfony\Component\Yaml\Dumper;
 use Symfony\Component\Yaml\Parser;
-use Symfony\Component\Yaml\Yaml;
 
 /**
  * Encodes YAML data.

--- a/src/Symfony/Component/VarDumper/Caster/StubCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/StubCaster.php
@@ -31,8 +31,8 @@ class StubCaster
             $stub->attr = $c->attr;
 
             if (Stub::TYPE_REF === $c->type && !$c->class && is_string($c->value) && !preg_match('//u', $c->value)) {
-                $stub->type = self::TYPE_STRING;
-                $stub->class = self::STRING_BINARY;
+                $stub->type = Stub::TYPE_STRING;
+                $stub->class = Stub::STRING_BINARY;
             }
 
             return array();

--- a/src/Symfony/Component/Workflow/Tests/StateMachineTest.php
+++ b/src/Symfony/Component/Workflow/Tests/StateMachineTest.php
@@ -2,7 +2,6 @@
 
 namespace Symfony\Component\Workflow\Tests;
 
-use Symfony\Component\Workflow\Marking;
 use Symfony\Component\Workflow\StateMachine;
 
 class StateMachineTest extends \PHPUnit_Framework_TestCase


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

This only fix minor issues in the codebase introduced in 3.2.

Refs:

- YamlEncoder https://github.com/symfony/symfony/commit/9366a7dc774299cdeb722f61349525f5b717e92c

- File helper: https://github.com/symfony/symfony/commit/d9a84990cf78a670b12ee6969e6c5a2a7e9a11ed

- VarDumper ClassStub: https://github.com/symfony/symfony/commit/788f7e84b0590f68f1facf14b5e1bba5589f8db1

- Cache tag based invalidation https://github.com/symfony/symfony/commit/19764af74f3412c5008790a9cc1deb1a7eeb8062

- CacheWarmer for Serializer: https://github.com/symfony/symfony/commit/810f4694af7b4a6562a9a656f11845b7dcbbfdd0

- SymfonyStyle simplified test: https://github.com/symfony/symfony/commit/85e5060fa136e39d4de491041e49fe4aeb9207f3

- Workflow Definition builder: https://github.com/symfony/symfony/commit/ffaeba39fc0013539be4bd969e29540b1817dceb

---

There are other issues in older branches, but I guess it's not worth it for them, as it'll only add more conflicts. But for 3.2, it should be feasible.