### PR TITLE
[TwigBundle] Attempted to call an undefined method named "getTemplate…

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/TwigEngine.php
+++ b/src/Symfony/Bundle/TwigBundle/TwigEngine.php
@@ -52,12 +52,14 @@ class TwigEngine extends BaseEngine implements EngineInterface
             if ($name instanceof TemplateReference) {
                 try {
                     // try to get the real name of the template where the error occurred
-                    $name = $e->getTemplateName();
-                    $path = (string) $this->locator->locate($this->parser->parse($name));
-                    if (method_exists($e, 'setSourceContext')) {
-                        $e->setSourceContext(new \Twig_Source('', $name, $path));
-                    } else {
-                        $e->setTemplateName($path);
+                    if(method_exists($e,"getTemplateName")) {
+                        $name = $e->getTemplateName();
+                        $path = (string) $this->locator->locate($this->parser->parse($name));
+                        if (method_exists($e, 'setSourceContext')) {
+                            $e->setSourceContext(new \Twig_Source('', $name, $path));
+                        } else {
+                            $e->setTemplateName($path);
+                        }
                     }
                 } catch (\Exception $e2) {
                 }


### PR DESCRIPTION
…Name" of class "Twig_Error_Runtime". #21176

[TwigBundle] Attempted to call an undefined method named "getTemplateName" of class "Twig_Error_Runtime". #21176

| Q             | A
| ------------- | ---
| Branch?       | master / 2.7, 2.8, 3.1 or 3.2 <!--see comment below-->
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Deprecations? | yes/no
| Tests pass?   | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!--highly recommended for new features-->

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the master branch.
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
