### PR TITLE
[Profiler][VarDumper] Fix minor color issue & duplicated selector

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -163,11 +163,10 @@
     font-size: 11px;
     padding: 4px 8px 4px 0;
 }
-.sf-toolbar-block .sf-toolbar-info-piece span {
-
+.sf-toolbar-block:not(.sf-toolbar-block-dump) .sf-toolbar-info-piece span {
+    color: #F5F5F5;
 }
 .sf-toolbar-block .sf-toolbar-info-piece span {
-    color: #F5F5F5;
     font-size: 12px;
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

While working on #21109, I spotted this minor issue with `sf-dump-const` and `.sf-dump-ref`:

| Before | After |
| --- | --- |
|<img width="276" alt="screenshot 2017-01-03 a 20 13 55" src="https://cloud.githubusercontent.com/assets/2211145/21619779/7e1e347e-d1f1-11e6-9d84-fbb1d5d6b1fa.PNG">| <img width="275" alt="screenshot 2017-01-03 a 20 14 04" src="https://cloud.githubusercontent.com/assets/2211145/21619786/86dde5dc-d1f1-11e6-8b13-dcfc5abe466a.PNG">|