### PR TITLE
[TwigBridge] Fix upgrade/changelog notes

### DIFF
--- a/UPGRADE-3.2.md
+++ b/UPGRADE-3.2.md
@@ -133,8 +133,36 @@ Serializer
 TwigBridge
 ----------
 
- * Deprecated the possibility to inject the Form Twig Renderer into the form
-   extension. Inject it into the `TwigRendererEngine` instead.
+ * Injecting the Form `TwigRenderer` into the `FormExtension` is deprecated and has no more effect.
+   Upgrade Twig to `^1.30`, inject the `Twig_Environment` into the `TwigRendererEngine` and load
+   the `TwigRenderer` using the `Twig_FactoryRuntimeLoader` instead.
+
+   Before:
+
+   ```php
+   use Symfony\Bridge\Twig\Extension\FormExtension;
+   use Symfony\Bridge\Twig\Form\TwigRenderer;
+   use Symfony\Bridge\Twig\Form\TwigRendererEngine;
+
+   // ...
+   $rendererEngine = new TwigRendererEngine(array('form_div_layout.html.twig'));
+   $rendererEngine->setEnvironment($twig);
+   $twig->addExtension(new FormExtension(new TwigRenderer($rendererEngine, $csrfTokenManager)));
+   ```
+
+   After:
+
+   ```php
+   $rendererEngine = new TwigRendererEngine(array('form_div_layout.html.twig'), $twig);
+   $twig->addRuntimeLoader(new \Twig_FactoryRuntimeLoader(array(
+       TwigRenderer::class => function () use ($rendererEngine, $csrfTokenManager) {
+           return new TwigRenderer($rendererEngine, $csrfTokenManager);
+       },
+   )));
+   $twig->addExtension(new FormExtension());
+   ```
+
+ * Deprecated the `TwigRendererEngineInterface` interface, it will be removed in 4.0.
 
 Validator
 ---------

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -186,8 +186,36 @@ Translation
 TwigBridge
 ----------
 
- * The possibility to inject the Form Twig Renderer into the form extension
-   has been removed. Inject it into the `TwigRendererEngine` instead.
+ * Removed the possibility to inject the Form `TwigRenderer` into the `FormExtension`.
+   Upgrade Twig to `^1.30`, inject the `Twig_Environment` into the `TwigRendererEngine` and load
+   the `TwigRenderer` using the `Twig_FactoryRuntimeLoader` instead.
+
+   Before:
+
+   ```php
+   use Symfony\Bridge\Twig\Extension\FormExtension;
+   use Symfony\Bridge\Twig\Form\TwigRenderer;
+   use Symfony\Bridge\Twig\Form\TwigRendererEngine;
+
+   // ...
+   $rendererEngine = new TwigRendererEngine(array('form_div_layout.html.twig'));
+   $rendererEngine->setEnvironment($twig);
+   $twig->addExtension(new FormExtension(new TwigRenderer($rendererEngine, $csrfTokenManager)));
+   ```
+
+   After:
+
+   ```php
+   $rendererEngine = new TwigRendererEngine(array('form_div_layout.html.twig'), $twig);
+   $twig->addRuntimeLoader(new \Twig_FactoryRuntimeLoader(array(
+       TwigRenderer::class => function () use ($rendererEngine, $csrfTokenManager) {
+           return new TwigRenderer($rendererEngine, $csrfTokenManager);
+       },
+   )));
+   $twig->addExtension(new FormExtension());
+   ```
+
+ * Removed the `TwigRendererEngineInterface` interface.
 
 Validator
 ---------

--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -5,8 +5,37 @@ CHANGELOG
 -----
 
  * added `AppVariable::getToken()`
- * Deprecated the possibility to inject the Form Twig Renderer into the form
-   extension. Inject it on TwigRendererEngine instead.
+ * Deprecated the possibility to inject the Form `TwigRenderer` into the `FormExtension`.
+ * [BC BREAK] Registering the `FormExtension` without configuring a runtime loader for the `TwigRenderer` 
+   doesn't work anymore.
+   
+   Before:
+
+   ```php
+   use Symfony\Bridge\Twig\Extension\FormExtension;
+   use Symfony\Bridge\Twig\Form\TwigRenderer;
+   use Symfony\Bridge\Twig\Form\TwigRendererEngine;
+
+   // ...
+   $rendererEngine = new TwigRendererEngine(array('form_div_layout.html.twig'));
+   $rendererEngine->setEnvironment($twig);
+   $twig->addExtension(new FormExtension(new TwigRenderer($rendererEngine, $csrfTokenManager)));
+   ```
+
+   After:
+
+   ```php
+   // ...
+   $rendererEngine = new TwigRendererEngine(array('form_div_layout.html.twig'), $twig);
+   // require Twig 1.30+
+   $twig->addRuntimeLoader(new \Twig_FactoryRuntimeLoader(array(
+       TwigRenderer::class => function () use ($rendererEngine, $csrfTokenManager) {
+           return new TwigRenderer($rendererEngine, $csrfTokenManager);
+       },
+   )));
+   $twig->addExtension(new FormExtension());
+   ```
+ * Deprecated the `TwigRendererEngineInterface` interface.
 
 2.7.0
 -----


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2

The current upgrade note is wrong, the renderer cannot be injected in the `TwigRendererEngine`, only the Twig Environment can be.
Also added a missing note about the deprecated `TwigRendererEngineInterface`.