### PR TITLE
[Yaml] Add tags support

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Dumper;
 
 use Symfony\Component\Yaml\Dumper as YmlDumper;
+use Symfony\Component\Yaml\Tag\TaggedValue;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Argument\ClosureProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
@@ -251,10 +252,10 @@ class YamlDumper extends Dumper
      */
     private function dumpValue($value)
     {
-        if ($value instanceof IteratorArgument) {
-            $value = array('=iterator' => $value->getValues());
-        } elseif ($value instanceof ClosureProxyArgument) {
-            $value = array('=closure_proxy' => $value->getValues());
+        if ($value instanceof IteratorArgument || $value instanceof ClosureProxyArgument) {
+            $tag = $value instanceof IteratorArgument ? 'iterator' : 'closure_proxy';
+
+            return new TaggedValue($this->dumpValue($value->getValues()), $tag);
         }
 
         if (is_array($value)) {

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -255,7 +255,7 @@ class YamlDumper extends Dumper
         if ($value instanceof IteratorArgument || $value instanceof ClosureProxyArgument) {
             $tag = $value instanceof IteratorArgument ? 'iterator' : 'closure_proxy';
 
-            return new TaggedValue($this->dumpValue($value->getValues()), $tag);
+            return new TaggedValue($tag, $this->dumpValue($value->getValues()));
         }
 
         if (is_array($value)) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection\Tests\Dumper;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Dumper\YamlDumper;
 use Symfony\Component\Yaml\Yaml;
+use Symfony\Component\Yaml\Parser;
 
 class YamlDumperTest extends \PHPUnit_Framework_TestCase
 {
@@ -62,8 +63,10 @@ class YamlDumperTest extends \PHPUnit_Framework_TestCase
         $this->assertStringEqualsFile(self::$fixturesPath.'/yaml/services24.yml', $dumper->dump());
     }
 
-    private function assertEqualYamlStructure($yaml, $expected, $message = '')
+    private function assertEqualYamlStructure($expected, $yaml, $message = '')
     {
-        $this->assertEquals(Yaml::parse($expected), Yaml::parse($yaml), $message);
+        $parser = new Parser();
+
+        $this->assertEquals($parser->parse($expected, Yaml::PARSE_CUSTOM_TAGS), $parser->parse($yaml, Yaml::PARSE_CUSTOM_TAGS), $message);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
@@ -109,12 +109,12 @@ services:
         factory: ['@factory_simple', getInstance]
     lazy_context:
         class: LazyContext
-        arguments: [{ '=iterator': [foo, '@foo.baz', { '%foo%': 'foo is %foo%', foobar: '%foo%' }, true, '@service_container'] }]
+        arguments: [!iterator [foo, '@foo.baz', { '%foo%': 'foo is %foo%', foobar: '%foo%' }, true, '@service_container']]
     lazy_context_ignore_invalid_ref:
         class: LazyContext
-        arguments: [{ '=iterator': ['@foo.baz', '@?invalid'] }]
+        arguments: [!iterator ['@foo.baz', '@?invalid']]
     closure_proxy:
         class: BarClass
-        arguments: [{ '=closure_proxy': ['@closure_proxy', getBaz] }]
+        arguments: [!closure_proxy ['@closure_proxy', getBaz]]
     alias_for_foo: '@foo'
     alias_for_alias: '@foo'

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.5.9"
     },
     "require-dev": {
-        "symfony/yaml": "~3.2",
+        "symfony/yaml": "~3.3",
         "symfony/config": "~3.3",
         "symfony/expression-language": "~2.8|~3.0"
     },
@@ -30,8 +30,8 @@
         "symfony/proxy-manager-bridge": "Generate service proxies to lazy load them"
     },
     "conflict": {
-        "symfony/config": "<3.3",
-        "symfony/yaml": "<3.2"
+        "symfony/yaml": "<3.3",
+        "symfony/config": "<3.3"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\DependencyInjection\\": "" },

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -714,6 +714,11 @@ class Inline
             return;
         }
 
+        // Built-in tags
+        if ($tag && '!' === $tag[0]) {
+            throw new ParseException(sprintf('The built-in tag "!%s" is not implemented.', $tag));
+        }
+
         if (Yaml::PARSE_CUSTOM_TAGS & $flags) {
             $i = $nextOffset;
 

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -110,7 +110,7 @@ class Inline
         }
 
         if (null !== $tag) {
-            return new TaggedValue($result, $tag);
+            return new TaggedValue($tag, $result);
         }
 
         // some comments are allowed at the end
@@ -430,7 +430,7 @@ class Inline
             }
 
             if (null !== $tag) {
-                $value = new TaggedValue($value, $tag);
+                $value = new TaggedValue($tag, $value);
             }
 
             $output[] = $value;
@@ -531,7 +531,7 @@ class Inline
 
                 if (!$duplicate) {
                     if (null !== $tag) {
-                        $output[$key] = new TaggedValue($value, $tag);
+                        $output[$key] = new TaggedValue($tag, $value);
                     } else {
                         $output[$key] = $value;
                     }

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Yaml;
 
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Exception\DumpException;
+use Symfony\Component\Yaml\Tag\TaggedValue;
 
 /**
  * Inline implements a YAML parser/dumper for the YAML inline syntax.
@@ -94,7 +95,8 @@ class Inline
         }
 
         $i = 0;
-        switch ($value[0]) {
+        $tag = self::parseTag($value, $i, $flags);
+        switch ($value[$i]) {
             case '[':
                 $result = self::parseSequence($value, $flags, $i, $references);
                 ++$i;
@@ -104,7 +106,11 @@ class Inline
                 ++$i;
                 break;
             default:
-                $result = self::parseScalar($value, $flags, null, $i, true, $references);
+                $result = self::parseScalar($value, $flags, null, $i, null === $tag, $references);
+        }
+
+        if (null !== $tag) {
+            return new TaggedValue($result, $tag);
         }
 
         // some comments are allowed at the end
@@ -159,6 +165,10 @@ class Inline
             case $value instanceof \DateTimeInterface:
                 return $value->format('c');
             case is_object($value):
+                if ($value instanceof TaggedValue) {
+                    return '!'.$value->getTag().' '.self::dump($value->getValue(), $flags);
+                }
+
                 if (Yaml::DUMP_OBJECT & $flags) {
                     return '!php/object:'.serialize($value);
                 }
@@ -382,23 +392,28 @@ class Inline
 
         // [foo, bar, ...]
         while ($i < $len) {
+            if (']' === $sequence[$i]) {
+                return $output;
+            }
+            if (',' === $sequence[$i] || ' ' === $sequence[$i]) {
+                ++$i;
+
+                continue;
+            }
+
+            $tag = self::parseTag($sequence, $i, $flags);
             switch ($sequence[$i]) {
                 case '[':
                     // nested sequence
-                    $output[] = self::parseSequence($sequence, $flags, $i, $references);
+                    $value = self::parseSequence($sequence, $flags, $i, $references);
                     break;
                 case '{':
                     // nested mapping
-                    $output[] = self::parseMapping($sequence, $flags, $i, $references);
-                    break;
-                case ']':
-                    return $output;
-                case ',':
-                case ' ':
+                    $value = self::parseMapping($sequence, $flags, $i, $references);
                     break;
                 default:
                     $isQuoted = in_array($sequence[$i], array('"', "'"));
-                    $value = self::parseScalar($sequence, $flags, array(',', ']'), $i, true, $references);
+                    $value = self::parseScalar($sequence, $flags, array(',', ']'), $i, null === $tag, $references);
 
                     // the value can be an array if a reference has been resolved to an array var
                     if (is_string($value) && !$isQuoted && false !== strpos($value, ': ')) {
@@ -411,10 +426,14 @@ class Inline
                         }
                     }
 
-                    $output[] = $value;
-
                     --$i;
             }
+
+            if (null !== $tag) {
+                $value = new TaggedValue($value, $tag);
+            }
+
+            $output[] = $value;
 
             ++$i;
         }
@@ -466,10 +485,15 @@ class Inline
                 @trigger_error('Using a colon that is not followed by an indication character (i.e. " ", ",", "[", "]", "{", "}" is deprecated since version 3.2 and will throw a ParseException in 4.0.', E_USER_DEPRECATED);
             }
 
-            // value
-            $done = false;
-
             while ($i < $len) {
+                if (':' === $mapping[$i] || ' ' === $mapping[$i]) {
+                    ++$i;
+
+                    continue;
+                }
+
+                $tag = self::parseTag($mapping, $i, $flags);
+                $duplicate = false;
                 switch ($mapping[$i]) {
                     case '[':
                         // nested sequence
@@ -477,12 +501,10 @@ class Inline
                         // Spec: Keys MUST be unique; first one wins.
                         // Parser cannot abort this mapping earlier, since lines
                         // are processed sequentially.
-                        if (!isset($output[$key])) {
-                            $output[$key] = $value;
-                        } else {
+                        if (isset($output[$key])) {
                             @trigger_error(sprintf('Duplicate key "%s" detected on line %d whilst parsing YAML. Silent handling of duplicate mapping keys in YAML is deprecated since version 3.2 and will throw \Symfony\Component\Yaml\Exception\ParseException in 4.0.', $key, self::$parsedLineNumber + 1), E_USER_DEPRECATED);
+                            $duplicate = true;
                         }
-                        $done = true;
                         break;
                     case '{':
                         // nested mapping
@@ -490,35 +512,33 @@ class Inline
                         // Spec: Keys MUST be unique; first one wins.
                         // Parser cannot abort this mapping earlier, since lines
                         // are processed sequentially.
-                        if (!isset($output[$key])) {
-                            $output[$key] = $value;
-                        } else {
+                        if (isset($output[$key])) {
                             @trigger_error(sprintf('Duplicate key "%s" detected on line %d whilst parsing YAML. Silent handling of duplicate mapping keys in YAML is deprecated since version 3.2 and will throw \Symfony\Component\Yaml\Exception\ParseException in 4.0.', $key, self::$parsedLineNumber + 1), E_USER_DEPRECATED);
+                            $duplicate = true;
                         }
-                        $done = true;
-                        break;
-                    case ':':
-                    case ' ':
                         break;
                     default:
-                        $value = self::parseScalar($mapping, $flags, array(',', '}'), $i, true, $references);
+                        $value = self::parseScalar($mapping, $flags, array(',', '}'), $i, null === $tag, $references);
                         // Spec: Keys MUST be unique; first one wins.
                         // Parser cannot abort this mapping earlier, since lines
                         // are processed sequentially.
-                        if (!isset($output[$key])) {
-                            $output[$key] = $value;
-                        } else {
+                        if (isset($output[$key])) {
                             @trigger_error(sprintf('Duplicate key "%s" detected on line %d whilst parsing YAML. Silent handling of duplicate mapping keys in YAML is deprecated since version 3.2 and will throw \Symfony\Component\Yaml\Exception\ParseException in 4.0.', $key, self::$parsedLineNumber + 1), E_USER_DEPRECATED);
+                            $duplicate = true;
                         }
-                        $done = true;
                         --$i;
                 }
 
+                if (!$duplicate) {
+                    if (null !== $tag) {
+                        $output[$key] = new TaggedValue($value, $tag);
+                    } else {
+                        $output[$key] = $value;
+                    }
+                }
                 ++$i;
 
-                if ($done) {
-                    continue 2;
-                }
+                continue 2;
             }
         }
 
@@ -569,8 +589,7 @@ class Inline
                 return true;
             case 'false' === $scalarLower:
                 return false;
-            // Optimise for returning strings.
-            case $scalar[0] === '+' || $scalar[0] === '-' || $scalar[0] === '.' || $scalar[0] === '!' || is_numeric($scalar[0]):
+            case $scalar[0] === '!':
                 switch (true) {
                     case 0 === strpos($scalar, '!str'):
                         return (string) substr($scalar, 5);
@@ -613,6 +632,15 @@ class Inline
                         return;
                     case 0 === strpos($scalar, '!!float '):
                         return (float) substr($scalar, 8);
+                    case 0 === strpos($scalar, '!!binary '):
+                        return self::evaluateBinaryScalar(substr($scalar, 9));
+                    default:
+                        @trigger_error(sprintf('Using the unquoted scalar value "%s" is deprecated since version 3.3 and will be considered as a tagged value in 4.0. You must quote it.', $scalar), E_USER_DEPRECATED);
+                }
+
+            // Optimize for returning strings.
+            case $scalar[0] === '+' || $scalar[0] === '-' || $scalar[0] === '.' || is_numeric($scalar[0]):
+                switch (true) {
                     case preg_match('{^[+-]?[0-9][0-9_]*$}', $scalar):
                         $scalar = str_replace('_', '', (string) $scalar);
                         // omitting the break / return as integers are handled in the next case
@@ -636,8 +664,6 @@ class Inline
                         return -log(0);
                     case '-.inf' === $scalarLower:
                         return log(0);
-                    case 0 === strpos($scalar, '!!binary '):
-                        return self::evaluateBinaryScalar(substr($scalar, 9));
                     case preg_match('/^(-|\+)?[0-9][0-9,]*(\.[0-9_]+)?$/', $scalar):
                     case preg_match('/^(-|\+)?[0-9][0-9_]*(\.[0-9_]+)?$/', $scalar):
                         if (false !== strpos($scalar, ',')) {
@@ -658,9 +684,43 @@ class Inline
 
                         return $time;
                 }
-            default:
-                return (string) $scalar;
         }
+
+        return (string) $scalar;
+    }
+
+    /**
+     * @param string $value
+     * @param int    &$i
+     * @param int    $flags
+     *
+     * @return null|string
+     */
+    private static function parseTag($value, &$i, $flags)
+    {
+        if ('!' !== $value[$i]) {
+            return;
+        }
+
+        $tagLength = strcspn($value, " \t\n", $i + 1);
+        $tag = substr($value, $i + 1, $tagLength);
+
+        $nextOffset = $i + $tagLength + 1;
+        $nextOffset += strspn($value, ' ', $nextOffset);
+
+        // Is followed by a scalar
+        if (!isset($value[$nextOffset]) || !in_array($value[$nextOffset], array('[', '{'), true)) {
+            // Manage scalars in {@link self::evaluateScalar()}
+            return;
+        }
+
+        if (Yaml::PARSE_CUSTOM_TAGS & $flags) {
+            $i = $nextOffset;
+
+            return $tag;
+        }
+
+        throw new ParseException(sprintf('Tags support is not enabled. Enable the `Yaml::PARSE_CUSTOM_TAGS` flag to use "!%s".', $tag));
     }
 
     /**

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -119,7 +119,7 @@ class Parser
 
         // Resolves the tag and returns if end of the document
         if (null !== ($tag = $this->getLineTag($this->currentLine, $flags, false)) && !$this->moveToNextLine()) {
-            return new TaggedValue('', $tag);
+            return new TaggedValue($tag, '');
         }
 
         do {
@@ -149,8 +149,8 @@ class Parser
                     $data[] = $this->parseBlock($this->getRealCurrentLineNb() + 1, $this->getNextEmbedBlock(null, true), $flags);
                 } elseif (null !== $subTag = $this->getLineTag(ltrim($values['value'], ' '), $flags)) {
                     $data[] = new TaggedValue(
-                        $this->parseBlock($this->getRealCurrentLineNb() + 1, $this->getNextEmbedBlock(null, true), $flags),
-                        $subTag
+                        $subTag,
+                        $this->parseBlock($this->getRealCurrentLineNb() + 1, $this->getNextEmbedBlock(null, true), $flags)
                     );
                 } else {
                     if (isset($values['leadspaces'])
@@ -266,7 +266,7 @@ class Parser
                         // But overwriting is allowed when a merge node is used in current block.
                         if ($allowOverwrite || !isset($data[$key])) {
                             if (null !== $subTag) {
-                                $data[$key] = new TaggedValue('', $subTag);
+                                $data[$key] = new TaggedValue($subTag, '');
                             } else {
                                 $data[$key] = null;
                             }
@@ -281,7 +281,7 @@ class Parser
                         // But overwriting is allowed when a merge node is used in current block.
                         if ($allowOverwrite || !isset($data[$key])) {
                             if (null !== $subTag) {
-                                $data[$key] = new TaggedValue($value, $subTag);
+                                $data[$key] = new TaggedValue($subTag, $value);
                             } else {
                                 $data[$key] = $value;
                             }
@@ -388,7 +388,7 @@ class Parser
         } while ($this->moveToNextLine());
 
         if (null !== $tag) {
-            $data = new TaggedValue($data, $tag);
+            $data = new TaggedValue($tag, $data);
         }
 
         if (isset($mbEncoding)) {

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -982,8 +982,15 @@ class Parser
             return;
         }
 
+        $tag = substr($matches['tag'], 1);
+
+        // Built-in tags
+        if ($tag && '!' === $tag[0]) {
+            throw new ParseException(sprintf('The built-in tag "!%s" is not implemented.', $tag));
+        }
+
         if (Yaml::PARSE_CUSTOM_TAGS & $flags) {
-            return substr($matches['tag'], 1);
+            return $tag;
         }
 
         throw new ParseException(sprintf('Tags support is not enabled. You must use the flag `Yaml::PARSE_CUSTOM_TAGS` to use "%s".', $matches['tag']));

--- a/src/Symfony/Component/Yaml/Tag/TaggedValue.php
+++ b/src/Symfony/Component/Yaml/Tag/TaggedValue.php
@@ -17,25 +17,17 @@ namespace Symfony\Component\Yaml\Tag;
  */
 final class TaggedValue
 {
-    private $value;
     private $tag;
+    private $value;
 
     /**
-     * @param mixed  $value
      * @param string $tag
+     * @param mixed  $value
      */
-    public function __construct($value, $tag)
+    public function __construct($tag, $value)
     {
-        $this->value = $value;
         $this->tag = $tag;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getValue()
-    {
-        return $this->value;
+        $this->value = $value;
     }
 
     /**
@@ -44,5 +36,13 @@ final class TaggedValue
     public function getTag()
     {
         return $this->tag;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
     }
 }

--- a/src/Symfony/Component/Yaml/Tag/TaggedValue.php
+++ b/src/Symfony/Component/Yaml/Tag/TaggedValue.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Yaml\Tag;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ * @author Guilhem N. <egetick@gmail.com>
+ */
+final class TaggedValue
+{
+    private $value;
+    private $tag;
+
+    /**
+     * @param mixed  $value
+     * @param string $tag
+     */
+    public function __construct($value, $tag)
+    {
+        $this->value = $value;
+        $this->tag = $tag;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTag()
+    {
+        return $this->tag;
+    }
+}

--- a/src/Symfony/Component/Yaml/Tag/TaggedValue.php
+++ b/src/Symfony/Component/Yaml/Tag/TaggedValue.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\Yaml\Tag;
 /**
  * @author Nicolas Grekas <p@tchwork.com>
  * @author Guilhem N. <egetick@gmail.com>
+ *
+ * @experimental in version 3.3
  */
 final class TaggedValue
 {

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -1510,27 +1510,27 @@ EOF;
     {
         return array(
             'sequences' => array(
-                array(new TaggedValue('foo', array('yaml')), new TaggedValue('!quz', array('bar'))),
+                array(new TaggedValue('foo', array('yaml')), new TaggedValue('quz', array('bar'))),
                 <<<YAML
 - !foo
     - yaml
-- !!quz [bar]
+- !quz [bar]
 YAML
             ),
             'mappings' => array(
-                new TaggedValue('foo', array('foo' => new TaggedValue('!quz', array('bar')), 'quz' => new TaggedValue('foo', array('quz' => 'bar')))),
+                new TaggedValue('foo', array('foo' => new TaggedValue('quz', array('bar')), 'quz' => new TaggedValue('foo', array('quz' => 'bar')))),
                 <<<YAML
 !foo
-foo: !!quz [bar]
+foo: !quz [bar]
 quz: !foo
    quz: bar
 YAML
             ),
             'inline' => array(
-                array(new TaggedValue('foo', array('foo', 'bar')), new TaggedValue('!quz', array('foo' => 'bar', 'quz' => new TaggedValue('bar', array('one' => 'bar'))))),
+                array(new TaggedValue('foo', array('foo', 'bar')), new TaggedValue('quz', array('foo' => 'bar', 'quz' => new TaggedValue('bar', array('one' => 'bar'))))),
                 <<<YAML
 - !foo [foo, bar]
-- !!quz {foo: bar, quz: !bar {one: bar}}
+- !quz {foo: bar, quz: !bar {one: bar}}
 YAML
             ),
         );
@@ -1552,6 +1552,15 @@ YAML
     public function testUnsupportedTagWithScalar()
     {
         $this->assertEquals('!iterator foo', $this->parser->parse('!iterator foo'));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
+     * @expectedExceptionMessage The built-in tag "!!foo" is not implemented.
+     */
+    public function testExceptionWhenUsingUnsuportedBuiltInTags()
+    {
+        $this->parser->parse('!!foo');
     }
 }
 

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Yaml\Tests;
 
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\Yaml\Parser;
+use Symfony\Component\Yaml\Tag\TaggedValue;
 
 class ParserTest extends \PHPUnit_Framework_TestCase
 {
@@ -1490,6 +1491,67 @@ EOF;
         );
 
         $this->assertEquals($expected, $this->parser->parse($yaml));
+    }
+
+    public function testTaggedInlineMapping()
+    {
+        $this->assertEquals(new TaggedValue(array('foo' => 'bar'), 'foo'), $this->parser->parse('!foo {foo: bar}', Yaml::PARSE_CUSTOM_TAGS));
+    }
+
+    /**
+     * @dataProvider taggedValuesProvider
+     */
+    public function testCustomTagSupport($expected, $yaml)
+    {
+        $this->assertEquals($expected, $this->parser->parse($yaml, Yaml::PARSE_CUSTOM_TAGS));
+    }
+
+    public function taggedValuesProvider()
+    {
+        return array(
+            'sequences' => array(
+                array(new TaggedValue(array('yaml'), 'foo'), new TaggedValue(array('bar'), '!quz')),
+                <<<YAML
+- !foo
+    - yaml
+- !!quz [bar]
+YAML
+            ),
+            'mappings' => array(
+                new TaggedValue(array('foo' => new TaggedValue(array('bar'), '!quz'), 'quz' => new TaggedValue(array('quz' => 'bar'), 'foo')), 'foo'),
+                <<<YAML
+!foo
+foo: !!quz [bar]
+quz: !foo
+   quz: bar
+YAML
+            ),
+            'inline' => array(
+                array(new TaggedValue(array('foo', 'bar'), 'foo'), new TaggedValue(array('foo' => 'bar', 'quz' => new TaggedValue(array('one' => 'bar'), 'bar')), '!quz')),
+                <<<YAML
+- !foo [foo, bar]
+- !!quz {foo: bar, quz: !bar {one: bar}}
+YAML
+            ),
+        );
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
+     * @expectedExceptionMessage Tags support is not enabled. Enable the `Yaml::PARSE_CUSTOM_TAGS` flag to use "!iterator" at line 1 (near "!iterator [foo]").
+     */
+    public function testCustomTagsDisabled()
+    {
+        $this->parser->parse('!iterator [foo]');
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Using the unquoted scalar value "!iterator foo" is deprecated since version 3.3 and will be considered as a tagged value in 4.0. You must quote it.
+     */
+    public function testUnsupportedTagWithScalar()
+    {
+        $this->assertEquals('!iterator foo', $this->parser->parse('!iterator foo'));
     }
 }
 

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -1495,7 +1495,7 @@ EOF;
 
     public function testTaggedInlineMapping()
     {
-        $this->assertEquals(new TaggedValue(array('foo' => 'bar'), 'foo'), $this->parser->parse('!foo {foo: bar}', Yaml::PARSE_CUSTOM_TAGS));
+        $this->assertEquals(new TaggedValue('foo', array('foo' => 'bar')), $this->parser->parse('!foo {foo: bar}', Yaml::PARSE_CUSTOM_TAGS));
     }
 
     /**
@@ -1510,7 +1510,7 @@ EOF;
     {
         return array(
             'sequences' => array(
-                array(new TaggedValue(array('yaml'), 'foo'), new TaggedValue(array('bar'), '!quz')),
+                array(new TaggedValue('foo', array('yaml')), new TaggedValue('!quz', array('bar'))),
                 <<<YAML
 - !foo
     - yaml
@@ -1518,7 +1518,7 @@ EOF;
 YAML
             ),
             'mappings' => array(
-                new TaggedValue(array('foo' => new TaggedValue(array('bar'), '!quz'), 'quz' => new TaggedValue(array('quz' => 'bar'), 'foo')), 'foo'),
+                new TaggedValue('foo', array('foo' => new TaggedValue('!quz', array('bar')), 'quz' => new TaggedValue('foo', array('quz' => 'bar')))),
                 <<<YAML
 !foo
 foo: !!quz [bar]
@@ -1527,7 +1527,7 @@ quz: !foo
 YAML
             ),
             'inline' => array(
-                array(new TaggedValue(array('foo', 'bar'), 'foo'), new TaggedValue(array('foo' => 'bar', 'quz' => new TaggedValue(array('one' => 'bar'), 'bar')), '!quz')),
+                array(new TaggedValue('foo', array('foo', 'bar')), new TaggedValue('!quz', array('foo' => 'bar', 'quz' => new TaggedValue('bar', array('one' => 'bar'))))),
                 <<<YAML
 - !foo [foo, bar]
 - !!quz {foo: bar, quz: !bar {one: bar}}

--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -29,6 +29,10 @@ class Yaml
     const DUMP_OBJECT_AS_MAP = 64;
     const DUMP_MULTI_LINE_LITERAL_BLOCK = 128;
     const PARSE_CONSTANT = 256;
+
+    /**
+     * @experimental in version 3.3
+     */
     const PARSE_CUSTOM_TAGS = 512;
 
     /**

--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -29,6 +29,7 @@ class Yaml
     const DUMP_OBJECT_AS_MAP = 64;
     const DUMP_MULTI_LINE_LITERAL_BLOCK = 128;
     const PARSE_CONSTANT = 256;
+    const PARSE_CUSTOM_TAGS = 512;
 
     /**
      * Parses YAML into a PHP value.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/issues/21185
| License       | MIT
| Doc PR        | 

This PR adds custom tags support to the Yaml component.
Symfony tags (`!!binary`, `!str`, etc.) are still managed in the parser to have a lighter diff but we'll be able to convert them later if we want to.

The primary addition of this PR is the `TagInterface`:
```php
interface TagInterface
{
    public function construct(mixed $value): mixed;
}
```

It can be used to register custom tags. An example that could be used to convert [the syntax `=iterator`](https://github.com/symfony/symfony/pull/20907#issuecomment-270728216) to a tag:
```php
final class IteratorTag implements TagInterface
{
    public function construct(mixed $value): mixed
    {
        return new IteratorArgument($value);
    }
}

$parser = new Parser(['iterator' => new IteratorTag()]);
```

If you think this is too complex, @nicolas-grekas [proposed an alternative](https://github.com/symfony/symfony/issues/21185#issuecomment-271074840) to my proposal externalizing this support by introducing a new class `TaggedValue`.