### PR TITLE
[HttpFoundation] Fix cookie to string conversion for raw cookies

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -80,21 +80,19 @@ class Cookie
      */
     public function __toString()
     {
-        $str = urlencode($this->getName()).'=';
+        $str = ($this->isRaw() ? $this->getName() : urlencode($this->getName())).'=';
 
         if ('' === (string) $this->getValue()) {
             $str .= 'deleted; expires='.gmdate('D, d-M-Y H:i:s T', time() - 31536001);
         } else {
-            $str .= urlencode($this->getValue());
+            $str .= $this->isRaw() ? $this->getValue() : urlencode($this->getValue());
 
             if ($this->getExpiresTime() !== 0) {
                 $str .= '; expires='.gmdate('D, d-M-Y H:i:s T', $this->getExpiresTime());
             }
         }
 
-        if ($this->path) {
-            $str .= '; path='.$this->path;
-        }
+        $str .= '; path='.$this->getPath() ?: '/';
 
         if ($this->getDomain()) {
             $str .= '; domain='.$this->getDomain();
@@ -124,7 +122,7 @@ class Cookie
     /**
      * Gets the value of the cookie.
      *
-     * @return string
+     * @return string|null
      */
     public function getValue()
     {
@@ -134,7 +132,7 @@ class Cookie
     /**
      * Gets the domain that the cookie is available to.
      *
-     * @return string
+     * @return string|null
      */
     public function getDomain()
     {

--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -92,7 +92,9 @@ class Cookie
             }
         }
 
-        $str .= '; path='.$this->getPath() ?: '/';
+        if ($this->getPath()) {
+            $str .= '; path='.$this->getPath();
+        }
 
         if ($this->getDomain()) {
             $str .= '; domain='.$this->getDomain();

--- a/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
@@ -154,10 +154,12 @@ class CookieTest extends \PHPUnit_Framework_TestCase
 
     public function testRawCookie()
     {
-        $cookie = new Cookie('foo', 'bar', 3600, '/', '.myfoodomain.com', false, true);
+        $cookie = new Cookie('foo', 'b a r', 3600, '/', '.myfoodomain.com', false, true);
         $this->assertFalse($cookie->isRaw());
+        $this->assertEquals('foo=b+a+r; expires=Thu, 01-Jan-1970 01:00:00 GMT; path=/; domain=.myfoodomain.com; httponly', (string) $cookie);
 
-        $cookie = new Cookie('foo', 'bar', 3600, '/', '.myfoodomain.com', false, true, true);
+        $cookie = new Cookie('foo', 'b+a+r', 3600, '/', '.myfoodomain.com', false, true, true);
         $this->assertTrue($cookie->isRaw());
+        $this->assertEquals('foo=b+a+r; expires=Thu, 01-Jan-1970 01:00:00 GMT; path=/; domain=.myfoodomain.com; httponly', (string) $cookie);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
@@ -154,12 +154,12 @@ class CookieTest extends \PHPUnit_Framework_TestCase
 
     public function testRawCookie()
     {
-        $cookie = new Cookie('foo', 'b a r', 3600, '/', '.myfoodomain.com', false, true);
+        $cookie = new Cookie('foo', 'b a r', 0, '/', null, false, false);
         $this->assertFalse($cookie->isRaw());
-        $this->assertEquals('foo=b+a+r; expires=Thu, 01-Jan-1970 01:00:00 GMT; path=/; domain=.myfoodomain.com; httponly', (string) $cookie);
+        $this->assertEquals('foo=b+a+r; path=/', (string) $cookie);
 
-        $cookie = new Cookie('foo', 'b+a+r', 3600, '/', '.myfoodomain.com', false, true, true);
+        $cookie = new Cookie('foo', 'b+a+r', 0, '/', null, false, false, true);
         $this->assertTrue($cookie->isRaw());
-        $this->assertEquals('foo=b+a+r; expires=Thu, 01-Jan-1970 01:00:00 GMT; path=/; domain=.myfoodomain.com; httponly', (string) $cookie);
+        $this->assertEquals('foo=b+a+r; path=/', (string) $cookie);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Bug fix?      | yes
| New feature?  | not really
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/20569#discussion_r92135987
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

Separated from #20569 

This mimics PHP's `setrawcookie` behavior.