### PR TITLE
[DI] Allow ~ instead of {} for services in Yaml

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -220,6 +220,10 @@ class YamlFileLoader extends FileLoader
             return;
         }
 
+        if (null === $service) {
+            $service = array();
+        }
+
         if (!is_array($service)) {
             throw new InvalidArgumentException(sprintf('A service definition must be an array or a string starting with "@" but %s found for service "%s" in %s. Check your YAML syntax.', gettype($service), $id, $file));
         }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services28.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services28.yml
@@ -5,6 +5,8 @@ services:
         tags:
             - name: foo
 
+    Acme\Foo: ~
+
     with_defaults:
         class: Foo
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Now we can omit the class name, Yaml config can look like this:
```yaml
services:
    AppBundle\Something: {}
```

While this works, the consistent way in Symfony for such cases is to use `~`. This PR allows to use `~` as well, ending up with:
```yaml
services:
    AppBundle\Something: ~
```