### PR TITLE
[FrameworkBundle] don't load translator services if not required

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 3.3.0
 -----
 
+ * Translation related services are not loaded anymore when the `framework.translator` option
+   is disabled.
  * Added `GlobalVariables::getToken()`
 
 3.2.0

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_csrf.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_csrf.xml
@@ -10,7 +10,7 @@
             <argument type="service" id="security.csrf.token_manager" />
             <argument>%form.type_extension.csrf.enabled%</argument>
             <argument>%form.type_extension.csrf.field_name%</argument>
-            <argument type="service" id="translator.default" />
+            <argument type="service" id="translator" />
             <argument>%validator.translation_domain%</argument>
             <argument type="service" id="form.server_params" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/identity_translator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/identity_translator.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="translator" class="Symfony\Component\Translation\IdentityTranslator">
+            <argument type="service" id="translator.selector" />
+        </service>
+
+        <service id="translator.selector" class="Symfony\Component\Translation\MessageSelector" public="false" />
+    </services>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
@@ -27,12 +27,6 @@
             <tag name="monolog.logger" channel="translation" />
         </service>
 
-        <service id="translator" class="Symfony\Component\Translation\IdentityTranslator">
-            <argument type="service" id="translator.selector" />
-        </service>
-
-        <service id="translator.selector" class="Symfony\Component\Translation\MessageSelector" public="false" />
-
         <service id="translation.loader.php" class="Symfony\Component\Translation\Loader\PhpFileLoader">
             <tag name="translation.loader" alias="php" />
         </service>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20791
| License       | MIT
| Doc PR        | 

One step further could be to remove all the loader services (or not register them at all) if only the identity translator is used (i.e. when only forms are enabled, but not translations), but that could be seen as a BC break.