### PR TITLE
[WebProfilerBundle] Fix PHP extensions in the toolbar

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -84,7 +84,8 @@
             <div class="sf-toolbar-info-piece sf-toolbar-info-php-ext">
                 <b>PHP Extensions</b>
                 <span class="sf-toolbar-status sf-toolbar-status-{{ collector.hasxdebug ? 'green' : 'red' }}">xdebug</span>
-                <span class="sf-toolbar-status sf-toolbar-status-{{ collector.hasaccelerator ? 'green' : 'red' }}">accel</span>
+                <span class="sf-toolbar-status sf-toolbar-status-{{ collector.hasapcu ? 'green' : 'red' }}">APCu</span>
+                <span class="sf-toolbar-status sf-toolbar-status-{{ collector.haszendopcache ? 'green' : 'red' }}">OPcache</span>
             </div>
 
             <div class="sf-toolbar-info-piece">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | yes (adding other extensions info)
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20697
| License       | MIT
| Doc PR        | N/A

`ConfigDataCollector::hasAccelerator()` has been removed.

Except if we want to reintroduce the method, I'd suggest to add apcu & opcache infos directly (or just remove the accelerator line).