### PR TITLE
[Form] DateIntervalType: Do not try to translate choices

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/DateIntervalType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateIntervalType.php
@@ -102,6 +102,7 @@ class DateIntervalType extends AbstractType
                     $childOptions[$part] = array();
                     $childOptions[$part]['error_bubbling'] = true;
                     if ('choice' === $options['widget']) {
+                        $childOptions[$part]['choice_translation_domain'] = false;
                         $childOptions[$part]['choices'] = $options[$part];
                         $childOptions[$part]['placeholder'] = $options['placeholder'][$part];
                     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateIntervalTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateIntervalTypeTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use Symfony\Component\Form\Extension\Core\Type\DateIntervalType;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\Test\TypeTestCase as TestCase;
 
@@ -363,5 +364,24 @@ class DateIntervalTypeTest extends TestCase
         $form['years']->addError($error);
         $this->assertSame(array(), iterator_to_array($form['years']->getErrors()));
         $this->assertSame(array($error), iterator_to_array($form->getErrors()));
+    }
+    public function testTranslationsAreDisabledForChoiceWidget()
+    {
+        $form = $this->factory->create(
+            DateIntervalType::class,
+            null,
+            array(
+                'widget' => 'choice',
+                'with_hours' => true,
+                'with_minutes' => true,
+                'with_seconds' => true,
+            )
+        );
+        $this->assertFalse($form->get('years')->getConfig()->getOption('choice_translation_domain'));
+        $this->assertFalse($form->get('months')->getConfig()->getOption('choice_translation_domain'));
+        $this->assertFalse($form->get('days')->getConfig()->getOption('choice_translation_domain'));
+        $this->assertFalse($form->get('hours')->getConfig()->getOption('choice_translation_domain'));
+        $this->assertFalse($form->get('minutes')->getConfig()->getOption('choice_translation_domain'));
+        $this->assertFalse($form->get('seconds')->getConfig()->getOption('choice_translation_domain'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

When using choice widgets, the form type should not try to translate each options, otherwise, you'll get something like this:

<img width="150" alt="screenshot 2016-12-12 a 23 37 09" src="https://cloud.githubusercontent.com/assets/2211145/21119721/25411620-c0c4-11e6-9848-95393d1d21c4.PNG">
<img width="1075" alt="screenshot 2016-12-12 a 23 37 23" src="https://cloud.githubusercontent.com/assets/2211145/21119722/2543ccf8-c0c4-11e6-9842-ae84dc895a0b.PNG">
 

