### PR TITLE
[HttpKernel] Added the SessionValueResolver

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
@@ -32,6 +32,10 @@
             <tag name="controller.argument_value_resolver" priority="50" />
         </service>
 
+        <service id="argument_resolver.session" class="Symfony\Component\HttpKernel\Controller\ArgumentResolver\SessionValueResolver" public="false">
+            <tag name="controller.argument_value_resolver" priority="50" />
+        </service>
+
         <service id="argument_resolver.default" class="Symfony\Component\HttpKernel\Controller\ArgumentResolver\DefaultValueResolver" public="false">
             <tag name="controller.argument_value_resolver" priority="-100" />
         </service>

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\DefaultValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestAttributeValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestValueResolver;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\SessionValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\VariadicValueResolver;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadataFactory;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadataFactoryInterface;
@@ -85,6 +86,7 @@ final class ArgumentResolver implements ArgumentResolverInterface
         return array(
             new RequestAttributeValueResolver(),
             new RequestValueResolver(),
+            new SessionValueResolver(),
             new DefaultValueResolver(),
             new VariadicValueResolver(),
         );

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/SessionValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/SessionValueResolver.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Controller\ArgumentResolver;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+
+/**
+ * Yields the Session.
+ *
+ * @author Iltar van der Berg <kjarli@gmail.com>
+ */
+final class SessionValueResolver implements ArgumentValueResolverInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(Request $request, ArgumentMetadata $argument)
+    {
+        if (SessionInterface::class !== $argument->getType() && !is_subclass_of($argument->getType(), SessionInterface::class)) {
+            return false;
+        }
+
+        $session = $request->getSession();
+
+        if (null === $session) {
+            return false;
+        }
+
+        $class = get_class($session);
+
+        return $class === $argument->getType() || is_subclass_of($class, $argument->getType());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolve(Request $request, ArgumentMetadata $argument)
+    {
+        yield $request->getSession();
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/Controller/ExtendingSession.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/Controller/ExtendingSession.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures\Controller;
+
+use Symfony\Component\HttpFoundation\Session\Session;
+
+class ExtendingSession extends Session
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21159
| License       | MIT
| Doc PR        | symfony/symfony-docs#7322

This feature adds the `SessionValueResolver`. That means that you no longer have to rely on injecting a `SessionInterface` implementation via the constructor or getting this implementation from the `Request`. Regardless of method, it does not know about the `getFlashBag()`.

By adding the `Session` to the action arguments, you can now type-hint against the implementation rather than interface, which contains the `getFlashBag()`, making it accessible rather than using duck-typing. 

_It should also feel less like injecting a service into the constructor which has a state or getting a service from the request._

**Old Situation**
```php
class Controller
{
    public function __construct(SessionInterface $session) { /* ... */ }

    public function fooAction(Request $request)
    {
        $this->get('session')->get(...);
        $request->getSession()->get(...);
        $this->session->get(...)

        // duck-typing
        $this->get('session')->getFlashBag();
        $request->getSession()->getFlashBag();
        $this->session->getFlashBag();

        $this->addFlash(...);
    }
}
```

**New Situation** _- The controller shortcut for flashbag could in theory be removed now_
```php
class Controller
{
    public function fooAction(Session $session)
    {
        $session->get(...);
        $session->getFlashBag();
    }
}
```
