### PR TITLE
Added missing headers in fixture files

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/Controller/BasicTypesController.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/Controller/BasicTypesController.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\HttpKernel\Tests\Fixtures\Controller;
 
 class BasicTypesController

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/Controller/ExtendingRequest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/Controller/ExtendingRequest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\HttpKernel\Tests\Fixtures\Controller;
 
 use Symfony\Component\HttpFoundation\Request;

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/Controller/VariadicController.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/Controller/VariadicController.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\HttpKernel\Tests\Fixtures\Controller;
 
 class VariadicController


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | n/a
| Fixed tickets | ~
| License       | MIT
| Doc PR        | ~

The headers were missing in a few files as mentioned in https://github.com/symfony/symfony/pull/21164#discussion_r94669787