### PR TITLE
[Form] DateTimeToLocalizedStringTransformer does not use timezone when using date only

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
@@ -130,11 +130,11 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
         try {
             if ($dateOnly) {
                 // we only care about year-month-date, which has been delivered as a timestamp pointing to UTC midnight
-                return new \DateTime(gmdate('Y-m-d', $timestamp), new \DateTimeZone($this->inputTimezone));
+                $dateTime = new \DateTime(gmdate('Y-m-d', $timestamp), new \DateTimeZone($this->outputTimezone));
+            } else {
+                // read timestamp into DateTime object - the formatter delivers a timestamp
+                $dateTime = new \DateTime(sprintf('@%s', $timestamp));
             }
-
-            // read timestamp into DateTime object - the formatter delivers a timestamp
-            $dateTime = new \DateTime(sprintf('@%s', $timestamp));
             // set timezone separately, as it would be ignored if set via the constructor,
             // see http://php.net/manual/en/datetime.construct.php
             $dateTime->setTimezone(new \DateTimeZone($this->outputTimezone));

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
@@ -240,6 +240,15 @@ class DateTimeToLocalizedStringTransformerTest extends DateTimeTestCase
         $this->assertDateTimeEquals($dateTime, $transformer->reverseTransform('03.02.2010, 04:05'));
     }
 
+    public function testReverseTransformOnlyDateWithDifferentTimezones()
+    {
+        $transformer = new DateTimeToLocalizedStringTransformer('Europe/Berlin', 'Pacific/Tahiti', \IntlDateFormatter::FULL, \IntlDateFormatter::FULL, \IntlDateFormatter::GREGORIAN, 'yyyy-MM-dd');
+
+        $dateTime = new \DateTime('2017-01-10 11:00', new \DateTimeZone('Europe/Berlin'));
+
+        $this->assertDateTimeEquals($dateTime, $transformer->reverseTransform('2017-01-10'));
+    }
+
     public function testReverseTransformWithDifferentPatterns()
     {
         $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', \IntlDateFormatter::FULL, \IntlDateFormatter::FULL, \IntlDateFormatter::GREGORIAN, 'MM*yyyy*dd HH|mm|ss');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21217
| License       | MIT

The `DateTimeToLocalizedStringTransformer` when used with a pattern that have only date (in `DateType` for instance) does not convert the result in the desired output

Reproduction steps:
- Use `DateType` in a form
- Set the `model_timezone` to `Pacific/Tahiti`, having default timezone to `Europe/Berlin`.
- Enter the date `2017-01-10`
- Submit the form
- Notice that the received data is `2017-01-10 00:00 Europe/Berlin`, whereas it should be `2017-01-10 11:00 Europe/Berlin`
