### PR TITLE
[TwigBundle] fixed usage when Templating is not installed

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
@@ -45,7 +45,7 @@ class ExtensionPass implements CompilerPassInterface
         if ($container->has('form.extension')) {
             $container->getDefinition('twig.extension.form')->addTag('twig.extension');
             $reflClass = new \ReflectionClass('Symfony\Bridge\Twig\Extension\FormExtension');
-            $container->getDefinition('twig.loader.filesystem')->addMethodCall('addPath', array(dirname(dirname($reflClass->getFileName())).'/Resources/views/Form'));
+            $container->getDefinition('twig.loader.native_filesystem')->addMethodCall('addPath', array(dirname(dirname($reflClass->getFileName())).'/Resources/views/Form'));
         }
 
         if ($container->has('fragment.handler')) {
@@ -88,11 +88,13 @@ class ExtensionPass implements CompilerPassInterface
             $container->getDefinition('twig.extension.debug')->addTag('twig.extension');
         }
 
-        if (!$container->has('templating')) {
-            $loader = $container->getDefinition('twig.loader.native_filesystem');
-            $loader->addTag('twig.loader');
-            $loader->setMethodCalls($container->getDefinition('twig.loader.filesystem')->getMethodCalls());
+        $twigLoader = $container->getDefinition('twig.loader.native_filesystem');
+        if ($container->has('templating')) {
+            $loader = $container->getDefinition('twig.loader.filesystem');
+            $loader->setMethodCalls($twigLoader->getMethodCalls());
 
+            $twigLoader->clearTag('twig.loader');
+        } else {
             $container->setAlias('twig.loader.filesystem', new Alias('twig.loader.native_filesystem', false));
         }
 

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -77,7 +77,7 @@ class TwigExtension extends Extension
         $envConfiguratorDefinition->replaceArgument(4, $config['number_format']['decimal_point']);
         $envConfiguratorDefinition->replaceArgument(5, $config['number_format']['thousands_separator']);
 
-        $twigFilesystemLoaderDefinition = $container->getDefinition('twig.loader.filesystem');
+        $twigFilesystemLoaderDefinition = $container->getDefinition('twig.loader.native_filesystem');
 
         // register user-configured paths
         foreach ($config['paths'] as $path => $namespace) {

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/templating.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/templating.xml
@@ -10,8 +10,6 @@
             <tag name="twig.loader"/>
         </service>
 
-        <service id="twig.loader" alias="twig.loader.filesystem" />
-
         <service id="templating.engine.twig" class="%templating.engine.twig.class%" public="false">
             <argument type="service" id="twig" />
             <argument type="service" id="templating.name_parser" />

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -53,6 +53,7 @@
 
         <service id="twig.loader.native_filesystem" class="Twig_Loader_Filesystem" public="false">
             <argument type="collection" />
+            <tag name="twig.loader"/>
         </service>
 
         <service id="twig.loader.chain" class="%twig.loader.chain.class%" public="false"/>

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
@@ -187,7 +187,7 @@ class TwigExtensionTest extends TestCase
         $this->loadFromFile($container, 'extra', $format);
         $this->compileContainer($container);
 
-        $def = $container->getDefinition('twig.loader.filesystem');
+        $def = $container->getDefinition('twig.loader.native_filesystem');
         $paths = array();
         foreach ($def->getMethodCalls() as $call) {
             if ('addPath' === $call[0] && false === strpos($call[1][0], 'Form')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | bug introduced in #20799
| License       | MIT
| Doc PR        | n/a

In #20799, the decoupling of the Templating definition means that the `twig.loader.filesystem` is not always defined, but used in Extension. So, this PR does the opposite as what was done before. Use `twig.loader.native_filesystem` by default and copy paths to `twig.loader.filesystem` when templating is used.

/cc @xabbuh
