### PR TITLE
[Form] TransformationFailedException: Support specifying message to display

### DIFF
--- a/src/Symfony/Component/Form/Exception/TransformationFailedException.php
+++ b/src/Symfony/Component/Form/Exception/TransformationFailedException.php
@@ -18,4 +18,35 @@ namespace Symfony\Component\Form\Exception;
  */
 class TransformationFailedException extends RuntimeException
 {
+    private $invalidMessage;
+    private $invalidMessageParameters;
+
+    public function __construct(string $message = '', int $code = 0, \Throwable $previous = null, string $invalidMessage = null, array $invalidMessageParameters = [])
+    {
+        parent::__construct($message, $code, $previous);
+
+        $this->setInvalidMessage($invalidMessage, $invalidMessageParameters);
+    }
+
+    /**
+     * Sets the message that will be shown to the user.
+     *
+     * @param string|null $invalidMessage           The message or message key
+     * @param array       $invalidMessageParameters Data to be passed into the translator
+     */
+    public function setInvalidMessage(string $invalidMessage = null, array $invalidMessageParameters = []): void
+    {
+        $this->invalidMessage = $invalidMessage;
+        $this->invalidMessageParameters = $invalidMessageParameters;
+    }
+
+    public function getInvalidMessage(): ?string
+    {
+        return $this->invalidMessage;
+    }
+
+    public function getInvalidMessageParameters(): array
+    {
+        return $this->invalidMessageParameters;
+    }
 }

--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -118,12 +118,18 @@ class FormValidator extends ConstraintValidator
                     ? (string) $form->getViewData()
                     : \gettype($form->getViewData());
 
+                $failure = $form->getTransformationFailure();
+
                 $this->context->setConstraint($formConstraint);
-                $this->context->buildViolation($config->getOption('invalid_message'))
-                    ->setParameters(array_replace(['{{ value }}' => $clientDataAsString], $config->getOption('invalid_message_parameters')))
+                $this->context->buildViolation($failure->getInvalidMessage() ?? $config->getOption('invalid_message'))
+                    ->setParameters(array_replace(
+                        ['{{ value }}' => $clientDataAsString],
+                        $config->getOption('invalid_message_parameters'),
+                        $failure->getInvalidMessageParameters()
+                    ))
                     ->setInvalidValue($form->getViewData())
                     ->setCode(Form::NOT_SYNCHRONIZED_ERROR)
-                    ->setCause($form->getTransformationFailure())
+                    ->setCause($failure)
                     ->addViolation();
             }
         }

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -1070,7 +1070,7 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
                 $value = $transformer->transform($value);
             }
         } catch (TransformationFailedException $exception) {
-            throw new TransformationFailedException('Unable to transform value for property path "'.$this->getPropertyPath().'": '.$exception->getMessage(), $exception->getCode(), $exception);
+            throw new TransformationFailedException('Unable to transform value for property path "'.$this->getPropertyPath().'": '.$exception->getMessage(), $exception->getCode(), $exception, $exception->getInvalidMessage(), $exception->getInvalidMessageParameters());
         }
 
         return $value;
@@ -1094,7 +1094,7 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
                 $value = $transformers[$i]->reverseTransform($value);
             }
         } catch (TransformationFailedException $exception) {
-            throw new TransformationFailedException('Unable to reverse value for property path "'.$this->getPropertyPath().'": '.$exception->getMessage(), $exception->getCode(), $exception);
+            throw new TransformationFailedException('Unable to reverse value for property path "'.$this->getPropertyPath().'": '.$exception->getMessage(), $exception->getCode(), $exception, $exception->getInvalidMessage(), $exception->getInvalidMessageParameters());
         }
 
         return $value;
@@ -1125,7 +1125,7 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
                 $value = $transformer->transform($value);
             }
         } catch (TransformationFailedException $exception) {
-            throw new TransformationFailedException('Unable to transform value for property path "'.$this->getPropertyPath().'": '.$exception->getMessage(), $exception->getCode(), $exception);
+            throw new TransformationFailedException('Unable to transform value for property path "'.$this->getPropertyPath().'": '.$exception->getMessage(), $exception->getCode(), $exception, $exception->getInvalidMessage(), $exception->getInvalidMessageParameters());
         }
 
         return $value;
@@ -1153,7 +1153,7 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
                 $value = $transformers[$i]->reverseTransform($value);
             }
         } catch (TransformationFailedException $exception) {
-            throw new TransformationFailedException('Unable to reverse value for property path "'.$this->getPropertyPath().'": '.$exception->getMessage(), $exception->getCode(), $exception);
+            throw new TransformationFailedException('Unable to reverse value for property path "'.$this->getPropertyPath().'": '.$exception->getMessage(), $exception->getCode(), $exception, $exception->getInvalidMessage(), $exception->getInvalidMessageParameters());
         }
 
         return $value;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #22501
| License       | MIT
| Doc PR        | N/A

Currently, a failed transformation can't display a very accurate message, as it only uses the value of the `invalid_message` option. I suggest to add more flexibility, somehow the same way we did for `CustomUserMessageAuthenticationException`.

A test case in `FormTypeTest` shows a use-case based on @webmozart's [blog post about value/immutable objects in Symfony forms](https://webmozart.io/blog/2015/09/09/value-objects-in-symfony-forms/).

~I named the exception properties and methods the same way as for `CustomUserMessageAuthenticationException`, but do you think the followings would be better:~

- ~`setSafeMessage` ➜ `setInvalidMessage`~
- ~`getMessageKey` ➜ `getInvalidMessageKey`~
- ~`getMessageData` ➜ `getInvalidMessageParameters`~

~in order to echoes `invalid_message` and `invalid_message_parameters` options?~

=> Replaced to use `invalidMessage` & `invalidMessageParameters`