### PR TITLE
[WebProfilerBundle][POC] Separate JS assets

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -430,6 +430,24 @@ class ProfilerController
          )), 200, array('Content-Type' => 'text/html'));
     }
 
+    public function jsAction(Request $request, $file)
+    {
+        switch ($file) {
+            case 'toolbar':
+                $files = array(dirname(__DIR__).'/Resources/js/base.js');
+                break;
+            case 'profiler':
+                $files = array(dirname(__DIR__).'/Resources/js/base.js');
+                break;
+            default:
+                throw new NotFoundHttpException(sprintf('The file "%s.js" cannot be found.', $file));
+        }
+
+        return new Response(implode("\n\n", array_map(function ($file) {
+            return file_get_contents($file);
+        }, $files)), 200, array('Content-Type' => 'application/javascript'));
+    }
+
     /**
      * Gets the Template Manager.
      *

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/profiler.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/profiler.xml
@@ -36,6 +36,10 @@
         <default key="_controller">web_profiler.controller.profiler:panelAction</default>
     </route>
 
+    <route id="_profiler_js_file" path="/js/{file}.js">
+        <default key="_controller">web_profiler.controller.profiler:jsAction</default>
+    </route>
+
     <route id="_profiler_router" path="/{token}/router">
         <default key="_controller">web_profiler.controller.router:panelAction</default>
     </route>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/js/base.js
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/js/base.js
@@ -1,0 +1,132 @@
+window.Sfjs = window.Sfjs || (function() {
+    "use strict";
+
+    var classListIsSupported = 'classList' in document.documentElement;
+
+    if (classListIsSupported) {
+        var hasClass = function (el, cssClass) { return el.classList.contains(cssClass); };
+        var removeClass = function(el, cssClass) { el.classList.remove(cssClass); };
+        var addClass = function(el, cssClass) { el.classList.add(cssClass); };
+        var toggleClass = function(el, cssClass) { el.classList.toggle(cssClass); };
+    } else {
+        var hasClass = function (el, cssClass) { return el.className.match(new RegExp('\\b' + cssClass + '\\b')); };
+        var removeClass = function(el, cssClass) { el.className = el.className.replace(new RegExp('\\b' + cssClass + '\\b'), ' '); };
+        var addClass = function(el, cssClass) { if (!hasClass(el, cssClass)) { el.className += " " + cssClass; } };
+        var toggleClass = function(el, cssClass) { hasClass(el, cssClass) ? removeClass(el, cssClass) : addClass(el, cssClass); };
+    }
+
+    var noop = function() {};
+
+    var profilerStorageKey = 'sf2/profiler/';
+
+    var request = function(url, onSuccess, onError, payload, options) {
+        var xhr = window.XMLHttpRequest ? new XMLHttpRequest() : new ActiveXObject('Microsoft.XMLHTTP');
+        options = options || {};
+        options.maxTries = options.maxTries || 0;
+        xhr.open(options.method || 'GET', url, true);
+        xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+        xhr.onreadystatechange = function(state) {
+            if (4 !== xhr.readyState) {
+                return null;
+            }
+
+            if (xhr.status == 404 && options.maxTries > 1) {
+                setTimeout(function(){
+                    options.maxTries--;
+                    request(url, onSuccess, onError, payload, options);
+                }, 500);
+
+                return null;
+            }
+
+            if (200 === xhr.status) {
+                (onSuccess || noop)(xhr);
+            } else {
+                (onError || noop)(xhr);
+            }
+        };
+        xhr.send(payload || '');
+    };
+
+    var getPreference = function(name) {
+        if (!window.localStorage) {
+            return null;
+        }
+
+        return localStorage.getItem(profilerStorageKey + name);
+    };
+
+    var setPreference = function(name, value) {
+        if (!window.localStorage) {
+            return null;
+        }
+
+        localStorage.setItem(profilerStorageKey + name, value);
+    };
+
+    var addEventListener;
+
+    var el = document.createElement('div');
+    if (!('addEventListener' in el)) {
+        addEventListener = function (element, eventName, callback) {
+            element.attachEvent('on' + eventName, callback);
+        };
+    } else {
+        addEventListener = function (element, eventName, callback) {
+            element.addEventListener(eventName, callback, false);
+        };
+    }
+
+    return {
+        hasClass: hasClass,
+
+        removeClass: removeClass,
+
+        addClass: addClass,
+
+        toggleClass: toggleClass,
+
+        getPreference: getPreference,
+
+        setPreference: setPreference,
+
+        addEventListener: addEventListener,
+
+        request: request,
+
+        load: function(selector, url, onSuccess, onError, options) {
+            var el = document.getElementById(selector);
+
+            if (el && el.getAttribute('data-sfurl') !== url) {
+                request(
+                    url,
+                    function(xhr) {
+                        el.innerHTML = xhr.responseText;
+                        el.setAttribute('data-sfurl', url);
+                        removeClass(el, 'loading');
+                        (onSuccess || noop)(xhr, el);
+                    },
+                    function(xhr) { (onError || noop)(xhr, el); },
+                    '',
+                    options
+                );
+            }
+
+            return this;
+        },
+
+        toggle: function(selector, elOn, elOff) {
+            var tmp = elOn.style.display,
+                el = document.getElementById(selector);
+
+            elOn.style.display = elOff.style.display;
+            elOff.style.display = tmp;
+
+            if (el) {
+                el.style.display = 'none' === tmp ? 'none' : 'block';
+            }
+
+            return this;
+        }
+    };
+})();

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -2,73 +2,7 @@
     {# Caution: the contents of this file are processed by Twig before loading
                 them as JavaScript source code. Always use '/*' comments instead
                 of '//' comments to avoid impossible-to-debug side-effects #}
-
-    Sfjs = (function() {
-        "use strict";
-
-        var classListIsSupported = 'classList' in document.documentElement;
-
-        if (classListIsSupported) {
-            var hasClass = function (el, cssClass) { return el.classList.contains(cssClass); };
-            var removeClass = function(el, cssClass) { el.classList.remove(cssClass); };
-            var addClass = function(el, cssClass) { el.classList.add(cssClass); };
-            var toggleClass = function(el, cssClass) { el.classList.toggle(cssClass); };
-        } else {
-            var hasClass = function (el, cssClass) { return el.className.match(new RegExp('\\b' + cssClass + '\\b')); };
-            var removeClass = function(el, cssClass) { el.className = el.className.replace(new RegExp('\\b' + cssClass + '\\b'), ' '); };
-            var addClass = function(el, cssClass) { if (!hasClass(el, cssClass)) { el.className += " " + cssClass; } };
-            var toggleClass = function(el, cssClass) { hasClass(el, cssClass) ? removeClass(el, cssClass) : addClass(el, cssClass); };
-        }
-
-        var noop = function() {};
-
-        var profilerStorageKey = 'sf2/profiler/';
-
-        var request = function(url, onSuccess, onError, payload, options) {
-            var xhr = window.XMLHttpRequest ? new XMLHttpRequest() : new ActiveXObject('Microsoft.XMLHTTP');
-            options = options || {};
-            options.maxTries = options.maxTries || 0;
-            xhr.open(options.method || 'GET', url, true);
-            xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
-            xhr.onreadystatechange = function(state) {
-                if (4 !== xhr.readyState) {
-                    return null;
-                }
-
-                if (xhr.status == 404 && options.maxTries > 1) {
-                    setTimeout(function(){
-                        options.maxTries--;
-                        request(url, onSuccess, onError, payload, options);
-                    }, 500);
-
-                    return null;
-                }
-
-                if (200 === xhr.status) {
-                    (onSuccess || noop)(xhr);
-                } else {
-                    (onError || noop)(xhr);
-                }
-            };
-            xhr.send(payload || '');
-        };
-
-        var getPreference = function(name) {
-            if (!window.localStorage) {
-                return null;
-            }
-
-            return localStorage.getItem(profilerStorageKey + name);
-        };
-
-        var setPreference = function(name, value) {
-            if (!window.localStorage) {
-                return null;
-            }
-
-            localStorage.setItem(profilerStorageKey + name, value);
-        };
-
+    window.Sfjs.renderAjaxRequests = window.Sfjs.renderAjaxRequests || (function() {
         var requestStack = [];
 
         var extractHeaders = function(xhr, stackElement) {
@@ -107,13 +41,13 @@
                 ajaxToolbarPanel.style.display = 'none';
             }
             if (pendingRequests > 0) {
-                addClass(ajaxToolbarPanel, 'sf-ajax-request-loading');
+                Sfjs.addClass(ajaxToolbarPanel, 'sf-ajax-request-loading');
             } else if (successStreak < 4) {
-                addClass(ajaxToolbarPanel, 'sf-toolbar-status-red');
-                removeClass(ajaxToolbarPanel, 'sf-ajax-request-loading');
+                Sfjs.addClass(ajaxToolbarPanel, 'sf-toolbar-status-red');
+                Sfjs.removeClass(ajaxToolbarPanel, 'sf-ajax-request-loading');
             } else {
-                removeClass(ajaxToolbarPanel, 'sf-ajax-request-loading');
-                removeClass(ajaxToolbarPanel, 'sf-toolbar-status-red');
+                Sfjs.removeClass(ajaxToolbarPanel, 'sf-ajax-request-loading');
+                Sfjs.removeClass(ajaxToolbarPanel, 'sf-toolbar-status-red');
             }
         };
 
@@ -216,19 +150,6 @@
             renderAjaxRequests();
         };
 
-        var addEventListener;
-
-        var el = document.createElement('div');
-        if (!('addEventListener' in el)) {
-            addEventListener = function (element, eventName, callback) {
-                element.attachEvent('on' + eventName, callback);
-            };
-        } else {
-            addEventListener = function (element, eventName, callback) {
-                element.addEventListener(eventName, callback, false);
-            };
-        }
-
         {% if excluded_ajax_paths is defined %}
             if (window.fetch && window.fetch.polyfill === undefined) {
                 var oldFetch = window.fetch;
@@ -325,175 +246,122 @@
             }
         {% endif %}
 
-        return {
-            hasClass: hasClass,
-
-            removeClass: removeClass,
-
-            addClass: addClass,
-
-            toggleClass: toggleClass,
-
-            getPreference: getPreference,
-
-            setPreference: setPreference,
-
-            addEventListener: addEventListener,
-
-            request: request,
-
-            renderAjaxRequests: renderAjaxRequests,
-
-            load: function(selector, url, onSuccess, onError, options) {
-                var el = document.getElementById(selector);
-
-                if (el && el.getAttribute('data-sfurl') !== url) {
-                    request(
-                        url,
-                        function(xhr) {
-                            el.innerHTML = xhr.responseText;
-                            el.setAttribute('data-sfurl', url);
-                            removeClass(el, 'loading');
-                            (onSuccess || noop)(xhr, el);
-                        },
-                        function(xhr) { (onError || noop)(xhr, el); },
-                        '',
-                        options
-                    );
-                }
-
-                return this;
-            },
-
-            toggle: function(selector, elOn, elOff) {
-                var tmp = elOn.style.display,
-                    el = document.getElementById(selector);
-
-                elOn.style.display = elOff.style.display;
-                elOff.style.display = tmp;
-
-                if (el) {
-                    el.style.display = 'none' === tmp ? 'none' : 'block';
-                }
-
-                return this;
-            },
-
-            createTabs: function() {
-                var tabGroups = document.querySelectorAll('.sf-tabs');
-
-                /* create the tab navigation for each group of tabs */
-                for (var i = 0; i < tabGroups.length; i++) {
-                    var tabs = tabGroups[i].querySelectorAll('.tab');
-                    var tabNavigation = document.createElement('ul');
-                    tabNavigation.className = 'tab-navigation';
-
-                    for (var j = 0; j < tabs.length; j++) {
-                        var tabId = 'tab-' + i + '-' + j;
-                        var tabTitle = tabs[j].querySelector('.tab-title').innerHTML;
-
-                        var tabNavigationItem = document.createElement('li');
-                        tabNavigationItem.setAttribute('data-tab-id', tabId);
-                        if (j == 0) { addClass(tabNavigationItem, 'active'); }
-                        if (hasClass(tabs[j], 'disabled')) { addClass(tabNavigationItem, 'disabled'); }
-                        tabNavigationItem.innerHTML = tabTitle;
-                        tabNavigation.appendChild(tabNavigationItem);
-
-                        var tabContent = tabs[j].querySelector('.tab-content');
-                        tabContent.parentElement.setAttribute('id', tabId);
-                    }
-
-                    tabGroups[i].insertBefore(tabNavigation, tabGroups[i].firstChild);
-                }
-
-                /* display the active tab and add the 'click' event listeners */
-                for (i = 0; i < tabGroups.length; i++) {
-                    tabNavigation = tabGroups[i].querySelectorAll('.tab-navigation li');
-
-                    for (j = 0; j < tabNavigation.length; j++) {
-                        tabId = tabNavigation[j].getAttribute('data-tab-id');
-                        document.getElementById(tabId).querySelector('.tab-title').className = 'hidden';
-
-                        if (hasClass(tabNavigation[j], 'active')) {
-                            document.getElementById(tabId).className = 'block';
-                        } else {
-                            document.getElementById(tabId).className = 'hidden';
-                        }
-
-                        tabNavigation[j].addEventListener('click', function(e) {
-                            var activeTab = e.target || e.srcElement;
-
-                            /* needed because when the tab contains HTML contents, user can click */
-                            /* on any of those elements instead of their parent '<li>' element */
-                            while (activeTab.tagName.toLowerCase() !== 'li') {
-                                activeTab = activeTab.parentNode;
-                            }
-
-                            /* get the full list of tabs through the parent of the active tab element */
-                            var tabNavigation = activeTab.parentNode.children;
-                            for (var k = 0; k < tabNavigation.length; k++) {
-                                var tabId = tabNavigation[k].getAttribute('data-tab-id');
-                                document.getElementById(tabId).className = 'hidden';
-                                removeClass(tabNavigation[k], 'active');
-                            }
-
-                            addClass(activeTab, 'active');
-                            var activeTabId = activeTab.getAttribute('data-tab-id');
-                            document.getElementById(activeTabId).className = 'block';
-                        });
-                    }
-                }
-            },
-
-            createToggles: function() {
-                var toggles = document.querySelectorAll('.sf-toggle');
-
-                for (var i = 0; i < toggles.length; i++) {
-                    var elementSelector = toggles[i].getAttribute('data-toggle-selector');
-                    var element = document.querySelector(elementSelector);
-
-                    addClass(element, 'sf-toggle-content');
-
-                    if (toggles[i].hasAttribute('data-toggle-initial') && toggles[i].getAttribute('data-toggle-initial') == 'display') {
-                        addClass(element, 'sf-toggle-visible');
-                    } else {
-                        addClass(element, 'sf-toggle-hidden');
-                    }
-
-                    addEventListener(toggles[i], 'click', function(e) {
-                        e.preventDefault();
-
-                        var toggle = e.target || e.srcElement;
-
-                        /* needed because when the toggle contains HTML contents, user can click */
-                        /* on any of those elements instead of their parent '.sf-toggle' element */
-                        while (!hasClass(toggle, 'sf-toggle')) {
-                            toggle = toggle.parentNode;
-                        }
-
-                        var element = document.querySelector(toggle.getAttribute('data-toggle-selector'));
-
-                        toggleClass(element, 'sf-toggle-hidden');
-                        toggleClass(element, 'sf-toggle-visible');
-
-                        /* the toggle doesn't change its contents when clicking on it */
-                        if (!toggle.hasAttribute('data-toggle-alt-content')) {
-                            return;
-                        }
-
-                        if (!toggle.hasAttribute('data-toggle-original-content')) {
-                            toggle.setAttribute('data-toggle-original-content', toggle.innerHTML);
-                        }
-
-                        var currentContent = toggle.innerHTML;
-                        var originalContent = toggle.getAttribute('data-toggle-original-content');
-                        var altContent = toggle.getAttribute('data-toggle-alt-content');
-                        toggle.innerHTML = currentContent !== altContent ? altContent : originalContent;
-                    });
-                }
-            }
-        };
+        return renderAjaxRequests;
     })();
+
+    window.Sfjs.createTabs = window.Sfjs.createTabs || function() {
+        var tabGroups = document.querySelectorAll('.sf-tabs');
+
+        /* create the tab navigation for each group of tabs */
+        for (var i = 0; i < tabGroups.length; i++) {
+            var tabs = tabGroups[i].querySelectorAll('.tab');
+            var tabNavigation = document.createElement('ul');
+            tabNavigation.className = 'tab-navigation';
+
+            for (var j = 0; j < tabs.length; j++) {
+                var tabId = 'tab-' + i + '-' + j;
+                var tabTitle = tabs[j].querySelector('.tab-title').innerHTML;
+
+                var tabNavigationItem = document.createElement('li');
+                tabNavigationItem.setAttribute('data-tab-id', tabId);
+                if (j == 0) { Sfjs.addClass(tabNavigationItem, 'active'); }
+                if (Sfjs.hasClass(tabs[j], 'disabled')) { Sfjs.addClass(tabNavigationItem, 'disabled'); }
+                tabNavigationItem.innerHTML = tabTitle;
+                tabNavigation.appendChild(tabNavigationItem);
+
+                var tabContent = tabs[j].querySelector('.tab-content');
+                tabContent.parentElement.setAttribute('id', tabId);
+            }
+
+            tabGroups[i].insertBefore(tabNavigation, tabGroups[i].firstChild);
+        }
+
+        /* display the active tab and add the 'click' event listeners */
+        for (i = 0; i < tabGroups.length; i++) {
+            tabNavigation = tabGroups[i].querySelectorAll('.tab-navigation li');
+
+            for (j = 0; j < tabNavigation.length; j++) {
+                tabId = tabNavigation[j].getAttribute('data-tab-id');
+                document.getElementById(tabId).querySelector('.tab-title').className = 'hidden';
+
+                if (Sfjs.hasClass(tabNavigation[j], 'active')) {
+                    document.getElementById(tabId).className = 'block';
+                } else {
+                    document.getElementById(tabId).className = 'hidden';
+                }
+
+                tabNavigation[j].addEventListener('click', function(e) {
+                    var activeTab = e.target || e.srcElement;
+
+                    /* needed because when the tab contains HTML contents, user can click */
+                    /* on any of those elements instead of their parent '<li>' element */
+                    while (activeTab.tagName.toLowerCase() !== 'li') {
+                        activeTab = activeTab.parentNode;
+                    }
+
+                    /* get the full list of tabs through the parent of the active tab element */
+                    var tabNavigation = activeTab.parentNode.children;
+                    for (var k = 0; k < tabNavigation.length; k++) {
+                        var tabId = tabNavigation[k].getAttribute('data-tab-id');
+                        document.getElementById(tabId).className = 'hidden';
+                        Sfjs.removeClass(tabNavigation[k], 'active');
+                    }
+
+                    Sfjs.addClass(activeTab, 'active');
+                    var activeTabId = activeTab.getAttribute('data-tab-id');
+                    document.getElementById(activeTabId).className = 'block';
+                });
+            }
+        }
+    };
+
+    window.Sfjs.createToggles = window.Sfjs.createToggles || function() {
+        var toggles = document.querySelectorAll('.sf-toggle');
+
+        for (var i = 0; i < toggles.length; i++) {
+            var elementSelector = toggles[i].getAttribute('data-toggle-selector');
+            var element = document.querySelector(elementSelector);
+
+            Sfjs.addClass(element, 'sf-toggle-content');
+
+            if (toggles[i].hasAttribute('data-toggle-initial') && toggles[i].getAttribute('data-toggle-initial') == 'display') {
+                Sfjs.addClass(element, 'sf-toggle-visible');
+            } else {
+                Sfjs.addClass(element, 'sf-toggle-hidden');
+            }
+
+            Sfjs.addEventListener(toggles[i], 'click', function(e) {
+                e.preventDefault();
+
+                var toggle = e.target || e.srcElement;
+
+                /* needed because when the toggle contains HTML contents, user can click */
+                /* on any of those elements instead of their parent '.sf-toggle' element */
+                while (!Sfjs.hasClass(toggle, 'sf-toggle')) {
+                    toggle = toggle.parentNode;
+                }
+
+                var element = document.querySelector(toggle.getAttribute('data-toggle-selector'));
+
+                Sfjs.toggleClass(element, 'sf-toggle-hidden');
+                Sfjs.toggleClass(element, 'sf-toggle-visible');
+
+                /* the toggle doesn't change its contents when clicking on it */
+                if (!toggle.hasAttribute('data-toggle-alt-content')) {
+                    return;
+                }
+
+                if (!toggle.hasAttribute('data-toggle-original-content')) {
+                    toggle.setAttribute('data-toggle-original-content', toggle.innerHTML);
+                }
+
+                var currentContent = toggle.innerHTML;
+                var originalContent = toggle.getAttribute('data-toggle-original-content');
+                var altContent = toggle.getAttribute('data-toggle-alt-content');
+                toggle.innerHTML = currentContent !== altContent ? altContent : originalContent;
+            });
+        }
+    };
 
     Sfjs.addEventListener(window, 'load', function() {
         Sfjs.createTabs();

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
@@ -86,6 +86,7 @@
         <div id="main">
             <div id="collector-wrapper">
                 <div id="collector-content">
+                    <script src="{{ path('_profiler_js_file', {file: 'profiler'}) }}"{% if csp_script_nonce is defined and csp_script_nonce %} nonce={{ csp_script_nonce }}{% endif %}></script>
                     {{ include('@WebProfiler/Profiler/base_js.html.twig') }}
                     {% block panel '' %}
                 </div>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -1,4 +1,5 @@
 <div id="sfwdt{{ token }}" class="sf-toolbar sf-display-none"></div>
+<script src="{{ path('_profiler_js_file', {file: 'toolbar'}) }}"{% if csp_script_nonce %} nonce={{ csp_script_nonce }}{% endif %}></script>
 {{ include('@WebProfiler/Profiler/base_js.html.twig') }}
 <script{% if csp_script_nonce %} nonce={{ csp_script_nonce }}{% endif %}>/*<![CDATA[*/
     (function () {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

POC to separate the WDT javascript assets from twig templates.

Pros
- Separation of concerns
- Better maintenance / features can be separated
- Allows compiling (currently toolbar loads toggle/tabs utils and profiler loads ajax utils)
- Allows browser caching
- Allows proper minifying

I propose to go with a `toolbar.js` and `profiler.js`, built from individual files (`base.js`, `ajax.js`, `toggles.js`, etc.)

If accepted, we can also try a lower branch first. But it should go at once imo.