### PR TITLE
[DI] Fix missing new line after private alias

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -165,7 +165,7 @@ class YamlDumper extends Dumper
             return sprintf("    %s: '@%s'\n", $alias, $id);
         }
 
-        return sprintf("    %s:\n        alias: %s\n        public: false", $alias, $id);
+        return sprintf("    %s:\n        alias: %s\n        public: false\n", $alias, $id);
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services6.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services6.yml
@@ -23,6 +23,8 @@ services:
     another_alias_for_foo:
         alias: foo
         public: false
+    another_third_alias_for_foo:
+        alias: foo
     decorator_service:
         decorates: decorated
     decorator_service_with_name:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/symfony/symfony/pull/21219#discussion_r95220565
| License       | MIT
| Doc PR        | N/A

Without this change, the output is:

```yml
# [...]
alias_for_foo: '@foo'
another_alias_for_foo:
    alias: foo
    public: false    another_third_alias_for_foo: '@foo' # <--- missing new line after `public: false`
```

(this is tested by the `CrossCheckTest` but there is no fixture file to update (automatically dumped and removed by the test case))