### PR TITLE
[cache] Bump RedisAdapter default timeout to 5s

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/RedisAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/RedisAdapter.php
@@ -25,8 +25,8 @@ class RedisAdapter extends AbstractAdapter
     private static $defaultConnectionOptions = array(
         'class' => null,
         'persistent' => 0,
-        'timeout' => 0,
-        'read_timeout' => 0,
+        'timeout' => 30,
+        'read_timeout' => 30,
         'retry_interval' => 0,
     );
     private $redis;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Bump RedisAdapter timeout to 5s because (at least with Predis) 0 means 0s