### PR TITLE
[Yaml] parse omitted inlined mapping values as null

### DIFF
--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 3.3.0
 -----
 
+ * Omitted mapping values will be parsed as `null`.
+
  * Omitting the key of a mapping is deprecated and will throw a `ParseException` in Symfony 4.0.
 
  * Added support for dumping empty PHP arrays as YAML sequences:

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -318,7 +318,7 @@ class Inline
                 if (preg_match('/[ \t]+#/', $output, $match, PREG_OFFSET_CAPTURE)) {
                     $output = substr($output, 0, $match[0][1]);
                 }
-            } elseif (preg_match('/^(.+?)('.implode('|', $delimiters).')/', substr($scalar, $i), $match)) {
+            } elseif (preg_match('/^(.*?)('.implode('|', $delimiters).')/', substr($scalar, $i), $match)) {
                 $output = $match[1];
                 $i += strlen($output);
             } else {

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -702,4 +702,20 @@ class InlineTest extends TestCase
     {
         $this->assertSame(array(':' => 'foo'), Inline::parse('{: foo}'));
     }
+
+    /**
+     * @dataProvider getTestsForNullValues
+     */
+    public function testParseMissingMappingValueAsNull($yaml, $expected)
+    {
+        $this->assertSame($expected, Inline::parse($yaml));
+    }
+
+    public function getTestsForNullValues()
+    {
+        return array(
+            'null before closing curly brace' => array('{foo:}', array('foo' => null)),
+            'null before comma' => array('{foo:, bar: baz}', array('foo' => null, 'bar' => 'baz')),
+        );
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/20841#discussion_r91751290
| License       | MIT
| Doc PR        | 

As @GuilhemN mentioned in https://github.com/symfony/symfony/pull/20841#discussion_r91751290 when using the inline YAML notation, it is currently not possible to completely omit the mapping value to have it parsed as `null` (you have to pass `~` or `null` explicitly).