### PR TITLE
[Serializer] Fix MaxDepth annotation exceptions

### DIFF
--- a/src/Symfony/Component/Serializer/Annotation/MaxDepth.php
+++ b/src/Symfony/Component/Serializer/Annotation/MaxDepth.php
@@ -30,8 +30,8 @@ class MaxDepth
 
     public function __construct(array $data)
     {
-        if (!isset($data['value']) || !$data['value']) {
-            throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" cannot be empty.', get_class($this)));
+        if (!isset($data['value'])) {
+            throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" should be set.', get_class($this)));
         }
 
         if (!is_int($data['value']) || $data['value'] <= 0) {

--- a/src/Symfony/Component/Serializer/Tests/Annotation/MaxDepthTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Annotation/MaxDepthTest.php
@@ -20,26 +20,32 @@ class MaxDepthTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @expectedException \Symfony\Component\Serializer\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Parameter of annotation "Symfony\Component\Serializer\Annotation\MaxDepth" should be set.
      */
     public function testNotSetMaxDepthParameter()
     {
         new MaxDepth(array());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Serializer\Exception\InvalidArgumentException
-     */
-    public function testEmptyMaxDepthParameter()
+    public function provideInvalidValues()
     {
-        new MaxDepth(array('value' => ''));
+        return array(
+            array(''),
+            array('foo'),
+            array('1'),
+            array(0),
+        );
     }
 
     /**
+     * @dataProvider provideInvalidValues
+     *
      * @expectedException \Symfony\Component\Serializer\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Parameter of annotation "Symfony\Component\Serializer\Annotation\MaxDepth" must be a positive integer.
      */
-    public function testNotAnIntMaxDepthParameter()
+    public function testNotAnIntMaxDepthParameter($value)
     {
-        new MaxDepth(array('value' => 'foo'));
+        new MaxDepth(array('value' => $value));
     }
 
     public function testMaxDepthParameters()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Bug fix?      | yesish (rather improving existing DX, the exception message is not always the most relevant)
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

I'd suggest to slightly change the `MaxDepth` value checks, as for instance setting a 0 value throws the following exception:

> Parameter of annotation "Symfony\Component\Serializer\Annotation\MaxDepth" cannot be empty.

where we should rather expect:

> Parameter of annotation "Symfony\Component\Serializer\Annotation\MaxDepth" must be a positive integer.

IMHO we could even keep the last one only, even if no value has been provided.