### PR TITLE
[Config] Improve PHPdoc / IDE autocomplete

### DIFF
--- a/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
@@ -198,7 +198,7 @@ class ExprBuilder
     /**
      * Returns the related node.
      *
-     * @return NodeDefinition
+     * @return NodeDefinition|ArrayNodeDefinition|VariableNodeDefinition
      *
      * @throws \RuntimeException
      */

--- a/src/Symfony/Component/Config/Definition/Builder/MergeBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/MergeBuilder.php
@@ -63,7 +63,7 @@ class MergeBuilder
     /**
      * Returns the related node.
      *
-     * @return NodeDefinition
+     * @return NodeDefinition|ArrayNodeDefinition|VariableNodeDefinition
      */
     public function end()
     {

--- a/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
@@ -107,7 +107,7 @@ abstract class NodeDefinition implements NodeParentInterface
     /**
      * Returns the parent node.
      *
-     * @return NodeParentInterface|NodeBuilder|NodeDefinition|null The builder of the parent node
+     * @return NodeParentInterface|NodeBuilder|NodeDefinition|ArrayNodeDefinition|VariableNodeDefinition|null The builder of the parent node
      */
     public function end()
     {

--- a/src/Symfony/Component/Config/Definition/Builder/ValidationBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ValidationBuilder.php
@@ -36,7 +36,7 @@ class ValidationBuilder
      *
      * @param \Closure $closure
      *
-     * @return ExprBuilder|ValidationBuilder
+     * @return ExprBuilder|$this
      */
     public function rule(\Closure $closure = null)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes-ish
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

The missing pieces for fixing the autocomplete in IDE's (tested in `PhpStorm 2016.3.2`).

Each method seems to be found now for the framework bundle configuration :scream: 

Actually uses #20923 where needed, but i think we should go with it consistently.

Relates to https://github.com/symfony/symfony/pull/20290#issuecomment-257303145