### PR TITLE
[FrameworkBundle] Remove Response* from classes to compile

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -206,9 +206,6 @@ class FrameworkExtension extends Extension
             'Symfony\\Component\\EventDispatcher\\Event',
             'Symfony\\Component\\EventDispatcher\\ContainerAwareEventDispatcher',
 
-            'Symfony\\Component\\HttpFoundation\\Response',
-            'Symfony\\Component\\HttpFoundation\\ResponseHeaderBag',
-
             'Symfony\\Component\\HttpKernel\\EventListener\\ResponseListener',
             'Symfony\\Component\\HttpKernel\\EventListener\\RouterListener',
             'Symfony\\Component\\HttpKernel\\Bundle\\Bundle',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20560, https://github.com/symfony/symfony-demo/issues/411, https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/issues/276
| License       | MIT
| Doc PR        | -

When HttpCache is used, Response is loaded first, then the kernel is booted (on cache miss), which triggers the loading of classes.php. Since 3.2 generates a context free classes.php, the Response class is now included there when it was excluded previously. And boom, "Cannot declare class Symfony\Component\HttpFoundation\Response".