### PR TITLE
[Console] fixed PHP7 Errors are now handled in Application::run and a…

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -116,8 +116,15 @@ class Application
         $this->configureIO($input, $output);
 
         try {
+            $e = null;
             $exitCode = $this->doRun($input, $output);
-        } catch (\Exception $e) {
+        } catch (\Exception $x) {
+            $e = $x;
+        } catch (\Throwable $x) {
+            $e = new FatalThrowableError($x);
+        }
+
+        if (null !== $e) {
             if (!$this->catchExceptions) {
                 throw $e;
             }

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -969,6 +969,24 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $tester->run(array('command' => 'dym'));
     }
 
+    public function testRunWithErrorCatchExceptionsFailingStatusCode()
+    {
+        $application = new Application();
+        $application->setDispatcher(new EventDispatcher());
+        $application->setCatchExceptions(true);
+        $application->setAutoExit(false);
+
+        $application->register('dym')->setCode(function (InputInterface $input, OutputInterface $output) {
+            $output->write('dym.');
+
+            throw new \Error('dymerr');
+        });
+
+        $tester = new ApplicationTester($application);
+        $tester->run(array('command' => 'dym'));
+        $this->assertSame(1, $tester->getStatusCode(), 'Status code should be 1');
+    }
+
     /**
      * @expectedException        \LogicException
      * @expectedExceptionMessage caught


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20775
| License       | MIT
| Doc PR        | n/a

PRs #19813 and #20736 do not complete solve every problem with PHP7 new \Error class. This PR adds additional catching in Application::run, and as such the Application now returns status code 1 when \Error occurs, and closes #20775.

More info:
If there is no dispatcher, due to #20736 everything will work fine, FatalThrowableError will be rethrown, and that is catched by the try/catch in Application::run.
When there is a dispatcher, but there is no console.exception Listener that **modifies** the exception, code in PR #19813 will rethrow the original exception (\Error), and not the wrapped one. Since Application:run only catches Exceptions \Error will not get caught by try/catch in Application::run, and as a result status code will be 0, which is obviously wrong.