### PR TITLE
[TwigBundle] Disable form in tests

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Tests/Functional/CacheWarmingTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Functional/CacheWarmingTest.php
@@ -90,6 +90,7 @@ class CacheWarmingKernel extends Kernel
         $loader->load(function ($container) {
             $container->loadFromExtension('framework', array(
                 'secret' => '$ecret',
+                'form' => array('enabled' => false),
             ));
         });
 
@@ -99,6 +100,7 @@ class CacheWarmingKernel extends Kernel
                     'secret' => '$ecret',
                     'templating' => array('engines' => array('twig')),
                     'router' => array('resource' => '%kernel.root_dir%/Resources/config/empty_routing.yml'),
+                    'form' => array('enabled' => false),
                 ));
             });
         }

--- a/src/Symfony/Bundle/TwigBundle/Tests/Functional/NoTemplatingEntryTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Functional/NoTemplatingEntryTest.php
@@ -62,6 +62,7 @@ class NoTemplatingEntryKernel extends Kernel
         $loader->load(function ($container) {
             $container->loadFromExtension('framework', array(
                 'secret' => '$ecret',
+                'form' => array('enabled' => false),
             ));
         });
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Tests are broken with high deps due to the changes made in #21196

> Symfony\Bundle\TwigBundle\Tests\NoTemplatingEntryTest::test
Symfony\Component\DependencyInjection\Exception\LogicException: Form support cannot be enabled as the Translation component is not installed.

> Symfony\Bundle\TwigBundle\Tests\NoTemplatingEntryTest::test
Symfony\Component\DependencyInjection\Exception\LogicException: The Validator component is required to use the Form component.

This will fix them.