### PR TITLE
DateIntervalType: 'invert' should not inherit the 'required' option

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/DateIntervalType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateIntervalType.php
@@ -107,9 +107,6 @@ class DateIntervalType extends AbstractType
                     }
                 }
             }
-            $invertOptions = array(
-                'error_bubbling' => true,
-            );
             // Append generic carry-along options
             foreach (array('required', 'translation_domain') as $passOpt) {
                 foreach ($this->timeParts as $part) {
@@ -117,10 +114,8 @@ class DateIntervalType extends AbstractType
                         $childOptions[$part][$passOpt] = $options[$passOpt];
                     }
                 }
-                if ($options['with_invert']) {
-                    $invertOptions[$passOpt] = $options[$passOpt];
-                }
             }
+
             foreach ($this->timeParts as $part) {
                 if ($options['with_'.$part]) {
                     $childForm = $builder->create($part, self::$widgets[$options['widget']], $childOptions[$part]);
@@ -134,10 +129,12 @@ class DateIntervalType extends AbstractType
                     $builder->add($childForm);
                 }
             }
-            // Invert should not inherit the required option
-            $invertOptions['required'] = false;
             if ($options['with_invert']) {
-                $builder->add('invert', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', $invertOptions);
+                $builder->add('invert', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
+                    'error_bubbling' => true,
+                    'required' => false,
+                    'translation_domain' => $options['translation_domain'],
+                ));
             }
             $builder->addViewTransformer(new DateIntervalToArrayTransformer($parts, 'text' === $options['widget']));
         }

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateIntervalType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateIntervalType.php
@@ -134,6 +134,8 @@ class DateIntervalType extends AbstractType
                     $builder->add($childForm);
                 }
             }
+            // Invert should not inherit the required option
+            $invertOptions['required'] = false;
             if ($options['with_invert']) {
                 $builder->add('invert', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', $invertOptions);
             }

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateIntervalType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateIntervalType.php
@@ -115,7 +115,6 @@ class DateIntervalType extends AbstractType
                     }
                 }
             }
-
             foreach ($this->timeParts as $part) {
                 if ($options['with_'.$part]) {
                     $childForm = $builder->create($part, self::$widgets[$options['widget']], $childOptions[$part]);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateIntervalTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateIntervalTypeTest.php
@@ -364,4 +364,18 @@ class DateIntervalTypeTest extends TestCase
         $this->assertSame(array(), iterator_to_array($form['years']->getErrors()));
         $this->assertSame(array($error), iterator_to_array($form->getErrors()));
     }
+
+    public function testInvertDoesNotInheritRequiredOption()
+    {
+        $form = $this->factory->create(
+            'Symfony\Component\Form\Extension\Core\Type\DateIntervalType',
+            null,
+            array(
+                'input' => 'dateinterval',
+                'with_invert' => true,
+                'required' => true,
+            )
+        );
+        $this->assertFalse($form->get('invert')->getConfig()->getOption('required'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20876
| License       | MIT
| Doc PR        | -

As explained in #20876, 

> In the DateIntervalType, there is a field, called 'invert', that allows for negative intervals. This is outputted as a checkbox. Which is fine, but it shouldn't be required.

