### PR TITLE
[WebServerBundle] Decouple server commands from the container

### DIFF
--- a/src/Symfony/Bundle/WebServerBundle/Command/ServerCommand.php
+++ b/src/Symfony/Bundle/WebServerBundle/Command/ServerCommand.php
@@ -11,14 +11,14 @@
 
 namespace Symfony\Bundle\WebServerBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 
 /**
  * Base methods for commands related to a local web server.
  *
  * @author Christian Flothmann <christian.flothmann@xabbuh.de>
  */
-abstract class ServerCommand extends ContainerAwareCommand
+abstract class ServerCommand extends Command
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Bundle/WebServerBundle/Command/ServerRunCommand.php
+++ b/src/Symfony/Bundle/WebServerBundle/Command/ServerRunCommand.php
@@ -27,6 +27,17 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  */
 class ServerRunCommand extends ServerCommand
 {
+    private $documentRoot;
+    private $environment;
+
+    public function __construct($documentRoot = null, $environment = null)
+    {
+        $this->documentRoot = $documentRoot;
+        $this->environment = $environment;
+
+        parent::__construct();
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -71,7 +82,12 @@ EOF
         $io = new SymfonyStyle($input, $output);
 
         if (null === $documentRoot = $input->getOption('docroot')) {
-            $documentRoot = $this->getContainer()->getParameter('kernel.root_dir').'/../web';
+            if (!$this->documentRoot) {
+                $io->error('The document root directory must be either passed as first argument of the constructor or through the "--docroot" input option.');
+
+                return 1;
+            }
+            $documentRoot = $this->documentRoot;
         }
 
         if (!is_dir($documentRoot)) {
@@ -80,7 +96,18 @@ EOF
             return 1;
         }
 
-        $env = $this->getContainer()->getParameter('kernel.environment');
+        if (!$env = $this->environment) {
+            if ($input->hasOption('env') && !$env = $input->getOption('env')) {
+                $io->error('The environment must be either passed as second argument of the constructor or through the "--env" input option.');
+
+                return 1;
+            } else {
+                $io->error('The environment must be passed as second argument of the constructor.');
+
+                return 1;
+            }
+        }
+
         if ('prod' === $env) {
             $io->error('Running this server in production environment is NOT recommended!');
         }

--- a/src/Symfony/Bundle/WebServerBundle/Command/ServerStartCommand.php
+++ b/src/Symfony/Bundle/WebServerBundle/Command/ServerStartCommand.php
@@ -26,6 +26,17 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  */
 class ServerStartCommand extends ServerCommand
 {
+    private $documentRoot;
+    private $environment;
+
+    public function __construct($documentRoot = null, $environment = null)
+    {
+        $this->documentRoot = $documentRoot;
+        $this->environment = $environment;
+
+        parent::__construct();
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -84,7 +95,12 @@ EOF
         }
 
         if (null === $documentRoot = $input->getOption('docroot')) {
-            $documentRoot = $this->getContainer()->getParameter('kernel.root_dir').'/../web';
+            if (!$this->documentRoot) {
+                $io->error('The document root directory must be either passed as first argument of the constructor or through the "docroot" input option.');
+
+                return 1;
+            }
+            $documentRoot = $this->documentRoot;
         }
 
         if (!is_dir($documentRoot)) {
@@ -93,7 +109,18 @@ EOF
             return 1;
         }
 
-        $env = $this->getContainer()->getParameter('kernel.environment');
+        if (!$env = $this->environment) {
+            if ($input->hasOption('env') && !$env = $input->getOption('env')) {
+                $io->error('The environment must be either passed as second argument of the constructor or through the "--env" input option.');
+
+                return 1;
+            } else {
+                $io->error('The environment must be passed as second argument of the constructor.');
+
+                return 1;
+            }
+        }
+
         if ('prod' === $env) {
             $io->error('Running this server in production environment is NOT recommended!');
         }

--- a/src/Symfony/Bundle/WebServerBundle/DependencyInjection/WebServerExtension.php
+++ b/src/Symfony/Bundle/WebServerBundle/DependencyInjection/WebServerExtension.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\WebServerBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\FileLocator;
+
+/**
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+class WebServerExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('webserver.xml');
+    }
+}

--- a/src/Symfony/Bundle/WebServerBundle/Resources/config/webserver.xml
+++ b/src/Symfony/Bundle/WebServerBundle/Resources/config/webserver.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="web_server.command.server_run" class="Symfony\Bundle\WebServerBundle\Command\ServerRunCommand">
+            <argument>%kernel.root_dir%/../web</argument>
+            <argument>%kernel.environment%</argument>
+            <tag name="console.command" />
+        </service>
+
+        <service id="web_server.command.server_start" class="Symfony\Bundle\WebServerBundle\Command\ServerStartCommand">
+            <argument>%kernel.root_dir%/../web</argument>
+            <argument>%kernel.environment%</argument>
+            <tag name="console.command" />
+        </service>
+
+        <service id="web_server.command.server_stop" class="Symfony\Bundle\WebServerBundle\Command\ServerStopCommand">
+            <tag name="console.command" />
+        </service>
+
+        <service id="web_server.command.server_status" class="Symfony\Bundle\WebServerBundle\Command\ServerStatusCommand">
+            <tag name="console.command" />
+        </service>
+    </services>
+
+</container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20429 
| License       | MIT
| Doc PR        | maybe

This removes the need for injecting the container in the new `server:*` commands, registering them as services when used in the framework and thus making them even more discoverable and extensible.
It would then be easy to reconsider extracting them in a `WebServer` component instead of having a bundle only. IMHO it would make sense to use these commands outside of the framework.

If the idea can be considered I'll add some tests at least ensuring that these commands are bootstrap-able. This must be done before that they are covered by the BC promise (3.3).