### PR TITLE
[Validator] Check cascasdedGroups for being countable

### DIFF
--- a/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
@@ -746,7 +746,7 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
         // The $cascadedGroups property is set, if the "Default" group is
         // overridden by a group sequence
         // See validateClassNode()
-        $cascadedGroups = count($cascadedGroups) > 0
+        $cascadedGroups = ((is_array($cascadedGroups) || $cascadedGroups instanceof \Countable) && count($cascadedGroups) > 0)
             ? $cascadedGroups
             : $groups;
 

--- a/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
@@ -746,7 +746,7 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
         // The $cascadedGroups property is set, if the "Default" group is
         // overridden by a group sequence
         // See validateClassNode()
-        $cascadedGroups = ((is_array($cascadedGroups) || $cascadedGroups instanceof \Countable) && count($cascadedGroups) > 0)
+        $cascadedGroups = (is_array($cascadedGroups) || $cascadedGroups instanceof \Countable) && count($cascadedGroups) > 0
             ? $cascadedGroups
             : $groups;
 

--- a/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
@@ -746,9 +746,7 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
         // The $cascadedGroups property is set, if the "Default" group is
         // overridden by a group sequence
         // See validateClassNode()
-        $cascadedGroups = (is_array($cascadedGroups) || $cascadedGroups instanceof \Countable) && count($cascadedGroups) > 0
-            ? $cascadedGroups
-            : $groups;
+        $cascadedGroups = null !== $cascadedGroups && count($cascadedGroups) > 0 ? $cascadedGroups : $groups;
 
         if (is_array($value)) {
             // Arrays are always traversed, independent of the specified


### PR DESCRIPTION
Prevents notice for PHP 7.2

| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | 

Just repeated for this place https://github.com/symfony/symfony/pull/20859
Waiting travis to fill in the `Tests pass` field

`cascasdedGroups` can be null at this point (according to failures and phpdoc)