### PR TITLE
[FrameworkBundle] Ignore AnnotationException exceptions in the AnnotationsCacheWarmer

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
@@ -84,8 +84,6 @@ class AnnotationsCacheWarmer implements CacheWarmerInterface
                      * In particular cases, an Annotation in your code can be used and defined only for a specific
                      * environment but is always added to the annotations.map file by some Symfony default behaviors,
                      * and you always end up with a not found Annotation.
-                     *
-                     * cf https://github.com/symfony/symfony/pull/20959 for a longer explanation.
                      */
                 }
             }

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
@@ -77,7 +77,16 @@ class AnnotationsCacheWarmer implements CacheWarmerInterface
                 } catch (\ReflectionException $e) {
                     // ignore failing reflection
                 } catch (AnnotationException $e) {
-
+                    /*
+                     * Ignore any AnnotationException to not break the cache warming process if an Annotation is badly
+                     * configured or could not be found / read / etc.
+                     *
+                     * In particular cases, an Annotation in your code can be used and defined only for a specific
+                     * environment but is always added to the annotations.map file by some Symfony default behaviors,
+                     * and you always end up with a not found Annotation.
+                     *
+                     * cf https://github.com/symfony/symfony/pull/20959 for a longer explanation.
+                     */
                 }
             }
         } finally {

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\CacheWarmer;
 
+use Doctrine\Common\Annotations\AnnotationException;
 use Doctrine\Common\Annotations\CachedReader;
 use Doctrine\Common\Annotations\Reader;
 use Psr\Cache\CacheItemPoolInterface;
@@ -75,6 +76,8 @@ class AnnotationsCacheWarmer implements CacheWarmerInterface
                     $this->readAllComponents($reader, $class);
                 } catch (\ReflectionException $e) {
                     // ignore failing reflection
+                } catch (AnnotationException $e) {
+
                 }
             }
         } finally {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

I ran into a case that led to an `AnnotationException` in the `AnnotationsCacheWarmer`. I deduced that these exceptions should be ignored to not break the cache warming process.

The case : 
* You have a controller in your `AppBundle\Controller\` directory.
* You have an annotation in this controller that will never be found (because you made a mistake in the class / annotation name) or not every time : for example your controller is only used in dev env and it uses an annotation that is defined in a vendor bundle that is only under the `require-dev` key in your `composer.json` because you don't need it in your production deployment. So in production, your controller exists but will never be used. However the vendor bundle does not exist.
* You dump your autoload files with composer using the `--optimize` option.
* You end up with an `AnnotationException`.

Why :
* In the [`FrameworkExtension`](https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L189), the `**Bundle\Controller\` pattern is added as an "annotated class to compile".
* In the [`AddClassesToCachePass`](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpKernel/DependencyInjection/AddClassesToCachePass.php#L50), all the classes defined in the `autoload_classmap.php` file are matched against the previous pattern.
* Your controller will match. So even if you don't use it at all in your application, the annotation will still be read and the exception will be thrown.
