### PR TITLE
[Security] use authenticated token for json authentication

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordJsonAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordJsonAuthenticationListener.php
@@ -101,8 +101,8 @@ class UsernamePasswordJsonAuthenticationListener implements ListenerInterface
         try {
             $token = new UsernamePasswordToken($username, $password, $this->providerKey);
 
-            $this->authenticationManager->authenticate($token);
-            $response = $this->onSuccess($request, $token);
+            $authenticatedToken = $this->authenticationManager->authenticate($token);
+            $response = $this->onSuccess($request, $authenticatedToken);
         } catch (AuthenticationException $e) {
             $response = $this->onFailure($request, $e);
         }

--- a/src/Symfony/Component/Security/Tests/Http/Firewall/UsernamePasswordJsonAuthenticationListenerTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Firewall/UsernamePasswordJsonAuthenticationListenerTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
@@ -38,8 +39,10 @@ class UsernamePasswordJsonAuthenticationListenerTest extends \PHPUnit_Framework_
         $tokenStorage = $this->getMockBuilder(TokenStorageInterface::class)->getMock();
         $authenticationManager = $this->getMockBuilder(AuthenticationManagerInterface::class)->getMock();
 
+        $authenticatedToken = $this->getMockBuilder(TokenInterface::class)->getMock();
+
         if ($success) {
-            $authenticationManager->method('authenticate')->willReturn(true);
+            $authenticationManager->method('authenticate')->willReturn($authenticatedToken);
         } else {
             $authenticationManager->method('authenticate')->willThrowException(new AuthenticationException());
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21123 
| License       | MIT
| Doc PR        | N/A

When using `UsernamePasswordJsonAuthenticationListener` with [LexikJWTAuthenticationBundle](https://github.com/lexik/LexikJWTAuthenticationBundle), we get a type exception
> Type error: Argument 1 passed to Lexik\Bundle\JWTAuthenticationBundle\Security\Http\Authentication\AuthenticationSuccessHandler::handleAuthenticationSuccess() must implement interface Symfony\Component\Security\Core\User\UserInterface, string given, called in .../vendor/lexik/jwt-authentication-bundle/Security/Http/Authentication/AuthenticationSuccessHandler.php on line 47

This error occurs because the `UsernamePasswordJsonAuthenticationListener` send to the authentication success handler the token which have the user as a string and not the authenticated one that have a UserInterface as user. 
