### PR TITLE
[DI] Optional class for named services

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -41,10 +41,11 @@ class PassConfig
 
         $this->optimizationPasses = array(array(
             new ExtensionCompilerPass(),
+            $resolveClassPass = new ResolveClassPass(),
             new ResolveDefinitionTemplatesPass(),
             new DecoratorServicePass(),
             new ResolveParameterPlaceHoldersPass(),
-            new FactoryReturnTypePass(),
+            new FactoryReturnTypePass($resolveClassPass),
             new CheckDefinitionValidityPass(),
             new ResolveReferencesToAliasesPass(),
             new ResolveInvalidReferencesPass(),

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveClassPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveClassPass.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class ResolveClassPass implements CompilerPassInterface
+{
+    private $changes = array();
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        foreach ($container->getDefinitions() as $id => $definition) {
+            if ($definition instanceof ChildDefinition || $definition->isSynthetic() || null !== $definition->getClass()) {
+                continue;
+            }
+            if (preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+(?:\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+)*+$/', $id)) {
+                $this->changes[$id] = $container->getCaseSensitiveId($id);
+                $definition->setClass($this->changes[$id]);
+            }
+        }
+    }
+
+    /**
+     * @internal
+     *
+     * @deprecated since 3.3, to be removed in 4.0.
+     */
+    public function getChanges()
+    {
+        $changes = $this->changes;
+        $this->changes = array();
+
+        return $changes;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -303,7 +303,7 @@ class XmlFileLoader extends FileLoader
         if (false !== $nodes = $xpath->query('//container:argument[@type="service"][not(@id)]|//container:property[@type="service"][not(@id)]')) {
             foreach ($nodes as $node) {
                 // give it a unique name
-                $id = sprintf('%s_%d', hash('sha256', $file), ++$count);
+                $id = sprintf('%d_%s', ++$count, hash('sha256', $file));
                 $node->setAttribute('id', $id);
 
                 if ($services = $this->getChildren($node, 'service')) {
@@ -321,15 +321,15 @@ class XmlFileLoader extends FileLoader
         if (false !== $nodes = $xpath->query('//container:services/container:service[not(@id)]')) {
             foreach ($nodes as $node) {
                 // give it a unique name
-                $id = sprintf('%s_%d', hash('sha256', $file), ++$count);
+                $id = sprintf('%d_%s', ++$count, hash('sha256', $file));
                 $node->setAttribute('id', $id);
                 $definitions[$id] = array($node, $file, true);
             }
         }
 
         // resolve definitions
-        krsort($definitions);
-        foreach ($definitions as $id => list($domElement, $file, $wild)) {
+        uksort($definitions, 'strnatcmp');
+        foreach (array_reverse($definitions) as $id => list($domElement, $file, $wild)) {
             if (null !== $definition = $this->parseDefinition($domElement, $file)) {
                 $this->container->setDefinition($id, $definition);
             }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/FactoryReturnTypePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/FactoryReturnTypePassTest.php
@@ -20,6 +20,8 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\FactoryParent;
 
 /**
  * @author Guilhem N. <egetick@gmail.com>
+ *
+ * @group legacy
  */
 class FactoryReturnTypePassTest extends \PHPUnit_Framework_TestCase
 {
@@ -103,17 +105,16 @@ class FactoryReturnTypePassTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($factory2->getClass());
     }
 
+    /**
+     * @requires function ReflectionMethod::getReturnType
+     * @expectedDeprecation Relying on its factory's return-type to define the class of service "factory" is deprecated since Symfony 3.3 and won't work in 4.0. Set the "class" attribute to "Symfony\Component\DependencyInjection\Tests\Fixtures\FactoryDummy" on the service definition instead.
+     */
     public function testCompile()
     {
         $container = new ContainerBuilder();
 
         $factory = $container->register('factory');
         $factory->setFactory(array(FactoryDummy::class, 'createFactory'));
-
-        if (!method_exists(\ReflectionMethod::class, 'getReturnType')) {
-            $this->setExpectedException(\RuntimeException::class, 'Please add the class to service "factory" even if it is constructed by a factory since we might need to add method calls based on compile-time checks.');
-        }
-
         $container->compile();
 
         $this->assertEquals(FactoryDummy::class, $container->getDefinition('factory')->getClass());

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/CaseSensitiveClass.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/CaseSensitiveClass.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+class CaseSensitiveClass
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/class_from_id.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/class_from_id.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="Symfony\Component\DependencyInjection\Tests\Fixtures\CaseSensitiveClass" />
+  </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/class_from_id.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/class_from_id.yml
@@ -1,0 +1,3 @@
+services:
+    Symfony\Component\DependencyInjection\Tests\Fixtures\CaseSensitiveClass:
+      autowire: true

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Loader\IniFileLoader;
 use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\CaseSensitiveClass;
 use Symfony\Component\ExpressionLanguage\Expression;
 
 class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
@@ -580,6 +581,16 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $container = new ContainerBuilder();
         $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
         $loader->load('services28.xml');
+    }
+
+    public function testClassFromId()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader->load('class_from_id.xml');
+        $container->compile();
+
+        $this->assertEquals(CaseSensitiveClass::class, $container->getDefinition(CaseSensitiveClass::class)->getClass());
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\DependencyInjection\Loader\IniFileLoader;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\CaseSensitiveClass;
 use Symfony\Component\ExpressionLanguage\Expression;
 
 class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
@@ -339,6 +340,16 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
 
         $loader->load('services27.yml');
         $this->assertEquals(array('set*', 'bar'), $container->getDefinition('autowire_array')->getAutowiredMethods());
+    }
+
+    public function testClassFromId()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('class_from_id.yml');
+        $container->compile();
+
+        $this->assertEquals(CaseSensitiveClass::class, $container->getDefinition(CaseSensitiveClass::class)->getClass());
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Continues #20264:
- makes the id-to-class mapping context-free (no `class_exist` check),
- deals with ChildDefinition (which should not have this rule applied on them),
- deprecates FactoryReturnTypePass as discussed on slack and reported in this comment: https://github.com/symfony/symfony/pull/19191#issuecomment-269949361

From @hason:

> I prefer class named services (in applications) because naming things are too hard:

``` yaml
services:
    Vendor\Namespace\Class:
        class: Vendor\Namespace\Class
        autowire: true
```

> This PR solves redundant parameter for class:

``` yaml
services:
    Vendor\Namespace\Class:
        autowire: true
```

> Inspirations: https://laravel.com/docs/5.3/container, #18268, http://php-di.org/, 
