### PR TITLE
[Form] ChoiceType: Fix cast to string from null choice

### DIFF
--- a/src/Symfony/Component/Form/ChoiceList/ArrayChoiceList.php
+++ b/src/Symfony/Component/Form/ChoiceList/ArrayChoiceList.php
@@ -234,7 +234,7 @@ class ArrayChoiceList implements ChoiceListInterface
                 }
 
                 continue;
-            } elseif (!is_scalar($choice)) {
+            } elseif (null !== $choice && !is_scalar($choice)) {
                 return false;
             }
 

--- a/src/Symfony/Component/Form/Tests/ChoiceList/ArrayChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/ArrayChoiceListTest.php
@@ -135,14 +135,14 @@ class ArrayChoiceListTest extends AbstractChoiceListTest
     {
         $choiceList = new ArrayChoiceList(array('Null' => null));
 
-        $this->assertSame(array(0 => null), $choiceList->getChoicesForValues(array('0')));
+        $this->assertSame(array(0 => null), $choiceList->getChoicesForValues(array('')));
     }
 
     public function testGetChoicesForValuesWithContainingFalseAndNull()
     {
         $choiceList = new ArrayChoiceList(array('False' => false, 'Null' => null));
 
-        $this->assertSame(array(0 => null), $choiceList->getChoicesForValues(array('1')));
+        $this->assertSame(array(0 => null), $choiceList->getChoicesForValues(array('')));
         $this->assertSame(array(0 => false), $choiceList->getChoicesForValues(array('0')));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | symfony/symfony-docs#6393

**Given the following:**

```php
$builder->add('attending', 'choice', [
        'choices' => [
            'Yes' => true,
            'No' => false,
            'Maybe' => null,
        ]
    ]);;
```

**Before:**

```html
<select id="form_attending" name="form[attending]">
    <option value="0">Yes</option>
    <option value="1">No</option>
    <option value="2" selected="selected">Maybe</option>
</select>
```

**After:**

```html
<select id="form_attending" name="form[attending]">
    <option value="1">Yes</option>
    <option value="0">No</option>
    <option value="" selected="selected">Maybe</option>
</select>
```

This results more consistent with expected behavior.