### PR TITLE
[HttpKernel] Fix "Locale class not found" in ConfigDataCollector

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -68,7 +68,7 @@ class ConfigDataCollector extends DataCollector
             'debug' => isset($this->kernel) ? $this->kernel->isDebug() : 'n/a',
             'php_version' => PHP_VERSION,
             'php_architecture' => PHP_INT_SIZE * 8,
-            'php_intl_locale' => \Locale::getDefault() ?: 'n/a',
+            'php_intl_locale' => class_exists('Locale', false) && \Locale::getDefault() ? \Locale::getDefault() : 'n/a',
             'php_timezone' => date_default_timezone_get(),
             'xdebug_enabled' => extension_loaded('xdebug'),
             'apcu_enabled' => extension_loaded('apcu') && ini_get('apc.enabled'),

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
@@ -32,7 +32,7 @@ class ConfigDataCollectorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('testkernel', $c->getAppName());
         $this->assertSame(PHP_VERSION, $c->getPhpVersion());
         $this->assertSame(PHP_INT_SIZE * 8, $c->getPhpArchitecture());
-        $this->assertSame(\Locale::getDefault() ?: 'n/a', $c->getPhpIntlLocale());
+        $this->assertSame(class_exists('Locale', false) && \Locale::getDefault() ? \Locale::getDefault() : 'n/a', $c->getPhpIntlLocale());
         $this->assertSame(date_default_timezone_get(), $c->getPhpTimezone());
         $this->assertSame(Kernel::VERSION, $c->getSymfonyVersion());
         $this->assertNull($c->getToken());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

PHP 7.0 & 7.1, no intl, "Locale" is not defined.