### PR TITLE
[DependencyInjection] moved up ResolveClassPass in the container pass list

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -39,9 +39,14 @@ class PassConfig
     {
         $this->mergePass = new MergeExtensionConfigurationPass();
 
+        $this->beforeOptimizationPasses = array(
+            100 => array(
+                $resolveClassPass = new ResolveClassPass(),
+            ),
+        );
+
         $this->optimizationPasses = array(array(
             new ExtensionCompilerPass(),
-            $resolveClassPass = new ResolveClassPass(),
             new ResolveDefinitionTemplatesPass(),
             new DecoratorServicePass(),
             new ResolveParameterPlaceHoldersPass(),

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/PassConfigTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/PassConfigTest.php
@@ -29,6 +29,8 @@ class PassConfigTest extends \PHPUnit_Framework_TestCase
         $pass2 = $this->getMockBuilder(CompilerPassInterface::class)->getMock();
         $config->addPass($pass2, PassConfig::TYPE_BEFORE_OPTIMIZATION, 30);
 
-        $this->assertSame(array($pass2, $pass1), $config->getBeforeOptimizationPasses());
+        $passes = $config->getBeforeOptimizationPasses();
+        $this->assertSame($pass2, $passes[1]);
+        $this->assertSame($pass1, $passes[2]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | bug from #21133
| License       | MIT
| Doc PR        | n/a

Some compiler passes need access to the service class names. But when using an empty class name (the service id being the class name), the resolution happens too late (during the optimization step). This PR fixes this by moving up the ResolveClassPass earlier in the stack.
