### PR TITLE
[Security] Add strategy resolvers

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -127,14 +127,14 @@ class SecurityDataCollector extends DataCollector
                 return $decision;
             }, $this->accessDecisionManager->getDecisionLog());
 
-            $this->data['voter_strategy'] = $this->accessDecisionManager->getStrategy();
+            $this->data['voter_default_strategy'] = $this->accessDecisionManager->getDefaultStrategy();
 
             foreach ($this->accessDecisionManager->getVoters() as $voter) {
                 $this->data['voters'][] = get_class($voter);
             }
         } else {
             $this->data['access_decision_log'] = array();
-            $this->data['voter_strategy'] = 'unknown';
+            $this->data['voter_default_strategy'] = 'unknown';
             $this->data['voters'] = array();
         }
 
@@ -263,13 +263,13 @@ class SecurityDataCollector extends DataCollector
     }
 
     /**
-     * Returns the strategy configured for the security voters.
+     * Returns the default strategy configured for the security voters.
      *
      * @return string
      */
-    public function getVoterStrategy()
+    public function getVoterDefaultStrategy()
     {
-        return $this->data['voter_strategy'];
+        return $this->data['voter_default_strategy'];
     }
 
     /**

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddStrategyResolversPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddStrategyResolversPass.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+class AddStrategyResolversPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('security.access.decision_manager')) {
+            return;
+        }
+
+        $strategyResolvers = new \SplPriorityQueue();
+        foreach ($container->findTaggedServiceIds('security.strategy_resolver') as $id => $attributes) {
+            $class = $container->getDefinition($id)->getClass();
+            $interface = 'Symfony\Component\Security\Core\Authorization\StrategyResolverInterface';
+            if (!is_subclass_of($class, $interface)) {
+                throw new \InvalidArgumentException(sprintf('Service "%s" must implement interface "%s".', $id, $interface));
+            }
+
+            $priority = isset($attributes[0]['priority']) ? $attributes[0]['priority'] : 0;
+            $strategyResolvers->insert(new Reference($id), $priority);
+        }
+
+        $strategyResolvers = iterator_to_array($strategyResolvers);
+        ksort($strategyResolvers);
+
+        $container->getDefinition('security.access.decision_manager')->replaceArgument(4, array_values($strategyResolvers));
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -84,6 +84,7 @@ class SecurityExtension extends Extension
             ->addArgument($config['access_decision_manager']['strategy'])
             ->addArgument($config['access_decision_manager']['allow_if_all_abstain'])
             ->addArgument($config['access_decision_manager']['allow_if_equal_granted_denied'])
+            ->addArgument(array());
         ;
         $container->setParameter('security.access.always_authenticate_before_granting', $config['always_authenticate_before_granting']);
         $container->setParameter('security.authentication.hide_user_not_found', $config['hide_user_not_found']);

--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -205,8 +205,8 @@
 
         <div class="metrics">
             <div class="metric">
-                <span class="value">{{ collector.voterStrategy|default('unknown') }}</span>
-                <span class="label">Strategy</span>
+                <span class="value">{{ collector.voterDefaultStrategy|default('unknown') }}</span>
+                <span class="label">Default strategy</span>
             </div>
         </div>
 
@@ -235,13 +235,15 @@
         <table class="decision-log">
             <col style="width: 30px">
             <col style="width: 120px">
+            <col style="width: 120px">
             <col style="width: 25%">
-            <col style="width: 60%">
+            <col style="width: 50%">
 
             <thead>
                 <tr>
                     <th>#</th>
                     <th>Result</th>
+                    <th>Strategy</th>
                     <th>Attributes</th>
                     <th>Object</th>
                 </tr>
@@ -257,6 +259,7 @@
                                 : '<span class="label status-error same-width">DENIED</span>'
                             }}
                         </td>
+                        <td>{{ decision.strategy }}</td>
                         <td>{{ decision.attributes|length == 1 ? decision.attributes|first : profiler_dump(decision.attributes) }}</td>
                         <td>{{ profiler_dump(decision.object) }}</td>
                     </tr>

--- a/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
+++ b/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\JsonLogin
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\AddSecurityVotersPass;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\AddStrategyResolversPass;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\FormLoginFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\FormLoginLdapFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\HttpBasicFactory;
@@ -57,5 +58,6 @@ class SecurityBundle extends Bundle
         $extension->addUserProviderFactory(new InMemoryFactory());
         $extension->addUserProviderFactory(new LdapFactory());
         $container->addCompilerPass(new AddSecurityVotersPass());
+        $container->addCompilerPass(new AddStrategyResolversPass());
     }
 }

--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
@@ -27,29 +27,35 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
     const STRATEGY_UNANIMOUS = 'unanimous';
 
     private $voters;
-    private $strategy;
+    private $defaultStrategyMethod;
     private $allowIfAllAbstainDecisions;
     private $allowIfEqualGrantedDeniedDecisions;
 
     /**
+     * @var array
+     */
+    private $strategyResolvers;
+
+    /**
      * Constructor.
      *
-     * @param VoterInterface[] $voters                             An array of VoterInterface instances
-     * @param string           $strategy                           The vote strategy
-     * @param bool             $allowIfAllAbstainDecisions         Whether to grant access if all voters abstained or not
-     * @param bool             $allowIfEqualGrantedDeniedDecisions Whether to grant access if result are equals
+     * @param VoterInterface[]            $voters                             An array of VoterInterface instances
+     * @param string                      $defaultStrategy                    The vote default strategy
+     * @param bool                        $allowIfAllAbstainDecisions         Whether to grant access if all voters abstained or not
+     * @param bool                        $allowIfEqualGrantedDeniedDecisions Whether to grant access if result are equals
+     * @param StrategyResolverInterface[] $strategyResolvers                  An array of StrategyResolver instances
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct(array $voters = array(), $strategy = self::STRATEGY_AFFIRMATIVE, $allowIfAllAbstainDecisions = false, $allowIfEqualGrantedDeniedDecisions = true)
+    public function __construct(array $voters = array(), $defaultStrategy = self::STRATEGY_AFFIRMATIVE, $allowIfAllAbstainDecisions = false, $allowIfEqualGrantedDeniedDecisions = true, array $strategyResolvers = array())
     {
-        $strategyMethod = 'decide'.ucfirst($strategy);
-        if (!is_callable(array($this, $strategyMethod))) {
-            throw new \InvalidArgumentException(sprintf('The strategy "%s" is not supported.', $strategy));
+        $defaultStrategyMethod = $this->getStrategyMethod($defaultStrategy);
+        if (!is_callable(array($this, $defaultStrategyMethod))) {
+            throw new \InvalidArgumentException(sprintf('The strategy "%s" is not supported.', $defaultStrategy));
         }
 
         $this->voters = $voters;
-        $this->strategy = $strategyMethod;
+        $this->defaultStrategyMethod = $defaultStrategyMethod;
         $this->allowIfAllAbstainDecisions = (bool) $allowIfAllAbstainDecisions;
         $this->allowIfEqualGrantedDeniedDecisions = (bool) $allowIfEqualGrantedDeniedDecisions;
     }
@@ -69,7 +75,27 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
      */
     public function decide(TokenInterface $token, array $attributes, $object = null)
     {
-        return $this->{$this->strategy}($token, $attributes, $object);
+        $strategyMethod = $this->defaultStrategyMethod;
+        /* @var $strategyResolver StrategyResolverInterface */
+        foreach ($this->strategyResolvers as $strategyResolver) {
+            if ($strategyResolver->supports($token, $attributes, $object)) {
+                $resolvedStrategy = $strategyResolver->getStrategy($token, $attributes, $object);
+                if (!is_string($resolvedStrategy)) {
+                    continue;
+                }
+
+                $resolvedStrategyMethod = $this->getStrategyMethod($resolvedStrategy);
+                if (!is_callable(array($this, $resolvedStrategyMethod))) {
+                    continue;
+                }
+
+                $strategyMethod = $resolvedStrategyMethod;
+
+                break;
+            }
+        }
+
+        return $this->{$strategyMethod}($token, $attributes, $object);
     }
 
     /**
@@ -187,5 +213,15 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
         }
 
         return $this->allowIfAllAbstainDecisions;
+    }
+
+    /**
+     * @param string $strategy
+     *
+     * @return string
+     */
+    private function getStrategyMethod($strategy)
+    {
+        return 'decide' . ucfirst($strategy);
     }
 }

--- a/src/Symfony/Component/Security/Core/Authorization/StrategyResolverInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/StrategyResolverInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authorization;
+
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+interface StrategyResolverInterface
+{
+    /**
+     * This method must return one of the following constants from the AccessDecisionManager :
+     * STRATEGY_AFFIRMATIVE, STRATEGY_CONSENSUS, or STRATEGY_UNANIMOUS.
+     *
+     * @param TokenInterface $token
+     * @param array $attributes
+     * @param mixed $object
+     *
+     * @return string
+     */
+    public function getStrategy(TokenInterface $token, array $attributes, $object = null);
+
+    /**
+     * @param TokenInterface $token
+     * @param array $attributes
+     * @param null $object
+     *
+     * @return bool
+     */
+    public function supports(TokenInterface $token, array $attributes, $object = null);
+}

--- a/src/Symfony/Component/Security/Core/Authorization/StrategyResolverInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/StrategyResolverInterface.php
@@ -30,7 +30,7 @@ interface StrategyResolverInterface
     /**
      * @param TokenInterface $token
      * @param array $attributes
-     * @param null $object
+     * @param mixed $object
      *
      * @return bool
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #15130 (kind of)
| License       | MIT
| Doc PR        | -

This PR is a way to be able to use a specific strategy (in the AccessDecisionManager) for particular attributes / object / token. Cf https://github.com/symfony/symfony/issues/15130 for more discussion about this.
I know the idea in the issue was rejected but this implementation is different and time have passed since then, so maybe there will be a new look on this.