### PR TITLE
[Console] increased code coverage of Output classes

### DIFF
--- a/src/Symfony/Component/Console/Tests/Output/ConsoleOutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/ConsoleOutputTest.php
@@ -35,7 +35,7 @@ class ConsoleOutputTest extends \PHPUnit_Framework_TestCase
     public function testSetVerbosity()
     {
         $output = new ConsoleOutput();
-        $output->setVerbosity(1);
-        $this->assertSame(1, $output->getVerbosity());
+        $output->setVerbosity(Output::VERBOSITY_VERBOSE);
+        $this->assertSame(Output::VERBOSITY_VERBOSE, $output->getVerbosity());
     }
 }

--- a/src/Symfony/Component/Console/Tests/Output/ConsoleOutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/ConsoleOutputTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Console\Tests\Output;
 
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\Output;
 
@@ -21,5 +22,20 @@ class ConsoleOutputTest extends \PHPUnit_Framework_TestCase
         $output = new ConsoleOutput(Output::VERBOSITY_QUIET, true);
         $this->assertEquals(Output::VERBOSITY_QUIET, $output->getVerbosity(), '__construct() takes the verbosity as its first argument');
         $this->assertSame($output->getFormatter(), $output->getErrorOutput()->getFormatter(), '__construct() takes a formatter or null as the third argument');
+    }
+
+    public function testSetFormatter()
+    {
+        $output = new ConsoleOutput();
+        $outputFormatter = new OutputFormatter();
+        $output->setFormatter($outputFormatter);
+        $this->assertSame($outputFormatter, $output->getFormatter());
+    }
+
+    public function testSetVerbosity()
+    {
+        $output = new ConsoleOutput();
+        $output->setVerbosity(1);
+        $this->assertSame(1, $output->getVerbosity());
     }
 }

--- a/src/Symfony/Component/Console/Tests/Output/NullOutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/NullOutputTest.php
@@ -11,7 +11,9 @@
 
 namespace Symfony\Component\Console\Tests\Output;
 
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class NullOutputTest extends \PHPUnit_Framework_TestCase
@@ -35,5 +37,51 @@ class NullOutputTest extends \PHPUnit_Framework_TestCase
 
         $output->setVerbosity(OutputInterface::VERBOSITY_VERBOSE);
         $this->assertSame(OutputInterface::VERBOSITY_QUIET, $output->getVerbosity(), '->getVerbosity() always returns VERBOSITY_QUIET for NullOutput');
+    }
+
+    public function testSetFormatter()
+    {
+        $output = new NullOutput();
+        $outputFormatter = new OutputFormatter();
+        $output->setFormatter($outputFormatter);
+        $this->assertNotSame($outputFormatter, $output->getFormatter());
+    }
+
+    public function testSetVerbosity()
+    {
+        $output = new NullOutput();
+        $output->setVerbosity(Output::VERBOSITY_NORMAL);
+        $this->assertEquals(Output::VERBOSITY_QUIET, $output->getVerbosity());
+    }
+
+    public function testSetDecorated()
+    {
+        $output = new NullOutput();
+        $output->setDecorated(true);
+        $this->assertFalse($output->isDecorated());
+    }
+
+    public function testIsQuiet()
+    {
+        $output = new NullOutput();
+        $this->assertTrue($output->isQuiet());
+    }
+
+    public function testIsVerbose()
+    {
+        $output = new NullOutput();
+        $this->assertFalse($output->isVerbose());
+    }
+
+    public function testIsVeryVerbose()
+    {
+        $output = new NullOutput();
+        $this->assertFalse($output->isVeryVerbose());
+    }
+
+    public function testIsDebug()
+    {
+        $output = new NullOutput();
+        $this->assertFalse($output->isDebug());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

This PR increases the coverage of Output classes of the Console component from 80.81% to 94.95%