### PR TITLE
Add missing upgrade path for Request::isMethodSafe() deprecation

### DIFF
--- a/UPGRADE-3.2.md
+++ b/UPGRADE-3.2.md
@@ -94,6 +94,11 @@ HttpFoundation
      - `isInvalid`/`isSuccessful`/`isRedirection`/`isClientError`/`isServerError`
      - `isOk`/`isForbidden`/`isNotFound`/`isRedirect`/`isEmpty`
 
+  * Checking only for cacheable HTTP methods with `Request::isMethodSafe()` is deprecated 
+    since version 3.2 and will throw an exception in 4.0. Disable checking only for 
+    cacheable methods by calling the method with `false` as first argument or use 
+    `Request::isMethodCacheable()` instead.
+
 HttpKernel
 ----------
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -151,6 +151,9 @@ HttpFoundation
     - `isInvalid`/`isSuccessful`/`isRedirection`/`isClientError`/`isServerError`
     - `isOk`/`isForbidden`/`isNotFound`/`isRedirect`/`isEmpty`
 
+ * The ability to check only for cacheable HTTP methods using `Request::isMethodSafe()` is
+   not supported anymore, use `Request::isMethodCacheable()` instead.
+
 HttpKernel
 ----------
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Fixed tickets| #20990 