### PR TITLE
[FrameworkBundle] Display original definition for aliases in debug:container

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -54,7 +54,7 @@ abstract class Descriptor implements DescriptorInterface
                 $this->describeContainerTags($object, $options);
                 break;
             case $object instanceof ContainerBuilder && isset($options['id']):
-                $this->describeContainerService($this->resolveServiceDefinition($object, $options['id']), $options);
+                $this->describeContainerService($this->resolveServiceDefinition($object, $options['id']), $options, $object);
                 break;
             case $object instanceof ContainerBuilder && isset($options['parameter']):
                 $this->describeContainerParameter($object->resolveEnvPlaceholders($object->getParameter($options['parameter'])), $options);
@@ -140,8 +140,9 @@ abstract class Descriptor implements DescriptorInterface
      *
      * @param Definition|Alias|object $service
      * @param array                   $options
+     * @param ContainerBuilder|null   $builder
      */
-    abstract protected function describeContainerService($service, array $options = array());
+    abstract protected function describeContainerService($service, array $options = array(), ContainerBuilder $builder = null);
 
     /**
      * Describes container services.
@@ -165,10 +166,11 @@ abstract class Descriptor implements DescriptorInterface
     /**
      * Describes a service alias.
      *
-     * @param Alias $alias
-     * @param array $options
+     * @param Alias                 $alias
+     * @param array                 $options
+     * @param ContainerBuilder|null $builder
      */
-    abstract protected function describeContainerAlias(Alias $alias, array $options = array());
+    abstract protected function describeContainerAlias(Alias $alias, array $options = array(), ContainerBuilder $builder = null);
 
     /**
      * Describes a container parameter.

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -77,14 +77,14 @@ class JsonDescriptor extends Descriptor
     /**
      * {@inheritdoc}
      */
-    protected function describeContainerService($service, array $options = array())
+    protected function describeContainerService($service, array $options = array(), ContainerBuilder $builder = null)
     {
         if (!isset($options['id'])) {
             throw new \InvalidArgumentException('An "id" option must be provided.');
         }
 
         if ($service instanceof Alias) {
-            $this->writeData($this->getContainerAliasData($service), $options);
+            $this->describeContainerAlias($service, $options, $builder);
         } elseif ($service instanceof Definition) {
             $this->writeData($this->getContainerDefinitionData($service), $options);
         } else {
@@ -129,9 +129,16 @@ class JsonDescriptor extends Descriptor
     /**
      * {@inheritdoc}
      */
-    protected function describeContainerAlias(Alias $alias, array $options = array())
+    protected function describeContainerAlias(Alias $alias, array $options = array(), ContainerBuilder $builder = null)
     {
-        $this->writeData($this->getContainerAliasData($alias), $options);
+        if (!$builder) {
+            return $this->writeData($this->getContainerAliasData($alias), $options);
+        }
+
+        $this->writeData(
+            array($this->getContainerAliasData($alias), $this->getContainerDefinitionData($builder->getDefinition((string) $alias))),
+            array_merge($options, array('id' => (string) $alias))
+        );
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -97,7 +97,7 @@ class MarkdownDescriptor extends Descriptor
     /**
      * {@inheritdoc}
      */
-    protected function describeContainerService($service, array $options = array())
+    protected function describeContainerService($service, array $options = array(), ContainerBuilder $builder = null)
     {
         if (!isset($options['id'])) {
             throw new \InvalidArgumentException('An "id" option must be provided.');
@@ -106,7 +106,7 @@ class MarkdownDescriptor extends Descriptor
         $childOptions = array('id' => $options['id'], 'as_array' => true);
 
         if ($service instanceof Alias) {
-            $this->describeContainerAlias($service, $childOptions);
+            $this->describeContainerAlias($service, $childOptions, $builder);
         } elseif ($service instanceof Definition) {
             $this->describeContainerDefinition($service, $childOptions);
         } else {
@@ -236,12 +236,23 @@ class MarkdownDescriptor extends Descriptor
     /**
      * {@inheritdoc}
      */
-    protected function describeContainerAlias(Alias $alias, array $options = array())
+    protected function describeContainerAlias(Alias $alias, array $options = array(), ContainerBuilder $builder = null)
     {
         $output = '- Service: `'.$alias.'`'
             ."\n".'- Public: '.($alias->isPublic() ? 'yes' : 'no');
 
-        $this->write(isset($options['id']) ? sprintf("%s\n%s\n\n%s\n", $options['id'], str_repeat('~', strlen($options['id'])), $output) : $output);
+        if (!isset($options['id'])) {
+            return $this->write($output);
+        }
+
+        $this->write(sprintf("%s\n%s\n\n%s\n", $options['id'], str_repeat('~', strlen($options['id'])), $output));
+
+        if (!$builder) {
+            return;
+        }
+
+        $this->write("\n");
+        $this->describeContainerDefinition($builder->getDefinition((string) $alias), array_merge($options, array('id' => (string) $alias)));
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -139,14 +139,14 @@ class TextDescriptor extends Descriptor
     /**
      * {@inheritdoc}
      */
-    protected function describeContainerService($service, array $options = array())
+    protected function describeContainerService($service, array $options = array(), ContainerBuilder $builder = null)
     {
         if (!isset($options['id'])) {
             throw new \InvalidArgumentException('An "id" option must be provided.');
         }
 
         if ($service instanceof Alias) {
-            $this->describeContainerAlias($service, $options);
+            $this->describeContainerAlias($service, $options, $builder);
         } elseif ($service instanceof Definition) {
             $this->describeContainerDefinition($service, $options);
         } else {
@@ -333,9 +333,15 @@ class TextDescriptor extends Descriptor
     /**
      * {@inheritdoc}
      */
-    protected function describeContainerAlias(Alias $alias, array $options = array())
+    protected function describeContainerAlias(Alias $alias, array $options = array(), ContainerBuilder $builder = null)
     {
         $options['output']->comment(sprintf('This service is an alias for the service <info>%s</info>', (string) $alias));
+
+        if (!$builder) {
+            return;
+        }
+
+        return $this->describeContainerDefinition($builder->getDefinition((string) $alias), array_merge($options, array('id' => (string) $alias)));
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTest.php
@@ -90,6 +90,35 @@ abstract class AbstractDescriptorTest extends \PHPUnit_Framework_TestCase
         return $this->getDescriptionTestData(ObjectsProvider::getContainerAliases());
     }
 
+    /** @dataProvider getDescribeContainerDefinitionWhichIsAnAliasTestData */
+    public function testDescribeContainerDefinitionWhichIsAnAlias(Alias $alias, $expectedDescription, ContainerBuilder $builder, $options = array())
+    {
+        $this->assertDescription($expectedDescription, $builder, $options);
+    }
+
+    public function getDescribeContainerDefinitionWhichIsAnAliasTestData()
+    {
+        $builder = current(ObjectsProvider::getContainerBuilders());
+        $builder->setDefinition('service_1', $builder->getDefinition('definition_1'));
+        $builder->setDefinition('service_2', $builder->getDefinition('definition_2'));
+
+        $aliases = ObjectsProvider::getContainerAliases();
+        $aliasesWithDefinitions = array();
+        foreach ($aliases as $name => $alias) {
+            $aliasesWithDefinitions[str_replace('alias_', 'alias_with_definition_', $name)] = $alias;
+        }
+
+        $i = 0;
+        $data = $this->getDescriptionTestData($aliasesWithDefinitions);
+        foreach ($aliases as $name => $alias) {
+            $data[$i][] = $builder;
+            $data[$i][] = array('id' => $name);
+            ++$i;
+        }
+
+        return $data;
+    }
+
     /** @dataProvider getDescribeContainerParameterTestData */
     public function testDescribeContainerParameter($parameter, $expectedDescription, array $options)
     {
@@ -146,7 +175,7 @@ abstract class AbstractDescriptorTest extends \PHPUnit_Framework_TestCase
         if ('json' === $this->getFormat()) {
             $this->assertEquals(json_decode($expectedDescription), json_decode($output->fetch()));
         } else {
-            $this->assertEquals(trim($expectedDescription), trim(str_replace(PHP_EOL, "\n", $output->fetch())));
+            $this->assertEquals(trim(preg_replace('/[\s\t\r]+/', ' ', $expectedDescription)), trim(preg_replace('/[\s\t\r]+/', ' ', str_replace(PHP_EOL, "\n", $output->fetch()))));
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_1.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_1.json
@@ -1,0 +1,20 @@
+[
+    {
+        "service": "service_1",
+        "public": true
+    },
+    {
+        "class": "Full\\Qualified\\Class1",
+        "public": true,
+        "synthetic": false,
+        "lazy": true,
+        "shared": true,
+        "abstract": true,
+        "autowire": false,
+        "autowiring_types": [],
+        "file": null,
+        "factory_class": "Full\\Qualified\\FactoryClass",
+        "factory_method": "get",
+        "tags": []
+    }
+]

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_1.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_1.md
@@ -1,0 +1,18 @@
+alias_1
+~~~~~~~
+
+- Service: `service_1`
+- Public: yes
+
+service_1
+~~~~~~~~~
+
+- Class: `Full\Qualified\Class1`
+- Public: yes
+- Synthetic: no
+- Lazy: yes
+- Shared: yes
+- Abstract: yes
+- Autowired: no
+- Factory Class: `Full\Qualified\FactoryClass`
+- Factory Method: `get`

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_1.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_1.txt
@@ -1,0 +1,21 @@
+[39;49m // [39;49mThis service is an alias for the service [32mservice_1[39m                                                                  
+
+[33mInformation for Service "[39m[32mservice_1[39m[33m"[39m
+[33m===================================[39m
+
+ ------------------ ----------------------------- 
+ [32m Option           [39m [32m Value                       [39m 
+ ------------------ ----------------------------- 
+  Service ID         service_1                    
+  Class              Full\Qualified\Class1        
+  Tags               -                            
+  Public             yes                          
+  Synthetic          no                           
+  Lazy               yes                          
+  Shared             yes                          
+  Abstract           yes                          
+  Autowired          no                           
+  Autowiring Types   -                            
+  Factory Class      Full\Qualified\FactoryClass  
+  Factory Method     get                          
+ ------------------ -----------------------------

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_1.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_1.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<alias id="alias_1" service="service_1" public="true"/>
+<definition id="service_1" class="Full\Qualified\Class1" public="true" synthetic="false" lazy="true" shared="true" abstract="true" autowired="false" file="">
+  <factory class="Full\Qualified\FactoryClass" method="get"/>
+</definition>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.json
@@ -1,0 +1,41 @@
+[
+    {
+        "service": "service_2",
+        "public": false
+    },
+    {
+        "class": "Full\\Qualified\\Class2",
+        "public": false,
+        "synthetic": true,
+        "lazy": false,
+        "shared": true,
+        "abstract": false,
+        "autowire": false,
+        "autowiring_types": [],
+        "file": "\/path\/to\/file",
+        "factory_service": "factory.service",
+        "factory_method": "get",
+        "calls": [
+            "setMailer"
+        ],
+        "tags": [
+            {
+                "name": "tag1",
+                "parameters": {
+                    "attr1": "val1",
+                    "attr2": "val2"
+                }
+            },
+            {
+                "name": "tag1",
+                "parameters": {
+                    "attr3": "val3"
+                }
+            },
+            {
+                "name": "tag2",
+                "parameters": []
+            }
+        ]
+    }
+]

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.md
@@ -1,0 +1,26 @@
+alias_2
+~~~~~~~
+
+- Service: `service_2`
+- Public: no
+
+service_2
+~~~~~~~~~
+
+- Class: `Full\Qualified\Class2`
+- Public: no
+- Synthetic: yes
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowired: no
+- File: `/path/to/file`
+- Factory Service: `factory.service`
+- Factory Method: `get`
+- Call: `setMailer`
+- Tag: `tag1`
+    - Attr1: val1
+    - Attr2: val2
+- Tag: `tag1`
+    - Attr3: val3
+- Tag: `tag2`

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.txt
@@ -1,0 +1,25 @@
+[39;49m // [39;49mThis service is an alias for the service [32mservice_2[39m                                                                  
+
+[33mInformation for Service "[39m[32mservice_2[39m[33m"[39m
+[33m===================================[39m
+
+ ------------------ --------------------------------- 
+ [32m Option           [39m [32m Value                           [39m 
+ ------------------ --------------------------------- 
+  Service ID         service_2                        
+  Class              Full\Qualified\Class2            
+  Tags               tag1 ([32mattr1[39m: val1, [32mattr2[39m: val2)  
+                     tag1 ([32mattr3[39m: val3)               
+                     tag2                             
+  Calls              setMailer                        
+  Public             no                               
+  Synthetic          yes                              
+  Lazy               no                               
+  Shared             yes                              
+  Abstract           no                               
+  Autowired          no                               
+  Autowiring Types   -                                
+  Required File      /path/to/file                    
+  Factory Service    factory.service                  
+  Factory Method     get                              
+ ------------------ ---------------------------------

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_2.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<alias id="alias_2" service="service_2" public="false"/>
+<definition id="service_2" class="Full\Qualified\Class2" public="false" synthetic="true" lazy="false" shared="true" abstract="false" autowired="false" file="/path/to/file">
+  <factory service="factory.service" method="get"/>
+  <calls>
+    <call method="setMailer"/>
+  </calls>
+  <tags>
+    <tag name="tag1">
+      <parameter name="attr1">val1</parameter>
+      <parameter name="attr2">val2</parameter>
+    </tag>
+    <tag name="tag1">
+      <parameter name="attr3">val3</parameter>
+    </tag>
+    <tag name="tag2"/>
+  </tags>
+</definition>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20954 
| License       | MIT
| Doc PR        | n/a

Before
![before-txt](http://image.prntscr.com/image/b0cb59f23ddb43669ba0aba093f454af.png)

After
![after-txt](http://image.prntscr.com/image/adf234957acf444292e45bded8efb9d8.png)

<details>
<summary>XML output</summary>

Before
![before-xml](http://image.prntscr.com/image/66212d92db654f88b8196b211046bcf2.png)

After
![after-xml](http://image.prntscr.com/image/3f6b5f9f1ea54a31aea36de5928b6ae9.png)
</details>

<details>
<summary>JSON output</summary>

Before
![before-json](http://image.prntscr.com/image/a7ffc4bcda61486f90af85c90e3d6caa.png)

After
![after-json](http://image.prntscr.com/image/15d0f37e78354dcf8e3015b94fcbdaed.png)

</details>

<details>
<summary>Markdown output</summary>

Before
![before-md](http://image.prntscr.com/image/be5289840ac64a5e80f11748f481686c.png)

After
![after-md](http://image.prntscr.com/image/cba4217863f647e9974e1715812eda01.png)
</details>