### PR TITLE
[HttpKernel] Give higher priority to adding request formats

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/AddRequestFormatsListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AddRequestFormatsListener.php
@@ -52,6 +52,6 @@ class AddRequestFormatsListener implements EventSubscriberInterface
      */
     public static function getSubscribedEvents()
     {
-        return array(KernelEvents::REQUEST => 'onKernelRequest');
+        return array(KernelEvents::REQUEST => array('onKernelRequest', 255));
     }
 }

--- a/src/Symfony/Component/HttpKernel/EventListener/AddRequestFormatsListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AddRequestFormatsListener.php
@@ -52,6 +52,6 @@ class AddRequestFormatsListener implements EventSubscriberInterface
      */
     public static function getSubscribedEvents()
     {
-        return array(KernelEvents::REQUEST => array('onKernelRequest', 255));
+        return array(KernelEvents::REQUEST => array('onKernelRequest', 1));
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/AddRequestFormatsListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/AddRequestFormatsListenerTest.php
@@ -45,7 +45,7 @@ class AddRequestFormatsListenerTest extends \PHPUnit_Framework_TestCase
     public function testRegisteredEvent()
     {
         $this->assertEquals(
-            array(KernelEvents::REQUEST => 'onKernelRequest'),
+            array(KernelEvents::REQUEST => array('onKernelRequest', 1)),
             AddRequestFormatsListener::getSubscribedEvents()
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | yes (unlikely to break projects*)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | not documented

\* Only applies to the unlikely case where formats are used before this event is loaded key. Users must have specified custom formats, and actually using them should then break their application. I think that's an unlikely case.

## Problem
It's possible to extend the formats known by the `Request` using a piece of config:
```yaml
framework:
    request:
        formats:
            json: 'application/merge-patch+json'
```

Using this in a `kernel.request` event is currently not possible, as it loads after any custom events. 

## Offered solution
Increasing the priority of the AddRequestFormatsListener listener resolves this problem.
This change only impacts projects that use the `framework.request.formats` configuration key, as the listener is not loaded if it isn't defined.