### PR TITLE
[FrameworkBundle] Fix misresolved parameters in debug:config

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDebugCommand.php
@@ -83,7 +83,7 @@ EOF
         $configs = $container->resolveEnvPlaceholders($container->getParameterBag()->resolveValue($configs));
 
         $processor = new Processor();
-        $config = $processor->processConfiguration($configuration, $configs);
+        $config = $container->resolveEnvPlaceholders($container->getParameterBag()->resolveValue($processor->processConfiguration($configuration, $configs)));
 
         if (null === $path = $input->getArgument('path')) {
             $io->title(
@@ -105,7 +105,7 @@ EOF
 
         $io->title(sprintf('Current configuration for "%s.%s"', $extensionAlias, $path));
 
-        $io->writeln(Yaml::dump($container->getParameterBag()->resolveValue($config), 10));
+        $io->writeln(Yaml::dump($config, 10));
     }
 
     private function compileContainer()
@@ -130,7 +130,7 @@ EOF
      *
      * @return mixed
      */
-    private function getConfigForPath(array $config = array(), $path, $alias)
+    private function getConfigForPath(array $config, $path, $alias)
     {
         $steps = explode('.', $path);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
@@ -48,6 +48,16 @@ class ConfigDebugCommandTest extends WebTestCase
         $this->assertContains('foo', $tester->getDisplay());
     }
 
+    public function testParametersValuesAreResolved()
+    {
+        $tester = $this->createCommandTester();
+        $ret = $tester->execute(array('name' => 'framework'));
+
+        $this->assertSame(0, $ret, 'Returns 0 in case of success');
+        $this->assertContains("locale: '%env(LOCALE)%'", $tester->getDisplay());
+        $this->assertContains('secret: test', $tester->getDisplay());
+    }
+
     public function testDumpUndefinedBundleOption()
     {
         $tester = $this->createCommandTester();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ConfigDump/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ConfigDump/config.yml
@@ -1,2 +1,10 @@
 imports:
     - { resource: ../config/default.yml }
+
+framework:
+    secret: '%secret%'
+    default_locale: '%env(LOCALE)%'
+
+parameters:
+    env(LOCALE): en
+    secret: test

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.5.9",
         "symfony/cache": "~3.2",
         "symfony/class-loader": "~3.2",
-        "symfony/dependency-injection": "~3.2",
+        "symfony/dependency-injection": "~3.2.1|~3.3",
         "symfony/config": "~2.8|~3.0",
         "symfony/event-dispatcher": "~2.8|~3.0",
         "symfony/http-foundation": "~3.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

This fixes parameters resolution (classic and env ones) in `debug:config`, again.
Merging #20714 broke the fix resolving env parameters made in #20688, and anyway it was mismerged (#20714 was not applied when using the `path` argument, my bad, I should have prevented it).

This adds a test which prevents regressions so I hope this is is the last PR on this subject.
The buggy output is unfortunately part of the last 3.2 release... It can easily be confirmed by running `debug:config doctrine` on a fresh symfony-demo project