### PR TITLE
[Config] Remap XML before normalization

### DIFF
--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -52,8 +52,12 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
      */
     protected function preNormalize($value)
     {
-        if (!$this->normalizeKeys || !is_array($value)) {
+        if (!is_array($value)) {
             return $value;
+        }
+
+        if (!$this->normalizeKeys) {
+            return $this->remapXml($value);
         }
 
         $normalized = array();
@@ -66,7 +70,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
             }
         }
 
-        return $normalized;
+        return $this->remapXml($normalized);
     }
 
     /**
@@ -298,8 +302,6 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
         if (false === $value) {
             return $value;
         }
-
-        $value = $this->remapXml($value);
 
         $normalized = array();
         foreach ($value as $name => $val) {

--- a/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
@@ -233,8 +233,6 @@ class PrototypedArrayNode extends ArrayNode
             return $value;
         }
 
-        $value = $this->remapXml($value);
-
         $isAssoc = array_keys($value) !== range(0, count($value) - 1);
         $normalized = array();
         foreach ($value as $k => $v) {

--- a/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Config\Tests\Definition;
 
 use Symfony\Component\Config\Definition\ArrayNode;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Definition\PrototypedArrayNode;
 use Symfony\Component\Config\Definition\ScalarNode;
 
 class ArrayNodeTest extends \PHPUnit_Framework_TestCase
@@ -68,11 +69,33 @@ class ArrayNodeTest extends \PHPUnit_Framework_TestCase
     public function testPreNormalize($denormalized, $normalized)
     {
         $node = new ArrayNode('foo');
+        $node->addChild(new ScalarNode('foo_bar'));
+        $node->addChild(new ScalarNode('foo-bar'));
+        $node->addChild(new ScalarNode('foo-bar_moo'));
+        $node->addChild(new ScalarNode('anything_with_dash_and_no_underscore'));
+        $node->addChild(new ScalarNode('no_dash'));
 
-        $r = new \ReflectionMethod($node, 'preNormalize');
-        $r->setAccessible(true);
+        $prototypeNode = new ArrayNode('subfoo');
+        $prototypeNode->addChild(new ScalarNode('bar'));
+        $prototype = new PrototypedArrayNode('plural');
+        $prototype->setPrototype($prototypeNode);
+        $prototype->setKeyAttribute('x');
 
-        $this->assertSame($normalized, $r->invoke($node, $denormalized));
+        $node->setXmlRemappings(array(
+            array('singular', 'plural'),
+        ));
+        $node->addChild($prototype);
+
+        $node->setNormalizationClosures(array(
+            function ($v) use ($normalized) {
+                $this->assertSame($normalized, $v);
+
+                return $v;
+            },
+        ));
+
+        $this->assertSame($normalized, $node->normalize($denormalized));
+
     }
 
     public function getPreNormalizationTests()
@@ -94,6 +117,10 @@ class ArrayNodeTest extends \PHPUnit_Framework_TestCase
                 array('foo-bar' => null, 'foo_bar' => 'foo'),
                 array('foo-bar' => null, 'foo_bar' => 'foo'),
             ),
+            array(
+                array('singular' => array(array('x' => 'foo', 'bar' => 'foo'), array('x' => 'bar', 'bar' => 'bar'))),
+                array('plural' => array('foo' => array('bar' => 'foo'), 'bar' => array('bar' => 'bar'))),
+            )
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes (should add one for regression though)
| Fixed tickets | https://github.com/symfony/symfony/pull/21051#discussion_r93830053
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

You never seem to get the remapped value with things like `beforeNormalization()` etc.

Meaning you never get the normalized form which makes deprecating for instance really hard ;-)