### PR TITLE
[Console] MarkdownDescriptor: Strip tags in app headers

### DIFF
--- a/src/Symfony/Component/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/MarkdownDescriptor.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Console\Descriptor;
 
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
@@ -122,8 +123,9 @@ class MarkdownDescriptor extends Descriptor
     {
         $describedNamespace = isset($options['namespace']) ? $options['namespace'] : null;
         $description = new ApplicationDescription($application, $describedNamespace);
+        $longVersion = strip_tags($application->getLongVersion());
 
-        $this->write($application->getLongVersion()."\n".str_repeat('=', strlen($application->getLongVersion())));
+        $this->write($longVersion."\n".str_repeat('=', Helper::strlen($longVersion)));
 
         foreach ($description->getNamespaces() as $namespace) {
             if (ApplicationDescription::GLOBAL_NAMESPACE !== $namespace['id']) {

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.md
@@ -1,5 +1,5 @@
-My Symfony application <info>v1.0</info>
-========================================
+My Symfony application v1.0
+===========================
 
 * `alias1`
 * `alias2`


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes, should not output tags
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20866 
| License       | MIT
| Doc PR        | N/A

For instance, with the Symfony demo:

```diff
- Symfony <info>3.3.0-DEV</info> (kernel: <comment>app</>, env: <comment>dev</>, debug: <comment>true</>)
- =======================================================================================================

+ Symfony 3.3.0-DEV (kernel: app, env: dev, debug: true)
+ ======================================================

```