### PR TITLE
Request exceptions

### DIFF
--- a/src/Symfony/Component/Debug/Exception/FlattenException.php
+++ b/src/Symfony/Component/Debug/Exception/FlattenException.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Debug\Exception;
 
+use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 
 /**
@@ -41,6 +42,8 @@ class FlattenException
         if ($exception instanceof HttpExceptionInterface) {
             $statusCode = $exception->getStatusCode();
             $headers = array_merge($headers, $exception->getHeaders());
+        } elseif ($exception instanceof SuspiciousOperationException) {
+            $statusCode = 400;
         }
 
         if (null === $statusCode) {

--- a/src/Symfony/Component/Debug/Exception/FlattenException.php
+++ b/src/Symfony/Component/Debug/Exception/FlattenException.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Debug\Exception;
 
-use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
+use Symfony\Component\HttpFoundation\Exception\RequestExceptionInterface;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 
 /**
@@ -42,7 +42,7 @@ class FlattenException
         if ($exception instanceof HttpExceptionInterface) {
             $statusCode = $exception->getStatusCode();
             $headers = array_merge($headers, $exception->getHeaders());
-        } elseif ($exception instanceof SuspiciousOperationException) {
+        } elseif ($exception instanceof RequestExceptionInterface) {
             $statusCode = 400;
         }
 

--- a/src/Symfony/Component/Debug/Tests/Exception/FlattenExceptionTest.php
+++ b/src/Symfony/Component/Debug/Tests/Exception/FlattenExceptionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Debug\Tests\Exception;
 
 use Symfony\Component\Debug\Exception\FlattenException;
+use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
@@ -78,6 +79,11 @@ class FlattenExceptionTest extends \PHPUnit_Framework_TestCase
 
         $flattened = FlattenException::create(new UnsupportedMediaTypeHttpException());
         $this->assertEquals('415', $flattened->getStatusCode());
+
+        if (class_exists(SuspiciousOperationException::class)) {
+            $flattened = FlattenException::create(new SuspiciousOperationException());
+            $this->assertEquals('400', $flattened->getStatusCode());
+        }
     }
 
     public function testHeadersForHttpException()

--- a/src/Symfony/Component/HttpFoundation/Exception/RequestExceptionInterface.php
+++ b/src/Symfony/Component/HttpFoundation/Exception/RequestExceptionInterface.php
@@ -12,10 +12,10 @@
 namespace Symfony\Component\HttpFoundation\Exception;
 
 /**
- * The HTTP request contains headers with conflicting information.
+ * Interface for Request exceptions.
  *
- * @author Magnus Nordlander <magnus@fervo.se>
+ * Exceptions implementing this interface should trigger an HTTP 400 response in the application code.
  */
-class ConflictingHeadersException extends \UnexpectedValueException implements RequestExceptionInterface
+interface RequestExceptionInterface
 {
 }

--- a/src/Symfony/Component/HttpFoundation/Exception/SuspiciousOperationException.php
+++ b/src/Symfony/Component/HttpFoundation/Exception/SuspiciousOperationException.php
@@ -15,6 +15,6 @@ namespace Symfony\Component\HttpFoundation\Exception;
  * Raised when a user has performed an operation that should be considered
  * suspicious from a security perspective.
  */
-class SuspiciousOperationException extends \UnexpectedValueException
+class SuspiciousOperationException extends \UnexpectedValueException implements RequestExceptionInterface
 {
 }

--- a/src/Symfony/Component/HttpFoundation/Exception/SuspiciousOperationException.php
+++ b/src/Symfony/Component/HttpFoundation/Exception/SuspiciousOperationException.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Exception;
+
+/**
+ * Raised when a user has performed an operation that should be considered
+ * suspicious from a security perspective.
+ */
+class SuspiciousOperationException extends \UnexpectedValueException
+{
+}

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -207,6 +207,9 @@ class Request
 
     protected static $requestFactory;
 
+    private $isHostValid = true;
+    private $isClientIpsValid = true;
+
     /**
      * Constructor.
      *
@@ -820,7 +823,12 @@ class Request
         }
 
         if ($hasTrustedForwardedHeader && $hasTrustedClientIpHeader && $forwardedClientIps !== $xForwardedForClientIps) {
-            throw new ConflictingHeadersException('The request has both a trusted Forwarded header and a trusted Client IP header, conflicting with each other with regards to the originating IP addresses of the request. This is the result of a misconfiguration. You should either configure your proxy only to send one of these headers, or configure Symfony to distrust one of them.');
+            if (!$this->isClientIpsValid) {
+                return array('0.0.0.0');
+            }
+            $this->isClientIpsValid = false;
+
+            throw new ConflictingHeadersException('The request has both a trusted Forwarded header and a trusted Client IP header, conflicting with each other with regards to the originating IP addresses of the request. This is the result of a misconfiguration. You should either configure your proxy only to send one of these headers, or configure your project to distrust one of them.');
         }
 
         if (!$hasTrustedForwardedHeader && !$hasTrustedClientIpHeader) {
@@ -1199,7 +1207,7 @@ class Request
      *
      * @return string
      *
-     * @throws SuspiciousOperationException when the host name is invalid
+     * @throws SuspiciousOperationException when the host name is invalid or not trusted
      */
     public function getHost()
     {
@@ -1221,7 +1229,12 @@ class Request
         // check that it does not contain forbidden characters (see RFC 952 and RFC 2181)
         // use preg_replace() instead of preg_match() to prevent DoS attacks with long host names
         if ($host && '' !== preg_replace('/(?:^\[)?[a-zA-Z0-9-:\]_]+\.?/', '', $host)) {
-            throw new SuspiciousOperationException(sprintf('Invalid Host "%s"', $host));
+            if (!$this->isHostValid) {
+                return '';
+            }
+            $this->isHostValid = false;
+
+            throw new SuspiciousOperationException(sprintf('Invalid Host "%s".', $host));
         }
 
         if (count(self::$trustedHostPatterns) > 0) {
@@ -1239,7 +1252,12 @@ class Request
                 }
             }
 
-            throw new SuspiciousOperationException(sprintf('Untrusted Host "%s"', $host));
+            if (!$this->isHostValid) {
+                return '';
+            }
+            $this->isHostValid = false;
+
+            throw new SuspiciousOperationException(sprintf('Untrusted Host "%s".', $host));
         }
 
         return $host;

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation;
 
 use Symfony\Component\HttpFoundation\Exception\ConflictingHeadersException;
+use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 /**
@@ -1198,7 +1199,7 @@ class Request
      *
      * @return string
      *
-     * @throws \UnexpectedValueException when the host name is invalid
+     * @throws SuspiciousOperationException when the host name is invalid
      */
     public function getHost()
     {
@@ -1220,7 +1221,7 @@ class Request
         // check that it does not contain forbidden characters (see RFC 952 and RFC 2181)
         // use preg_replace() instead of preg_match() to prevent DoS attacks with long host names
         if ($host && '' !== preg_replace('/(?:^\[)?[a-zA-Z0-9-:\]_]+\.?/', '', $host)) {
-            throw new \UnexpectedValueException(sprintf('Invalid Host "%s"', $host));
+            throw new SuspiciousOperationException(sprintf('Invalid Host "%s"', $host));
         }
 
         if (count(self::$trustedHostPatterns) > 0) {
@@ -1238,7 +1239,7 @@ class Request
                 }
             }
 
-            throw new \UnexpectedValueException(sprintf('Untrusted Host "%s"', $host));
+            throw new SuspiciousOperationException(sprintf('Untrusted Host "%s"', $host));
         }
 
         return $host;

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1873,7 +1873,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             $request->getHost();
             $this->fail('Request::getHost() should throw an exception when host is not trusted.');
         } catch (SuspiciousOperationException $e) {
-            $this->assertEquals('Untrusted Host "evil.com"', $e->getMessage());
+            $this->assertEquals('Untrusted Host "evil.com".', $e->getMessage());
         }
 
         // trusted hosts

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpFoundation\Tests;
 
+use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Request;
@@ -1871,7 +1872,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         try {
             $request->getHost();
             $this->fail('Request::getHost() should throw an exception when host is not trusted.');
-        } catch (\UnexpectedValueException $e) {
+        } catch (SuspiciousOperationException $e) {
             $this->assertEquals('Untrusted Host "evil.com"', $e->getMessage());
         }
 
@@ -1935,7 +1936,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
                 $this->assertSame($expectedPort, $request->getPort());
             }
         } else {
-            $this->setExpectedException('UnexpectedValueException', 'Invalid Host');
+            $this->setExpectedException(SuspiciousOperationException::class, 'Invalid Host');
             $request->getHost();
         }
     }

--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\EventListener;
 
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -68,7 +69,11 @@ class RouterListener implements EventSubscriberInterface
     private function setCurrentRequest(Request $request = null)
     {
         if (null !== $request) {
-            $this->context->fromRequest($request);
+            try {
+                $this->context->fromRequest($request);
+            } catch (SuspiciousOperationException $e) {
+                // Do nothing.
+            }
         }
     }
 

--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\HttpKernel\EventListener;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -69,11 +68,7 @@ class RouterListener implements EventSubscriberInterface
     private function setCurrentRequest(Request $request = null)
     {
         if (null !== $request) {
-            try {
-                $this->context->fromRequest($request);
-            } catch (SuspiciousOperationException $e) {
-                // Do nothing.
-            }
+            $this->context->fromRequest($request);
         }
     }
 

--- a/src/Symfony/Component/HttpKernel/EventListener/ValidateRequestListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ValidateRequestListener.php
@@ -16,8 +16,7 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
- * Validates that the headers and other information indicating the
- * client IP address of a request are consistent.
+ * Validates Requests.
  *
  * @author Magnus Nordlander <magnus@fervo.se>
  */
@@ -36,9 +35,10 @@ class ValidateRequestListener implements EventSubscriberInterface
         $request = $event->getRequest();
 
         if ($request::getTrustedProxies()) {
-            // This will throw an exception if the headers are inconsistent.
             $request->getClientIps();
         }
+
+        $request->getHost();
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -25,7 +25,7 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\Event\PostResponseEvent;
-use Symfony\Component\HttpFoundation\Exception\ConflictingHeadersException;
+use Symfony\Component\HttpFoundation\Exception\RequestExceptionInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
@@ -67,8 +67,8 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
         try {
             return $this->handleRaw($request, $type);
         } catch (\Exception $e) {
-            if ($e instanceof ConflictingHeadersException) {
-                $e = new BadRequestHttpException('The request headers contain conflicting information regarding the origin of this request.', $e);
+            if ($e instanceof RequestExceptionInterface) {
+                $e = new BadRequestHttpException($e->getMessage(), $e);
             }
             if (false === $catch) {
                 $this->finishRequest($request, $type);

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
@@ -9,11 +9,17 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\HttpKernel\Tests\EventListener;
-
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver;
+use Symfony\Component\HttpKernel\Controller\ControllerResolver;
+use Symfony\Component\HttpKernel\EventListener\ExceptionListener;
 use Symfony\Component\HttpKernel\EventListener\RouterListener;
+use Symfony\Component\HttpKernel\EventListener\ValidateRequestListener;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Routing\RequestContext;
 
@@ -153,5 +159,27 @@ class RouterListenerTest extends \PHPUnit_Framework_TestCase
             array(array('_route' => 'foo'), 'Matched route "{route}".', array('route' => 'foo', 'route_parameters' => array('_route' => 'foo'), 'request_uri' => 'http://localhost/', 'method' => 'GET')),
             array(array(), 'Matched route "{route}".', array('route' => 'n/a', 'route_parameters' => array(), 'request_uri' => 'http://localhost/', 'method' => 'GET')),
         );
+    }
+
+    public function testWithBadRequest()
+    {
+        $requestStack = new RequestStack();
+
+        $requestMatcher = $this->getMock('Symfony\Component\Routing\Matcher\RequestMatcherInterface');
+        $requestMatcher->expects($this->never())->method('matchRequest');
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new ValidateRequestListener());
+        $dispatcher->addSubscriber(new RouterListener($requestMatcher, $requestStack, new RequestContext()));
+        $dispatcher->addSubscriber(new ExceptionListener(function () {
+            return new Response('Exception handled', 400);
+        }));
+
+        $kernel = new HttpKernel($dispatcher, new ControllerResolver(), $requestStack, new ArgumentResolver());
+
+        $request = Request::create('http://localhost/');
+        $request->headers->set('host', '###');
+        $response = $kernel->handle($request);
+        $this->assertSame(400, $response->getStatusCode());
     }
 }

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.5.9",
         "symfony/event-dispatcher": "~2.8|~3.0",
-        "symfony/http-foundation": "~2.8.13|~3.1.6|~3.2",
+        "symfony/http-foundation": "~3.3",
         "symfony/debug": "~2.8|~3.0",
         "psr/log": "~1.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20389, #20615, #20662
| License       | MIT
| Doc PR        | n/a

Replaces #20389 and #20662. The idea is to generically manage 400 responses when an exception implements `RequestExceptionInterface`.

The "weird" caches on the request for the host and the clients IPs allows to correctly manage exceptions in an exception listener/controller (as we are duplicating the request there, but we don't want to throw an exception there).
