### PR TITLE
[Validator] support DateTimeInterface instances for times

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/TimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TimeValidator.php
@@ -47,7 +47,7 @@ class TimeValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Time');
         }
 
-        if (null === $value || '' === $value || $value instanceof \DateTime) {
+        if (null === $value || '' === $value || $value instanceof \DateTimeInterface) {
             return;
         }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimeValidatorTest.php
@@ -99,4 +99,11 @@ class TimeValidatorTest extends ConstraintValidatorTestCase
             array('00:00:60', Time::INVALID_TIME_ERROR),
         );
     }
+
+    public function testDateTimeImmutableIsValid()
+    {
+        $this->validator->validate(new \DateTimeImmutable(), new Time());
+
+        $this->assertNoViolation();
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

The same has already been done for the `Date` and `DateTime` constraints in #18759.