### PR TITLE
[Console] Add a way to check if an argument/option was provided

### DIFF
--- a/src/Symfony/Component/Console/Input/Input.php
+++ b/src/Symfony/Component/Console/Input/Input.php
@@ -142,6 +142,22 @@ abstract class Input implements InputInterface, StreamableInputInterface
     }
 
     /**
+     * @param string $name
+     *
+     * @return bool True if the argument was provided for this input
+     *
+     * @throws InvalidArgumentException When no InputArgument exists in the InputDefinition with this name
+     */
+    public function isArgumentProvided($name)
+    {
+        if (!$this->definition->hasArgument($name)) {
+            throw new InvalidArgumentException(sprintf('The "%s" argument does not exist.', $name));
+        }
+
+        return array_key_exists($name, $this->arguments);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getOptions()
@@ -179,6 +195,22 @@ abstract class Input implements InputInterface, StreamableInputInterface
     public function hasOption($name)
     {
         return $this->definition->hasOption($name);
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return bool True if the option was provided for this input
+     *
+     * @throws InvalidArgumentException When no InputOption exists in the InputDefinition with this name
+     */
+    public function isOptionProvided($name)
+    {
+        if (!$this->definition->hasOption($name)) {
+            throw new InvalidArgumentException(sprintf('The "%s" option does not exist.', $name));
+        }
+
+        return array_key_exists($name, $this->options);
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Input/InputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputTest.php
@@ -137,4 +137,46 @@ class InputTest extends \PHPUnit_Framework_TestCase
         $input->setStream($stream);
         $this->assertSame($stream, $input->getStream());
     }
+
+    public function testIsArgumentProvided()
+    {
+        $definition = new InputDefinition(array(new InputArgument('name')));
+
+        $input = new ArrayInput(array(), $definition);
+        $this->assertFalse($input->isArgumentProvided('name'));
+
+        $input = new ArrayInput(array('name' => 'foo'), $definition);
+        $this->assertTrue($input->isArgumentProvided('name'));
+    }
+
+    /**
+     * @expectedException        \Symfony\Component\Console\Exception\InvalidArgumentException
+     * @expectedExceptionMessage The "name" argument does not exist.
+     */
+    public function testIsArgumentProvidedThrowsOnUndefinedArgument()
+    {
+        $input = new ArrayInput(array(), new InputDefinition());
+        $input->isArgumentProvided('name');
+    }
+
+    public function testIsOptionProvided()
+    {
+        $definition = new InputDefinition(array(new InputOption('bar')));
+
+        $input = new ArrayInput(array(), $definition);
+        $this->assertFalse($input->isOptionProvided('bar'));
+
+        $input = new ArrayInput(array('--bar' => 'foo'), $definition);
+        $this->assertTrue($input->isOptionProvided('bar'));
+    }
+
+    /**
+     * @expectedException        \Symfony\Component\Console\Exception\InvalidArgumentException
+     * @expectedExceptionMessage The "bar" option does not exist.
+     */
+    public function testIsOptionProvidedThrowsOnUndefinedOption()
+    {
+        $input = new ArrayInput(array(), new InputDefinition());
+        $input->isOptionProvided('bar');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #17597
| License       | MIT
| Doc PR        | todo

#17597 was closed by making the docblock clearer, but the feature is still interesting IMHO.
I think it's fine without interface, and I don't have a good name for a new one anyway.

Regarding the methods naming, I hesitated between:

1. `is(Argument/Option)Provided`
1. `is(Argument/Option)Given`