### PR TITLE
[DI] More generic loaders

### DIFF
--- a/src/Symfony/Component/Config/Loader/ImportingLoaderInterface.php
+++ b/src/Symfony/Component/Config/Loader/ImportingLoaderInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Loader;
+
+/**
+ * @author Roland Franssen <franssen.roland@gmail.com>
+ */
+interface ImportingLoaderInterface extends LoaderInterface
+{
+    /**
+     * Imports a resource.
+     *
+     * @param mixed       $resource     A Resource
+     * @param string|null $type         The resource type or null if unknown
+     * @param bool        $ignoreErrors Whether to ignore import errors or not
+     *
+     * @return mixed
+     */
+    public function import($resource, $type = null, $ignoreErrors = false);
+}

--- a/src/Symfony/Component/Config/Loader/Loader.php
+++ b/src/Symfony/Component/Config/Loader/Loader.php
@@ -18,7 +18,7 @@ use Symfony\Component\Config\Exception\FileLoaderLoadException;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-abstract class Loader implements LoaderInterface
+abstract class Loader implements ImportingLoaderInterface
 {
     protected $resolver;
 
@@ -39,16 +39,19 @@ abstract class Loader implements LoaderInterface
     }
 
     /**
-     * Imports a resource.
+     * {@inheritdoc}
      *
-     * @param mixed       $resource A resource
-     * @param string|null $type     The resource type or null if unknown
-     *
-     * @return mixed
+     * @throws \Exception
      */
-    public function import($resource, $type = null)
+    public function import($resource, $type = null, $ignoreErrors = false)
     {
-        return $this->resolve($resource, $type)->load($resource, $type);
+        try {
+            return $this->resolve($resource, $type)->load($resource, $type);
+        } catch (\Exception $e) {
+            if (!$ignoreErrors) {
+                throw $e;
+            }
+        }
     }
 
     /**
@@ -70,7 +73,7 @@ abstract class Loader implements LoaderInterface
         $loader = null === $this->resolver ? false : $this->resolver->resolve($resource, $type);
 
         if (false === $loader) {
-            throw new FileLoaderLoadException($resource);
+            throw new FileLoaderLoadException($resource); // @FIXME
         }
 
         return $loader;

--- a/src/Symfony/Component/Config/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/Config/Tests/Loader/FileLoaderTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Config\Tests\Loader;
 
+use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\Config\Loader\FileLoader;
 use Symfony\Component\Config\Loader\LoaderResolver;
 
@@ -22,6 +23,7 @@ class FileLoaderTest extends \PHPUnit_Framework_TestCase
 
         $locatorMockForAdditionalLoader = $this->getMockBuilder('Symfony\Component\Config\FileLocatorInterface')->getMock();
         $locatorMockForAdditionalLoader->expects($this->any())->method('locate')->will($this->onConsecutiveCalls(
+                'path/to/file1',                           // Default
                 array('path/to/file1'),                    // Default
                 array('path/to/file1', 'path/to/file2'),   // First is imported
                 array('path/to/file1', 'path/to/file2'),   // Second is imported
@@ -31,10 +33,8 @@ class FileLoaderTest extends \PHPUnit_Framework_TestCase
 
         $fileLoader = new TestFileLoader($locatorMock);
         $fileLoader->setSupports(false);
-        $fileLoader->setCurrentDir('.');
 
         $additionalLoader = new TestFileLoader($locatorMockForAdditionalLoader);
-        $additionalLoader->setCurrentDir('.');
 
         $fileLoader->setResolver($loaderResolver = new LoaderResolver(array($fileLoader, $additionalLoader)));
 
@@ -70,6 +70,13 @@ class FileLoaderTest extends \PHPUnit_Framework_TestCase
 class TestFileLoader extends FileLoader
 {
     private $supports = true;
+
+    public function __construct(FileLocatorInterface $locator, $currentResource = './foo')
+    {
+        parent::__construct($locator);
+
+        $this->setCurrentResource($currentResource);
+    }
 
     public function load($resource, $type = null)
     {

--- a/src/Symfony/Component/DependencyInjection/Loader/DirectoryLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/DirectoryLoader.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\DependencyInjection\Loader;
 
-use Symfony\Component\Config\Resource\DirectoryResource;
-
 /**
  * DirectoryLoader is a recursive loader to go through directories.
  *
@@ -25,19 +23,16 @@ class DirectoryLoader extends FileLoader
      */
     public function load($file, $type = null)
     {
-        $file = rtrim($file, '/');
-        $path = $this->locator->locate($file);
-        $this->container->addResource(new DirectoryResource($path));
+        $this->setCurrentResource($file);
 
+        $path = $this->locate(rtrim($file, '/'));
         foreach (scandir($path) as $dir) {
             if ('.' !== $dir[0]) {
                 if (is_dir($path.'/'.$dir)) {
                     $dir .= '/'; // append / to allow recursion
                 }
 
-                $this->setCurrentDir($path);
-
-                $this->import($dir, null, false, $path);
+                $this->import($dir);
             }
         }
     }

--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\DependencyInjection\Loader;
 
+use Symfony\Component\Config\Resource\DirectoryResource;
+use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\Loader\FileLoader as BaseFileLoader;
 use Symfony\Component\Config\FileLocatorInterface;
@@ -33,5 +35,14 @@ abstract class FileLoader extends BaseFileLoader
         $this->container = $container;
 
         parent::__construct($locator);
+    }
+
+    public function setCurrentResource($resource)
+    {
+        parent::setCurrentResource($resource);
+
+        $path = $this->locate($resource);
+
+        $this->container->addResource('/' === substr($path, -1) || is_dir($path) ? new DirectoryResource($path) : new FileResource($path));
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Loader/IniFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/IniFileLoader.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\DependencyInjection\Loader;
 
-use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Config\Util\XmlUtils;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 
@@ -27,9 +26,9 @@ class IniFileLoader extends FileLoader
      */
     public function load($resource, $type = null)
     {
-        $path = $this->locator->locate($resource);
+        $this->setCurrentResource($resource);
 
-        $this->container->addResource(new FileResource($path));
+        $path = $this->locate($resource);
 
         // first pass to catch parsing errors
         $result = parse_ini_file($path, true);

--- a/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\DependencyInjection\Loader;
 
-use Symfony\Component\Config\Resource\FileResource;
-
 /**
  * PhpFileLoader loads service definitions from a PHP file.
  *
@@ -28,15 +26,13 @@ class PhpFileLoader extends FileLoader
      */
     public function load($resource, $type = null)
     {
+        $this->setCurrentResource($resource);
+
         // the container and loader variables are exposed to the included file below
         $container = $this->container;
         $loader = $this;
 
-        $path = $this->locator->locate($resource);
-        $this->setCurrentDir(dirname($path));
-        $this->container->addResource(new FileResource($path));
-
-        include $path;
+        include $this->locate($resource);
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\DependencyInjection\Loader;
 
-use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Config\Util\XmlUtils;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Alias;
@@ -36,11 +35,11 @@ class XmlFileLoader extends FileLoader
      */
     public function load($resource, $type = null)
     {
-        $path = $this->locator->locate($resource);
+        $this->setCurrentResource($resource);
+
+        $path = $this->locate($resource);
 
         $xml = $this->parseFileToDOM($path);
-
-        $this->container->addResource(new FileResource($path));
 
         // anonymous services
         $this->processAnonymousServices($xml, $path);
@@ -93,10 +92,8 @@ class XmlFileLoader extends FileLoader
             return;
         }
 
-        $defaultDirectory = dirname($file);
         foreach ($imports as $import) {
-            $this->setCurrentDir($defaultDirectory);
-            $this->import($import->getAttribute('resource'), null, (bool) XmlUtils::phpize($import->getAttribute('ignore-errors')), $file);
+            $this->import($import->getAttribute('resource'), null, (bool) XmlUtils::phpize($import->getAttribute('ignore-errors')));
         }
     }
 

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -18,7 +18,6 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
-use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Parser as YamlParser;
 use Symfony\Component\Yaml\Yaml;
@@ -64,14 +63,14 @@ class YamlFileLoader extends FileLoader
      */
     public function load($resource, $type = null)
     {
-        $path = $this->locator->locate($resource);
+        $this->setCurrentResource($resource);
+
+        $path = $this->locate($resource);
 
         $content = $this->loadFile($path);
 
-        $this->container->addResource(new FileResource($path));
-
         // empty file
-        if (null === $content) {
+        if (null === $content || !is_array($content)) {
             return;
         }
 
@@ -120,14 +119,12 @@ class YamlFileLoader extends FileLoader
             throw new InvalidArgumentException(sprintf('The "imports" key should contain an array in %s. Check your YAML syntax.', $file));
         }
 
-        $defaultDirectory = dirname($file);
         foreach ($content['imports'] as $import) {
             if (!is_array($import)) {
                 throw new InvalidArgumentException(sprintf('The values in the "imports" key should be arrays in %s. Check your YAML syntax.', $file));
             }
 
-            $this->setCurrentDir($defaultDirectory);
-            $this->import($import['resource'], null, isset($import['ignore_errors']) ? (bool) $import['ignore_errors'] : false, $file);
+            $this->import($import['resource'], null, isset($import['ignore_errors']) ? (bool) $import['ignore_errors'] : false);
         }
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/DirectoryLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/DirectoryLoaderTest.php
@@ -59,7 +59,7 @@ class DirectoryLoaderTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException        \InvalidArgumentException
-     * @expectedExceptionMessage The file "foo" does not exist (in:
+     * @expectedExceptionMessage The file "foo/" does not exist (in:
      */
     public function testExceptionIsRaisedWhenDirectoryDoesNotExist()
     {

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "symfony/yaml": "~3.2",
-        "symfony/config": "~2.8|~3.0",
+        "symfony/config": "~3.3",
         "symfony/expression-language": "~2.8|~3.0"
     },
     "suggest": {

--- a/src/Symfony/Component/Routing/Loader/AnnotationDirectoryLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationDirectoryLoader.php
@@ -34,7 +34,9 @@ class AnnotationDirectoryLoader extends AnnotationFileLoader
      */
     public function load($path, $type = null)
     {
-        $dir = $this->locator->locate($path);
+        $this->setCurrentResource($path);
+
+        $dir = $this->locate($path);
 
         $collection = new RouteCollection();
         $collection->addResource(new DirectoryResource($dir, '/\.php$/'));

--- a/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
@@ -57,7 +57,9 @@ class AnnotationFileLoader extends FileLoader
      */
     public function load($file, $type = null)
     {
-        $path = $this->locator->locate($file);
+        $this->setCurrentResource($file);
+
+        $path = $this->locate($file);
 
         $collection = new RouteCollection();
         if ($class = $this->findClass($path)) {

--- a/src/Symfony/Component/Routing/Loader/DirectoryLoader.php
+++ b/src/Symfony/Component/Routing/Loader/DirectoryLoader.php
@@ -22,24 +22,24 @@ class DirectoryLoader extends FileLoader
      */
     public function load($file, $type = null)
     {
-        $path = $this->locator->locate($file);
+        $file = rtrim($file, '/');
+
+        $this->setCurrentResource($file.'/');
+
+        $path = $this->locate($file);
 
         $collection = new RouteCollection();
         $collection->addResource(new DirectoryResource($path));
 
         foreach (scandir($path) as $dir) {
             if ('.' !== $dir[0]) {
-                $this->setCurrentDir($path);
-                $subPath = $path.'/'.$dir;
-                $subType = null;
-
-                if (is_dir($subPath)) {
-                    $subPath .= '/';
-                    $subType = 'directory';
+                $type = null;
+                if (is_dir($path.'/'.$dir)) {
+                    $dir .= '/';
+                    $type = 'directory';
                 }
 
-                $subCollection = $this->import($subPath, $subType, false, $path);
-                $collection->addCollection($subCollection);
+                $collection->addCollection($this->import($dir, $type));
             }
         }
 

--- a/src/Symfony/Component/Routing/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/PhpFileLoader.php
@@ -34,8 +34,9 @@ class PhpFileLoader extends FileLoader
      */
     public function load($file, $type = null)
     {
-        $path = $this->locator->locate($file);
-        $this->setCurrentDir(dirname($path));
+        $this->setCurrentResource($file);
+
+        $path = $this->locate($file);
 
         $collection = self::includeFile($path, $this);
         $collection->addResource(new FileResource($path));

--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -41,7 +41,9 @@ class XmlFileLoader extends FileLoader
      */
     public function load($file, $type = null)
     {
-        $path = $this->locator->locate($file);
+        $this->setCurrentResource($file);
+
+        $path = $this->locate($file);
 
         $xml = $this->loadFile($path);
 
@@ -144,9 +146,8 @@ class XmlFileLoader extends FileLoader
 
         list($defaults, $requirements, $options, $condition) = $this->parseConfigs($node, $path);
 
-        $this->setCurrentDir(dirname($path));
+        $subCollection = $this->import($resource, ('' !== $type ? $type : null));
 
-        $subCollection = $this->import($resource, ('' !== $type ? $type : null), false, $file);
         /* @var $subCollection RouteCollection */
         $subCollection->addPrefix($prefix);
         if (null !== $host) {

--- a/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
@@ -43,7 +43,9 @@ class YamlFileLoader extends FileLoader
      */
     public function load($file, $type = null)
     {
-        $path = $this->locator->locate($file);
+        $this->setCurrentResource($file);
+
+        $path = $this->locate($file);
 
         if (!stream_is_local($path)) {
             throw new \InvalidArgumentException(sprintf('This is not a local file "%s".', $path));
@@ -140,9 +142,8 @@ class YamlFileLoader extends FileLoader
         $schemes = isset($config['schemes']) ? $config['schemes'] : null;
         $methods = isset($config['methods']) ? $config['methods'] : null;
 
-        $this->setCurrentDir(dirname($path));
+        $subCollection = $this->import($config['resource'], $type);
 
-        $subCollection = $this->import($config['resource'], $type, false, $file);
         /* @var $subCollection RouteCollection */
         $subCollection->addPrefix($prefix);
         if (null !== $host) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no (could introduce some though)
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

- Standardizes `Config\Loader::import()` with `ImportingLoaderInterface` (new interface)
- Favors `Config\FileLoader::setCurrentResource` over `setCurrentDir`
- Moves container resource tracking to `DI\FileLoader::setCurrentResource` fixing nested resource tracking out-of-the box.

If we deprecate `setCurrentDir` the upgrade path would be;

```php
// before
$loader->setCurrentDir($currentDir);
$loader->import($resource, $format, $ignoreErrors, $currentFile);

// after
$loader->setCurrentResource($currentFile);
$loader->import($resource, $format, $ignoreErrors);
```