### PR TITLE
[POC][Security] Split tokens in request token + authentication token (towards making tokens first-class citizens)

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Provider/AnonymousAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/AnonymousAuthenticationProvider.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Security\Core\Authentication\Provider;
 
+use Symfony\Component\Security\Core\Authentication\Token\AnonymousRequestToken;
+use Symfony\Component\Security\Core\Authentication\Token\AuthenticatedAnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
@@ -53,7 +55,7 @@ class AnonymousAuthenticationProvider implements AuthenticationProviderInterface
             throw new BadCredentialsException('The Token does not contain the expected key.');
         }
 
-        return $token;
+        return new AuthenticatedAnonymousToken($token->getSecret(), $token->getUsername());
     }
 
     /**
@@ -61,6 +63,15 @@ class AnonymousAuthenticationProvider implements AuthenticationProviderInterface
      */
     public function supports(TokenInterface $token)
     {
-        return $token instanceof AnonymousToken;
+        if ($token instanceof AnonymousRequestToken) {
+            return true;
+        }
+
+        if (!$token instanceof AnonymousToken || $token instanceof AuthenticatedAnonymousToken) {
+            return false;
+        }
+
+        @trigger_error('Support for AnonymousToken in the AnonymousAuthenticationProvider class is deprecated in 3.1 and will be removed in 4.0. Pass an AnonymousRequestToken object instead.', E_USER_DEPRECATED);
+        return true;
     }
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/RememberMeAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/RememberMeAuthenticationProvider.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\Security\Core\Authentication\Provider;
 
+use Symfony\Component\Security\Core\Authentication\Token\AuthenticatedRememberMeToken;
+use Symfony\Component\Security\Core\Authentication\Token\AuthenticatedUserToken;
+use Symfony\Component\Security\Core\Authentication\Token\RememberMeRequestToken;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
@@ -52,7 +55,7 @@ class RememberMeAuthenticationProvider implements AuthenticationProviderInterfac
         $user = $token->getUser();
         $this->userChecker->checkPreAuth($user);
 
-        $authenticatedToken = new RememberMeToken($user, $this->providerKey, $this->secret);
+        $authenticatedToken = new AuthenticatedRememberMeToken($user, $this->providerKey, $this->secret);
         $authenticatedToken->setAttributes($token->getAttributes());
 
         return $authenticatedToken;
@@ -63,6 +66,16 @@ class RememberMeAuthenticationProvider implements AuthenticationProviderInterfac
      */
     public function supports(TokenInterface $token)
     {
-        return $token instanceof RememberMeToken && $token->getProviderKey() === $this->providerKey;
+        if ($token instanceof RememberMeRequestToken) {
+            return $token->getProviderKey() === $this->providerKey;
+        }
+
+        if ($token instanceof RememberMeToken) {
+            @trigger_error('Support for RememberMeToken in the RememberMeAuthenticationProvider class is deprecated in 3.1 and will be removed in 4.0. Pass a RememberMeRequestToken object instead.', E_USER_DEPRECATED);
+
+            return $token->getProviderKey() === $this->providerKey;
+        }
+
+        return false;
     }
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractAuthenticatedToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractAuthenticatedToken.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Symfony\Component\Security\Core\Authentication\Token;
+
+/**
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ */
+abstract class AbstractAuthenticatedToken extends AbstractToken implements AuthenticatedTokenInterface
+{
+    private $identifier;
+
+    /**
+     * @param string $identifier An identifier for the authenticated user
+     * @param object $user       The current user
+     * @param array  $roles      The roles of the authenticated user
+     */
+    public function __construct($identifier, $user, array $roles)
+    {
+        parent::__construct($roles);
+
+        $this->setUser($user);
+    }
+
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCredentials()
+    {
+        @trigger_error(__METHOD__.' is deprecated since version 3.1 and will be removed in 4.0.', E_USER_DEPRECATED);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function eraseCredentials()
+    {
+        @trigger_error(__METHOD__.' is deprecated since version 3.1 and will be removed in 4.0.', E_USER_DEPRECATED);
+
+        parent::eraseCredentials();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isAuthenticated()
+    {
+        @trigger_error(__METHOD__.' is deprecated since version 3.1 and will be removed in 4.0. Use an instance of check with AuthenticatedTokenInterface instead.', E_USER_DEPRECATED);
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setAuthenticated($authenticated)
+    {
+        @trigger_error(__METHOD__.' is deprecated since version 3.1 and will be removed in 4.0.', E_USER_DEPRECATED);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize()
+    {
+        return serialize(array($this->identifier, $this->roles, $this->attributes));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize($serialized)
+    {
+        list($this->identifier, $this->roles, $this->attributes) = unserialize($serialized);
+    }
+}

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -22,13 +22,15 @@ use Symfony\Component\Security\Core\User\EquatableInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * @deprecated Since version 3.1, to be removed in 4.0. Use AbstractAuthenticatedToken or AbstractRequestToken instead.
  */
 abstract class AbstractToken implements TokenInterface
 {
-    private $user;
-    private $roles = array();
+    protected $user;
+    protected $roles = array();
     private $authenticated = false;
-    private $attributes = array();
+    protected $attributes = array();
 
     /**
      * Constructor.

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AnonymousRequestToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AnonymousRequestToken.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Symfony\Component\Security\Core\Authentication\Token;
+
+/**
+ * Requests anonymous authentication.
+ *
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class AnonymousRequestToken extends AnonymousToken implements AuthenticationRequestTokenInterface
+{
+    /**
+     * @param string $secret     A secret used to make sure the token is created by the app and not by a malicious client
+     * @param string $identifier The name of the user (probably "anon.")
+     * @param array  $roles      Deprecated, auth request tokens cannot have roles
+     */
+    public function __construct($secret, $identifier, array $roles = [])
+    {
+        if (0 < count($roles)) {
+            @trigger_error('The roles parameter of the constructor of '.__CLASS__.' is deprecated since vesion 3.1 and will be removed in 4.0.', E_USER_DEPRECATED);
+        }
+
+        parent::__construct($secret, $identifier, $roles, false);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated Since version 3.1, to be removed in 4.0. Unauthenticated tokens cannot have roles.
+     */
+    public function getRoles()
+    {
+        @trigger_error('Method '.__METHOD__.' on unauthenticated tokens is deprecated since version 3.1 and will be removed in 4.0.', E_USER_DEPRECATED);
+
+        return parent::getRoles();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated Since version 3.1, to be removed in 4.0. Unauthenticated tokens cannot have a user object.
+     */
+    public function getUser()
+    {
+        @trigger_error('Method '.__METHOD__.' on unauthenticated tokens is deprecated since version 3.1 and will be removed in 4.0. Use getUsername() instead to retrieve the identifier passed with the request.', E_USER_DEPRECATED);
+
+        return parent::getUser();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isAuthenticated()
+    {
+        @trigger_error('Method '.__METHOD__.' is deprecated since version 3.1 and will be removed in 4.0. Use an instance of check with AuthenticatedTokenInterface instead.', E_USER_DEPRECATED);
+
+        return false;
+    }
+}

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AnonymousToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AnonymousToken.php
@@ -17,6 +17,8 @@ use Symfony\Component\Security\Core\Role\Role;
  * AnonymousToken represents an anonymous token.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated Since version 3.1, to be removed in 4.0. Use AnonymousRequestToken or AuthenticatedAnonymousToken instead.
  */
 class AnonymousToken extends AbstractToken
 {
@@ -29,8 +31,12 @@ class AnonymousToken extends AbstractToken
      * @param string|object $user   The user can be a UserInterface instance, or an object implementing a __toString method or the username as a regular string
      * @param Role[]        $roles  An array of roles
      */
-    public function __construct($secret, $user, array $roles = array())
+    public function __construct($secret, $user, array $roles = array(), $deprecation = true)
     {
+        if ($deprecation) {
+            @trigger_error(__CLASS__.' is deprecated since version 3.1 and will be removed in 4.0. Use AnonymousRequestToken or AuthenticatedAnonymousToken instead.', E_USER_DEPRECATED);
+        }
+
         parent::__construct($roles);
 
         $this->secret = $secret;

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AuthenticatedAnonymousToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AuthenticatedAnonymousToken.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Symfony\Component\Security\Core\Authentication\Token;
+
+/**
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class AuthenticatedAnonymousToken extends AnonymousToken implements AuthenticatedTokenInterface
+{
+    /**
+     * @param string $secret     A secret used to make sure the token is created by the app and not by a malicious client
+     * @param string $identifier A unique identifier for the user (probably "anon.")
+     * @param array  $roles
+     */
+    public function __construct($secret, $identifier, array $roles = [])
+    {
+        if (0 < count($roles)) {
+            @trigger_error('The roles parameter of the constructor of '.__CLASS__.' is deprecated since vesion 3.1 and will be removed in 4.0.', E_USER_DEPRECATED);
+        }
+
+        parent::__construct($secret, $identifier, $roles, false);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isAuthenticated()
+    {
+        @trigger_error('Method '.__METHOD__.' is deprecated since version 3.1 and will be removed in 4.0. Use an instance of check with AuthenticatedTokenInterface instead.', E_USER_DEPRECATED);
+
+        return true;
+    }
+}

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AuthenticatedRememberMeToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AuthenticatedRememberMeToken.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Symfony\Component\Security\Core\Authentication\Token;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ */
+class AuthenticatedRememberMeToken extends RememberMeToken implements AuthenticatedTokenInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(UserInterface $user, $providerKey, $secret)
+    {
+        parent::__construct($user, $providerKey, $secret, false);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isAuthenticated()
+    {
+        @trigger_error('Method '.__METHOD__.' is deprecated since version 3.1 and will be removed in 4.0. Use an instance of check with AuthenticatedTokenInterface instead.', E_USER_DEPRECATED);
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setAuthenticated($authenticated)
+    {
+        @trigger_error(__METHOD__.' is deprecated since version 3.1 and will be removed in 4.0.', E_USER_DEPRECATED);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCredentials()
+    {
+        @trigger_error(__METHOD__.' is deprecated since version 3.1 and will be removed in 4.0.', E_USER_DEPRECATED);
+
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function eraseCredentials()
+    {
+        @trigger_error(__METHOD__.' is deprecated since version 3.1 and will be removed in 4.0.', E_USER_DEPRECATED);
+
+        parent::eraseCredentials();
+    }
+}

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AuthenticatedTokenInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AuthenticatedTokenInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\Security\Core\Authentication\Token;
+
+/**
+ * Represents the data available after the client
+ * is authenticated.
+ *
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ */
+interface AuthenticatedTokenInterface extends TokenInterface
+{
+}

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AuthenticatedUserToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AuthenticatedUserToken.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Symfony\Component\Security\Core\Authentication\Token;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ */
+class AuthenticatedUserToken extends UsernamePasswordToken implements AuthenticatedTokenInterface
+{
+    /**
+     * @param UserInterface $user        The authenticated user
+     * @param array         $roles
+     * @param string        $providerKey The provider key (usually the firewall context when using Security Http)
+     */
+    public function __construct(UserInterface $user, array $roles, $providerKey)
+    {
+        parent::__construct($user, '', $providerKey, $roles);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isAuthenticated()
+    {
+        @trigger_error('Method '.__METHOD__.' is deprecated since version 3.1 and will be removed in 4.0. Use an instance of check with AuthenticatedTokenInterface instead.', E_USER_DEPRECATED);
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setAuthenticated($authenticated)
+    {
+        @trigger_error(__METHOD__.' is deprecated since version 3.1 and will be removed in 4.0.', E_USER_DEPRECATED);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCredentials()
+    {
+        @trigger_error(__METHOD__.' is deprecated since version 3.1 and will be removed in 4.0.', E_USER_DEPRECATED);
+
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function eraseCredentials()
+    {
+        @trigger_error(__METHOD__.' is deprecated since version 3.1 and will be removed in 4.0.', E_USER_DEPRECATED);
+
+        parent::eraseCredentials();
+    }
+}

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AuthenticationRequestTokenInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AuthenticationRequestTokenInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Symfony\Component\Security\Core\Authentication\Token;
+
+/**
+ * Represents all data available for authentication.
+ *
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ */
+interface AuthenticationRequestTokenInterface extends TokenInterface
+{
+}

--- a/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeRequestToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeRequestToken.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Symfony\Component\Security\Core\Authentication\Token;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ */
+class RememberMeRequestToken extends RememberMeToken implements AuthenticationRequestTokenInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(UserInterface $user, $providerKey, $secret)
+    {
+        parent::__construct($user, $providerKey, $secret, false);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isAuthenticated()
+    {
+        @trigger_error('Method '.__METHOD__.' is deprecated since version 3.1 and will be removed in 4.0. Use an instance of check with AuthenticatedTokenInterface instead.', E_USER_DEPRECATED);
+
+        return false;
+    }
+}

--- a/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeToken.php
@@ -17,6 +17,8 @@ use Symfony\Component\Security\Core\User\UserInterface;
  * Authentication Token for "Remember-Me".
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * @deprecated Since version 3.1, to be removed in 4.0. Use RememberMeRequestToken or AuthenticatedUserToken instead.
  */
 class RememberMeToken extends AbstractToken
 {
@@ -32,8 +34,12 @@ class RememberMeToken extends AbstractToken
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct(UserInterface $user, $providerKey, $secret)
+    public function __construct(UserInterface $user, $providerKey, $secret, $deprecation = true)
     {
+        if ($deprecation) {
+            @trigger_error(__CLASS__.' is deprecated since version 3.1 and will be removed in 4.0. Use RememberMeRequestToken or AuthenticatedUserToken instead.');
+        }
+
         parent::__construct($user->getRoles());
 
         if (empty($secret)) {

--- a/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
@@ -72,6 +72,8 @@ interface TokenInterface extends \Serializable
      * Returns whether the user is authenticated or not.
      *
      * @return bool true if the token has been authenticated, false otherwise
+     *
+     * @deprecated Since version 3.1, to be removed in 4.0. Use instance of checks for AuthenticationRequestTokenInterface or AuthenticatedTokenInterface instead.
      */
     public function isAuthenticated();
 
@@ -79,6 +81,8 @@ interface TokenInterface extends \Serializable
      * Sets the authenticated flag.
      *
      * @param bool $isAuthenticated The authenticated flag
+     *
+     * @deprecated Since version 3.1, to be removed in 4.0. Use instance of checks for AuthenticationRequestTokenInterface or AuthenticatedTokenInterface instead.
      */
     public function setAuthenticated($isAuthenticated);
 

--- a/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordRequestToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordRequestToken.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Symfony\Component\Security\Core\Authentication\Token;
+
+/**
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ */
+class UsernamePasswordRequestToken extends UsernamePasswordToken implements AuthenticationRequestTokenInterface
+{
+    /**
+     * @param string $username    The passed username
+     * @param string $credentials The used password to authenticate
+     * @param string $providerKey The provider key (usually the firewall context when using Security Http)
+     * @param array  $roles       Deprecated since 3.1, to be removed in 4.0.
+     */
+    public function __construct($username, $credentials, $providerKey, array $roles = array())
+    {
+        if (0 < count($roles)) {
+            @trigger_error('The roles parameter of the constructor of '.__CLASS__.' is deprecated since version 3.1 and will be removed in 4.0.', E_USER_DEPRECATED);
+        }
+
+        parent::__construct($username, $credentials, $providerKey, $roles);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @deprecated Since version 3.1, to be removed in 4.0. Unauthenticated tokens cannot have a user object.
+     */
+    public function getUser()
+    {
+        @trigger_error('Method '.__METHOD__.' on unauthenticated tokens is deprecated since version 3.1 and will be removed in 4.0. Use getUsername() instead to retrieve the identifier passed with the request.', E_USER_DEPRECATED);
+
+        return parent::getUser();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isAuthenticated()
+    {
+        @trigger_error('Method '.__METHOD__.' is deprecated since version 3.1 and will be removed in 4.0. Use an instance of check with AuthenticatedTokenInterface instead.', E_USER_DEPRECATED);
+
+        return false;
+    }
+}

--- a/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
@@ -17,6 +17,8 @@ use Symfony\Component\Security\Core\Role\Role;
  * UsernamePasswordToken implements a username and password token.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated Since Symfony 3.1, to be removed in 4.0. Use UsernamePasswordRequestToken or AuthenticatedUserToken instead.
  */
 class UsernamePasswordToken extends AbstractToken
 {
@@ -33,8 +35,12 @@ class UsernamePasswordToken extends AbstractToken
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct($user, $credentials, $providerKey, array $roles = array())
+    public function __construct($user, $credentials, $providerKey, array $roles = array(), $deprecation = true)
     {
+        if ($deprecation) {
+            @trigger_error(__CLASS__.' is deprecated since version 3.1 and will be removed in 4.0. Use UsernamePasswordRequestToken or AuthenticatedUserToken instead.');
+        }
+
         parent::__construct($roles);
 
         if (empty($providerKey)) {

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationTrustResolverTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationTrustResolverTest.php
@@ -52,7 +52,7 @@ class AuthenticationTrustResolverTest extends \PHPUnit_Framework_TestCase
 
     protected function getAnonymousToken()
     {
-        return $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\AnonymousToken')->setConstructorArgs(array('', ''))->getMock();
+        return $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\AuthenticatedAnonymousToken')->setConstructorArgs(array('', ''))->getMock();
     }
 
     protected function getRememberMeToken()
@@ -63,7 +63,7 @@ class AuthenticationTrustResolverTest extends \PHPUnit_Framework_TestCase
     protected function getResolver()
     {
         return new AuthenticationTrustResolver(
-            'Symfony\\Component\\Security\\Core\\Authentication\\Token\\AnonymousToken',
+            'Symfony\\Component\\Security\\Core\\Authentication\\Token\\AuthenticatedAnonymousToken',
             'Symfony\\Component\\Security\\Core\\Authentication\\Token\\RememberMeToken'
         );
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/RememberMeAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/RememberMeAuthenticationProviderTest.php
@@ -25,6 +25,13 @@ class RememberMeAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($provider->supports($this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock()));
     }
 
+    public function testLegacySupports()
+    {
+        $provider = $this->getProvider();
+
+        $this->assertTrue($provider->supports($this->getSupportedToken(null, 'secret', 'RememberMeToken')));
+    }
+
     public function testAuthenticateWhenTokenIsNotSupported()
     {
         $provider = $this->getProvider();
@@ -74,10 +81,9 @@ class RememberMeAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken', $authToken);
         $this->assertSame($user, $authToken->getUser());
         $this->assertEquals(array(new Role('ROLE_FOO')), $authToken->getRoles());
-        $this->assertEquals('', $authToken->getCredentials());
     }
 
-    protected function getSupportedToken($user = null, $secret = 'test')
+    protected function getSupportedToken($user = null, $secret = 'test', $class = 'RememberMeRequestToken')
     {
         if (null === $user) {
             $user = $this->getMockBuilder('Symfony\Component\Security\Core\User\UserInterface')->getMock();
@@ -87,7 +93,7 @@ class RememberMeAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
                 ->will($this->returnValue(array()));
         }
 
-        $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken')->setMethods(array('getProviderKey'))->setConstructorArgs(array($user, 'foo', $secret))->getMock();
+        $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\\'.$class)->setMethods(array('getProviderKey'))->setConstructorArgs(array($user, 'foo', $secret))->getMock();
         $token
             ->expects($this->once())
             ->method('getProviderKey')

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/AnonymousTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/AnonymousTokenTest.php
@@ -14,6 +14,9 @@ namespace Symfony\Component\Security\Core\Tests\Authentication\Token;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Role\Role;
 
+/**
+ * @group legacy
+ */
 class AnonymousTokenTest extends \PHPUnit_Framework_TestCase
 {
     public function testConstructor()

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/UsernamePasswordTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/UsernamePasswordTokenTest.php
@@ -14,6 +14,9 @@ namespace Symfony\Component\Security\Core\Tests\Authentication\Token;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Role\Role;
 
+/**
+ * @group legacy
+ */
 class UsernamePasswordTokenTest extends \PHPUnit_Framework_TestCase
 {
     public function testConstructor()

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/ExpressionLanguageTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Core\Tests\Authorization;
 
+use Symfony\Component\Security\Core\Authentication\Token\AuthenticatedAnonymousToken;
 use Symfony\Component\Security\Core\Authorization\ExpressionLanguage;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolver;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
@@ -25,7 +26,7 @@ class ExpressionLanguageTest extends \PHPUnit_Framework_TestCase
      */
     public function testIsAuthenticated($token, $expression, $result, array $roles = array())
     {
-        $anonymousTokenClass = 'Symfony\\Component\\Security\\Core\\Authentication\\Token\\AnonymousToken';
+        $anonymousTokenClass = 'Symfony\\Component\\Security\\Core\\Authentication\\Token\\AuthenticatedAnonymousToken';
         $rememberMeTokenClass = 'Symfony\\Component\\Security\\Core\\Authentication\\Token\\RememberMeToken';
         $expressionLanguage = new ExpressionLanguage();
         $trustResolver = new AuthenticationTrustResolver($anonymousTokenClass, $rememberMeTokenClass);
@@ -44,7 +45,7 @@ class ExpressionLanguageTest extends \PHPUnit_Framework_TestCase
         $user = new User('username', 'password', $roles);
 
         $noToken = null;
-        $anonymousToken = new AnonymousToken('firewall', 'anon.');
+        $anonymousToken = new AuthenticatedAnonymousToken('firewall', 'anon.');
         $rememberMeToken = new RememberMeToken($user, 'providerkey', 'firewall');
         $usernamePasswordToken = new UsernamePasswordToken('username', 'password', 'providerkey', $roles);
 

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/AuthenticatedVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/AuthenticatedVoterTest.php
@@ -66,7 +66,7 @@ class AuthenticatedVoterTest extends \PHPUnit_Framework_TestCase
         } elseif ('remembered' === $authenticated) {
             return $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken')->setMethods(array('setPersistent'))->disableOriginalConstructor()->getMock();
         } else {
-            return $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\AnonymousToken')->setConstructorArgs(array('', ''))->getMock();
+            return $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\AuthenticatedAnonymousToken')->setConstructorArgs(array('', ''))->getMock();
         }
     }
 }

--- a/src/Symfony/Component/Security/Http/Firewall/AnonymousAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AnonymousAuthenticationListener.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Firewall;
 
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
+use Symfony\Component\Security\Core\Authentication\Token\AnonymousRequestToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Psr\Log\LoggerInterface;
@@ -51,7 +52,7 @@ class AnonymousAuthenticationListener implements ListenerInterface
         }
 
         try {
-            $token = new AnonymousToken($this->secret, 'anon.', array());
+            $token = new AnonymousRequestToken($this->secret, 'anon.');
             if (null !== $this->authenticationManager) {
                 $token = $this->authenticationManager->authenticate($token);
             }

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AnonymousAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AnonymousAuthenticationListenerTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Http\Tests\Firewall;
 
+use Symfony\Component\Security\Core\Authentication\Token\AnonymousRequestToken;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Http\Firewall\AnonymousAuthenticationListener;
 
@@ -48,7 +49,7 @@ class AnonymousAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(null))
         ;
 
-        $anonymousToken = new AnonymousToken('TheSecret', 'anon.', array());
+        $anonymousToken = new AnonymousRequestToken('TheSecret', 'anon.');
 
         $authenticationManager = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface')->getMock();
         $authenticationManager


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #
| License       | MIT
| Doc PR        | todo

Started a long time ago with this branch, so I thought it was time to create a POC PR to get the opinion of core teammembers and contributors on this topic.

 > *NOTE* This PR is just to give an insight in the idea. Please don't review the details (e.g. the version numbers in deprecations), I know there is work left to do 😄.

The Story: Removing `UserInterface`
---

The Security system currently manages users with 2 types of classes: `UserInterface` and `TokenInterface`. The devs using Symfony most of the time end up using `UserInterface` as their user object in the application. This has some drawbacks:

 * You're forced to implement methods you never need to use (`getPassword()`, `getSalt()`, etc.) (#10316)
 * The complete application user object will be serialized in the session
 * You need to configure the serialization of your application user (http://symfony.com/doc/current/security/entity_provider.html#understanding-serialize-and-how-a-user-is-saved-in-the-session)

Probably more than a year back, @iltar, @weaverryan and me had a discussion about this on IRC. A nice idea was born there:

 * Make `Token` the first-class citizen of the Security system. All information that the security system needs to know about the user should be saved in the token.
 * The `Token` will be serialized in the session
 * There still is a user/identity object in the token, to allow the very conventient `getUser()` method and `app.user` var. This user object should have a `getIdentifier()` method, returning an identifier for the user which is saved in the serialized token.

This Pull Request
---

In order to store all security information in a token, the token needs to be split into 2 seperate tokens: Authentication request tokens and Authenticated tokens. The authentication request token contains all information before authenticating (such as the username and password passed through the login form). The authenticated token contains the identifier (see previous section) of the logged in user and the roles bound to this token.

Splitting the token also has other major advantages:

 * The weird "user has to be a string, UserInterface or object with `__toString()`" thing in the security system is removed. Users are now always an object instance of `UserInterface` in authenticated tokens.
 * The 2 types of tokens are actually very different. It doesn't make much sense to use the same class to represent them (e.g. unauthenticated tokens don't have roles, there is no concept of user in unauthenticated tokens, etc.).

The Future
---

In follow-up pull requests, the rest of the story of removing the `UserInterface` can be done.