### PR TITLE
[DI] Add "inherit-tags" with configurable defaults + same for "public", "tags" & "autowire"

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -4,11 +4,13 @@ CHANGELOG
 3.3.0
 -----
 
- * Add "iterator" argument type for lazy iteration over a set of values and services
-
- * Using the `PhpDumper` with an uncompiled `ContainerBuilder` is deprecated and
-   will not be supported anymore in 4.0.
-
+ * added "iterator" argument type for lazy iteration over a set of values and services
+ * added "closure-proxy" argument type for turning services' methods into lazy callables
+ * added file-wide configurable defaults for service attributes "public", "tags",
+   "autowire" and a new "inherit-tags"
+ * made the "class" attribute optional, using the "id" as fallback
+ * using the `PhpDumper` with an uncompiled `ContainerBuilder` is deprecated and
+   will not be supported anymore in 4.0
  * deprecated the `DefinitionDecorator` class in favor of `ChildDefinition`
 
 3.2.0

--- a/src/Symfony/Component/DependencyInjection/ChildDefinition.php
+++ b/src/Symfony/Component/DependencyInjection/ChildDefinition.php
@@ -22,6 +22,7 @@ use Symfony\Component\DependencyInjection\Exception\OutOfBoundsException;
 class ChildDefinition extends Definition
 {
     private $parent;
+    private $inheritTags = false;
     private $changes = array();
 
     /**
@@ -52,6 +53,30 @@ class ChildDefinition extends Definition
     public function getChanges()
     {
         return $this->changes;
+    }
+
+    /**
+     * Sets whether tags should be inherited from the parent or not.
+     *
+     * @param bool $boolean
+     *
+     * @return $this
+     */
+    public function setInheritTags($boolean)
+    {
+        $this->inheritTags = (bool) $boolean;
+
+        return $this;
+    }
+
+    /**
+     * Returns whether tags should be inherited from the parent or not.
+     *
+     * @return bool
+     */
+    public function getInheritTags()
+    {
+        return $this->inheritTags;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
@@ -216,6 +216,15 @@ class ResolveDefinitionTemplatesPass implements CompilerPassInterface
         $def->setShared($definition->isShared());
         $def->setTags($definition->getTags());
 
+        // append parent tags when inheriting is enabled
+        if ($definition->getInheritTags()) {
+            foreach ($parentDef->getTags() as $k => $v) {
+                foreach ($v as $v) {
+                    $def->addTag($k, $v);
+                }
+            }
+        }
+
         return $def;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -102,6 +102,7 @@
     </xsd:choice>
     <xsd:attribute name="public" type="boolean" />
     <xsd:attribute name="autowire" type="boolean" />
+    <xsd:attribute name="inherit-tags" type="boolean" />
   </xsd:complexType>
 
   <xsd:complexType name="service">
@@ -130,6 +131,7 @@
     <xsd:attribute name="decoration-inner-name" type="xsd:string" />
     <xsd:attribute name="decoration-priority" type="xsd:integer" />
     <xsd:attribute name="autowire" type="boolean" />
+    <xsd:attribute name="inherit-tags" type="boolean" />
   </xsd:complexType>
 
   <xsd:complexType name="tag">

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -52,8 +52,9 @@
         Enclosing element for the definition of all services
       ]]></xsd:documentation>
     </xsd:annotation>
-    <xsd:choice minOccurs="1" maxOccurs="unbounded">
-      <xsd:element name="service" type="service" />
+    <xsd:choice maxOccurs="unbounded">
+      <xsd:element name="service" type="service" minOccurs="1" />
+      <xsd:element name="defaults" type="defaults" minOccurs="0" maxOccurs="1" />
     </xsd:choice>
   </xsd:complexType>
 
@@ -87,6 +88,20 @@
     <xsd:attribute name="class" type="xsd:string" />
     <xsd:attribute name="method" type="xsd:string" />
     <xsd:attribute name="function" type="xsd:string" />
+  </xsd:complexType>
+
+  <xsd:complexType name="defaults">
+    <xsd:annotation>
+      <xsd:documentation><![CDATA[
+        Enclosing element for the service definitions' defaults for the current file
+      ]]></xsd:documentation>
+    </xsd:annotation>
+    <xsd:choice maxOccurs="unbounded">
+      <xsd:element name="tag" type="tag" minOccurs="0" maxOccurs="unbounded" />
+      <xsd:element name="autowire" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+    </xsd:choice>
+    <xsd:attribute name="public" type="boolean" />
+    <xsd:attribute name="autowire" type="boolean" />
   </xsd:complexType>
 
   <xsd:complexType name="service">

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services29.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services29.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <defaults public="false" autowire="true">
+            <tag name="foo" />
+        </defaults>
+
+        <service id="with_defaults" class="Foo" />
+        <service id="no_defaults" class="Foo" public="true" autowire="false">
+            <tag name="bar" />
+        </service>
+        <service id="no_defaults_child" class="Foo" parent="no_defaults">
+            <tag name="bar" />
+        </service>
+        <service id="with_defaults_child" class="Foo" parent="with_defaults" />
+    </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services29.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services29.xml
@@ -6,12 +6,13 @@
         </defaults>
 
         <service id="with_defaults" class="Foo" />
-        <service id="no_defaults" class="Foo" public="true" autowire="false">
-            <tag name="bar" />
+        <service id="no_defaults" class="Foo" public="true" autowire="false" inherit-tags="false">
         </service>
         <service id="no_defaults_child" class="Foo" parent="no_defaults">
             <tag name="bar" />
         </service>
-        <service id="with_defaults_child" class="Foo" parent="with_defaults" />
+        <service id="with_defaults_child" class="Foo" parent="with_defaults" public="true" inherit-tags="true">
+            <tag name="baz" />
+        </service>
     </services>
 </container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services30.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services30.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <defaults public="false">
+            <autowire>__construct</autowire>
+        </defaults>
+
+        <service id="with_defaults" class="Foo" />
+        <service id="no_defaults" class="Foo" public="true">
+            <autowire>setFoo</autowire>
+        </service>
+        <service id="no_defaults_child" class="Foo" parent="no_defaults">
+            <autowire>setFoo</autowire>
+        </service>
+        <service id="with_defaults_child" class="Foo" parent="with_defaults" />
+    </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services28.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services28.yml
@@ -10,9 +10,9 @@ services:
 
     with_null:
         class: Foo
-        public: ~
+        public: true
         autowire: ~
-        tags: ~
+        inherit_tags: false
 
     no_defaults:
         class: Foo
@@ -28,3 +28,7 @@ services:
 
     with_defaults_child:
         parent: with_defaults
+        public: true
+        inherit_tags: true
+        tags:
+            - name: baz

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services28.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services28.yml
@@ -1,0 +1,30 @@
+services:
+    _defaults:
+        public: false
+        autowire: true
+        tags:
+            - name: foo
+
+    with_defaults:
+        class: Foo
+
+    with_null:
+        class: Foo
+        public: ~
+        autowire: ~
+        tags: ~
+
+    no_defaults:
+        class: Foo
+        public: true
+        autowire: false
+        tags: []
+
+    no_defaults_child:
+        parent: no_defaults
+        autowire: ~
+        tags:
+            - name: bar
+
+    with_defaults_child:
+        parent: with_defaults

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -625,19 +625,23 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $loader->load('services29.xml');
 
         $this->assertFalse($container->getDefinition('with_defaults')->isPublic());
+        $this->assertSame(array('foo' => array(array())), $container->getDefinition('with_defaults')->getTags());
+        $this->assertTrue($container->getDefinition('with_defaults')->isAutowired());
+
+        $this->assertArrayNotHasKey('public', $container->getDefinition('no_defaults_child')->getChanges());
+        $this->assertArrayNotHasKey('autowire', $container->getDefinition('no_defaults_child')->getChanges());
+
+        $container->compile();
+
         $this->assertTrue($container->getDefinition('no_defaults')->isPublic());
         $this->assertTrue($container->getDefinition('no_defaults_child')->isPublic());
-        $this->assertArrayNotHasKey('public', $container->getDefinition('no_defaults_child')->getChanges());
 
-        $this->assertSame(array('foo' => array(array())), $container->getDefinition('with_defaults')->getTags());
-        $this->assertSame(array('bar' => array(array())), $container->getDefinition('no_defaults')->getTags());
+        $this->assertSame(array(), $container->getDefinition('no_defaults')->getTags());
         $this->assertSame(array('bar' => array(array())), $container->getDefinition('no_defaults_child')->getTags());
-        $this->assertSame(array(), $container->getDefinition('with_defaults_child')->getTags());
+        $this->assertSame(array('baz' => array(array()), 'foo' => array(array())), $container->getDefinition('with_defaults_child')->getTags());
 
-        $this->assertTrue($container->getDefinition('with_defaults')->isAutowired());
         $this->assertFalse($container->getDefinition('no_defaults')->isAutowired());
         $this->assertFalse($container->getDefinition('no_defaults_child')->isAutowired());
-        $this->assertArrayNotHasKey('autowire', $container->getDefinition('no_defaults_child')->getChanges());
     }
 
     public function testDefaultsWithAutowiredMethods()

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -617,4 +617,38 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame(array('type' => 'foo', 'bar'), $container->getDefinition('foo')->getArguments());
     }
+
+    public function testDefaults()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader->load('services29.xml');
+
+        $this->assertFalse($container->getDefinition('with_defaults')->isPublic());
+        $this->assertTrue($container->getDefinition('no_defaults')->isPublic());
+        $this->assertTrue($container->getDefinition('no_defaults_child')->isPublic());
+        $this->assertArrayNotHasKey('public', $container->getDefinition('no_defaults_child')->getChanges());
+
+        $this->assertSame(array('foo' => array(array())), $container->getDefinition('with_defaults')->getTags());
+        $this->assertSame(array('bar' => array(array())), $container->getDefinition('no_defaults')->getTags());
+        $this->assertSame(array('bar' => array(array())), $container->getDefinition('no_defaults_child')->getTags());
+        $this->assertSame(array(), $container->getDefinition('with_defaults_child')->getTags());
+
+        $this->assertTrue($container->getDefinition('with_defaults')->isAutowired());
+        $this->assertFalse($container->getDefinition('no_defaults')->isAutowired());
+        $this->assertFalse($container->getDefinition('no_defaults_child')->isAutowired());
+        $this->assertArrayNotHasKey('autowire', $container->getDefinition('no_defaults_child')->getChanges());
+    }
+
+    public function testDefaultsWithAutowiredMethods()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader->load('services30.xml');
+
+        $this->assertSame(array('__construct'), $container->getDefinition('with_defaults')->getAutowiredMethods());
+        $this->assertSame(array('setFoo'), $container->getDefinition('no_defaults')->getAutowiredMethods());
+        $this->assertSame(array('setFoo'), $container->getDefinition('no_defaults_child')->getAutowiredMethods());
+        $this->assertSame(array(), $container->getDefinition('with_defaults_child')->getAutowiredMethods());
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -359,22 +359,26 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $loader->load('services28.yml');
 
         $this->assertFalse($container->getDefinition('with_defaults')->isPublic());
-        $this->assertFalse($container->getDefinition('with_null')->isPublic());
+        $this->assertSame(array('foo' => array(array())), $container->getDefinition('with_defaults')->getTags());
+        $this->assertTrue($container->getDefinition('with_defaults')->isAutowired());
+
+        $this->assertArrayNotHasKey('public', $container->getDefinition('no_defaults_child')->getChanges());
+        $this->assertArrayNotHasKey('autowire', $container->getDefinition('no_defaults_child')->getChanges());
+
+        $container->compile();
+
+        $this->assertTrue($container->getDefinition('with_null')->isPublic());
         $this->assertTrue($container->getDefinition('no_defaults')->isPublic());
         $this->assertTrue($container->getDefinition('no_defaults_child')->isPublic());
-        $this->assertArrayNotHasKey('public', $container->getDefinition('no_defaults_child')->getChanges());
 
-        $this->assertSame(array('foo' => array(array())), $container->getDefinition('with_defaults')->getTags());
-        $this->assertSame(array('foo' => array(array())), $container->getDefinition('with_null')->getTags());
+        $this->assertSame(array(), $container->getDefinition('with_null')->getTags());
         $this->assertSame(array(), $container->getDefinition('no_defaults')->getTags());
         $this->assertSame(array('bar' => array(array())), $container->getDefinition('no_defaults_child')->getTags());
-        $this->assertSame(array(), $container->getDefinition('with_defaults_child')->getTags());
+        $this->assertSame(array('baz' => array(array()), 'foo' => array(array())), $container->getDefinition('with_defaults_child')->getTags());
 
-        $this->assertTrue($container->getDefinition('with_defaults')->isAutowired());
         $this->assertTrue($container->getDefinition('with_null')->isAutowired());
         $this->assertFalse($container->getDefinition('no_defaults')->isAutowired());
         $this->assertFalse($container->getDefinition('no_defaults_child')->isAutowired());
-        $this->assertArrayNotHasKey('autowire', $container->getDefinition('no_defaults_child')->getChanges());
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -352,6 +352,31 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(CaseSensitiveClass::class, $container->getDefinition(CaseSensitiveClass::class)->getClass());
     }
 
+    public function testDefaults()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('services28.yml');
+
+        $this->assertFalse($container->getDefinition('with_defaults')->isPublic());
+        $this->assertFalse($container->getDefinition('with_null')->isPublic());
+        $this->assertTrue($container->getDefinition('no_defaults')->isPublic());
+        $this->assertTrue($container->getDefinition('no_defaults_child')->isPublic());
+        $this->assertArrayNotHasKey('public', $container->getDefinition('no_defaults_child')->getChanges());
+
+        $this->assertSame(array('foo' => array(array())), $container->getDefinition('with_defaults')->getTags());
+        $this->assertSame(array('foo' => array(array())), $container->getDefinition('with_null')->getTags());
+        $this->assertSame(array(), $container->getDefinition('no_defaults')->getTags());
+        $this->assertSame(array('bar' => array(array())), $container->getDefinition('no_defaults_child')->getTags());
+        $this->assertSame(array(), $container->getDefinition('with_defaults_child')->getTags());
+
+        $this->assertTrue($container->getDefinition('with_defaults')->isAutowired());
+        $this->assertTrue($container->getDefinition('with_null')->isAutowired());
+        $this->assertFalse($container->getDefinition('no_defaults')->isAutowired());
+        $this->assertFalse($container->getDefinition('no_defaults_child')->isAutowired());
+        $this->assertArrayNotHasKey('autowire', $container->getDefinition('no_defaults_child')->getChanges());
+    }
+
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
      * @expectedExceptionMessage The value of the "decorates" option for the "bar" service must be the id of the service without the "@" prefix (replace "@foo" with "foo").


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20048
| License       | MIT
| Doc PR        | -

Instead of making services private by default (#20048), which is going to create a big migration burden that might not be worth it, I'd like to propose the idea of changing the default for the current file.

Having a place to redefine some defaults, this can also be used to enable autowiring for a file, making it much lighter in the end.

This PR handles defaults for "public", "autowired" and "tags". Not sure the other options need a configurable default. Please comment if you think otherwise.

Short example (the feat is more interesting with a longer list of services):
```yaml
services:
    _defaults:
        public: false
        autowire: ['_construct', 'set*']

    foo:
        class: Foo
```

```xml
<?xml version="1.0" encoding="utf-8"?>
<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
    <services>
        <defaults public="false">
            <autowire>__construct</autowire>
            <tag name="foo"/>
        </defaults>
    </services>
</container>
```

ping @dunglas @weaverryan