### PR TITLE
[Autowiring] Add interface FQCN as a valid service name to avoid collisions

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -346,7 +346,7 @@ class AutowirePass implements CompilerPassInterface
             $classOrInterface = $typeHint->isInterface() ? 'interface' : 'class';
             $matchingServices = implode(', ', $this->ambiguousServiceTypes[$typeHint->name]);
 
-            throw new RuntimeException(sprintf('Unable to autowire argument of type "%s" for the service "%s". Multiple services exist for this %s (%s).', $typeHint->name, $id, $classOrInterface, $matchingServices));
+            throw new RuntimeException(sprintf('Unable to autowire argument of type "%s" for the service "%s". Multiple services exist for this %s (%s).', $typeHint->name, $id, $classOrInterface, $matchingServices), 1);
         }
 
         if (!$typeHint->isInstantiable()) {

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -338,11 +338,15 @@ class AutowirePass implements CompilerPassInterface
      */
     private function createAutowiredDefinition(\ReflectionClass $typeHint, $id)
     {
-        if (isset($this->ambiguousServiceTypes[$typeHint->name])) {
+        if (isset($this->ambiguousServiceTypes[$typeHintName = $typeHint->name])) {
+            if ($this->container->has($typeHintName)) {
+                return new Reference($typeHintName);
+            }
+
             $classOrInterface = $typeHint->isInterface() ? 'interface' : 'class';
             $matchingServices = implode(', ', $this->ambiguousServiceTypes[$typeHint->name]);
 
-            throw new RuntimeException(sprintf('Unable to autowire argument of type "%s" for the service "%s". Multiple services exist for this %s (%s).', $typeHint->name, $id, $classOrInterface, $matchingServices), 1);
+            throw new RuntimeException(sprintf('Unable to autowire argument of type "%s" for the service "%s". Multiple services exist for this %s (%s).', $typeHintName, $id, $classOrInterface, $matchingServices));
         }
 
         if (!$typeHint->isInstantiable()) {

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -338,15 +338,15 @@ class AutowirePass implements CompilerPassInterface
      */
     private function createAutowiredDefinition(\ReflectionClass $typeHint, $id)
     {
-        if (isset($this->ambiguousServiceTypes[$typeHintName = $typeHint->name])) {
-            if ($this->container->has($typeHintName)) {
-                return new Reference($typeHintName);
+        if (isset($this->ambiguousServiceTypes[$typeHint->name])) {
+            if ($this->container->has($typeHint->name)) {
+                return new Reference($typeHint->name);
             }
 
             $classOrInterface = $typeHint->isInterface() ? 'interface' : 'class';
             $matchingServices = implode(', ', $this->ambiguousServiceTypes[$typeHint->name]);
 
-            throw new RuntimeException(sprintf('Unable to autowire argument of type "%s" for the service "%s". Multiple services exist for this %s (%s).', $typeHintName, $id, $classOrInterface, $matchingServices));
+            throw new RuntimeException(sprintf('Unable to autowire argument of type "%s" for the service "%s". Multiple services exist for this %s (%s).', $typeHint->name, $id, $classOrInterface, $matchingServices));
         }
 
         if (!$typeHint->isInstantiable()) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -123,13 +123,13 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('c1', __NAMESPACE__.'\CollisionA');
-        $container->register('c2', __NAMESPACE__.'\CollisionB');
-        $container->register('c3', __NAMESPACE__.'\CollisionB');
+        $container->register('c1', CollisionA::class);
+        $container->register('c2', CollisionB::class);
+        $container->register('c3', CollisionB::class);
 
-        $container->register(__NAMESPACE__.'\CollisionInterface', 'c3');
+        $container->register(CollisionInterface::class, 'c3');
 
-        $aDefinition = $container->register('a', __NAMESPACE__.'\AutowiredInterface');
+        $aDefinition = $container->register('a', AutowiredInterface::class);
         $aDefinition->setAutowired(true);
 
         $pass = new AutowirePass();

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -119,6 +119,28 @@ class AutowirePassTest extends \PHPUnit_Framework_TestCase
         $pass->process($container);
     }
 
+    public function testTypeCollisionWithInterfaceAsServiceId()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('c1', __NAMESPACE__.'\CollisionA');
+        $container->register('c2', __NAMESPACE__.'\CollisionB');
+        $container->register('c3', __NAMESPACE__.'\CollisionB');
+
+        $container->register(__NAMESPACE__.'\CollisionInterface', 'c3');
+
+        $aDefinition = $container->register('a', __NAMESPACE__.'\AutowiredInterface');
+        $aDefinition->setAutowired(true);
+
+        $pass = new AutowirePass();
+        $pass->process($container);
+
+        $aDefinition = $container->getDefinition('a');
+
+        $this->assertCount(1, $aDefinition->getArguments());
+        $this->assertEquals(new Reference(__NAMESPACE__.'\CollisionInterface'), $aDefinition->getArgument(0));
+    }
+
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\RuntimeException
      * @expectedExceptionMessage Unable to autowire argument of type "Symfony\Component\DependencyInjection\Tests\Compiler\Foo" for the service "a". Multiple services exist for this class (a1, a2).
@@ -653,6 +675,16 @@ class CannotBeAutowired
 {
     public function __construct(CollisionInterface $collision)
     {
+    }
+}
+
+class AutowiredInterface
+{
+    public $collision;
+
+    public function __construct(CollisionInterface $collision)
+    {
+        $this->collision = $collision;
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master? (not sure)
| Bug fix?      | yes/no (not sure)
| New feature?  | yes
| BC breaks?    | possibly
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | TODO

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the master branch.
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->

As of now, if you have:

```php
interface CollisionInterface {}

class A implements CollisionInterface {}

class UseCollision
{
  function __construct(CollisionInterface $collision) {}
}
```

```yaml
services:
  app.a:
    class: A
    autowire: true

  app.b:
    class: A

  CollisionInterface: '@app.b'

  app.use_collision:
    class: UseCollision
    autowire: true
```

It would fail, because you have `app.a` and `app.b` which are both implementing `CollisionInterface`. However as you can see, in this scenario this is a bit stupid, as if you bother doing `CollisionInterface: '@app.b'`, this is equivalent to (or rather should be IMO) have:

```yaml
services:
  #...

  app.b:
    class: A
    autowired_types: [ CollisionInterface ]
```

You might wonder what's the diff and why bother yourself with that, the diff IMO is the location of your service definitions. For example I may try to follow a more DDD oriented architecture, e.g. the hexagonal architecture, where I have:

```
config/
  domain.yml # service definitions related to the domain layer
  infrastructure.yml # service definitions related to the infrastructure layer

src/
  Domain/
    CollisionInterface.php
  Infrastructure/
    A.php
    UseCollision.php
```

and try to have something like:

```yaml
# config/domain.yml
services:
  App\Domain\CollisionInterface: '@app.b'
```

```yaml
# config/infrastructure.yml
  app.a:
    class: A
    autowire: true

  app.b:
    class: A

  app.use_collision:
    class: UseCollision
    autowire: true
```

I am not sure if this can be caused any BC and if this should be considered as a feature or a bugfix.

/cc @dunglas 
