### PR TITLE
[HttpKernel] Fix missing psr/cache dev requirement

### DIFF
--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -37,7 +37,8 @@
         "symfony/stopwatch": "~2.8|~3.0",
         "symfony/templating": "~2.8|~3.0",
         "symfony/translation": "~2.8|~3.0",
-        "symfony/var-dumper": "~3.2"
+        "symfony/var-dumper": "~3.2",
+        "psr/cache": "~1.0"
     },
     "conflict": {
         "symfony/config": "<2.8"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes, tests are broken
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Because #20810 added a test for the `Psr6CacheClearer` that mocks methods of the `CacheItemPoolInterface`. It should fix the travis build on master and deps=low