### PR TITLE
No fallback to REQUEST_TIME in TimeDataCollector

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/TimeDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/TimeDataCollector.php
@@ -39,7 +39,7 @@ class TimeDataCollector extends DataCollector implements LateDataCollectorInterf
         if (null !== $this->kernel) {
             $startTime = $this->kernel->getStartTime();
         } else {
-            $startTime = $request->server->get('REQUEST_TIME_FLOAT', $request->server->get('REQUEST_TIME'));
+            $startTime = $request->server->get('REQUEST_TIME_FLOAT');
         }
 
         $this->data = array(

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/TimeDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/TimeDataCollectorTest.php
@@ -29,7 +29,7 @@ class TimeDataCollectorTest extends \PHPUnit_Framework_TestCase
 
         $c->collect($request, new Response());
 
-        $this->assertEquals(1000, $c->getStartTime());
+        $this->assertEquals(0, $c->getStartTime());
 
         $request->server->set('REQUEST_TIME_FLOAT', 2);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no (?)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ~
| License       | MIT
| Doc PR        | ~

As of PHP 5.4 the `REQUEST_TIME_FLOAT` is available and the minimum version of PHP is 5.5 in Symfony. I think it's safe to use as I can't find cases where this is _not_ defined. 
