### PR TITLE
[MonologBridge] skip DebugHandler on CLI to prevent OOM errors

### DIFF
--- a/src/Symfony/Bridge/Monolog/Handler/DebugHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/DebugHandler.php
@@ -22,6 +22,29 @@ use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
  */
 class DebugHandler extends TestHandler implements DebugLoggerInterface
 {
+    private $skip = true;
+
+    public function __construct($level = Logger::DEBUG, $bubble = true)
+    {
+        parent::__construct($level, $bubble);
+
+        if (func_num_args() >= 3) {
+            $this->skip = (bool) func_get_arg(2) && 'cli' === PHP_SAPI;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isHandling(array $record)
+    {
+        if ($this->skip) {
+            return false;
+        }
+
+        return parent::isHandling($record);
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Bridge/Monolog/Tests/LoggerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/LoggerTest.php
@@ -63,7 +63,7 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
     public function testGetLogs()
     {
         $logger = new Logger('test');
-        $logger->pushHandler(new DebugHandler());
+        $logger->pushHandler(new DebugHandler(Logger::DEBUG, true, false));
 
         $logger->addInfo('test');
         $this->assertCount(1, $logger->getLogs());
@@ -85,7 +85,7 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
     public function testCountErrors()
     {
         $logger = new Logger('test');
-        $logger->pushHandler(new DebugHandler());
+        $logger->pushHandler(new DebugHandler(Logger::DEBUG, true, false));
 
         $logger->addInfo('test');
         $logger->addError('uh-oh');
@@ -102,5 +102,14 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
         $logger->addError('uh-oh');
 
         $this->assertEquals(0, $logger->countErrors());
+    }
+
+    public function testDebugHandlerAbstainsInCliEnvironments()
+    {
+        $logger = new Logger('test');
+        $logger->pushHandler(new DebugHandler(Logger::DEBUG, true));
+
+        $logger->addInfo('test');
+        $this->assertCount(0, $logger->getLogs());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | symfony/monolog-bundle#165
| License       | MIT
| Doc PR        | 

This fixes symfony/monolog-bundle#165 in a way that allows to revert symfony/monolog-bundle@fbbcefd7821edfaa31a48712bba0960979243c1c (see symfony/monolog-bundle#195 for the reverting change) which prevented the container from being built properly leading to missing logs in the profiler.