### PR TITLE
[HttpKernel] Fix Bundle name regression

### DIFF
--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -223,6 +223,8 @@ abstract class Bundle implements BundleInterface
     {
         $pos = strrpos(static::class, '\\');
         $this->namespace = false === $pos ? '' : substr(static::class, 0, $pos);
-        $this->name = false === $pos ? static::class : substr(static::class, $pos + 1);
+        if (null === $this->name) {
+            $this->name = false === $pos ? static::class : substr(static::class, $pos + 1);
+        }
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Bundle/BundleTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests\Bundle;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\Tests\Fixtures\ExtensionNotValidBundle\ExtensionNotValidBundle;
 use Symfony\Component\HttpKernel\Tests\Fixtures\ExtensionPresentBundle\ExtensionPresentBundle;
 use Symfony\Component\HttpKernel\Tests\Fixtures\ExtensionAbsentBundle\ExtensionAbsentBundle;
@@ -66,4 +67,33 @@ class BundleTest extends \PHPUnit_Framework_TestCase
         $bundle->setContainer($container);
         $bundle->registerCommands($application);
     }
+
+    public function testBundleNameIsGuessedFromClass()
+    {
+        $bundle = new GuessedNameBundle();
+
+        $this->assertSame('Symfony\Component\HttpKernel\Tests\Bundle', $bundle->getNamespace());
+        $this->assertSame('GuessedNameBundle', $bundle->getName());
+    }
+
+    public function testBundleNameCanBeExplicitlyProvided()
+    {
+        $bundle = new NamedBundle();
+
+        $this->assertSame('ExplicitlyNamedBundle', $bundle->getName());
+        $this->assertSame('Symfony\Component\HttpKernel\Tests\Bundle', $bundle->getNamespace());
+        $this->assertSame('ExplicitlyNamedBundle', $bundle->getName());
+    }
+}
+
+class NamedBundle extends Bundle
+{
+    public function __construct()
+    {
+        $this->name = 'ExplicitlyNamedBundle';
+    }
+}
+
+class GuessedNameBundle extends Bundle
+{
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20117
| License       | MIT
| Doc PR        | N/A

The bundle name can be set manually instead of being guessed from the class name, as the property is protected.
However, a regression prevents this name to be used, as calling `Bundle::getNamespace()` recomputes the bundle name from class instead.

The ability to name explicitly bundles is appreciable when dealing with "virtual" ones, or when providing bundles in a library under a `Vendor\MyPackage\Bridge\Symfony\Bundle` namespace. No need to rename the bundle class `VendorMyPackageBundle` which will make the instantiation in `Kernel::registerBundle()` quite ugly:

```diff
- new Vendor\MyPackage\Bridge\Symfony\Bundle\VendorMyPackageBundle()
+ new Vendor\MyPackage\Bridge\Symfony\Bundle\Bundle()
```

What about removing `Bundle::parseClassName()` and processing the namespace and bundle name separately, but keeping the `namespace` property introduced in #20117?