### PR TITLE
[DI] Fix DefinitionDecorator existency for composer authoritative+IDEs

### DIFF
--- a/src/Symfony/Component/DependencyInjection/DefinitionDecorator.php
+++ b/src/Symfony/Component/DependencyInjection/DefinitionDecorator.php
@@ -13,6 +13,10 @@ namespace Symfony\Component\DependencyInjection;
 
 @trigger_error('The '.__NAMESPACE__.'\DefinitionDecorator class is deprecated since version 3.3 and will be removed in 4.0. Use the Symfony\Component\DependencyInjection\ChildDefinition class instead.', E_USER_DEPRECATED);
 
+class_exists(ChildDefinition::class);
+
+return;
+
 /**
  * This definition decorates another definition.
  *
@@ -20,4 +24,6 @@ namespace Symfony\Component\DependencyInjection;
  *
  * @deprecated The DefinitionDecorator class is deprecated since version 3.3 and will be removed in 4.0. Use the Symfony\Component\DependencyInjection\ChildDefinition class instead.
  */
-class_exists(ChildDefinition::class);
+class DefinitionDecorator extends Definition
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

So that the class is defined for naive parser (e.g. IDEs & composer class map generator).
Fixes autoloading in authoritative mode.