### PR TITLE
[FrameworkBundle] deprecated cache:clear with warmup

### DIFF
--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -123,6 +123,9 @@ Finder
 FrameworkBundle
 ---------------
 
+ * The `cache:clear` command should always be called with the `--no-warmup` option.
+   Warmup should be done via the `cache:warmup` command.
+
  * The `Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddConsoleCommandPass` has been deprecated. Use `Symfony\Component\Console\DependencyInjection\AddConsoleCommandPass` instead.
 
  * The `Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\SerializerPass` class has been

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -124,7 +124,7 @@ EventDispatcher
    Use `EventDispatcher` with closure-proxy injection instead.
 
 ExpressionLanguage
-----------
+------------------
 
  * The ability to pass a `ParserCacheInterface` instance to the `ExpressionLanguage`
    class has been removed. You should use the `CacheItemPoolInterface` interface
@@ -186,6 +186,9 @@ Form
 
 FrameworkBundle
 ---------------
+
+ * The `cache:clear` command does not warmup the cache anymore. Warmup should
+   be done via the `cache:warmup` command.
 
  * Support for absolute template paths has been removed.
 

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 3.3.0
 -----
 
+ * Deprecated `cache:clear` with warmup (always call it with `--no-warmup`)
  * Changed default configuration for
    assets/forms/validation/translation/serialization/csrf from `canBeEnabled()` to
    `canBeDisabled()` when Flex is used

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/CacheClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/CacheClearCommandTest.php
@@ -43,6 +43,9 @@ class CacheClearCommandTest extends TestCase
         $this->fs->remove($this->rootDir);
     }
 
+    /**
+     * @group legacy
+     */
     public function testCacheIsFreshAfterCacheClearedWithWarmup()
     {
         $input = new ArrayInput(array('cache:clear'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

The warmup part of `cache:clear` does not work well, and does not deliver the guarantee that the generated cache is exactly the same as the one that would have been generated via `cache:warmup`.

As one of the goal of Symfony 4 is to be able to generate all the cache for read-only filsystem, I propose to deprecate the warmup part of `cache:clear` in 3.3 to be able to remove it completely in 4.0. In 4.0, the `--no-warmup` option would be a noop (and can then be removed in 5.0).
