### PR TITLE
[Console] Fix question formatting using SymfonyStyle::ask()

### DIFF
--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -33,6 +33,20 @@ class OutputFormatter implements OutputFormatterInterface
     {
         $text = preg_replace('/([^\\\\]?)</', '$1\\<', $text);
 
+        return self::escapeTrailingBackslash($text);
+    }
+
+    /**
+     * Escapes trailing "\" in given text.
+     *
+     * @param string $text Text to escape
+     *
+     * @return string Escaped text
+     *
+     * @internal
+     */
+    public static function escapeTrailingBackslash($text)
+    {
         if ('\\' === substr($text, -1)) {
             $len = strlen($text);
             $text = rtrim($text, '\\');

--- a/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
@@ -53,7 +53,7 @@ class SymfonyQuestionHelper extends QuestionHelper
      */
     protected function writePrompt(OutputInterface $output, Question $question)
     {
-        $text = OutputFormatter::escape($question->getQuestion());
+        $text = $question->getQuestion();
         $default = $question->getDefault();
 
         switch (true) {

--- a/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
@@ -53,7 +53,7 @@ class SymfonyQuestionHelper extends QuestionHelper
      */
     protected function writePrompt(OutputInterface $output, Question $question)
     {
-        $text = $question->getQuestion();
+        $text = OutputFormatter::escapeTrailingBackslash($question->getQuestion());
         $default = $question->getDefault();
 
         switch (true) {

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -121,7 +121,7 @@ class SymfonyStyle extends OutputStyle
     {
         $this->autoPrependBlock();
         $this->writeln(array(
-            sprintf('<comment>%s</>', $message),
+            sprintf('<comment>%s</>', OutputFormatter::escapeTrailingBackslash($message)),
             sprintf('<comment>%s</>', str_repeat('=', strlen($message))),
         ));
         $this->newLine();
@@ -134,7 +134,7 @@ class SymfonyStyle extends OutputStyle
     {
         $this->autoPrependBlock();
         $this->writeln(array(
-            sprintf('<comment>%s</>', $message),
+            sprintf('<comment>%s</>', OutputFormatter::escapeTrailingBackslash($message)),
             sprintf('<comment>%s</>', str_repeat('-', strlen($message))),
         ));
         $this->newLine();

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_12.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_12.php
@@ -1,0 +1,13 @@
+<?php
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tests\Style\SymfonyStyleWithForcedLineLength;
+
+//Ensure symfony style helper methods handle trailing backslashes properly when decorating user texts
+return function (InputInterface $input, OutputInterface $output) {
+    $output = new SymfonyStyleWithForcedLineLength($input, $output);
+
+    $output->title('Title ending with \\');
+    $output->section('Section ending with \\');
+};

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_12.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_12.txt
@@ -1,0 +1,7 @@
+
+Title ending with \
+===================
+
+Section ending with \
+---------------------
+

--- a/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
@@ -79,9 +79,7 @@ class SymfonyQuestionHelperTest extends \PHPUnit_Framework_TestCase
         $questionHelper = new SymfonyQuestionHelper();
         $questionHelper->setInputStream($this->getInputStream("\n"));
         $question = new Question('What is your favorite superhero?');
-        $question->setValidator(function ($value) {
-            return $value;
-        });
+        $question->setValidator(function ($value) { return $value; });
         $this->assertNull($questionHelper->ask($this->createInputInterfaceMock(), $this->createOutputInterface(), $question));
     }
 
@@ -101,6 +99,15 @@ class SymfonyQuestionHelperTest extends \PHPUnit_Framework_TestCase
         $helper->ask($this->createInputInterfaceMock(), $output = $this->createOutputInterface(), new Question('Do you want to use Foo\\Bar <comment>or</comment> Foo\\Baz\\?', 'Foo\\Baz'));
 
         $this->assertOutputContains('Do you want to use Foo\\Bar or Foo\\Baz\\? [Foo\\Baz]:', $output);
+    }
+
+    public function testLabelTrailingBackslash()
+    {
+        $helper = new SymfonyQuestionHelper();
+        $helper->setInputStream($this->getInputStream('sure'));
+        $helper->ask($this->createInputInterfaceMock(), $output = $this->createOutputInterface(), new Question('Question with a trailing \\'));
+
+        $this->assertOutputContains('Question with a trailing \\', $output);
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
@@ -79,7 +79,9 @@ class SymfonyQuestionHelperTest extends \PHPUnit_Framework_TestCase
         $questionHelper = new SymfonyQuestionHelper();
         $questionHelper->setInputStream($this->getInputStream("\n"));
         $question = new Question('What is your favorite superhero?');
-        $question->setValidator(function ($value) { return $value; });
+        $question->setValidator(function ($value) {
+            return $value;
+        });
         $this->assertNull($questionHelper->ask($this->createInputInterfaceMock(), $this->createOutputInterface(), $question));
     }
 
@@ -92,13 +94,13 @@ class SymfonyQuestionHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertOutputContains('Can I have a backslash? [\]', $output);
     }
 
-    public function testAskEscapeLabel()
+    public function testAskEscapeAndFormatLabel()
     {
         $helper = new SymfonyQuestionHelper();
-        $helper->setInputStream($this->getInputStream('sure'));
-        $helper->ask($this->createInputInterfaceMock(), $output = $this->createOutputInterface(), new Question('Do you want a \?'));
+        $helper->setInputStream($this->getInputStream('Foo\\Bar'));
+        $helper->ask($this->createInputInterfaceMock(), $output = $this->createOutputInterface(), new Question('Do you want to use Foo\\Bar <comment>or</comment> Foo\\Baz\\?', 'Foo\\Baz'));
 
-        $this->assertOutputContains('Do you want a \?', $output);
+        $this->assertOutputContains('Do you want to use Foo\\Bar or Foo\\Baz\\? [Foo\\Baz]:', $output);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20964 
| License       | MIT
| Doc PR        | n/a

Given
```php
$io = new SymfonyStyle($input, $output);
$io->ask('Do you want to use Foo\\Bar <comment>or</comment> Foo\\Baz\\?', 'Foo\\Bar');
```

Before output
![before](http://image.prntscr.com/image/af3806f866654deda2dec79b50d1ffa2.png)

After output
![after](http://image.prntscr.com/image/59c031d9e02949cebeae7a4734c7043f.png)