### PR TITLE
[Framework] allow to create kernel-aware console applications without default commands

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -28,7 +28,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 class Application extends BaseApplication
 {
     private $kernel;
-    private $commandsRegistered = false;
+    private $commandsRegistered;
 
     /**
      * Constructor.

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -33,11 +33,13 @@ class Application extends BaseApplication
     /**
      * Constructor.
      *
-     * @param KernelInterface $kernel A KernelInterface instance
+     * @param KernelInterface $kernel              A KernelInterface instance
+     * @param bool            $loadDefaultCommands Load all the default commands
      */
-    public function __construct(KernelInterface $kernel)
+    public function __construct(KernelInterface $kernel, $loadDefaultCommands = true)
     {
         $this->kernel = $kernel;
+        $this->commandsRegistered = !$loadDefaultCommands;
 
         parent::__construct('Symfony', Kernel::VERSION);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT
| Doc PR        |  https://github.com/symfony/symfony-docs/pull/7296


Suppose that you need to create a kernel-aware application:

```
// ...
$kernel = new AppKernel($env, $debug);
$application = new MyApplication($kernel);

$application->addCommands([
    // CUstom commands
    new MyCustomCommand(),
]);

$application->run($input);
```
The code above will create a console application with  ``MyCustomCommand`` plus all the other default symfony commands.

With this PR you are able to specify whether or not you want to add the default commands:

``$application = new MyApplication($kernel, false);``
or
``$application = new MyApplication($kernel, true);`` (default)
