### PR TITLE
[DependencyInjection] Fix the priority order of compiler pass trait

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/PriorityTaggedServiceTraitTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/PriorityTaggedServiceTraitTest.php
@@ -33,6 +33,12 @@ class PriorityTaggedServiceTraitTest extends \PHPUnit_Framework_TestCase
             'my_service11' => array('my_custom_tag' => array('priority' => -1001)),
             'my_service12' => array('my_custom_tag' => array('priority' => -1002)),
             'my_service13' => array('my_custom_tag' => array('priority' => -1003)),
+            'my_service14' => array('my_custom_tag' => array('priority' => -1000)),
+            'my_service15' => array('my_custom_tag' => array('priority' => 1)),
+            'my_service16' => array('my_custom_tag' => array('priority' => -1)),
+            'my_service17' => array('my_custom_tag' => array('priority' => 200)),
+            'my_service18' => array('my_custom_tag' => array('priority' => 100)),
+            'my_service19' => array('my_custom_tag' => array()),
         );
 
         $container = new ContainerBuilder();
@@ -47,15 +53,21 @@ class PriorityTaggedServiceTraitTest extends \PHPUnit_Framework_TestCase
 
         $expected = array(
             new Reference('my_service2'),
+            new Reference('my_service17'),
             new Reference('my_service1'),
+            new Reference('my_service18'),
             new Reference('my_service8'),
+            new Reference('my_service15'),
             new Reference('my_service4'),
+            new Reference('my_service19'),
             new Reference('my_service5'),
+            new Reference('my_service16'),
             new Reference('my_service9'),
             new Reference('my_service7'),
             new Reference('my_service6'),
             new Reference('my_service3'),
             new Reference('my_service10'),
+            new Reference('my_service14'),
             new Reference('my_service11'),
             new Reference('my_service12'),
             new Reference('my_service13'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20332, #20993
| License       | MIT
| Doc PR        | ~

A regression has appeared between the version `3.1` and `3.2` on the compilation passes using a priority option (see #20332).

Indeed, the order is no longer preserved for service definitions with the same priority. This is caused by the `SplPriorityQueue` class that does not have a FIFO implementation (see this [comment](https://github.com/symfony/symfony/issues/20332#issuecomment-268096527)).

The PR #20993 fixes the problem but only for Forms, not for all compiler passes using the `PriorityTaggedServiceTrait` trait since `3.2`.