### PR TITLE
[TwigBridge] Add a runtime loader to the twig bridge to ease upgrading to 3.2+

### DIFF
--- a/src/Symfony/Bridge/Twig/TwigRuntimeLoader.php
+++ b/src/Symfony/Bridge/Twig/TwigRuntimeLoader.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig;
+
+/**
+ * Loads Twig extension runtimes.
+ *
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+class TwigRuntimeLoader implements \Twig_RuntimeLoaderInterface
+{
+    private $mapping;
+
+    public function __construct(array $mapping)
+    {
+        $this->mapping = $mapping;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function load($class)
+    {
+        if (isset($this->mapping[$class])) {
+            return $this->mapping[$class];
+        }
+
+        throw new \InvalidArgumentException(sprintf('Class "%s" is not mapped as a Twig runtime.', $class));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | todo

This is related to the BC break reported in #21008 which has been introduced in #20093.

I think the BC break is acceptable since it is about bootstraping the form component with the twig bridge only, outside of the fullstack.
What I propose here is to ease upgrading by adding a simple runtime loader to the bridge, useful only when using the twig-bridge standalone.

So the upgrade would be as simple as:

```diff
use Symfony\Bridge\Twig\TwigRuntimeLoader;

$twig = new Twig_Environment(...);
$formEngine = new TwigRendererEngine(array('form_div_layout.html.twig'), $twig);
- $twig->addExtension(new FormExtension(new TwigRenderer($formEngine, $csrfManager)));
+ $twig->addExtension(new FormExtension());
+ $twig->addRuntimeLoader(new TwigRuntimeLoader(array(TwigRenderer::class => new TwigRenderer($formEngine, $csrfManager)));
```

Instead of having to write this runtime loader yourself. UPGRADE files and documentation should be updated accordingly (with or without this PR).
Please see #21008 for details and an exemple of how this could be applied.