### PR TITLE
[Asset] Provide default context

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -53,7 +53,8 @@ CHANGELOG
    `EventDispatcherDebugCommand`, `RouterDebugCommand`, `RouterMatchCommand`,
    `TranslationDebugCommand`, `TranslationUpdateCommand`, `XliffLintCommand`
     and `YamlLintCommand` classes have been marked as final
- * Added `asset.request_context.base_path` and `asset.request_context.secure` parameters to provide a request context on e.g. CLI (similar to `router.request_context.*` parameters)
+ * Added `asset.request_context.base_path` and `asset.request_context.secure` parameters
+   to provide a default request context in case the stack is empty (similar to `router.request_context.*` parameters)
 
 3.3.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -53,6 +53,7 @@ CHANGELOG
    `EventDispatcherDebugCommand`, `RouterDebugCommand`, `RouterMatchCommand`,
    `TranslationDebugCommand`, `TranslationUpdateCommand`, `XliffLintCommand`
     and `YamlLintCommand` classes have been marked as final
+ * Added `asset.request_context.base_path` and `asset.request_context.secure` parameters to provide a request context on e.g. CLI (similar to `router.request_context.*` parameters)
 
 3.3.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/assets.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/assets.xml
@@ -4,6 +4,11 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
+    <parameters>
+        <parameter key="asset.request_context.base_path"></parameter>
+        <parameter key="asset.request_context.secure">false</parameter>
+    </parameters>
+
     <services>
         <defaults public="false" />
 
@@ -19,6 +24,8 @@
 
         <service id="assets.context" class="Symfony\Component\Asset\Context\RequestStackContext" public="true">
             <argument type="service" id="request_stack" />
+            <argument>%asset.request_context.base_path%</argument>
+            <argument>%asset.request_context.secure%</argument>
         </service>
 
         <service id="assets.path_package" class="Symfony\Component\Asset\PathPackage" abstract="true" public="true">

--- a/src/Symfony/Component/Asset/CHANGELOG.md
+++ b/src/Symfony/Component/Asset/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+3.4.0
+-----
+
+ * added optional arguments `$basePath` and `$secure` in `RequestStackContext::__construct()`
+   to provide a default request context in case the stack is empty
+
 3.3.0
 -----
  * Added `JsonManifestVersionStrategy` as a way to read final,

--- a/src/Symfony/Component/Asset/Context/RequestStackContext.php
+++ b/src/Symfony/Component/Asset/Context/RequestStackContext.php
@@ -21,10 +21,19 @@ use Symfony\Component\HttpFoundation\RequestStack;
 class RequestStackContext implements ContextInterface
 {
     private $requestStack;
+    private $basePath;
+    private $secure;
 
-    public function __construct(RequestStack $requestStack)
+    /**
+     * @param RequestStack $requestStack
+     * @param string       $basePath
+     * @param bool         $secure
+     */
+    public function __construct(RequestStack $requestStack, $basePath = '', $secure = false)
     {
         $this->requestStack = $requestStack;
+        $this->basePath = $basePath;
+        $this->secure = $secure;
     }
 
     /**
@@ -33,7 +42,7 @@ class RequestStackContext implements ContextInterface
     public function getBasePath()
     {
         if (!$request = $this->requestStack->getMasterRequest()) {
-            return '';
+            return $this->basePath;
         }
 
         return $request->getBasePath();
@@ -45,7 +54,7 @@ class RequestStackContext implements ContextInterface
     public function isSecure()
     {
         if (!$request = $this->requestStack->getMasterRequest()) {
-            return false;
+            return $this->secure;
         }
 
         return $request->isSecure();

--- a/src/Symfony/Component/Asset/Tests/Context/RequestStackContextTest.php
+++ b/src/Symfony/Component/Asset/Tests/Context/RequestStackContextTest.php
@@ -61,4 +61,13 @@ class RequestStackContextTest extends TestCase
 
         $this->assertTrue($requestStackContext->isSecure());
     }
+
+    public function testDefaultContext()
+    {
+        $requestStack = $this->getMockBuilder('Symfony\Component\HttpFoundation\RequestStack')->getMock();
+        $requestStackContext = new RequestStackContext($requestStack, 'default-path', true);
+
+        $this->assertSame('default-path', $requestStackContext->getBasePath());
+        $this->assertTrue($requestStackContext->isSecure());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #19396
| License       | MIT
| Doc PR        | should be noted somewhere, ill create an issue

Allows configuring the default asset context to make things works on CLI for example. Same approach as the routing component.

Introduces
```yaml
# parameters.yml
asset.request_context.base_path: '/base/path'
asset.request_context.secure: false
```