### PR TITLE
[Validator] Add object handling of invalid constraints in Composite

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Composite.php
+++ b/src/Symfony/Component/Validator/Constraints/Composite.php
@@ -69,6 +69,10 @@ abstract class Composite extends Constraint
 
         foreach ($nestedConstraints as $constraint) {
             if (!$constraint instanceof Constraint) {
+                if (is_object($constraint)) {
+                    $constraint = get_class($constraint);
+                }
+
                 throw new ConstraintDefinitionException(sprintf('The value %s is not an instance of Constraint in constraint %s', $constraint, get_class($this)));
             }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/CompositeTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CompositeTest.php
@@ -129,6 +129,17 @@ class CompositeTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
      */
+    public function testFailIfNoConstraintObject()
+    {
+        new ConcreteComposite(array(
+            new NotNull(array('groups' => 'Default')),
+            new \ArrayObject(),
+        ));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     */
     public function testValidCantBeNested()
     {
         new ConcreteComposite(array(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21206
| License       | MIT
| Doc PR        | n/a

This PR fixes a minor bug described in #21206. The constraint `Symfony\Component\Validator\Constraints\Composite` doesn't check in it's exception handling if the wrongly created instance of a nested constraint is an object, which is the expected type for a constraint.