### PR TITLE
[Finder] Deprecate ExceptionInterface

### DIFF
--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -7,6 +7,11 @@ ClassLoader
  * The ApcClassLoader, WinCacheClassLoader and XcacheClassLoader classes have been deprecated
    in favor of the `--apcu-autoloader` option introduced in composer 1.3
 
+Finder
+------
+
+ * The `ExceptionInterface` has been deprecated and will be removed in 4.0.
+
 Security
 --------
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -43,6 +43,11 @@ ExpressionLanguage
    class has been removed. You should use the `CacheItemPoolInterface` interface
    instead.
 
+Finder
+------
+
+ * The `ExceptionInterface` has been removed.
+
 Form
 ----
 

--- a/src/Symfony/Component/Finder/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/Finder/Exception/ExceptionInterface.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Finder\Exception;
 
 /**
  * @author Jean-François Simon <contact@jfsimon.fr>
+ *
+ * @deprecated since 3.3, to be removed in 4.0.
  */
 interface ExceptionInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

This interface was missed in https://github.com/symfony/symfony/pull/15805, and should have been removed in 3.0.

Ideally, the component should have such an interface, though, as other components does. But the only domain exception in this component is an `AccessDeniedException` used by the `RecursiveDirectoryIterator`. So it isn't worth it right now.

I think this interface was almost internal actually, but anyway the `\Symfony\Component\Finder\Adapter\AdapterInterface` interface does not exist anymore. So the `ExceptionInterface::getAdapter()` signature cannot be satisfied anyway. I guess anyone relying on this interface in any way should have notice that and removed anything related to Symfony Finder's adapters when upgrading to 3.0.
Should we consider removing it directly in the 3.1 branch instead?

