### PR TITLE
[Form][FrameworkBundle][TwigBridge] do not depend on a fixed date in layout tests

### DIFF
--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "symfony/asset": "~2.7",
         "symfony/finder": "~2.3",
-        "symfony/form": "~2.7.11|~2.8.4",
+        "symfony/form": "~2.7.23|~2.8.16",
         "symfony/http-kernel": "~2.3",
         "symfony/intl": "~2.3",
         "symfony/routing": "~2.2",

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -40,7 +40,7 @@
         "symfony/dom-crawler": "~2.0,>=2.0.5",
         "symfony/intl": "~2.3",
         "symfony/security": "~2.6",
-        "symfony/form": "~2.7,>=2.7.2",
+        "symfony/form": "~2.7.23|~2.8.16",
         "symfony/class-loader": "~2.1",
         "symfony/expression-language": "~2.6",
         "symfony/process": "~2.0,>=2.0.5",

--- a/src/Symfony/Component/Form/Tests/AbstractBootstrap3LayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractBootstrap3LayoutTest.php
@@ -1333,7 +1333,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testDateTime()
     {
-        $form = $this->factory->createNamed('name', 'datetime', '2011-02-03 04:05:06', array(
+        $form = $this->factory->createNamed('name', 'datetime', date('Y').'-02-03 04:05:06', array(
             'input' => 'string',
             'with_seconds' => false,
         ));
@@ -1352,7 +1352,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
         /following-sibling::select
             [@id="name_date_year"]
             [@class="form-control"]
-            [./option[@value="2011"][@selected="selected"]]
+            [./option[@value="'.date('Y').'"][@selected="selected"]]
         /following-sibling::select
             [@id="name_time_hour"]
             [@class="form-control"]
@@ -1407,7 +1407,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testDateTimeWithHourAndMinute()
     {
-        $data = array('year' => '2011', 'month' => '2', 'day' => '3', 'hour' => '4', 'minute' => '5');
+        $data = array('year' => date('Y'), 'month' => '2', 'day' => '3', 'hour' => '4', 'minute' => '5');
 
         $form = $this->factory->createNamed('name', 'datetime', $data, array(
             'input' => 'array',
@@ -1429,7 +1429,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
         /following-sibling::select
             [@id="name_date_year"]
             [@class="form-control"]
-            [./option[@value="2011"][@selected="selected"]]
+            [./option[@value="'.date('Y').'"][@selected="selected"]]
         /following-sibling::select
             [@id="name_time_hour"]
             [@class="form-control"]
@@ -1446,7 +1446,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testDateTimeWithSeconds()
     {
-        $form = $this->factory->createNamed('name', 'datetime', '2011-02-03 04:05:06', array(
+        $form = $this->factory->createNamed('name', 'datetime', date('Y').'-02-03 04:05:06', array(
             'input' => 'string',
             'with_seconds' => true,
         ));
@@ -1466,7 +1466,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
         /following-sibling::select
             [@id="name_date_year"]
             [@class="form-control"]
-            [./option[@value="2011"][@selected="selected"]]
+            [./option[@value="'.date('Y').'"][@selected="selected"]]
         /following-sibling::select
             [@id="name_time_hour"]
             [@class="form-control"]
@@ -1556,7 +1556,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testDateChoice()
     {
-        $form = $this->factory->createNamed('name', 'date', '2011-02-03', array(
+        $form = $this->factory->createNamed('name', 'date', date('Y').'-02-03', array(
             'input' => 'string',
             'widget' => 'choice',
         ));
@@ -1576,7 +1576,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
         /following-sibling::select
             [@id="name_year"]
             [@class="form-control"]
-            [./option[@value="2011"][@selected="selected"]]
+            [./option[@value="'.date('Y').'"][@selected="selected"]]
     ]
     [count(./select)=3]
 '

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -1226,7 +1226,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testDateTime()
     {
-        $form = $this->factory->createNamed('name', 'datetime', '2011-02-03 04:05:06', array(
+        $form = $this->factory->createNamed('name', 'datetime', date('Y').'-02-03 04:05:06', array(
             'input' => 'string',
             'with_seconds' => false,
         ));
@@ -1245,7 +1245,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
                     [./option[@value="3"][@selected="selected"]]
                 /following-sibling::select
                     [@id="name_date_year"]
-                    [./option[@value="2011"][@selected="selected"]]
+                    [./option[@value="'.date('Y').'"][@selected="selected"]]
             ]
         /following-sibling::div
             [@id="name_time"]
@@ -1305,7 +1305,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testDateTimeWithHourAndMinute()
     {
-        $data = array('year' => '2011', 'month' => '2', 'day' => '3', 'hour' => '4', 'minute' => '5');
+        $data = array('year' => date('Y'), 'month' => '2', 'day' => '3', 'hour' => '4', 'minute' => '5');
 
         $form = $this->factory->createNamed('name', 'datetime', $data, array(
             'input' => 'array',
@@ -1326,7 +1326,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
                     [./option[@value="3"][@selected="selected"]]
                 /following-sibling::select
                     [@id="name_date_year"]
-                    [./option[@value="2011"][@selected="selected"]]
+                    [./option[@value="'.date('Y').'"][@selected="selected"]]
             ]
         /following-sibling::div
             [@id="name_time"]
@@ -1346,7 +1346,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testDateTimeWithSeconds()
     {
-        $form = $this->factory->createNamed('name', 'datetime', '2011-02-03 04:05:06', array(
+        $form = $this->factory->createNamed('name', 'datetime', date('Y').'-02-03 04:05:06', array(
             'input' => 'string',
             'with_seconds' => true,
         ));
@@ -1365,7 +1365,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
                     [./option[@value="3"][@selected="selected"]]
                 /following-sibling::select
                     [@id="name_date_year"]
-                    [./option[@value="2011"][@selected="selected"]]
+                    [./option[@value="'.date('Y').'"][@selected="selected"]]
             ]
         /following-sibling::div
             [@id="name_time"]
@@ -1452,7 +1452,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
 
     public function testDateChoice()
     {
-        $form = $this->factory->createNamed('name', 'date', '2011-02-03', array(
+        $form = $this->factory->createNamed('name', 'date', date('Y').'-02-03', array(
             'input' => 'string',
             'widget' => 'choice',
         ));
@@ -1468,7 +1468,7 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
             [./option[@value="3"][@selected="selected"]]
         /following-sibling::select
             [@id="name_year"]
-            [./option[@value="2011"][@selected="selected"]]
+            [./option[@value="'.date('Y').'"][@selected="selected"]]
     ]
     [count(./select)=3]
 '


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

By default, the `DateType` as well as the `DateTimeType` set the choices being available for the year to a range starting five years in the past. After some time, this will make tests fail when the year of the fixed date being used as the initial data is before the first year being part of the choices.
