### PR TITLE
[Form] Fixed invalid state of non synchronized forms

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -758,7 +758,7 @@ class Form implements \IteratorAggregate, FormInterface
      */
     public function isValid()
     {
-        if (!$this->submitted) {
+        if (!$this->submitted || $this->transformationFailure) {
             return false;
         }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -524,6 +524,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 
         $this->assertNull($form->getData());
         $this->assertEquals('foobar', $form->getViewData());
+        $this->assertFalse($form->isValid());
         $this->assertFalse($form->isSynchronized());
     }
 
@@ -945,6 +946,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertNull($form->getData());
         $this->assertSame('foobar', $form->getViewData());
         $this->assertEmpty($form->getExtraData());
+        $this->assertFalse($form->isValid());
         $this->assertFalse($form->isSynchronized());
 
         $this->assertFalse($form[0]->getData());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20916
| License       | MIT
| Doc PR        | ~

The approach of this patch fixes the valid state of any form (including `ChoiceType`, see the related issue) for a minimal performance impact, but also introduces a minor BC break that we should allow in this case IMHO, because some data could be persisted with the pre set data ignoring an error occurring with a transformation failure and causing the field to not be synchronized, which looks really wrong to me.