### PR TITLE
[WIP] [Security] improved DaoAuthenticationProvider exception handling

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Provider/DaoAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/DaoAuthenticationProvider.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Core\Authentication\Provider;
 
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
+use Symfony\Component\Security\Core\Exception\AccountStatusException;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -89,6 +90,9 @@ class DaoAuthenticationProvider extends UserAuthenticationProvider
             return $user;
         } catch (UsernameNotFoundException $e) {
             $e->setUsername($username);
+            throw $e;
+        } catch (AccountStatusException $e) {
+            $e->setToken($token);
             throw $e;
         } catch (\Exception $e) {
             $e = new AuthenticationServiceException($e->getMessage(), 0, $e);

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/DaoAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/DaoAuthenticationProviderTest.php
@@ -13,6 +13,11 @@ namespace Symfony\Component\Security\Core\Tests\Authentication\Provider;
 
 use Symfony\Component\Security\Core\Encoder\PlaintextPasswordEncoder;
 use Symfony\Component\Security\Core\Authentication\Provider\DaoAuthenticationProvider;
+use Symfony\Component\Security\Core\Exception\AccountExpiredException;
+use Symfony\Component\Security\Core\Exception\AuthenticationExpiredException;
+use Symfony\Component\Security\Core\Exception\CredentialsExpiredException;
+use Symfony\Component\Security\Core\Exception\DisabledException;
+use Symfony\Component\Security\Core\Exception\LockedException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 
 class DaoAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
@@ -38,6 +43,96 @@ class DaoAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
         $userProvider->expects($this->once())
                      ->method('loadUserByUsername')
                      ->will($this->throwException(new UsernameNotFoundException()))
+        ;
+
+        $provider = new DaoAuthenticationProvider($userProvider, $this->getMock('Symfony\\Component\\Security\\Core\\User\\UserCheckerInterface'), 'key', $this->getMock('Symfony\\Component\\Security\\Core\\Encoder\\EncoderFactoryInterface'));
+        $method = new \ReflectionMethod($provider, 'retrieveUser');
+        $method->setAccessible(true);
+
+        $method->invoke($provider, 'fabien', $this->getSupportedToken());
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\DisabledException
+     */
+    public function testRetrieveUserWhenDisabledExceptionOccurs()
+    {
+        $userProvider = $this->getMock('Symfony\\Component\\Security\\Core\\User\\UserProviderInterface');
+        $userProvider->expects($this->once())
+                     ->method('loadUserByUsername')
+                     ->will($this->throwException(new DisabledException()))
+        ;
+
+        $provider = new DaoAuthenticationProvider($userProvider, $this->getMock('Symfony\\Component\\Security\\Core\\User\\UserCheckerInterface'), 'key', $this->getMock('Symfony\\Component\\Security\\Core\\Encoder\\EncoderFactoryInterface'));
+        $method = new \ReflectionMethod($provider, 'retrieveUser');
+        $method->setAccessible(true);
+
+        $method->invoke($provider, 'fabien', $this->getSupportedToken());
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationExpiredException
+     */
+    public function testRetrieveUserWhenAuthenticationExpiredExceptionOccurs()
+    {
+        $userProvider = $this->getMock('Symfony\\Component\\Security\\Core\\User\\UserProviderInterface');
+        $userProvider->expects($this->once())
+                     ->method('loadUserByUsername')
+                     ->will($this->throwException(new AuthenticationExpiredException()))
+        ;
+
+        $provider = new DaoAuthenticationProvider($userProvider, $this->getMock('Symfony\\Component\\Security\\Core\\User\\UserCheckerInterface'), 'key', $this->getMock('Symfony\\Component\\Security\\Core\\Encoder\\EncoderFactoryInterface'));
+        $method = new \ReflectionMethod($provider, 'retrieveUser');
+        $method->setAccessible(true);
+
+        $method->invoke($provider, 'fabien', $this->getSupportedToken());
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\CredentialsExpiredException
+     */
+    public function testRetrieveUserWhenCredentialsExpiredExceptionOccurs()
+    {
+        $userProvider = $this->getMock('Symfony\\Component\\Security\\Core\\User\\UserProviderInterface');
+        $userProvider->expects($this->once())
+                     ->method('loadUserByUsername')
+                     ->will($this->throwException(new CredentialsExpiredException()))
+        ;
+
+        $provider = new DaoAuthenticationProvider($userProvider, $this->getMock('Symfony\\Component\\Security\\Core\\User\\UserCheckerInterface'), 'key', $this->getMock('Symfony\\Component\\Security\\Core\\Encoder\\EncoderFactoryInterface'));
+        $method = new \ReflectionMethod($provider, 'retrieveUser');
+        $method->setAccessible(true);
+
+        $method->invoke($provider, 'fabien', $this->getSupportedToken());
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\LockedException
+     */
+    public function testRetrieveUserWhenLockedExceptionOccurs()
+    {
+        $userProvider = $this->getMock('Symfony\\Component\\Security\\Core\\User\\UserProviderInterface');
+        $userProvider->expects($this->once())
+                     ->method('loadUserByUsername')
+                     ->will($this->throwException(new LockedException()))
+        ;
+
+        $provider = new DaoAuthenticationProvider($userProvider, $this->getMock('Symfony\\Component\\Security\\Core\\User\\UserCheckerInterface'), 'key', $this->getMock('Symfony\\Component\\Security\\Core\\Encoder\\EncoderFactoryInterface'));
+        $method = new \ReflectionMethod($provider, 'retrieveUser');
+        $method->setAccessible(true);
+
+        $method->invoke($provider, 'fabien', $this->getSupportedToken());
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\AccountExpiredException
+     */
+    public function testRetrieveUserWhenAccountExpiredExceptionOccurs()
+    {
+        $userProvider = $this->getMock('Symfony\\Component\\Security\\Core\\User\\UserProviderInterface');
+        $userProvider->expects($this->once())
+                     ->method('loadUserByUsername')
+                     ->will($this->throwException(new AccountExpiredException()))
         ;
 
         $provider = new DaoAuthenticationProvider($userProvider, $this->getMock('Symfony\\Component\\Security\\Core\\User\\UserCheckerInterface'), 'key', $this->getMock('Symfony\\Component\\Security\\Core\\Encoder\\EncoderFactoryInterface'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | NA
| License       | MIT

In short, this improves the way how the DaoAuthenticationProvider handles exceptions.

I encountered myself in the following situation:
Event though I throw a DisabledException on my implementation of the UserProviderInterface (pointing that the user status is not active anymore), the DaoAuthenticationProvider would then throw a "generic" AuthenticationServiceException which only provides the user with a "system problem" message even though it's a user status problem.

This pr is a simple, but efficient way of dealing with this issue.
Let me know if you guys agree with this, if yes I will add tests in DaoAuthenticationProviderTest.

Ps: this is my 1st pr on symfony...please be extra patient. :laughing: 

