### PR TITLE
[Console] ProgressBar LogicException shouldn't be thrown when max == 0

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -580,7 +580,7 @@ class ProgressBar
                     throw new \LogicException('Unable to display the remaining time if the maximum number of steps is not set.');
                 }
 
-                if (!$bar->getProgress()) {
+                if (!$bar->getProgress() || $bar->getMaxSteps() == 0) {
                     $remaining = 0;
                 } else {
                     $remaining = round((time() - $bar->getStartTime()) / $bar->getProgress() * ($bar->getMaxSteps() - $bar->getProgress()));
@@ -593,7 +593,7 @@ class ProgressBar
                     throw new \LogicException('Unable to display the estimated time if the maximum number of steps is not set.');
                 }
 
-                if (!$bar->getProgress()) {
+                if (!$bar->getProgress() || $bar->getMaxSteps() == 0) {
                     $estimated = 0;
                 } else {
                     $estimated = round((time() - $bar->getStartTime()) / $bar->getProgress() * $bar->getMaxSteps());

--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -576,7 +576,7 @@ class ProgressBar
                 return Helper::formatTime(time() - $bar->getStartTime());
             },
             'remaining' => function (ProgressBar $bar) {
-                if (!$bar->getMaxSteps()) {
+                if (null === $bar->getMaxSteps()) {
                     throw new \LogicException('Unable to display the remaining time if the maximum number of steps is not set.');
                 }
 
@@ -589,7 +589,7 @@ class ProgressBar
                 return Helper::formatTime($remaining);
             },
             'estimated' => function (ProgressBar $bar) {
-                if (!$bar->getMaxSteps()) {
+                if (null === $bar->getMaxSteps()) {
                     throw new \LogicException('Unable to display the estimated time if the maximum number of steps is not set.');
                 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

ProgressBar should throw exception only when the ``max`` attribute is null. If the ``max`` value is 0, everything is fine and the progress will correctly be shown 0/0

EDIT:

As a further explaination about this...

Supposing you are developing an application for a pizzeria. You need to check orders and deliver every pizza. So somewhere in your command you will have:

```
$pizzaOrders = $pizzaDeliveryService->getPizzaOrders(); // somehow retrieve orders

$progressBar->start(count($pizzaOrders));

foreach ($pizzaOrders as $order) {
    $pizzaDeliveryService->deliverPizza($order); // somehow deliver orders
    $progressBar->advance();
}


$progressBar->finish();
```

now as it is currently, you should check for ``count($pizzaOrders) > 0`` before calling ``$progressBar->start(count($pizzaOrders));``.

But actually it shouldn't be needed, because with this Pull Request changes, you will be able to call $progressBar->start(0); with no problems and it will correclty show ``0/0`` as output.