### PR TITLE
[FrameworkBundle] Make TemplateController working without the Templating component

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/TemplateController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/TemplateController.php
@@ -33,8 +33,14 @@ class TemplateController extends ContainerAware
      */
     public function templateAction($template, $maxAge = null, $sharedAge = null, $private = null)
     {
-        /** @var $response \Symfony\Component\HttpFoundation\Response */
-        $response = $this->container->get('templating')->renderResponse($template);
+        /* @var $response \Symfony\Component\HttpFoundation\Response */
+        if ($this->container->has('templating')) {
+            $response = $this->container->get('templating')->renderResponse($template);
+        } elseif ($this->container->has('twig')) {
+            $response = new Response($this->container->get('twig')->render($template));
+        } else {
+            throw new \LogicException('You can not use the TemplateController if the Templating Component or the Twig Bundle are not available.');
+        }
 
         if ($maxAge) {
             $response->setMaxAge($maxAge);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TemplateControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TemplateControllerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\TemplateController;
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class TemplateControllerTest extends TestCase
+{
+    public function testTwig()
+    {
+        $twig = $this->getMockBuilder('\Twig_Environment')->disableOriginalConstructor()->getMock();
+        $twig->expects($this->once())->method('render')->willReturn('bar');
+
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
+        $container->expects($this->at(0))->method('has')->will($this->returnValue(false));
+        $container->expects($this->at(1))->method('has')->will($this->returnValue(true));
+        $container->expects($this->at(2))->method('get')->will($this->returnValue($twig));
+
+        $controller = new TemplateController();
+        $controller->setContainer($container);
+
+        $this->assertEquals('bar', $controller->templateAction('mytemplate')->getContent());
+    }
+
+    public function testTemplating()
+    {
+        $templating = $this->getMockBuilder('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface')->getMock();
+        $templating->expects($this->once())->method('renderResponse')->willReturn(new Response('bar'));
+
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
+        $container->expects($this->at(0))->method('has')->willReturn(true);
+        $container->expects($this->at(1))->method('get')->will($this->returnValue($templating));
+
+        $controller = new TemplateController();
+        $controller->setContainer($container);
+
+        $this->assertEquals('bar', $controller->templateAction('mytemplate')->getContent());
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage You can not use the TemplateController if the Templating Component or the Twig Bundle are not available.
+     */
+    public function testNoTwigNorTemplating()
+    {
+        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
+        $container->expects($this->at(0))->method('has')->willReturn(false);
+        $container->expects($this->at(1))->method('has')->willReturn(false);
+
+        $controller = new TemplateController();
+        $controller->setContainer($container);
+
+        $controller->templateAction('mytemplate')->getContent();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

The template controller was missed during #15502. Btw I've added some tests for this controller.