### PR TITLE
[Form] Fixed DateType format option for single text widget

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -51,11 +51,11 @@ class DateType extends AbstractType
             throw new InvalidOptionsException('The "format" option must be one of the IntlDateFormatter constants (FULL, LONG, MEDIUM, SHORT) or a string representing a custom format.');
         }
 
-        if (null !== $pattern && (false === strpos($pattern, 'y') || false === strpos($pattern, 'M') || false === strpos($pattern, 'd'))) {
-            throw new InvalidOptionsException(sprintf('The "format" option should contain the letters "y", "M" and "d". Its current value is "%s".', $pattern));
-        }
-
         if ('single_text' === $options['widget']) {
+            if (null !== $pattern && false === strpos($pattern, 'y') && false === strpos($pattern, 'M') && false === strpos($pattern, 'd')) {
+                throw new InvalidOptionsException(sprintf('The "format" option should contain the letters "y", "M" or "d". Its current value is "%s".', $pattern));
+            }
+
             $builder->addViewTransformer(new DateTimeToLocalizedStringTransformer(
                 $options['model_timezone'],
                 $options['view_timezone'],
@@ -65,6 +65,10 @@ class DateType extends AbstractType
                 $pattern
             ));
         } else {
+            if (null !== $pattern && (false === strpos($pattern, 'y') || false === strpos($pattern, 'M') || false === strpos($pattern, 'd'))) {
+                throw new InvalidOptionsException(sprintf('The "format" option should contain the letters "y", "M" and "d". Its current value is "%s".', $pattern));
+            }
+
             $yearOptions = $monthOptions = $dayOptions = array(
                 'error_bubbling' => true,
             );

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -67,6 +67,22 @@ class DateTypeTest extends TestCase
         $this->assertEquals('2010-06-02', $form->getViewData());
     }
 
+    public function testSubmitFromSingleTextDateTimeWithCustomFormat()
+    {
+        $form = $this->factory->create('date', null, array(
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
+            'widget' => 'single_text',
+            'input' => 'datetime',
+            'format' => 'yyyy',
+        ));
+
+        $form->submit('2010');
+
+        $this->assertDateTimeEquals(new \DateTime('2010-01-01 UTC'), $form->getData());
+        $this->assertEquals('2010', $form->getViewData());
+    }
+
     public function testSubmitFromSingleTextDateTime()
     {
         // we test against "de_AT", so we need the full implementation
@@ -337,12 +353,25 @@ class DateTypeTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedExceptionMessage The "format" option should contain the letters "y", "M" and "d". Its current value is "yy".
      */
     public function testThrowExceptionIfFormatDoesNotContainYearMonthAndDay()
     {
         $this->factory->create('date', null, array(
             'months' => array(6, 7),
             'format' => 'yy',
+        ));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedExceptionMessage The "format" option should contain the letters "y", "M" or "d". Its current value is "wrong".
+     */
+    public function testThrowExceptionIfFormatDoesNotContainYearMonthOrDay()
+    {
+        $this->factory->create('date', null, array(
+            'widget' => 'single_text',
+            'format' => 'wrong',
         ));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ~
| License       | MIT
| Doc PR        | ~

It's currently not possible to use a custom format with `DateType` when not using one of the three values day, month or year (i.e in my case "MM/yyyy").

The formatter handles it, it looks like this option check is wrong, this PR fixes it.