### PR TITLE
[TwigBundle] Config is now a hard dependency

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
+        "symfony/config": "~3.2",
         "symfony/twig-bridge": "^3.2.1",
         "symfony/http-foundation": "~2.8|~3.0",
         "symfony/http-kernel": "~2.8|~3.0",
@@ -27,7 +28,6 @@
         "symfony/stopwatch": "~2.8|~3.0",
         "symfony/dependency-injection": "~2.8|~3.0",
         "symfony/expression-language": "~2.8|~3.0",
-        "symfony/config": "~3.2",
         "symfony/finder": "~2.8|~3.0",
         "symfony/routing": "~2.8|~3.0",
         "symfony/templating": "~2.8|~3.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

TwigBundle now has a hard dependency to the config component: https://github.com/symfony/twig-bundle/blob/3.2/DependencyInjection/Compiler/ExtensionPass.php#L85

It breaks API Platform builds: https://travis-ci.org/api-platform/core/jobs/183638888

