### PR TITLE
[ExpressionLanguage][WIP] Parse PHP functions

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
@@ -32,12 +32,14 @@ class ExpressionLanguage
     private $compiler;
 
     protected $functions = array();
+    protected $parsePhpFunctions;
 
     /**
      * @param CacheItemPoolInterface                $cache
      * @param ExpressionFunctionProviderInterface[] $providers
+     * @param bool                                  $parsePhpFunctions Parse PHP functions like <code>strtoupper()</code>
      */
-    public function __construct($cache = null, array $providers = array())
+    public function __construct($cache = null, array $providers = array(), $parsePhpFunctions = false)
     {
         if (null !== $cache) {
             if ($cache instanceof ParserCacheInterface) {
@@ -53,6 +55,8 @@ class ExpressionLanguage
         foreach ($providers as $provider) {
             $this->registerProvider($provider);
         }
+
+        $this->parsePhpFunctions = $parsePhpFunctions;
     }
 
     /**
@@ -162,7 +166,7 @@ class ExpressionLanguage
     private function getParser()
     {
         if (null === $this->parser) {
-            $this->parser = new Parser($this->functions);
+            $this->parser = new Parser($this->functions, $this->parsePhpFunctions);
         }
 
         return $this->parser;

--- a/src/Symfony/Component/ExpressionLanguage/Parser.php
+++ b/src/Symfony/Component/ExpressionLanguage/Parser.php
@@ -214,6 +214,7 @@ class Parser
                             } else {
                                 throw new SyntaxError(sprintf('The function "%s" does not exist', $token->value), $token->cursor);
                             }
+
                             $node = new Node\FunctionNode($token->value, $this->parseArguments());
                         } else {
                             if (!in_array($token->value, $this->names, true)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

This feature allows the ``ExpressionLanguage`` componant to parse automagically PHP functions (like [strtoupper](http://php.net/manual/en/function.strtolower.php) function) without to do [custom registration](http://symfony.com/doc/current/components/expression_language/extending.html).

To enable this behavior, set ``$parsePhpFunctions`` param's ``ExpressionLanguage`` to ``true``:

```php
$el = new ExpressionLanguage(null, array(), $parsePhpFunctions = true);
```

And in this way, we can evaluate any PHP functions:

```php
echo $el->evaluate("strtoupper('hello')"); // => HELLO
echo $el->compile("strtoupper('hello')"); // => strtoupper("hello")
```

And even with a more *complex* example:

```php
echo $el->evaluate("strtoupper(implode(' ', array_merge(['hello'], ['symfony']))) ~ ' from ' ~ constant('PHP_OS')");
// => HELLO SYMFONY from Linux
```

WDYT?