### PR TITLE
[Debug] UndefinedMethodFatalErrorHandler - Handle anonymous classes

### DIFF
--- a/src/Symfony/Component/Debug/FatalErrorHandler/UndefinedMethodFatalErrorHandler.php
+++ b/src/Symfony/Component/Debug/FatalErrorHandler/UndefinedMethodFatalErrorHandler.php
@@ -36,7 +36,8 @@ class UndefinedMethodFatalErrorHandler implements FatalErrorHandlerInterface
 
         $message = sprintf('Attempted to call an undefined method named "%s" of class "%s".', $methodName, $className);
 
-        if (null === $methods = get_class_methods($className)) {
+        if (!class_exists($className) || null === $methods = get_class_methods($className)) {
+            // failed to get the class or its methods on which an unknown method was called (for example on an anonymous class)
             return new UndefinedMethodException($message, $exception);
         }
 
@@ -56,6 +57,7 @@ class UndefinedMethodFatalErrorHandler implements FatalErrorHandlerInterface
             } else {
                 $candidates = '"'.$last;
             }
+
             $message .= "\nDid you mean to call ".$candidates;
         }
 

--- a/src/Symfony/Component/Debug/FatalErrorHandler/UndefinedMethodFatalErrorHandler.php
+++ b/src/Symfony/Component/Debug/FatalErrorHandler/UndefinedMethodFatalErrorHandler.php
@@ -36,8 +36,12 @@ class UndefinedMethodFatalErrorHandler implements FatalErrorHandlerInterface
 
         $message = sprintf('Attempted to call an undefined method named "%s" of class "%s".', $methodName, $className);
 
+        if (null === $methods = get_class_methods($className)) {
+            return new UndefinedMethodException($message, $exception);
+        }
+
         $candidates = array();
-        foreach (get_class_methods($className) as $definedMethodName) {
+        foreach ($methods as $definedMethodName) {
             $lev = levenshtein($methodName, $definedMethodName);
             if ($lev <= strlen($methodName) / 3 || false !== strpos($definedMethodName, $methodName)) {
                 $candidates[] = $definedMethodName;

--- a/src/Symfony/Component/Debug/Tests/FatalErrorHandler/UndefinedMethodFatalErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/FatalErrorHandler/UndefinedMethodFatalErrorHandlerTest.php
@@ -61,6 +61,15 @@ class UndefinedMethodFatalErrorHandlerTest extends \PHPUnit_Framework_TestCase
                 ),
                 "Attempted to call an undefined method named \"offsetFet\" of class \"SplObjectStorage\".\nDid you mean to call e.g. \"offsetGet\", \"offsetSet\" or \"offsetUnset\"?",
             ),
+            array(
+                array(
+                  'type' => 1,
+                  'message' => 'Call to undefined method class@anonymous::test()',
+                  'file' => '/home/possum/work/symfony/test.php',
+                  'line' => 11,
+                ),
+                'Attempted to call an undefined method named "test" of class "class@anonymous".',
+            ),
         );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

When trying to call a method on an anonymous class (with or without methods) the `UndefinedMethodFatalErrorHandler` tries to iterate `null`.

For ref.: https://3v4l.org/l26u1