### PR TITLE
[DI] Fix DefinitionDecorator deprecation layer

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ChildDefinition.php
+++ b/src/Symfony/Component/DependencyInjection/ChildDefinition.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\DependencyInjection;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\OutOfBoundsException;
 
+class_alias(ChildDefinition::class, DefinitionDecorator::class);
+
 /**
  * This definition extends another definition.
  *

--- a/src/Symfony/Component/DependencyInjection/DefinitionDecorator.php
+++ b/src/Symfony/Component/DependencyInjection/DefinitionDecorator.php
@@ -20,6 +20,4 @@ namespace Symfony\Component\DependencyInjection;
  *
  * @deprecated The DefinitionDecorator class is deprecated since version 3.3 and will be removed in 4.0. Use the Symfony\Component\DependencyInjection\ChildDefinition class instead.
  */
-class DefinitionDecorator extends ChildDefinition
-{
-}
+class_exists(ChildDefinition::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This should make Travis green from 3.1 to master.
ping @xabbuh FYI

Restores compat with `instanceof DefinitionDecorator` checks.