### PR TITLE
[FrameworkBundle] fix IPv6 address handling in server commands

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerCommand.php
@@ -54,7 +54,9 @@ abstract class ServerCommand extends ContainerAwareCommand
             return true;
         }
 
-        list($hostname, $port) = explode(':', $address);
+        $pos = strrpos($address, ':');
+        $hostname = substr($address, 0, $pos);
+        $port = substr($address, $pos + 1);
 
         $fp = @fsockopen($hostname, $port, $errno, $errstr, 5);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/21039#discussion_r93915788
| License       | MIT
| Doc PR        | 

This fixes https://github.com/symfony/symfony/pull/21039#discussion_r93915788 as reported by @sstok for the existing commands by backporting @fabpot's patch from #21039.