### PR TITLE
[FrameworkBundle][Asset] Add default_package config and simplify configuration

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -107,22 +107,21 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $configuration = new Configuration(true);
         $config = $processor->processConfiguration($configuration, array(array('assets' => null)));
 
-        $defaultConfig = array(
-            'enabled' => true,
+        $this->assertTrue($config['assets']['enabled']);
+        $this->assertArrayHasKey($config['assets']['default_package'], $config['assets']['packages']);
+        $this->assertSame(array(
+            'version_format' => '%%s?%%s',
             'version_strategy' => null,
             'version' => null,
-            'version_format' => '%%s?%%s',
             'base_path' => '',
             'base_urls' => array(),
-            'packages' => array(),
-        );
-
-        $this->assertEquals($defaultConfig, $config['assets']);
+        ), $config['assets']['packages'][$config['assets']['default_package']]);
     }
 
     /**
+     * @group legacy
      * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage You cannot use both "version_strategy" and "version" at the same time under "assets".
+     * @expectedExceptionMessage You cannot use both "version_strategy" and "version" at the same time under "assets" packages.
      */
     public function testInvalidVersionStrategy()
     {
@@ -151,8 +150,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $processor->processConfiguration($configuration, array(
             array(
                 'assets' => array(
-                    'base_urls' => '//example.com',
-                    'version' => 1,
+                    'default_package' => 'foo',
                     'packages' => array(
                         'foo' => array(
                             'base_urls' => '//example.com',
@@ -259,11 +257,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             ),
             'assets' => array(
                 'enabled' => false,
-                'version_strategy' => null,
-                'version' => null,
-                'version_format' => '%%s?%%s',
-                'base_path' => '',
-                'base_urls' => array(),
+                'default_package' => null,
                 'packages' => array(),
             ),
             'cache' => array(

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -299,7 +299,7 @@ abstract class FrameworkExtensionTest extends TestCase
 
         // packages
         $packages = $packages->getArgument(1);
-        $this->assertCount(5, $packages);
+        $this->assertCount(6, $packages);
 
         $package = $container->getDefinition($packages['images_path']);
         $this->assertPathPackage($container, $package, '/foo', 'SomeVersionScheme', '%%s?version=%%s');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes (except internal deprecations)
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

This changes the `framework.asset` configuration in a way you can assign a package to be used as default and avoid duplicating logic.

This cleans things up as we consistently rely on `assets.packages` (always having a package now). Where the default is referenced by `assets.default_package`.

For BC a default package is generated if needed.

- Removed (internal) services `assets._default_package` and `assets._version__default`  (but we can alias it for BC if needed)
- We could deprecate service `assets.empty_package` as it unused. There's always a package, also before this PR.
   - Imo. this should become `assets.default_package` instead (an alias ;-)).

Imo. it works more intuitive, as it creates no confusion about `framework.assets.base_path` being some default/global/contextual base path. Which it's not.

```yaml
# before
framework:
  assets:
     base_path: '/assets'
     version: 1

# after
framework:
  assets:
    default_package: assets
    packages:
      assets:
        base_path: '/assets'
        version: 1
```

I know config looks more complex, but at least it shows what's really going on.