### PR TITLE
use HHVM 3.15 to run tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
 matrix:
     include:
         # Use the newer stack for HHVM as HHVM does not support Precise anymore since a long time and so Precise has an outdated version
-        - php: hhvm-stable
+        - php: hhvm-3.15
           sudo: required
           dist: trusty
           group: edge


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

For some reason, tests with the latest HHVM release fail on Travis CI. Neither do I have an idea why they are failing nor do I have the ability to trace the issue down so far to be able to open an issue for them. However, as tests pass with HHVM 3.15 I suggest that we use this version to run tests on Travis until we figure out the reason or tests pass again with a more recent release.