### PR TITLE
[DI] Add getter injection

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 3.3.0
 -----
 
+ * [EXPERIMENTAL] added support for getter-injection
  * added support for omitting the factory class name in a service definition if the definition class is set
  * deprecated case insensitivity of service identifiers
  * added "iterator" argument type for lazy iteration over a set of values and services

--- a/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
@@ -61,6 +61,7 @@ abstract class AbstractRecursivePass implements CompilerPassInterface
         } elseif ($value instanceof Definition) {
             $value->setArguments($this->processValue($value->getArguments()));
             $value->setProperties($this->processValue($value->getProperties()));
+            $value->setOverriddenGetters($this->processValue($value->getOverriddenGetters()));
             $value->setMethodCalls($this->processValue($value->getMethodCalls()));
 
             if ($v = $value->getFactory()) {

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
@@ -89,6 +89,7 @@ class ResolveDefinitionTemplatesPass extends AbstractRecursivePass implements Co
         $def->setClass($parentDef->getClass());
         $def->setArguments($parentDef->getArguments());
         $def->setMethodCalls($parentDef->getMethodCalls());
+        $def->setOverriddenGetters($parentDef->getOverriddenGetters());
         $def->setProperties($parentDef->getProperties());
         $def->setAutowiringTypes($parentDef->getAutowiringTypes());
         if ($parentDef->isDeprecated()) {
@@ -159,6 +160,11 @@ class ResolveDefinitionTemplatesPass extends AbstractRecursivePass implements Co
         // append method calls
         if ($calls = $definition->getMethodCalls()) {
             $def->setMethodCalls(array_merge($def->getMethodCalls(), $calls));
+        }
+
+        // merge overridden getters
+        foreach ($definition->getOverriddenGetters() as $k => $v) {
+            $def->setOverriddenGetter($k, $v);
         }
 
         // merge autowiring types

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInvalidReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInvalidReferencesPass.php
@@ -59,6 +59,7 @@ class ResolveInvalidReferencesPass implements CompilerPassInterface
             }
             $value->setArguments($this->processValue($value->getArguments(), 0));
             $value->setProperties($this->processValue($value->getProperties(), 1));
+            $value->setOverriddenGetters($this->processValue($value->getOverriddenGetters(), 1));
             $value->setMethodCalls($this->processValue($value->getMethodCalls(), 2));
         } elseif (is_array($value)) {
             $i = 0;

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveReferencesToAliasesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveReferencesToAliasesPass.php
@@ -42,6 +42,7 @@ class ResolveReferencesToAliasesPass implements CompilerPassInterface
 
             $definition->setArguments($this->processArguments($definition->getArguments()));
             $definition->setMethodCalls($this->processArguments($definition->getMethodCalls()));
+            $definition->setOverriddenGetters($this->processArguments($definition->getOverriddenGetters()));
             $definition->setProperties($this->processArguments($definition->getProperties()));
             $definition->setFactory($this->processFactory($definition->getFactory()));
         }

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -29,6 +29,7 @@ class Definition
     private $deprecationTemplate = 'The "%service_id%" service is deprecated. You should stop using it, as it will soon be removed.';
     private $properties = array();
     private $calls = array();
+    private $getters = array();
     private $configurator;
     private $tags = array();
     private $public = true;
@@ -317,6 +318,37 @@ class Definition
     public function getMethodCalls()
     {
         return $this->calls;
+    }
+
+    /**
+     * @experimental in version 3.3
+     */
+    public function setOverriddenGetter($name, $returnValue)
+    {
+        if (!$name) {
+            throw new InvalidArgumentException(sprintf('Getter name cannot be empty.'));
+        }
+        $this->getters[strtolower($name)] = $returnValue;
+
+        return $this;
+    }
+
+    /**
+     * @experimental in version 3.3
+     */
+    public function setOverriddenGetters(array $getters)
+    {
+        $this->getters = array_change_key_case($getters, CASE_LOWER);
+
+        return $this;
+    }
+
+    /**
+     * @experimental in version 3.3
+     */
+    public function getOverriddenGetters()
+    {
+        return $this->getters;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
@@ -80,6 +80,13 @@ class GraphvizDumper extends Dumper
                     $this->findEdges($id, $call[1], false, $call[0].'()')
                 );
             }
+
+            foreach ($definition->getOverriddenGetters() as $name => $value) {
+                $this->edges[$id] = array_merge(
+                    $this->edges[$id],
+                    $this->findEdges($id, $value, false, $name.'()')
+                );
+            }
         }
 
         return $this->container->resolveEnvPlaceholders($this->startDot().$this->addNodes().$this->addEdges().$this->endDot(), '__ENV_%s__');

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -24,6 +24,7 @@ use Symfony\Component\DependencyInjection\Exception\EnvParameterException;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
+use Symfony\Component\DependencyInjection\LazyProxy\GetterProxyInterface;
 use Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\DumperInterface as ProxyDumper;
 use Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\NullDumper;
 use Symfony\Component\DependencyInjection\ExpressionLanguage;
@@ -65,6 +66,9 @@ class PhpDumper extends Dumper
     private $usedMethodNames;
     private $classResources = array();
     private $baseClass;
+    private $getterProxies = array();
+    private $useInstantiateProxy;
+    private $salt;
 
     /**
      * @var \Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\DumperInterface
@@ -120,6 +124,9 @@ class PhpDumper extends Dumper
             'debug' => true,
         ), $options);
 
+        $this->salt = substr(strtr(base64_encode(md5($options['namespace'].'\\'.$options['class'].'+'.$options['base_class'], true)), '+/', '__'), 0, -2);
+        $this->getterProxies = array();
+        $this->useInstantiateProxy = false;
         $this->classResources = array();
         $this->initializeMethodNamesMap($options['base_class']);
         $this->baseClass = $options['base_class'];
@@ -168,6 +175,12 @@ class PhpDumper extends Dumper
             $this->addProxyClasses()
         ;
         $this->targetDirRegex = null;
+        $this->getterProxies = array();
+
+        foreach ($this->classResources as $r) {
+            $this->container->addClassResource($r);
+        }
+        $this->classResources = array();
 
         foreach ($this->classResources as $r) {
             $this->container->addClassResource($r);
@@ -274,6 +287,10 @@ class PhpDumper extends Dumper
                 $proxyCode = substr(Kernel::stripComments($proxyCode), 5);
             }
             $code .= $proxyCode;
+        }
+
+        foreach ($this->getterProxies as $proxyClass => $proxyCode) {
+            $code .= sprintf("\nclass %s extends %s", $proxyClass, $proxyCode);
         }
 
         return $code;
@@ -487,6 +504,72 @@ class PhpDumper extends Dumper
         }
 
         return $calls;
+    }
+
+    private function addServiceOverriddenGetters($id, Definition $definition)
+    {
+        if (!isset($this->classResources[$class = $definition->getClass()])) {
+            $this->classResources[$class] = new \ReflectionClass($class);
+        }
+        $class = $this->classResources[$class];
+        if ($class->isFinal()) {
+            throw new RuntimeException(sprintf('Unable to configure getter injection for service "%s": class "%s" cannot be marked as final.', $id, $class->name));
+        }
+
+        if ($r = $class->getConstructor()) {
+            if ($r->isAbstract()) {
+                throw new RuntimeException(sprintf('Unable to configure service "%s": the constructor of the "%s" class cannot be abstract.', $id, $class->name));
+            }
+            if (!$r->isPublic()) {
+                throw new RuntimeException(sprintf('Unable to configure service "%s": the constructor of the "%s" class must be public.', $id, $class->name));
+            }
+            if (!$r->isFinal()) {
+                if (0 < $r->getNumberOfParameters()) {
+                    $getters = implode('($container'.$this->salt.', ', explode('(', $this->generateSignature($r), 2));
+                } else {
+                    $getters = '($container'.$this->salt.')';
+                }
+                $getters = sprintf("\n    public function %s\n    {\n        \$this->container%3\$s = \$container%3\$s;\n        parent::%s;\n    }\n", $getters, $this->generateCall($r), $this->salt);
+            } else {
+                $getters = '';
+            }
+        } else {
+            $getters = sprintf("\n    public function __construct(\$container%1\$s)\n    {\n        \$this->container%1\$s = \$container%1\$s;\n    }\n", $this->salt);
+        }
+
+        foreach ($definition->getOverriddenGetters() as $name => $returnValue) {
+            $r = ContainerBuilder::getGetterReflector($class, $name, $id, $type);
+            $getter = array();
+            $getter[] = sprintf('%s function %s()%s', $r->isProtected() ? 'protected' : 'public', $r->name, $type);
+            $getter[] = '{';
+
+            if (false === strpos($dumpedReturnValue = $this->dumpValue($returnValue), '$this')) {
+                $getter[] = sprintf('    return %s;', $dumpedReturnValue);
+            } else {
+                $getter[] = sprintf('    if (null === $g = &$this->getters%s[__FUNCTION__]) {', $this->salt);
+                $getter[] = sprintf('        $g = \Closure::bind(function () { return %s; }, %2$s, %2$s);', $dumpedReturnValue, '$this->container'.$this->salt);
+                $getter[] = '    }';
+                $getter[] = '';
+                foreach (explode("\n", $this->wrapServiceConditionals($returnValue, "        return \$g();\n", $isUnconditional, '$this->container'.$this->salt)) as $code) {
+                    if ($code) {
+                        $getter[] = substr($code, 4);
+                    }
+                }
+                if (!$isUnconditional) {
+                    $getter[] = '';
+                    $getter[] = sprintf('    return parent::%s();', $r->name);
+                }
+            }
+
+            $getter[] = '}';
+            $getter[] = '';
+
+            foreach ($getter as $code) {
+                $getters .= $code ? "\n    ".$code : "\n";
+            }
+        }
+
+        return $getters;
     }
 
     private function addServiceProperties($id, Definition $definition, $variableName = 'instance')
@@ -734,6 +817,9 @@ EOF;
         }
 
         if (null !== $definition->getFactory()) {
+            if ($definition->getOverriddenGetters()) {
+                throw new RuntimeException(sprintf('Cannot dump definition for service "%s": factories and overridden getters are incompatible with each other.', $id));
+            }
             $callable = $definition->getFactory();
             if (is_array($callable)) {
                 if (!preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $callable[1])) {
@@ -766,10 +852,30 @@ EOF;
         }
 
         if (false !== strpos($class, '$')) {
+            if ($definition->getOverriddenGetters()) {
+                throw new RuntimeException(sprintf('Cannot dump definition for service "%s": dynamic class names and overridden getters are incompatible with each other.', $id));
+            }
+
             return sprintf("        \$class = %s;\n\n        $return{$instantiation}new \$class(%s);\n", $class, implode(', ', $arguments));
         }
+        $class = $this->dumpLiteralClass($class);
 
-        return sprintf("        $return{$instantiation}new %s(%s);\n", $this->dumpLiteralClass($class), implode(', ', $arguments));
+        if ($definition->getOverriddenGetters()) {
+            $getterProxy = sprintf("%s implements \\%s\n{\n    private \$container%s;\n    private \$getters%3\$s;\n%s}\n", $class, GetterProxyInterface::class, $this->salt, $this->addServiceOverriddenGetters($id, $definition));
+            $class = 'SymfonyProxy_'.md5($getterProxy);
+            $this->getterProxies[$class] = $getterProxy;
+            $constructor = $this->classResources[$definition->getClass()]->getConstructor();
+
+            if ($constructor && $constructor->isFinal()) {
+                $this->useInstantiateProxy = true;
+                $useConstructor = $constructor->getDeclaringClass()->isInternal() ? "defined('HHVM_VERSION')" : 'true';
+
+                return sprintf("        $return{$instantiation}\$this->instantiateProxy(%s::class, array(%s), %s);\n", $class, implode(', ', $arguments), $useConstructor);
+            }
+            array_unshift($arguments, '$this');
+        }
+
+        return sprintf("        $return{$instantiation}new %s(%s);\n", $class, implode(', ', $arguments));
     }
 
     /**
@@ -1210,6 +1316,34 @@ EOF;
      */
     private function endClass()
     {
+        if ($this->useInstantiateProxy) {
+            return sprintf(<<<'EOF'
+
+    private function instantiateProxy($class, $args, $useConstructor)
+    {
+        static $reflectionCache;
+
+        if (null === $r = &$reflectionCache[$class]) {
+            $r[0] = new \ReflectionClass($class);
+            $r[1] = $r[0]->getProperty('container%s');
+            $r[1]->setAccessible(true);
+            $r[2] = $r[0]->getConstructor();
+        }
+        $service = $useConstructor ? $r[0]->newInstanceWithoutConstructor() : $r[0]->newInstanceArgs($args);
+        $r[1]->setValue($service, $this);
+        if ($r[2] && $useConstructor) {
+            $r[2]->invokeArgs($service, $args);
+        }
+
+        return $service;
+    }
+}
+
+EOF
+                , $this->salt
+            );
+        }
+
         return <<<'EOF'
 }
 
@@ -1221,18 +1355,20 @@ EOF;
      *
      * @param string $value
      * @param string $code
+     * @param bool   &$isUnconditional
+     * @param string $containerRef
      *
      * @return string
      */
-    private function wrapServiceConditionals($value, $code)
+    private function wrapServiceConditionals($value, $code, &$isUnconditional = null, $containerRef = '$this')
     {
-        if (!$services = ContainerBuilder::getServiceConditionals($value)) {
+        if ($isUnconditional = !$services = ContainerBuilder::getServiceConditionals($value)) {
             return $code;
         }
 
         $conditions = array();
         foreach ($services as $service) {
-            $conditions[] = sprintf("\$this->has('%s')", $service);
+            $conditions[] = sprintf("%s->has('%s')", $containerRef, $service);
         }
 
         // re-indent the wrapped code
@@ -1283,6 +1419,7 @@ EOF;
             $definitions = array_merge(
                 $this->getDefinitionsFromArguments($definition->getArguments()),
                 $this->getDefinitionsFromArguments($definition->getMethodCalls()),
+                $this->getDefinitionsFromArguments($definition->getOverriddenGetters()),
                 $this->getDefinitionsFromArguments($definition->getProperties()),
                 $this->getDefinitionsFromArguments(array($definition->getConfigurator())),
                 $this->getDefinitionsFromArguments(array($definition->getFactory()))
@@ -1404,8 +1541,11 @@ EOF;
             if (null !== $this->definitionVariables && $this->definitionVariables->contains($value)) {
                 return $this->dumpValue($this->definitionVariables->offsetGet($value), $interpolate);
             }
-            if (count($value->getMethodCalls()) > 0) {
+            if ($value->getMethodCalls()) {
                 throw new RuntimeException('Cannot dump definitions which have method calls.');
+            }
+            if ($value->getOverriddenGetters()) {
+                throw new RuntimeException('Cannot dump definitions which have overridden getters.');
             }
             if (null !== $value->getConfigurator()) {
                 throw new RuntimeException('Cannot dump definitions which have a configurator.');
@@ -1755,7 +1895,7 @@ EOF;
             } elseif (preg_match('/^(?:[^ ]++ ){4}([a-zA-Z_\x7F-\xFF][^ ]++)/', $p, $type)) {
                 $type = $type[1];
             }
-            if ($type && $type = $this->generateTypeHint($type, $r)) {
+            if ($type && $type = ContainerBuilder::generateTypeHint($type, $r)) {
                 $k = $type.' '.$k;
             }
             if ($type && $p->allowsNull()) {
@@ -1794,36 +1934,5 @@ EOF;
         }
 
         return ($r->isClosure() ? '' : $r->name).'('.implode(', ', $call).')';
-    }
-
-    private function generateTypeHint($type, \ReflectionFunctionAbstract $r)
-    {
-        if (is_string($type)) {
-            $name = $type;
-
-            if ('callable' === $name || 'array' === $name) {
-                return $name;
-            }
-        } else {
-            $name = $type instanceof \ReflectionNamedType ? $type->getName() : $type->__toString();
-
-            if ($type->isBuiltin()) {
-                return $name;
-            }
-        }
-        $lcName = strtolower($name);
-
-        if ('self' !== $lcName && 'parent' !== $lcName) {
-            return '\\'.$name;
-        }
-        if (!$r instanceof \ReflectionMethod) {
-            return;
-        }
-        if ('self' === $lcName) {
-            return '\\'.$r->getDeclaringClass()->name;
-        }
-        if ($parent = $r->getDeclaringClass()->getParentClass()) {
-            return '\\'.$parent->name;
-        }
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -167,6 +167,10 @@ class XmlDumper extends Dumper
             $this->convertParameters($parameters, 'property', $service, 'name');
         }
 
+        if ($parameters = $definition->getOverriddenGetters()) {
+            $this->convertParameters($parameters, 'getter', $service, 'name');
+        }
+
         $this->addMethodCalls($definition->getMethodCalls(), $service);
 
         if ($callable = $definition->getFactory()) {

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -126,6 +126,10 @@ class YamlDumper extends Dumper
             $code .= sprintf("        properties: %s\n", $this->dumper->dump($this->dumpValue($definition->getProperties()), 0));
         }
 
+        if ($definition->getOverriddenGetters()) {
+            $code .= sprintf("        getters:\n%s\n", $this->dumper->dump($this->dumpValue($definition->getOverriddenGetters()), 0));
+        }
+
         if ($definition->getMethodCalls()) {
             $code .= sprintf("        calls:\n%s\n", $this->dumper->dump($this->dumpValue($definition->getMethodCalls()), 1, 12));
         }

--- a/src/Symfony/Component/DependencyInjection/LazyProxy/GetterProxyInterface.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/GetterProxyInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\LazyProxy;
+
+/**
+ * Interface used to label proxy classes with overridden getters as generated while compiling the container.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @experimental in version 3.3
+ */
+interface GetterProxyInterface
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -244,6 +244,7 @@ class XmlFileLoader extends FileLoader
 
         $definition->setArguments($this->getArgumentsAsPhp($service, 'argument'));
         $definition->setProperties($this->getArgumentsAsPhp($service, 'property'));
+        $definition->setOverriddenGetters($this->getArgumentsAsPhp($service, 'getter'));
 
         if ($factories = $this->getChildren($service, 'factory')) {
             $factory = $factories[0];
@@ -385,7 +386,7 @@ class XmlFileLoader extends FileLoader
         $xpath->registerNamespace('container', self::NS);
 
         // anonymous services as arguments/properties
-        if (false !== $nodes = $xpath->query('//container:argument[@type="service"][not(@id)]|//container:property[@type="service"][not(@id)]')) {
+        if (false !== $nodes = $xpath->query('//container:argument[@type="service"][not(@id)]|//container:property[@type="service"][not(@id)]|//container:getter[@type="service"][not(@id)]')) {
             foreach ($nodes as $node) {
                 // give it a unique name
                 $id = sprintf('%d_%s', ++$count, hash('sha256', $file));

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -49,6 +49,7 @@ class YamlFileLoader extends FileLoader
         'file' => 'file',
         'arguments' => 'arguments',
         'properties' => 'properties',
+        'getters' => 'getters',
         'configurator' => 'configurator',
         'calls' => 'calls',
         'tags' => 'tags',
@@ -331,6 +332,10 @@ class YamlFileLoader extends FileLoader
 
         if (isset($service['configurator'])) {
             $definition->setConfigurator($this->parseCallable($service['configurator'], 'configurator', $id, $file));
+        }
+
+        if (isset($service['getters'])) {
+            $definition->setOverriddenGetters($this->resolveServices($service['getters']));
         }
 
         if (isset($service['calls'])) {

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -116,6 +116,7 @@
       <xsd:element name="call" type="call" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="tag" type="tag" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="property" type="property" minOccurs="0" maxOccurs="unbounded" />
+      <xsd:element name="getter" type="getter" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="autowiring-type" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="autowire" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
     </xsd:choice>
@@ -169,6 +170,18 @@
     <xsd:attribute name="name" type="xsd:string" />
     <xsd:attribute name="on-invalid" type="invalid_sequence" />
     <xsd:attribute name="strict" type="boolean" />
+  </xsd:complexType>
+
+  <xsd:complexType name="getter" mixed="true">
+    <xsd:choice minOccurs="0" maxOccurs="1">
+      <xsd:element name="getter" type="getter" minOccurs="0" maxOccurs="unbounded" />
+      <xsd:element name="service" type="service" />
+    </xsd:choice>
+    <xsd:attribute name="type" type="argument_type" />
+    <xsd:attribute name="id" type="xsd:string" />
+    <xsd:attribute name="key" type="xsd:string" />
+    <xsd:attribute name="name" type="xsd:string" />
+    <xsd:attribute name="on-invalid" type="invalid_sequence" />
   </xsd:complexType>
 
   <xsd:complexType name="argument" mixed="true">

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInvalidReferencesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInvalidReferencesPassTest.php
@@ -107,6 +107,19 @@ class ResolveInvalidReferencesPassTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(), $def->getProperties());
     }
 
+    public function testProcessRemovesOverriddenGettersOnInvalid()
+    {
+        $container = new ContainerBuilder();
+        $def = $container
+            ->register('foo')
+            ->setOverriddenGetter('foo', new Reference('bar', ContainerInterface::IGNORE_ON_INVALID_REFERENCE))
+        ;
+
+        $this->process($container);
+
+        $this->assertEquals(array(), $def->getOverriddenGetters());
+    }
+
     protected function process(ContainerBuilder $container)
     {
         $pass = new ResolveInvalidReferencesPass();

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -797,6 +797,59 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array($second, $first), $configs);
     }
 
+    public function testOverriddenGetter()
+    {
+        $builder = new ContainerBuilder();
+        $builder
+            ->register('foo', 'ReflectionClass')
+            ->addArgument('stdClass')
+            ->setOverriddenGetter('getName', 'bar');
+
+        $foo = $builder->get('foo');
+
+        $this->assertInstanceOf('ReflectionClass', $foo);
+        $this->assertSame('bar', $foo->getName());
+    }
+
+    public function testOverriddenGetterOnInvalid()
+    {
+        $builder = new ContainerBuilder();
+        $builder
+            ->register('foo', 'ReflectionClass')
+            ->addArgument('stdClass')
+            ->setOverriddenGetter('getName', new Reference('bar', ContainerInterface::IGNORE_ON_INVALID_REFERENCE));
+
+        $foo = $builder->get('foo');
+
+        $this->assertInstanceOf('ReflectionClass', $foo);
+        $this->assertSame('stdClass', $foo->getName());
+    }
+
+    /**
+     * @dataProvider provideBadOverridenGetters
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
+     */
+    public function testBadOverridenGetters($expectedMessage, $getter, $id = 'foo')
+    {
+        $container = include __DIR__.'/Fixtures/containers/container30.php';
+        $container->getDefinition($id)->setOverriddenGetter($getter, 123);
+
+        $this->setExpectedException(RuntimeException::class, $expectedMessage);
+        $container->get($id);
+    }
+
+    public function provideBadOverridenGetters()
+    {
+        yield array('Unable to configure getter injection for service "foo": method "Symfony\Component\DependencyInjection\Tests\Fixtures\Container30\Foo::getnotfound" does not exist.', 'getNotFound');
+        yield array('Unable to configure getter injection for service "foo": method "Symfony\Component\DependencyInjection\Tests\Fixtures\Container30\Foo::getPrivate" must be public or protected.', 'getPrivate');
+        yield array('Unable to configure getter injection for service "foo": method "Symfony\Component\DependencyInjection\Tests\Fixtures\Container30\Foo::getStatic" cannot be static.', 'getStatic');
+        yield array('Unable to configure getter injection for service "foo": method "Symfony\Component\DependencyInjection\Tests\Fixtures\Container30\Foo::getFinal" cannot be marked as final.', 'getFinal');
+        yield array('Unable to configure getter injection for service "foo": method "Symfony\Component\DependencyInjection\Tests\Fixtures\Container30\Foo::getRef" cannot return by reference.', 'getRef');
+        yield array('Unable to configure getter injection for service "foo": method "Symfony\Component\DependencyInjection\Tests\Fixtures\Container30\Foo::getParam" cannot have any arguments.', 'getParam');
+        yield array('Unable to configure getter injection for service "bar": class "Symfony\Component\DependencyInjection\Tests\Fixtures\Container30\Bar" cannot be marked as final.', 'getParam', 'bar');
+        yield array('Cannot create service "baz": factories and overridden getters are incompatible with each other.', 'getParam', 'baz');
+    }
+
     public function testAbstractAlias()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Variable;
 use Symfony\Component\ExpressionLanguage\Expression;
@@ -309,6 +310,66 @@ class PhpDumperTest extends \PHPUnit_Framework_TestCase
         $dumper = new PhpDumper($container);
 
         $this->assertStringEqualsFile(self::$fixturesPath.'/php/services24.php', $dumper->dump());
+    }
+
+    public function testDumpOverridenGetters()
+    {
+        $container = include self::$fixturesPath.'/containers/container29.php';
+        $container->compile();
+        $container->getDefinition('foo')
+            ->setOverriddenGetter('getInvalid', array(new Reference('bar', ContainerBuilder::IGNORE_ON_INVALID_REFERENCE)));
+        $dumper = new PhpDumper($container);
+
+        $dump = $dumper->dump(array('class' => 'Symfony_DI_PhpDumper_Test_Overriden_Getters'));
+        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services29.php', $dump);
+        $res = $container->getResources();
+        $this->assertSame(realpath(self::$fixturesPath.'/containers/container29.php'), array_pop($res)->getResource());
+
+        eval('?>'.$dump);
+
+        $container = new \Symfony_DI_PhpDumper_Test_Overriden_Getters();
+
+        $foo = $container->get('foo');
+
+        $this->assertSame('public', $foo->getPublic());
+        $this->assertSame('protected', $foo->getGetProtected());
+        $this->assertSame($foo, $foo->getSelf());
+        $this->assertSame(456, $foo->getInvalid());
+
+        $baz = $container->get('baz');
+        $r = new \ReflectionMethod($baz, 'getBaz');
+        $r->setAccessible(true);
+
+        $this->assertTrue($r->isProtected());
+        $this->assertSame('baz', $r->invoke($baz));
+    }
+
+    /**
+     * @dataProvider provideBadOverridenGetters
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
+     */
+    public function testBadOverridenGetters($expectedMessage, $getter, $id = 'foo')
+    {
+        $container = include self::$fixturesPath.'/containers/container30.php';
+        $container->getDefinition($id)->setOverriddenGetter($getter, 123);
+
+        $container->compile();
+        $dumper = new PhpDumper($container);
+
+        $this->setExpectedException(RuntimeException::class, $expectedMessage);
+        $dumper->dump();
+    }
+
+    public function provideBadOverridenGetters()
+    {
+        yield array('Unable to configure getter injection for service "foo": method "Symfony\Component\DependencyInjection\Tests\Fixtures\Container30\Foo::getnotfound" does not exist.', 'getNotFound');
+        yield array('Unable to configure getter injection for service "foo": method "Symfony\Component\DependencyInjection\Tests\Fixtures\Container30\Foo::getPrivate" must be public or protected.', 'getPrivate');
+        yield array('Unable to configure getter injection for service "foo": method "Symfony\Component\DependencyInjection\Tests\Fixtures\Container30\Foo::getStatic" cannot be static.', 'getStatic');
+        yield array('Unable to configure getter injection for service "foo": method "Symfony\Component\DependencyInjection\Tests\Fixtures\Container30\Foo::getFinal" cannot be marked as final.', 'getFinal');
+        yield array('Unable to configure getter injection for service "foo": method "Symfony\Component\DependencyInjection\Tests\Fixtures\Container30\Foo::getRef" cannot return by reference.', 'getRef');
+        yield array('Unable to configure getter injection for service "foo": method "Symfony\Component\DependencyInjection\Tests\Fixtures\Container30\Foo::getParam" cannot have any arguments.', 'getParam');
+        yield array('Unable to configure getter injection for service "bar": class "Symfony\Component\DependencyInjection\Tests\Fixtures\Container30\Bar" cannot be marked as final.', 'getParam', 'bar');
+        yield array('Cannot dump definition for service "baz": factories and overridden getters are incompatible with each other.', 'getParam', 'baz');
     }
 
     public function testEnvParameter()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container29.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container29.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Container29;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+if (!class_exists(Foo::class, false)) {
+    abstract class Foo
+    {
+        abstract public function getPublic();
+        abstract protected function getProtected();
+
+        public function getSelf()
+        {
+            return 123;
+        }
+
+        public function getInvalid()
+        {
+            return 456;
+        }
+
+        public function getGetProtected()
+        {
+            return $this->getProtected();
+        }
+    }
+
+    class Baz
+    {
+        final public function __construct()
+        {
+        }
+
+        protected function getBaz()
+        {
+            return 234;
+        }
+    }
+}
+
+$container = new ContainerBuilder();
+
+$container
+    ->register('foo', Foo::class)
+    ->setOverriddenGetter('getPublic', 'public')
+    ->setOverriddenGetter('getProtected', 'protected')
+    ->setOverriddenGetter('getSelf', new Reference('foo'))
+;
+
+$container
+    ->register('baz', Baz::class)
+    ->setOverriddenGetter('getBaz', 'baz')
+;
+
+return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container30.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container30.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Container30;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+if (!class_exists(Foo::class, false)) {
+    class Foo
+    {
+        public static function getStatic()
+        {
+        }
+
+        final public function getFinal()
+        {
+        }
+
+        public function &getRef()
+        {
+        }
+
+        public function getParam($a = null)
+        {
+        }
+
+        private function getPrivate()
+        {
+        }
+    }
+
+    final class Bar
+    {
+    }
+}
+
+$container = new ContainerBuilder();
+
+$container->register('foo', Foo::class);
+$container->register('bar', Bar::class);
+$container->register('baz', Bar::class)->setFactory('foo');
+
+return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services29.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services29.php
@@ -1,0 +1,152 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
+
+/**
+ * Symfony_DI_PhpDumper_Test_Overriden_Getters.
+ *
+ * This class has been auto-generated
+ * by the Symfony Dependency Injection Component.
+ *
+ * @final since Symfony 3.3
+ */
+class Symfony_DI_PhpDumper_Test_Overriden_Getters extends Container
+{
+    private $parameters;
+    private $targetDirs = array();
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->services = array();
+        $this->methodMap = array(
+            'baz' => 'getBazService',
+            'foo' => 'getFooService',
+        );
+
+        $this->aliases = array();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function compile()
+    {
+        throw new LogicException('You cannot compile a dumped frozen container.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isFrozen()
+    {
+        return true;
+    }
+
+    /**
+     * Gets the 'baz' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\Container29\Baz A Symfony\Component\DependencyInjection\Tests\Fixtures\Container29\Baz instance
+     */
+    protected function getBazService()
+    {
+        return $this->services['baz'] = $this->instantiateProxy(SymfonyProxy_46eafd3003c2798ed583593e686cb95e::class, array(), true);
+    }
+
+    /**
+     * Gets the 'foo' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\Container29\Foo A Symfony\Component\DependencyInjection\Tests\Fixtures\Container29\Foo instance
+     */
+    protected function getFooService()
+    {
+        return $this->services['foo'] = new SymfonyProxy_78f39120a5353f811849a5b3f3e6d70c($this);
+    }
+
+    private function instantiateProxy($class, $args, $useConstructor)
+    {
+        static $reflectionCache;
+
+        if (null === $r = &$reflectionCache[$class]) {
+            $r[0] = new \ReflectionClass($class);
+            $r[1] = $r[0]->getProperty('container6HqvH3fsTTC6dr66HyT2Jw');
+            $r[1]->setAccessible(true);
+            $r[2] = $r[0]->getConstructor();
+        }
+        $service = $useConstructor ? $r[0]->newInstanceWithoutConstructor() : $r[0]->newInstanceArgs($args);
+        $r[1]->setValue($service, $this);
+        if ($r[2] && $useConstructor) {
+            $r[2]->invokeArgs($service, $args);
+        }
+
+        return $service;
+    }
+}
+
+class SymfonyProxy_46eafd3003c2798ed583593e686cb95e extends \Symfony\Component\DependencyInjection\Tests\Fixtures\Container29\Baz implements \Symfony\Component\DependencyInjection\LazyProxy\GetterProxyInterface
+{
+    private $container6HqvH3fsTTC6dr66HyT2Jw;
+    private $getters6HqvH3fsTTC6dr66HyT2Jw;
+
+    protected function getBaz()
+    {
+        return 'baz';
+    }
+}
+
+class SymfonyProxy_78f39120a5353f811849a5b3f3e6d70c extends \Symfony\Component\DependencyInjection\Tests\Fixtures\Container29\Foo implements \Symfony\Component\DependencyInjection\LazyProxy\GetterProxyInterface
+{
+    private $container6HqvH3fsTTC6dr66HyT2Jw;
+    private $getters6HqvH3fsTTC6dr66HyT2Jw;
+
+    public function __construct($container6HqvH3fsTTC6dr66HyT2Jw)
+    {
+        $this->container6HqvH3fsTTC6dr66HyT2Jw = $container6HqvH3fsTTC6dr66HyT2Jw;
+    }
+
+    public function getPublic()
+    {
+        return 'public';
+    }
+
+    protected function getProtected()
+    {
+        return 'protected';
+    }
+
+    public function getSelf()
+    {
+        if (null === $g = &$this->getters6HqvH3fsTTC6dr66HyT2Jw[__FUNCTION__]) {
+            $g = \Closure::bind(function () { return ${($_ = isset($this->services['foo']) ? $this->services['foo'] : $this->get('foo')) && false ?: '_'}; }, $this->container6HqvH3fsTTC6dr66HyT2Jw, $this->container6HqvH3fsTTC6dr66HyT2Jw);
+        }
+
+        return $g();
+    }
+
+    public function getInvalid()
+    {
+        if (null === $g = &$this->getters6HqvH3fsTTC6dr66HyT2Jw[__FUNCTION__]) {
+            $g = \Closure::bind(function () { return array(0 => $this->get('bar', ContainerInterface::NULL_ON_INVALID_REFERENCE)); }, $this->container6HqvH3fsTTC6dr66HyT2Jw, $this->container6HqvH3fsTTC6dr66HyT2Jw);
+        }
+
+        if ($this->container6HqvH3fsTTC6dr66HyT2Jw->has('bar')) {
+            return $g();
+        }
+
+        return parent::getInvalid();
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services31.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services31.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="foo" class="Foo">
+            <getter name="getBar" type="collection">
+                <getter key="bar" type="service" id="bar" />
+            </getter>
+        </service>
+    </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services31.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services31.yml
@@ -1,0 +1,6 @@
+services:
+    foo:
+        class: Foo
+        getters:
+            getBar: { bar: '@bar' }
+

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -576,6 +576,15 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('set*', 'bar'), $container->getDefinition('autowire_array')->getAutowiredMethods());
     }
 
+    public function testGetter()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader->load('services31.xml');
+
+        $this->assertEquals(array('getbar' => array('bar' => new Reference('bar'))), $container->getDefinition('foo')->getOverriddenGetters());
+    }
+
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
      */

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -405,6 +405,15 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($container->getDefinition('no_defaults_child')->isAutowired());
     }
 
+    public function testGetter()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('services31.yml');
+
+        $this->assertEquals(array('getbar' => array('bar' => new Reference('bar'))), $container->getDefinition('foo')->getOverriddenGetters());
+    }
+
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
      * @expectedExceptionMessage The value of the "decorates" option for the "bar" service must be the id of the service without the "@" prefix (replace "@foo" with "foo").

--- a/src/Symfony/Component/VarDumper/Caster/SymfonyCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/SymfonyCaster.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\VarDumper\Caster;
 
+use Symfony\Component\DependencyInjection\LazyProxy\GetterProxyInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\VarDumper\Cloner\Stub;
 
@@ -35,6 +36,21 @@ class SymfonyCaster
                     $clone = clone $request;
                 }
                 $a[Caster::PREFIX_VIRTUAL.$prop] = $clone->{$getter}();
+            }
+        }
+
+        return $a;
+    }
+
+    public static function castGetterProxy(GetterProxyInterface $proxy, array $a, Stub $stub, $isNested)
+    {
+        $privatePrefix = sprintf("\0%s\0", $stub->class);
+        $stub->class = get_parent_class($proxy).'@proxy';
+
+        foreach ($a as $k => $v) {
+            if ("\0" === $k[0] && 0 === strpos($k, $privatePrefix)) {
+                ++$stub->cut;
+                unset($a[$k]);
             }
         }
 

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -75,6 +75,7 @@ abstract class AbstractCloner implements ClonerInterface
         'Exception' => 'Symfony\Component\VarDumper\Caster\ExceptionCaster::castException',
         'Error' => 'Symfony\Component\VarDumper\Caster\ExceptionCaster::castError',
         'Symfony\Component\DependencyInjection\ContainerInterface' => 'Symfony\Component\VarDumper\Caster\StubCaster::cutInternals',
+        'Symfony\Component\DependencyInjection\LazyProxy\GetterProxyInterface' => 'Symfony\Component\VarDumper\Caster\SymfonyCaster::castGetterProxy',
         'Symfony\Component\HttpFoundation\Request' => 'Symfony\Component\VarDumper\Caster\SymfonyCaster::castRequest',
         'Symfony\Component\VarDumper\Exception\ThrowingCasterException' => 'Symfony\Component\VarDumper\Caster\ExceptionCaster::castThrowingCasterException',
         'Symfony\Component\VarDumper\Caster\TraceStub' => 'Symfony\Component\VarDumper\Caster\ExceptionCaster::castTraceStub',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20657, #835
| License       | MIT
| Doc PR        | symfony/symfony-docs#7300

Getter overriding by the container will allow a new kind of dependency injection which enables easier laziness and more immutable classes, by not requiring any corresponding setter. See linked issue for more.

This is WIP:
- [x] wire the concept
- [x] dump anonymous classes with PhpDumper
- [x] generate at runtime in ContainerBuilder::createService
- [x] tests
- [x] make it work on PHP 5