### PR TITLE
[VarDumper] Add SymfonyCaster::castRequest()

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/SymfonyCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/SymfonyCaster.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Caster;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\VarDumper\Cloner\Stub;
+
+class SymfonyCaster
+{
+    private static $requestGetters = array(
+        'pathInfo' => 'getPathInfo',
+        'requestUri' => 'getRequestUri',
+        'baseUrl' => 'getBaseUrl',
+        'basePath' => 'getBasePath',
+        'method' => 'getMethod',
+        'format' => 'getRequestFormat',
+    );
+
+    public static function castRequest(Request $request, array $a, Stub $stub, $isNested)
+    {
+        $clone = null;
+
+        foreach (self::$requestGetters as $prop => $getter) {
+            if (null === $a[Caster::PREFIX_PROTECTED.$prop]) {
+                if (null === $clone) {
+                    $clone = clone $request;
+                }
+                $a[Caster::PREFIX_VIRTUAL.$prop] = $clone->{$getter}();
+            }
+        }
+
+        return $a;
+    }
+}

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -75,6 +75,7 @@ abstract class AbstractCloner implements ClonerInterface
         'Exception' => 'Symfony\Component\VarDumper\Caster\ExceptionCaster::castException',
         'Error' => 'Symfony\Component\VarDumper\Caster\ExceptionCaster::castError',
         'Symfony\Component\DependencyInjection\ContainerInterface' => 'Symfony\Component\VarDumper\Caster\StubCaster::cutInternals',
+        'Symfony\Component\HttpFoundation\Request' => 'Symfony\Component\VarDumper\Caster\SymfonyCaster::castRequest',
         'Symfony\Component\VarDumper\Exception\ThrowingCasterException' => 'Symfony\Component\VarDumper\Caster\ExceptionCaster::castThrowingCasterException',
         'Symfony\Component\VarDumper\Caster\TraceStub' => 'Symfony\Component\VarDumper\Caster\ExceptionCaster::castTraceStub',
         'Symfony\Component\VarDumper\Caster\FrameStub' => 'Symfony\Component\VarDumper\Caster\ExceptionCaster::castFrameStub',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Because these properties are lazily initialized.