### PR TITLE
[Console] Show hidden commands in json & xml descriptors

### DIFF
--- a/src/Symfony/Component/Console/Descriptor/ApplicationDescription.php
+++ b/src/Symfony/Component/Console/Descriptor/ApplicationDescription.php
@@ -50,15 +50,22 @@ class ApplicationDescription
     private $aliases;
 
     /**
+     * @var bool
+     */
+    private $showHidden;
+
+    /**
      * Constructor.
      *
      * @param Application $application
      * @param string|null $namespace
+     * @param bool        $showHidden
      */
-    public function __construct(Application $application, $namespace = null)
+    public function __construct(Application $application, $namespace = null, $showHidden = false)
     {
         $this->application = $application;
         $this->namespace = $namespace;
+        $this->showHidden = $showHidden;
     }
 
     /**
@@ -112,7 +119,7 @@ class ApplicationDescription
 
             /** @var Command $command */
             foreach ($commands as $name => $command) {
-                if (!$command->getName() || $command->isHidden()) {
+                if (!$command->getName() || (!$this->showHidden && $command->isHidden())) {
                     continue;
                 }
 

--- a/src/Symfony/Component/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/JsonDescriptor.php
@@ -64,7 +64,7 @@ class JsonDescriptor extends Descriptor
     protected function describeApplication(Application $application, array $options = array())
     {
         $describedNamespace = isset($options['namespace']) ? $options['namespace'] : null;
-        $description = new ApplicationDescription($application, $describedNamespace);
+        $description = new ApplicationDescription($application, $describedNamespace, true);
         $commands = array();
 
         foreach ($description->getCommands() as $command) {
@@ -173,6 +173,7 @@ class JsonDescriptor extends Descriptor
             'description' => $command->getDescription(),
             'help' => $command->getProcessedHelp(),
             'definition' => $this->getInputDefinitionData($command->getNativeDefinition()),
+            'hidden' => $command->isHidden(),
         );
     }
 }

--- a/src/Symfony/Component/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/XmlDescriptor.php
@@ -64,6 +64,7 @@ class XmlDescriptor extends Descriptor
 
         $commandXML->setAttribute('id', $command->getName());
         $commandXML->setAttribute('name', $command->getName());
+        $commandXML->setAttribute('hidden', $command->isHidden() ? 1 : 0);
 
         $commandXML->appendChild($usagesXML = $dom->createElement('usages'));
 
@@ -103,7 +104,7 @@ class XmlDescriptor extends Descriptor
 
         $rootXml->appendChild($commandsXML = $dom->createElement('commands'));
 
-        $description = new ApplicationDescription($application, $namespace);
+        $description = new ApplicationDescription($application, $namespace, true);
 
         if ($namespace) {
             $commandsXML->setAttribute('namespace', $namespace);

--- a/src/Symfony/Component/Console/Tests/Command/ListCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/ListCommandTest.php
@@ -30,7 +30,7 @@ class ListCommandTest extends \PHPUnit_Framework_TestCase
         $application = new Application();
         $commandTester = new CommandTester($command = $application->get('list'));
         $commandTester->execute(array('command' => $command->getName(), '--format' => 'xml'));
-        $this->assertRegExp('/<command id="list" name="list">/', $commandTester->getDisplay(), '->execute() returns a list of available commands in XML if --xml is passed');
+        $this->assertRegExp('/<command id="list" name="list" hidden="0">/', $commandTester->getDisplay(), '->execute() returns a list of available commands in XML if --xml is passed');
     }
 
     public function testExecuteListsCommandsWithRawOption()

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.json
@@ -2,6 +2,7 @@
     "commands": [
         {
             "name": "help",
+            "hidden": false,
             "usage": [
                 "help [--format FORMAT] [--raw] [--] [<command_name>]"
             ],
@@ -104,6 +105,7 @@
         },
         {
             "name": "list",
+            "hidden": false,
             "usage": [
                 "list [--raw] [--format FORMAT] [--] [<namespace>]"
             ],

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <symfony>
   <commands>
-    <command id="help" name="help">
+    <command id="help" name="help" hidden="0">
       <usages>
         <usage>help [--format FORMAT] [--raw] [--] [&lt;command_name&gt;]</usage>
       </usages>
@@ -56,7 +56,7 @@
         </option>
       </options>
     </command>
-    <command id="list" name="list">
+    <command id="list" name="list" hidden="0">
       <usages>
         <usage>list [--raw] [--format FORMAT] [--] [&lt;namespace&gt;]</usage>
       </usages>

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.json
@@ -6,6 +6,7 @@
     "commands": [
         {
             "name": "help",
+            "hidden": false,
             "usage": [
                 "help [--format FORMAT] [--raw] [--] [<command_name>]"
             ],
@@ -108,6 +109,7 @@
         },
         {
             "name": "list",
+            "hidden": false,
             "usage": [
                 "list [--raw] [--format FORMAT] [--] [<namespace>]"
             ],
@@ -147,6 +149,7 @@
         },
         {
             "name": "descriptor:command1",
+            "hidden": false,
             "usage": [
                 "descriptor:command1",
                 "alias1",
@@ -225,6 +228,7 @@
         },
         {
             "name": "descriptor:command2",
+            "hidden": false,
             "usage": [
                 "descriptor:command2 [-o|--option_name] [--] <argument_name>",
                 "descriptor:command2 -o|--option_name <argument_name>",
@@ -317,6 +321,83 @@
                     }
                 }
             }
+        },
+        {
+            "name": "descriptor:command3",
+            "hidden": true,
+            "usage": [
+                "descriptor:command3"
+            ],
+            "description": "command 3 description",
+            "help": "command 3 help",
+            "definition": {
+                "arguments": {},
+                "options": {
+                    "help": {
+                        "name": "--help",
+                        "shortcut": "-h",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Display this help message",
+                        "default": false
+                    },
+                    "quiet": {
+                        "name": "--quiet",
+                        "shortcut": "-q",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Do not output any message",
+                        "default": false
+                    },
+                    "verbose": {
+                        "name": "--verbose",
+                        "shortcut": "-v|-vv|-vvv",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug",
+                        "default": false
+                    },
+                    "version": {
+                        "name": "--version",
+                        "shortcut": "-V",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Display this application version",
+                        "default": false
+                    },
+                    "ansi": {
+                        "name": "--ansi",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Force ANSI output",
+                        "default": false
+                    },
+                    "no-ansi": {
+                        "name": "--no-ansi",
+                        "shortcut": "",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Disable ANSI output",
+                        "default": false
+                    },
+                    "no-interaction": {
+                        "name": "--no-interaction",
+                        "shortcut": "-n",
+                        "accept_value": false,
+                        "is_value_required": false,
+                        "is_multiple": false,
+                        "description": "Do not ask any interactive question",
+                        "default": false
+                    }
+                }
+            }
         }
     ],
     "namespaces": [
@@ -333,7 +414,8 @@
             "id": "descriptor",
             "commands": [
                 "descriptor:command1",
-                "descriptor:command2"
+                "descriptor:command2",
+                "descriptor:command3"
             ]
         }
     ]

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <symfony name="My Symfony application" version="v1.0">
   <commands>
-    <command id="help" name="help">
+    <command id="help" name="help" hidden="0">
       <usages>
         <usage>help [--format FORMAT] [--raw] [--] [&lt;command_name&gt;]</usage>
       </usages>
@@ -56,7 +56,7 @@
         </option>
       </options>
     </command>
-    <command id="list" name="list">
+    <command id="list" name="list" hidden="0">
       <usages>
         <usage>list [--raw] [--format FORMAT] [--] [&lt;namespace&gt;]</usage>
       </usages>
@@ -94,7 +94,7 @@
         </option>
       </options>
     </command>
-    <command id="descriptor:command1" name="descriptor:command1">
+    <command id="descriptor:command1" name="descriptor:command1" hidden="0">
       <usages>
         <usage>descriptor:command1</usage>
         <usage>alias1</usage>
@@ -127,7 +127,7 @@
         </option>
       </options>
     </command>
-    <command id="descriptor:command2" name="descriptor:command2">
+    <command id="descriptor:command2" name="descriptor:command2" hidden="0">
       <usages>
         <usage>descriptor:command2 [-o|--option_name] [--] &lt;argument_name&gt;</usage>
         <usage>descriptor:command2 -o|--option_name &lt;argument_name&gt;</usage>
@@ -168,6 +168,37 @@
         </option>
       </options>
     </command>
+    <command id="descriptor:command3" name="descriptor:command3" hidden="1">
+      <usages>
+        <usage>descriptor:command3</usage>
+      </usages>
+      <description>command 3 description</description>
+      <help>command 3 help</help>
+      <arguments/>
+      <options>
+        <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Display this help message</description>
+        </option>
+        <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Do not output any message</description>
+        </option>
+        <option name="--verbose" shortcut="-v" shortcuts="-v|-vv|-vvv" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug</description>
+        </option>
+        <option name="--version" shortcut="-V" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Display this application version</description>
+        </option>
+        <option name="--ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Force ANSI output</description>
+        </option>
+        <option name="--no-ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Disable ANSI output</description>
+        </option>
+        <option name="--no-interaction" shortcut="-n" accept_value="0" is_value_required="0" is_multiple="0">
+          <description>Do not ask any interactive question</description>
+        </option>
+      </options>
+    </command>
   </commands>
   <namespaces>
     <namespace id="_global">
@@ -179,6 +210,7 @@
     <namespace id="descriptor">
       <command>descriptor:command1</command>
       <command>descriptor:command2</command>
+      <command>descriptor:command3</command>
     </namespace>
   </namespaces>
 </symfony>

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_1.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_1.json
@@ -1,5 +1,6 @@
 {
     "name": "descriptor:command1",
+    "hidden": false,
     "usage": [
         "descriptor:command1",
         "alias1",

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_1.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<command id="descriptor:command1" name="descriptor:command1">
+<command id="descriptor:command1" name="descriptor:command1" hidden="0">
   <usages>
     <usage>descriptor:command1</usage>
     <usage>alias1</usage>

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_2.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_2.json
@@ -1,5 +1,6 @@
 {
     "name": "descriptor:command2",
+    "hidden": false,
     "usage": [
         "descriptor:command2 [-o|--option_name] [--] <argument_name>",
         "descriptor:command2 -o|--option_name <argument_name>",

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_2.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<command id="descriptor:command2" name="descriptor:command2">
+<command id="descriptor:command2" name="descriptor:command2" hidden="0">
   <usages>
     <usage>descriptor:command2 [-o|--option_name] [--] &lt;argument_name&gt;</usage>
     <usage>descriptor:command2 -o|--option_name &lt;argument_name&gt;</usage>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no (may be considered, but as hidden commands did not exist before 3.2, looks more like a behavior change, hence a feature)
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/20866#issuecomment-266678895
| License       | MIT
| Doc PR        | N/A