### PR TITLE
[DI] Auto register extension configuration classes as a resource

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ConfigurationExtensionInterface;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 
 /**
@@ -47,6 +48,9 @@ class MergeExtensionConfigurationPass implements CompilerPassInterface
             $tmpContainer = new ContainerBuilder($container->getParameterBag());
             $tmpContainer->setResourceTracking($container->isTrackingResources());
             $tmpContainer->addObjectResource($extension);
+            if ($extension instanceof ConfigurationExtensionInterface && null !== $configuration = $extension->getConfiguration($config, $tmpContainer)) {
+                $tmpContainer->addObjectResource($configuration);
+            }
 
             foreach ($exprLangProviders as $provider) {
                 $tmpContainer->addExpressionLanguageProvider($provider);

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\Compiler\MergeExtensionConfigurationPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
@@ -47,5 +50,33 @@ class MergeExtensionConfigurationPassTest extends \PHPUnit_Framework_TestCase
         $pass->process($container);
 
         $this->assertEquals(array($provider), $tmpProviders);
+    }
+
+    public function testExtensionConfigurationIsTrackedByDefault()
+    {
+        $extension = $this->getMockBuilder('Symfony\\Component\\DependencyInjection\\Extension\\Extension')->getMock();
+        $extension->expects($this->once())
+            ->method('getConfiguration')
+            ->will($this->returnValue(new FooConfiguration()));
+        $extension->expects($this->any())
+            ->method('getAlias')
+            ->will($this->returnValue('foo'));
+
+        $container = new ContainerBuilder(new ParameterBag());
+        $container->registerExtension($extension);
+        $container->prependExtensionConfig('foo', array('bar' => true));
+
+        $pass = new MergeExtensionConfigurationPass();
+        $pass->process($container);
+
+        $this->assertContains(new FileResource(__FILE__), $container->getResources(), '', false, false);
+    }
+}
+
+class FooConfiguration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder()
+    {
+        return new TreeBuilder();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

Auto-register an extension configuration class as a resource from a compiler pass; not implicitly by the base extension class.

Causing some extensions to register its configuration, whereas others dont (e.g. framework bundle).

Fixes consistent cache invalidation whenever a configuration definition changes. 