### PR TITLE
[POC] Introcude the request on CLI by default

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -419,7 +419,25 @@ class Configuration implements ConfigurationInterface
                     ->info('request configuration')
                     ->canBeEnabled()
                     ->fixXmlConfig('format')
+                    ->beforeNormalization()
+                        ->ifTrue(function ($v) { return is_array($v) && !isset($v['base_url']); })
+                        ->then(function (array $v) {
+                            $v['base_url'] = isset($v['base_path']) ? $v['base_path'] : null;
+
+                            return $v;
+                        })
+                    ->end()
                     ->children()
+                        ->scalarNode('scheme')->defaultValue('http')->end()
+                        ->scalarNode('host')->defaultValue('localhost')->end()
+                        ->scalarNode('base_url')
+                            ->beforeNormalization()->ifString()->then(function ($v) { return '/'.trim($v, '/'); })->end()
+                            ->defaultValue('/')
+                        ->end()
+                        ->scalarNode('base_path')
+                            ->beforeNormalization()->ifString()->then(function ($v) { return '/'.trim($v, '/'); })->end()
+                            ->defaultValue('/')
+                        ->end()
                         ->arrayNode('formats')
                             ->useAttributeAsKey('name')
                             ->prototype('array')

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -26,6 +26,7 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Config\Resource\DirectoryResource;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
@@ -138,6 +139,7 @@ class FrameworkExtension extends Extension
             $this->registerSessionConfiguration($config['session'], $container, $loader);
         }
 
+        $container->setParameter('request', $config['request']);
         if ($this->isConfigEnabled($container, $config['request'])) {
             $this->registerRequestConfiguration($config['request'], $container, $loader);
         }

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1792,6 +1792,10 @@ class Request
      */
     protected function prepareBaseUrl()
     {
+        if ($this->server->has('SF_BASE_URL')) {
+            return $this->server->get('SF_BASE_URL');
+        }
+
         $filename = basename($this->server->get('SCRIPT_FILENAME'));
 
         if (basename($this->server->get('SCRIPT_NAME')) === $filename) {
@@ -1858,6 +1862,10 @@ class Request
      */
     protected function prepareBasePath()
     {
+        if ($this->server->has('SF_BASE_PATH')) {
+            return $this->server->get('SF_BASE_PATH');
+        }
+
         $filename = basename($this->server->get('SCRIPT_FILENAME'));
         $baseUrl = $this->getBaseUrl();
         if (empty($baseUrl)) {

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -120,6 +120,17 @@ abstract class Kernel implements KernelInterface, TerminableInterface
             $bundle->boot();
         }
 
+        // initialize request on CLI
+        if ('cli' === PHP_SAPI && $this->container->hasParameter('request')) {
+            $config = $this->container->getParameter('request');
+            $request = Request::create($config['scheme'].'://'.$config['host'].$config['base_url']);
+            $request->server->set('REQUEST_URI', $config['base_url']);
+            $request->server->set('SF_BASE_URL', $config['base_url']);
+            $request->server->set('SF_BASE_PATH', $config['base_path']);
+
+            $this->container->get('request_stack')->push($request);
+        }
+
         $this->booted = true;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | #19396, #16968, #21027, #21043
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

TLDR; it works.

This introduces a concept of having a request object on CLI. And it truly seems to be convenient.

The idea is to push a static request (`Request::create`) to the request stack, this fixes an issue in a way we have a (imo.) good defaulting strategy (things just work). No need for introducing context objects, additional class properties storing defaults, etc.

To be clear, this is not about actually calling `Kernel::handle($request)` on CLI. However, in a way, we do have to consider the `REQUEST` event on this.

I did a quick setup for config proposal. 

```yaml
framework:
  request:
    host: foo.com
    scheme: https
    base_url: '/sub/app_dev.php' # dev
    base_path: '/sub' # prod + dev
```

Additionally, when dealing with a "real" request we could opt-in to validate it against our definition, and perhaps throw a `SuspiciousOperationException` if things dont match.

This can also be a user-land strategy, so im curious about SF adopting it.