### PR TITLE
[FrameworkBundle] Validator cache fails with annotations

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ValidatorCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/ValidatorCacheWarmerTest.php
@@ -51,6 +51,40 @@ class ValidatorCacheWarmerTest extends TestCase
         $this->assertArrayHasKey('Symfony.Bundle.FrameworkBundle.Tests.Fixtures.Validation.Author', $values);
     }
 
+    public function testWarmUpWithAnnotations()
+    {
+        $validatorBuilder = new ValidatorBuilder();
+        $validatorBuilder->addYamlMapping(__DIR__.'/../Fixtures/Validation/Resources/categories.yml');
+        $validatorBuilder->enableAnnotationMapping();
+
+        $file = sys_get_temp_dir().'/cache-validator-with-annotations.php';
+        @unlink($file);
+
+        $fallbackPool = new ArrayAdapter();
+
+        $warmer = new ValidatorCacheWarmer($validatorBuilder, $file, $fallbackPool);
+        $warmer->warmUp(dirname($file));
+
+        $this->assertFileExists($file);
+
+        $values = require $file;
+
+        $this->assertInternalType('array', $values);
+        $this->assertCount(2, $values);
+        $this->assertArrayHasKey('Symfony.Bundle.FrameworkBundle.Tests.Fixtures.Validation.Category', $values);
+        $this->assertArrayHasKey('Symfony.Bundle.FrameworkBundle.Tests.Fixtures.Validation.SubCategory', $values);
+
+        // Simple check to make sure that at least one constraint is actually cached, in this case the "id" property Type.
+        $this->assertContains('"int"', $values['Symfony.Bundle.FrameworkBundle.Tests.Fixtures.Validation.Category']);
+
+        $values = $fallbackPool->getValues();
+
+        $this->assertInternalType('array', $values);
+        $this->assertCount(2, $values);
+        $this->assertArrayHasKey('Symfony.Bundle.FrameworkBundle.Tests.Fixtures.Validation.Category', $values);
+        $this->assertArrayHasKey('Symfony.Bundle.FrameworkBundle.Tests.Fixtures.Validation.SubCategory', $values);
+    }
+
     public function testWarmUpWithoutLoader()
     {
         $validatorBuilder = new ValidatorBuilder();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Validation/Category.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Validation/Category.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Validation;
+
+class Category
+{
+    const NAME_PATTERN = '/\w+/';
+
+    public $id;
+
+    /**
+     * @Assert\Type(self::NAME_PATTERN)
+     */
+    public $name;
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Validation/Resources/categories.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Validation/Resources/categories.yml
@@ -1,0 +1,9 @@
+Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Validation\Category:
+    properties:
+        id:
+            - Type: int
+
+Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Validation\SubCategory:
+    properties:
+        id:
+            - Type: int

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Validation/SubCategory.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Validation/SubCategory.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Validation;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class SubCategory extends Category
+{
+    /**
+     * @Assert\Type(Category::class)
+     */
+    public $main;
+}

--- a/src/Symfony/Component/Validator/Mapping/Factory/LazyLoadingMetadataFactory.php
+++ b/src/Symfony/Component/Validator/Mapping/Factory/LazyLoadingMetadataFactory.php
@@ -99,8 +99,12 @@ class LazyLoadingMetadataFactory implements MetadataFactoryInterface
             return $this->loadedClasses[$class];
         }
 
-        if (null !== $this->cache && false !== ($this->loadedClasses[$class] = $this->cache->read($class))) {
-            return $this->loadedClasses[$class];
+        if (null !== $this->cache) {
+            $cached = $this->cache->read($class);
+
+            if (false !== $cached) {
+                return $this->loadedClasses[$class] = $cached;
+            }
         }
 
         if (!class_exists($class) && !interface_exists($class)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Validation cache warmup can fail if the validated classes contain annotations that use constants.

The cause is the autoloader introduced in #20830. Using another autoloader in addition to the default composer one changes the behavior of the annotation reader: `DocParser` [may check for constants in undefined classes](https://github.com/doctrine/annotations/blob/30e07cf03edc3cd3ef579d0dd4dd8c58250799a5/lib/Doctrine/Common/Annotations/DocParser.php#L919). With the new autoloader that check causes a `\ReflectionException` and caching that class fails.

This can also cause an error in `LazyLoadingMetadataFactory`: If loading a class fails, value `false` may remain in the `loadedClasses` property. If that class is a parent of another validated class, merging the parent constraints will now fail.


This PR currently includes a fix for the second problem: Invalid state in `LazyLoadingMetadataFactory` is no longer possible. This gets rid of the error, but the cache is still not built correctly as demonstrated by the failing test case. I'm not quite sure how to fix this correctly.

Ping @nicolas-grekas 


There are still problems to solve:

- [ ] Fix loading the annotated classes correctly.
- [ ] Decide if the metadata factory fix should be included in an earlier branch (or at all), or use the fix from #20793.
