### PR TITLE
[TwigBridge] Late deprecation for TwigRendererEngine::setEnvironment()

### DIFF
--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -38,3 +38,9 @@ SecurityBundle
 
  * The `FirewallContext::getContext()` method has been deprecated and will be removed in 4.0.
    Use the `getListeners()` method instead.
+
+TwigBridge
+----------
+
+ * The `TwigRendererEngine::setEnvironment()` method has been deprecated and will be removed
+   in 4.0. Pass the Twig Environment as second argument of the constructor instead.

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -217,6 +217,9 @@ TwigBridge
  * The possibility to inject the Form Twig Renderer into the form extension
    has been removed. Inject it into the `TwigRendererEngine` instead.
 
+ * The `TwigRendererEngine::setEnvironment()` method has been removed.
+   Pass the Twig Environment as second argument of the constructor instead.
+
 Validator
 ---------
 

--- a/src/Symfony/Bridge/Twig/Form/TwigRendererEngine.php
+++ b/src/Symfony/Bridge/Twig/Form/TwigRendererEngine.php
@@ -41,9 +41,15 @@ class TwigRendererEngine extends AbstractRendererEngine implements TwigRendererE
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated since version 3.3, to be removed in 4.0
      */
     public function setEnvironment(\Twig_Environment $environment)
     {
+        if ($this->environment) {
+            @trigger_error(sprintf('The "%s()" method is deprecated since version 3.3 and will be removed in 4.0. Pass the Twig Environment as second argument of the constructor instead.', __METHOD__), E_USER_DEPRECATED);
+        }
+
         $this->environment = $environment;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/20093#discussion_r81309117
| License       | MIT
| Doc PR        | n/a

This method should have been deprecated in 3.2 since the twig environment should be injected through the constructor and replacing it later can break things (see https://github.com/symfony/symfony/pull/20093#discussion_r81309117 for details). 

Maybe this could target 3.2