### PR TITLE
Changed DomCrawler from Closure to callable

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -360,15 +360,15 @@ class Crawler implements \Countable, \IteratorAggregate
      *         return $node->text();
      *     });
      *
-     * @param \Closure $closure An anonymous function
+     * @param callable $callable An anonymous function
      *
      * @return array An array of values returned by the anonymous function
      */
-    public function each(\Closure $closure)
+    public function each(callable $callable)
     {
         $data = array();
         foreach ($this->nodes as $i => $node) {
-            $data[] = $closure($this->createSubCrawler($node), $i);
+            $data[] = $callable($this->createSubCrawler($node), $i);
         }
 
         return $data;
@@ -392,15 +392,15 @@ class Crawler implements \Countable, \IteratorAggregate
      *
      * To remove a node from the list, the anonymous function must return false.
      *
-     * @param \Closure $closure An anonymous function
+     * @param callable $callable An anonymous function
      *
      * @return Crawler A Crawler instance with the selected nodes
      */
-    public function reduce(\Closure $closure)
+    public function reduce(callable $callable)
     {
         $nodes = array();
         foreach ($this->nodes as $i => $node) {
-            if (false !== $closure($this->createSubCrawler($node), $i)) {
+            if (false !== $callable($this->createSubCrawler($node), $i)) {
                 $nodes[] = $node;
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

Allows to send in callable (for example a class with __invoke method) instead of just \Closure. May break code which extends Symfony\Component\DomCrawler\Crawler and overwrites the methods each and reduce.
