### PR TITLE
[DI] Getter autowiring

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * deprecated `ContainerBuilder::getClassResource()`, use `ContainerBuilder::getReflectionClass()` or `ContainerBuilder::addObjectResource()` instead
  * added `ContainerBuilder::fileExists()` for checking and tracking file or directory existence
  * deprecated autowiring-types, use aliases instead
+ * [EXPERIMENTAL] added support for getter autowiring
  * [EXPERIMENTAL] added support for getter-injection
  * added support for omitting the factory class name in a service definition if the definition class is set
  * deprecated case insensitivity of service identifiers

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -354,8 +354,8 @@ class PhpDumperTest extends \PHPUnit_Framework_TestCase
 
         $dump = $dumper->dump(array('class' => 'Symfony_DI_PhpDumper_Test_Overriden_Getters_With_Constructor'));
         $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_dump_overriden_getters_with_constructor.php', $dump);
-        $resources = array_map('strval', $container->getResources());
-        $this->assertContains(realpath(self::$fixturesPath.'/containers/container_dump_overriden_getters_with_constructor.php'), $resources);
+        $res = $container->getResources();
+        $this->assertSame('reflection.Symfony\Component\DependencyInjection\Tests\Fixtures\Container34\Foo', (string) array_pop($res));
 
         $baz = $container->get('baz');
         $r = new \ReflectionMethod($baz, 'getBaz');

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/GetterOverriding.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/GetterOverriding.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Tests\Compiler\A;
+use Symfony\Component\DependencyInjection\Tests\Compiler\B;
+use Symfony\Component\DependencyInjection\Tests\Compiler\Bar;
+use Symfony\Component\DependencyInjection\Tests\Compiler\Foo;
+
+/**
+ * To test getter autowiring with PHP >= 7.1.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class GetterOverriding
+{
+    public function getFoo(): ?Foo
+    {
+        // should be called
+    }
+
+    protected function getBar(): Bar
+    {
+        // should be called
+    }
+
+    public function getNoTypeHint()
+    {
+        // should not be called
+    }
+
+    public function getUnknown(): NotExist
+    {
+        // should not be called
+    }
+
+    public function getExplicitlyDefined(): B
+    {
+        // should be called but not autowired
+    }
+
+    public function getScalar(): string
+    {
+        // should not be called
+    }
+
+    final public function getFinal(): A
+    {
+        // should not be called
+    }
+
+    public function &getReference(): A
+    {
+        // should not be called
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | todo

This PR adds support for getter autowiring. #20973 must be merged first.

Example:

```yaml
# app/config/config.yml

services:
    Foo\Bar:
        autowire: ['get*']
```

```php
namespace Foo;

class Bar
{
    protected function getBaz(): Baz // this feature only works with PHP 7+
    {
    }
}

class Baz
{
}
````

`Baz` will be automatically registered as a service and an instance will be returned when `Bar::getBaz` will be called (and only at this time, lazy loading).

This feature requires PHP 7 or superior.