### PR TITLE
[Cache] remove is_writable check on filesystem cache

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
@@ -16,6 +16,7 @@ use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Cache\CacheItem;
+use Symfony\Component\Cache\Exception\CacheException;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
@@ -129,6 +130,8 @@ abstract class AbstractAdapter implements AdapterInterface, LoggerAwareInterface
      * @param int   $lifetime The lifetime of the cached values, 0 for persisting until manual cleaning
      *
      * @return array|bool The identifiers that failed to be cached or a boolean stating if caching succeeded or not
+     *
+     * @throws CacheException If write can not be performed
      */
     abstract protected function doSave(array $values, $lifetime);
 

--- a/src/Symfony/Component/Cache/Adapter/FilesystemAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/FilesystemAdapter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Adapter;
 
+use Symfony\Component\Cache\Exception\CacheException;
 use Symfony\Component\Cache\Exception\InvalidArgumentException;
 
 /**
@@ -39,9 +40,7 @@ class FilesystemAdapter extends AbstractAdapter
         if (false === $dir = realpath($dir) ?: (file_exists($dir) ? $dir : false)) {
             throw new InvalidArgumentException(sprintf('Cache directory does not exist (%s)', $directory));
         }
-        if (!is_writable($dir .= DIRECTORY_SEPARATOR)) {
-            throw new InvalidArgumentException(sprintf('Cache directory is not writable (%s)', $directory));
-        }
+        $dir .= DIRECTORY_SEPARATOR;
         // On Windows the whole path is limited to 258 chars
         if ('\\' === DIRECTORY_SEPARATOR && strlen($dir) > 234) {
             throw new InvalidArgumentException(sprintf('Cache directory too long (%s)', $directory));
@@ -139,6 +138,10 @@ class FilesystemAdapter extends AbstractAdapter
             } else {
                 $ok = false;
             }
+        }
+
+        if (!$ok && !is_writable($this->directory)) {
+            throw new CacheException(sprintf('Cache directory is not writable (%s)', $this->directory));
         }
 
         return $ok;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21024 
| License       | MIT
| Doc PR        | -

* Use 755 mode for directories creation
* Remove `is_writable` check in FilesystemAdapter to avoid exception on read-only filesystems
