### PR TITLE
[Console] OS X Can't call cli_set_process_title php without superuser

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -227,7 +227,14 @@ class Command
 
         if (null !== $this->processTitle) {
             if (function_exists('cli_set_process_title')) {
-                cli_set_process_title($this->processTitle);
+                if (false === @cli_set_process_title($this->processTitle)) {
+                    if ('Darwin' === PHP_OS) {
+                        $output->writeln('<comment>Running "cli_get_process_title" as an unprivileged user is not supported on MacOS.</comment>');
+                    } else {
+                        $error = error_get_last();
+                        trigger_error($error['message'], E_USER_WARNING);
+                    }
+                }
             } elseif (function_exists('setproctitle')) {
                 setproctitle($this->processTitle);
             } elseif (OutputInterface::VERBOSITY_VERY_VERBOSE === $output->getVerbosity()) {

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -328,6 +328,9 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $command->setProcessTitle('foo');
         $this->assertSame(0, $command->run(new StringInput(''), new NullOutput()));
         if (function_exists('cli_set_process_title')) {
+            if (null === @cli_get_process_title() && 'Darwin' === PHP_OS) {
+                $this->markTestSkipped('Running "cli_get_process_title" as an unprivileged user is not supported on MacOS.');
+            }
             $this->assertEquals('foo', cli_get_process_title());
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

The console component test suite is failing on OS X (10.12.2) as the `cli_set_process_title` function seems not to be allowed to be called without superuser. It seems to be an OS X limitation.
At least, the test suite should pass and a warning should be shown when using the component with this feature on OS X.

--- 

refs:

- http://stackoverflow.com/questions/27803120/cannot-set-process-title-in-a-php-command-line-script-using-cli-set-process-titl
- https://github.com/liip/php-osx/issues/139
- https://github.com/zfcampus/zf-console/pull/22