### PR TITLE
[Form] Fix Array to string conversion

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/TextType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TextType.php
@@ -28,6 +28,18 @@ class TextType extends AbstractType implements DataTransformerInterface
         if ('' === $options['empty_data']) {
             $builder->addViewTransformer($this);
         }
+
+        $builder->addEventListener(
+            FormEvents::PRE_SUBMIT,
+            function (FormEvent $event) {
+                if (is_array($event->getData())) {
+                    $event->setData('');
+                    $event->getForm()->addError(
+                        new FormError('Invalid value.')
+                    );
+                }
+            }
+        );
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        |

Let's have a form with a textarea and some other field. Open the form in browser, open debug tools and add `[]` to the name attribute of the textarea. Put some invalid value into the other field. The result is an Array to string conversion on [this line](https://github.com/symfony/symfony/blob/d88f2a483f0961d9ef40779e1314417b73a56e2e/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig#L34) in TwigBridge. It's of course because the submitted value of the textarea is actually an array because of our manipulation via debug tools.

No matter what the user input is Symfony should not fail on an error like this which is why I consider this a bug.

**I'm not quite sure if overwriting the submitted value and adding an error in a PRE_SUBMIT event is a good fix for this issue. Please share any suggestions.**

Of course the current implementation is far from ready - this should be solved by a form extension for all fields except ChoiceType with multiple option and CollectionType. Those on the other hand need some protection against non-array values.

By the way adding a `Type("string")` constraint to the field does not help (obviously).