### PR TITLE
[Console] Ease validating input options/arguments

### DIFF
--- a/src/Symfony/Component/Console/Input/InputArgument.php
+++ b/src/Symfony/Component/Console/Input/InputArgument.php
@@ -29,6 +29,7 @@ class InputArgument
     private $mode;
     private $default;
     private $description;
+    private $validator;
 
     /**
      * Constructor.
@@ -127,5 +128,21 @@ class InputArgument
     public function getDescription()
     {
         return $this->description;
+    }
+
+    /**
+     * @param callable $validator A callable that returns the validated value or throws an exception
+     */
+    public function setValidator(callable $validator)
+    {
+        $this->validator = $validator;
+    }
+
+    /**
+     * @return callable|null
+     */
+    public function getValidator()
+    {
+        return $this->validator;
     }
 }

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -31,6 +31,7 @@ class InputOption
     private $mode;
     private $default;
     private $description;
+    private $validator;
 
     /**
      * Constructor.
@@ -190,6 +191,22 @@ class InputOption
     public function getDescription()
     {
         return $this->description;
+    }
+
+    /**
+     * @param callable $validator A callable that returns the validated value or throws an exception
+     */
+    public function setValidator(callable $validator)
+    {
+        $this->validator = $validator;
+    }
+
+    /**
+     * @return callable|null
+     */
+    public function getValidator()
+    {
+        return $this->validator;
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Input/InputArgumentTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputArgumentTest.php
@@ -108,4 +108,23 @@ class InputArgumentTest extends \PHPUnit_Framework_TestCase
         $argument = new InputArgument('foo', InputArgument::IS_ARRAY);
         $argument->setDefault('default');
     }
+
+    /**
+     * @expectedException        \InvalidArgumentException
+     * @expectedExceptionMessage Invalid value "value".
+     */
+    public function testGetSetValidator()
+    {
+        $argument = new InputArgument('foo');
+        $argument->setValidator(function ($v) {
+            if ('value' === $v) {
+                throw new \InvalidArgumentException(sprintf('Invalid value "%s".', $v));
+            }
+
+            return $v;
+        });
+
+        $validator = $argument->getValidator();
+        $validator('value');
+    }
 }

--- a/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
@@ -201,4 +201,23 @@ class InputOptionTest extends \PHPUnit_Framework_TestCase
         $option2 = new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL, 'Some description');
         $this->assertFalse($option->equals($option2));
     }
+
+    /**
+     * @expectedException        \InvalidArgumentException
+     * @expectedExceptionMessage Invalid value "value".
+     */
+    public function testGetSetValidator()
+    {
+        $argument = new InputOption('foo');
+        $argument->setValidator(function ($v) {
+            if ('value' === $v) {
+                throw new \InvalidArgumentException(sprintf('Invalid value "%s".', $v));
+            }
+
+            return $v;
+        });
+
+        $validator = $argument->getValidator();
+        $validator('value');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | todo if accepted

This allows validating input definition from `Command::configure()` using validators instead of doing it manually in `execute()`. 
`InputArgument`/`InputOption` would now have a `setValidator(callable $validator)`. 
Validators can throw an exception in case of invalid value or must return the value, modified or not (e.g. prefixed or converted to an object), quite similar to the input validation of the question helper.

<details>
<summary>Simple example which prefixes a given argument value</summary>

```php
protected function configure() 
{
    $arg = new InputArgument('bar');
    $arg->setValidator(function ($v) { return 'prefix_'.$v; });
    $this->getDefinition()->addArgument($arg);
}

protected function execute($input, $output)
{
    $output->writeln($input->getArgument('bar'));
}
```

```
$ bin/console test baz
prefix_baz
```
</details>

<details>
<summary>Example using the validator component</summary>

```php
use Symfony\Component\Validator\Validation;
use Symfony\Component\Validator\Constraints\Email;

protected function configure() 
{
    $validator = Validation::createValidator();
    $option = new InputOption('email');
    $option->setValidator(function ($email) use ($validator) {
        if (0 !== count($validator->validate($email, new Email()))) {
            throw new \InvalidArgumentException('The "email" option must be a valid email address.');
        }

        return $email;
    });
    $this->getDefinition()->addOption($option);
}
```

```
$ bin/console test --email wrong
[InvalidArgumentException] The "email" option must be a valid email address.
```
</details>
<br>

This is a simpler alternative to #20899 which proposes "form like" commands including support for annotations, param converters, validation constraints... that is a bit too much imho but could still be added later.