### PR TITLE
Secure unserialize by restricting allowed classes when using PHP 7

### DIFF
--- a/src/Symfony/Bridge/Twig/DataCollector/TwigDataCollector.php
+++ b/src/Symfony/Bridge/Twig/DataCollector/TwigDataCollector.php
@@ -93,7 +93,11 @@ class TwigDataCollector extends DataCollector implements LateDataCollectorInterf
     public function getProfile()
     {
         if (null === $this->profile) {
-            $this->profile = unserialize($this->data['profile']);
+            if (PHP_VERSION_ID >= 70000) {
+                $this->profile = unserialize($this->data['profile'], array('allowed_classes' => array('Twig_Profiler_Profile')));
+            } else {
+                $this->profile = unserialize($this->data['profile']);
+            }
         }
 
         return $this->profile;

--- a/src/Symfony/Component/DependencyInjection/Config/AutowireServiceResource.php
+++ b/src/Symfony/Component/DependencyInjection/Config/AutowireServiceResource.php
@@ -60,7 +60,11 @@ class AutowireServiceResource implements SelfCheckingResourceInterface, \Seriali
 
     public function unserialize($serialized)
     {
-        list($this->class, $this->filePath, $this->autowiringMetadata) = unserialize($serialized);
+        if (PHP_VERSION_ID >= 70000) {
+            list($this->class, $this->filePath, $this->autowiringMetadata) = unserialize($serialized, array('allowed_classes' => false));
+        } else {
+            list($this->class, $this->filePath, $this->autowiringMetadata) = unserialize($serialized);
+        }
     }
 
     /**

--- a/src/Symfony/Component/Form/FormError.php
+++ b/src/Symfony/Component/Form/FormError.php
@@ -185,6 +185,10 @@ class FormError implements \Serializable
      */
     public function unserialize($serialized)
     {
-        list($this->message, $this->messageTemplate, $this->messageParameters, $this->messagePluralization, $this->cause) = unserialize($serialized);
+        if (PHP_VERSION_ID >= 70000) {
+            list($this->message, $this->messageTemplate, $this->messageParameters, $this->messagePluralization, $this->cause) = unserialize($serialized, array('allowed_classes' => false));
+        } else {
+            list($this->message, $this->messageTemplate, $this->messageParameters, $this->messagePluralization, $this->cause) = unserialize($serialized);
+        }
     }
 }

--- a/src/Symfony/Component/HttpKernel/Config/EnvParametersResource.php
+++ b/src/Symfony/Component/HttpKernel/Config/EnvParametersResource.php
@@ -72,7 +72,11 @@ class EnvParametersResource implements SelfCheckingResourceInterface, \Serializa
 
     public function unserialize($serialized)
     {
-        $unserialized = unserialize($serialized);
+        if (PHP_VERSION_ID >= 70000) {
+            $unserialized = unserialize($serialized, array('allowed_classes' => false));
+        } else {
+            $unserialized = unserialize($serialized);
+        }
 
         $this->prefix = $unserialized['prefix'];
         $this->variables = $unserialized['variables'];

--- a/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
+++ b/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
@@ -63,7 +63,11 @@ class FileLinkFormatter implements \Serializable
 
     public function unserialize($serialized)
     {
-        $this->fileLinkFormat = unserialize($serialized);
+        if (PHP_VERSION_ID >= 70000) {
+            $this->fileLinkFormat = unserialize($serialized, array('allowed_classes' => false));
+        } else {
+            $this->fileLinkFormat = unserialize($serialized);
+        }
     }
 
     private function getFileLinkFormat()

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -734,7 +734,11 @@ abstract class Kernel implements KernelInterface, TerminableInterface
 
     public function unserialize($data)
     {
-        list($environment, $debug) = unserialize($data);
+        if (PHP_VERSION_ID >= 70000) {
+            list($environment, $debug) = unserialize($data, array('allowed_classes' => false));
+        } else {
+            list($environment, $debug) = unserialize($data);
+        }
 
         $this->__construct($environment, $debug);
     }

--- a/src/Symfony/Component/Routing/CompiledRoute.php
+++ b/src/Symfony/Component/Routing/CompiledRoute.php
@@ -73,7 +73,12 @@ class CompiledRoute implements \Serializable
      */
     public function unserialize($serialized)
     {
-        $data = unserialize($serialized);
+        if (PHP_VERSION_ID >= 70000) {
+            $data = unserialize($serialized, array('allowed_classes' => false));
+        } else {
+            $data = unserialize($serialized);
+        }
+
         $this->variables = $data['vars'];
         $this->staticPrefix = $data['path_prefix'];
         $this->regex = $data['path_regex'];

--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -116,7 +116,11 @@ class Route implements \Serializable
      */
     public function unserialize($serialized)
     {
-        $data = unserialize($serialized);
+        if (PHP_VERSION_ID >= 70000) {
+            $data = unserialize($serialized, array('allowed_classes' => array(CompiledRoute::class)));
+        } else {
+            $data = unserialize($serialized);
+        }
         $this->path = $data['path'];
         $this->host = $data['host'];
         $this->defaults = $data['defaults'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ---
| License       | MIT
| Doc PR        | ---

While playing around with Symfony in a PHP 7.1 application I noticed a warning in how EnvParameterResoure uses unserialize. Since PHP 7.0 introduced the options argument which allows to restrict which classes can be unserialized for better security, it might make sense to use it here. As far as I can tell this is no BC break, it only provides an additional safety mechanism.