### PR TITLE
[Security] Fix error when calling HttpUtils::generateUri()

### DIFF
--- a/src/Symfony/Component/Security/Http/HttpUtils.php
+++ b/src/Symfony/Component/Security/Http/HttpUtils.php
@@ -135,6 +135,10 @@ class HttpUtils
             return $path;
         }
 
+        if (!$request instanceof Request) {
+            throw new \InvalidArgumentException(sprintf('The first argument of %s() must be an instance of %s.', __METHOD__, Request::class));
+        }
+
         if ('/' === $path[0]) {
             return $request->getUriForPath($path);
         }

--- a/src/Symfony/Component/Security/Http/Tests/HttpUtilsTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/HttpUtilsTest.php
@@ -239,6 +239,16 @@ class HttpUtilsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @expectedException        \InvalidArgumentException
+     * @expectedExceptionMessage The first argument of Symfony\Component\Security\Http\HttpUtils::generateUri() must be an instance of Symfony\Component\HttpFoundation\Request.
+     */
+    public function testGenerateUriThrowsExceptionIfNotAnInstanceOfRequest()
+    {
+        $utils = new HttpUtils();
+        $utils->generateUri(null, '/foo/bar');
+    }
+
+    /**
      * @expectedException \LogicException
      * @expectedExceptionMessage You must provide a UrlGeneratorInterface instance to be able to use routes.
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

So we could get a useful message instead of `Call to a member function getUriForPath() on null` fatal error (or a `Trying to get property of non-object` notice one check lower).