### PR TITLE
[Validator] add Indonesian translation

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.id.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.id.xlf
@@ -310,6 +310,10 @@
                 <source>This value does not match the expected {{ charset }} charset.</source>
                 <target>Nilai ini tidak memenuhi set karakter {{ charset }} yang diharapkan.</target>
             </trans-unit>
+            <trans-unit id="81">
+                <source>This is not a valid Business Identifier Code (BIC).</source>
+                <target>Ini bukan Business Identifier Code (BIC) yang sah.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | -
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Business Identifier Code (BIC) is not translate to Bahasa Indonesia because i cant found the formal translation.
i found http://www.bi.go.id/id/peraturan/sistem-pembayaran/Documents/se_173115.pdf page:24 Bank Identifier Code (BIC) is still in English.
