### PR TITLE
[Framework] allow to create kernel-aware console application with no default commands

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -28,16 +28,19 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 class Application extends BaseApplication
 {
     private $kernel;
+    private $loadDefaultCommands;
     private $commandsRegistered = false;
 
     /**
      * Constructor.
      *
      * @param KernelInterface $kernel A KernelInterface instance
+     * @param bool $loadDefaultCommands
      */
-    public function __construct(KernelInterface $kernel)
+    public function __construct(KernelInterface $kernel, $loadDefaultCommands = true)
     {
         $this->kernel = $kernel;
+        $this->$loadDefaultCommands = $loadDefaultCommands;
 
         parent::__construct('Symfony', Kernel::VERSION.' - '.$kernel->getName().'/'.$kernel->getEnvironment().($kernel->isDebug() ? '/debug' : ''));
 
@@ -122,7 +125,7 @@ class Application extends BaseApplication
 
     protected function registerCommands()
     {
-        if ($this->commandsRegistered) {
+        if ($this->commandsRegistered || !$this->loadDefaultCommands) {
             return;
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -34,8 +34,8 @@ class Application extends BaseApplication
     /**
      * Constructor.
      *
-     * @param KernelInterface $kernel               A KernelInterface instance
-     * @param bool            $loadDefaultCommands  Load all the default commands
+     * @param KernelInterface $kernel              A KernelInterface instance
+     * @param bool            $loadDefaultCommands Load all the default commands
      */
     public function __construct(KernelInterface $kernel, $loadDefaultCommands = true)
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -34,13 +34,13 @@ class Application extends BaseApplication
     /**
      * Constructor.
      *
-     * @param KernelInterface $kernel A KernelInterface instance
-     * @param bool $loadDefaultCommands
+     * @param KernelInterface $kernel               A KernelInterface instance
+     * @param bool            $loadDefaultCommands  Load all the default commands
      */
     public function __construct(KernelInterface $kernel, $loadDefaultCommands = true)
     {
         $this->kernel = $kernel;
-        $this->$loadDefaultCommands = $loadDefaultCommands;
+        $this->loadDefaultCommands = $loadDefaultCommands;
 
         parent::__construct('Symfony', Kernel::VERSION.' - '.$kernel->getName().'/'.$kernel->getEnvironment().($kernel->isDebug() ? '/debug' : ''));
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT


Suppose that you need to create a kernel-aware application:

```
// ...
$kernel = new AppKernel($env, $debug);
$application = new MyApplication($kernel);

$application->addCommands([
    // CUstom commands
    new MyCustomCommand(),
]);

$application->run($input);
```
The code above will create a console application with  ``MyCustomCommand`` plus all the other default symfony commands.

With this PR you are able to specify whether or not you want to add the default commands:

``$application = new MyApplication($kernel, false);``
or
``$application = new MyApplication($kernel, true);`` (default)