### PR TITLE
[PHPUnitBridge] Cross compatibility between PHPUnit 5 and 6

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Compat/Framework/AssertionFailedError.php
+++ b/src/Symfony/Bridge/PhpUnit/Compat/Framework/AssertionFailedError.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Compat\Framework;
+
+if (class_exists('PHPUnit\Framework\AssertionFailedError')) {
+    /**
+     * Class AssertionFailedError
+     * @package Symfony\Bridge\PhpUnit\Compat\Framework
+     * @internal
+     */
+    class AssertionFailedError extends \PHPUnit\Framework\AssertionFailedError
+    {}
+} else {
+    /**
+     * Class AssertionFailedError
+     * @package Symfony\Bridge\PhpUnit\Compat\Framework
+     * @internal
+     */
+    class AssertionFailedError extends \PHPUnit_Framework_AssertionFailedError
+    {}
+}

--- a/src/Symfony/Bridge/PhpUnit/Compat/Framework/BaseTestListener.php
+++ b/src/Symfony/Bridge/PhpUnit/Compat/Framework/BaseTestListener.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Compat\Framework;
+
+if (class_exists('PHPUnit\Framework\BaseTestListener')) {
+    /**
+     * Class BaseTestListener
+     * @package Symfony\Bridge\PhpUnit\Compat\Framework
+     * @internal
+     */
+    abstract class BaseTestListener extends \PHPUnit\Framework\BaseTestListener
+    {}
+} else {
+    /**
+     * Class BaseTestListener
+     * @package Symfony\Bridge\PhpUnit\Compat\Framework
+     * @internal
+     */
+    abstract class BaseTestListener extends \PHPUnit_Framework_BaseTestListener
+    {}
+}

--- a/src/Symfony/Bridge/PhpUnit/Compat/Framework/TestCase.php
+++ b/src/Symfony/Bridge/PhpUnit/Compat/Framework/TestCase.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Compat\Framework;
+
+if (class_exists('PHPUnit\Framework\TestCase')) {
+    /**
+     * Class TestCase
+     * @package Symfony\Bridge\PhpUnit\Compat\Framework
+     * @internal
+     */
+    class TestCase extends \PHPUnit\Framework\TestCase
+    {}
+} else {
+    /**
+     * Class TestCase
+     * @package Symfony\Bridge\PhpUnit\Compat\Framework
+     * @internal
+     */
+    class TestCase extends \PHPUnit_Framework_TestCase
+    {}
+}

--- a/src/Symfony/Bridge/PhpUnit/Compat/Framework/Warning.php
+++ b/src/Symfony/Bridge/PhpUnit/Compat/Framework/Warning.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Compat\Framework;
+
+if (class_exists('PHPUnit\Framework\Warning')) {
+    /**
+     * Class Warning
+     * @package Symfony\Bridge\PhpUnit\Compat\Framework
+     * @internal
+     */
+    class Warning extends \PHPUnit\Framework\Warning
+    {}
+} else {
+    /**
+     * Class Warning
+     * @package Symfony\Bridge\PhpUnit\Compat\Framework
+     * @internal
+     */
+    class Warning extends \PHPUnit_Framework_Warning
+    {}
+}

--- a/src/Symfony/Bridge/PhpUnit/Compat/Runner/BaseTestRunner.php
+++ b/src/Symfony/Bridge/PhpUnit/Compat/Runner/BaseTestRunner.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Compat\Runner;
+
+if (class_exists('PHPUnit\Runner\BaseTestRunner')) {
+    /**
+     * Class BaseTestRunner
+     * @package Symfony\Bridge\PhpUnit\Compat\Runner
+     * @internal
+     */
+    abstract class BaseTestRunner extends \PHPUnit\Runner\BaseTestRunner
+    {}
+} else {
+    /**
+     * Class BaseTestRunner
+     * @package Symfony\Bridge\PhpUnit\Compat\Runner
+     * @internal
+     */
+    abstract class BaseTestRunner extends \PHPUnit_Runner_BaseTestRunner
+    {}
+}

--- a/src/Symfony/Bridge/PhpUnit/Compat/TextUI/Command.php
+++ b/src/Symfony/Bridge/PhpUnit/Compat/TextUI/Command.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Compat\TextUI;
+
+if (class_exists('PHPUnit\TextUI\Command')) {
+    /**
+     * Class Command
+     * @package Symfony\Bridge\PhpUnit\Compat\TextUI
+     * @internal
+     */
+    class Command extends \PHPUnit\TextUI\Command
+    {}
+} else {
+    /**
+     * Class Command
+     * @package Symfony\Bridge\PhpUnit\Compat\TextUI
+     * @internal
+     */
+    class Command extends \PHPUnit_TextUI_Command
+    {}
+}

--- a/src/Symfony/Bridge/PhpUnit/Compat/TextUI/TestRunner.php
+++ b/src/Symfony/Bridge/PhpUnit/Compat/TextUI/TestRunner.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Compat\TextUI;
+
+if (class_exists('PHPUnit\TextUI\TestRunner')) {
+    /**
+     * Class TestRunner
+     * @package Symfony\Bridge\PhpUnit\Compat\TextUI
+     * @internal
+     */
+    class TestRunner extends \PHPUnit\TextUI\TestRunner
+    {}
+} else {
+    /**
+     * Class TestRunner
+     * @package Symfony\Bridge\PhpUnit\Compat\TextUI
+     * @internal
+     */
+    class TestRunner extends \PHPUnit_TextUI_TestRunner
+    {}
+}

--- a/src/Symfony/Bridge/PhpUnit/Compat/Util/Blacklist.php
+++ b/src/Symfony/Bridge/PhpUnit/Compat/Util/Blacklist.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Compat\Util;
+
+if (class_exists('PHPUnit\Util\Blacklist')) {
+    /**
+     * Class Blacklist
+     * @package Symfony\Bridge\PhpUnit\Compat\Util
+     * @internal
+     */
+    class Blacklist extends \PHPUnit\Util\Blacklist
+    {}
+} else {
+    /**
+     * Class Blacklist
+     * @package Symfony\Bridge\PhpUnit\Compat\Util
+     * @internal
+     */
+    class Blacklist extends \PHPUnit_Util_Blacklist
+    {}
+}

--- a/src/Symfony/Bridge/PhpUnit/Compat/Util/ErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/Compat/Util/ErrorHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Compat\Util;
+
+if (class_exists('PHPUnit\Util\ErrorHandler')) {
+    /**
+     * Class ErrorHandler
+     * @package Symfony\Bridge\PhpUnit\Compat\Util
+     * @internal
+     */
+    class ErrorHandler extends \PHPUnit\Util\ErrorHandler
+    {}
+} else {
+    /**
+     * Class ErrorHandler
+     * @package Symfony\Bridge\PhpUnit\Compat\Util
+     * @internal
+     */
+    class ErrorHandler extends \PHPUnit_Util_ErrorHandler
+    {}
+}

--- a/src/Symfony/Bridge/PhpUnit/Compat/Util/Test.php
+++ b/src/Symfony/Bridge/PhpUnit/Compat/Util/Test.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Compat\Util;
+
+if (class_exists('PHPUnit\Util\Test')) {
+    /**
+     * Class Test
+     * @package Symfony\Bridge\PhpUnit\Compat\Util
+     * @internal
+     */
+    class Test extends \PHPUnit\Util\Test
+    {}
+} else {
+    /**
+     * Class Test
+     * @package Symfony\Bridge\PhpUnit\Compat\Util
+     * @internal
+     */
+    class Test extends \PHPUnit_Util_Test
+    {}
+}

--- a/src/Symfony/Bridge/PhpUnit/SymfonyTestsListener.php
+++ b/src/Symfony/Bridge/PhpUnit/SymfonyTestsListener.php
@@ -285,7 +285,7 @@ class SymfonyTestsListener extends BaseTestListener
 
     private function assertIsInstanceOfTest($test)
     {
-        if (!$test instanceof \PHPUnit_Framework_Test || !$test instanceof Test) {
+        if (!$this->isInstanceOfTest($test)) {
             $argType = is_object($test) ? get_class($test) : gettype($test);
             throw new \InvalidArgumentException('Wrong parameter: expected \PHPUnit_Framework_Test or PHPUnit\Framework\Test, got ' . $argType);
         }
@@ -301,7 +301,7 @@ class SymfonyTestsListener extends BaseTestListener
 
     private function assertIsInstanceOfWarning($warning)
     {
-        if (!$warning instanceof \PHPUnit_Framework_Warning || !$warning instanceof Warning) {
+        if (!$this->isInstanceOfWarning($warning)) {
             $argType = is_object($warning) ? get_class($warning) : gettype($warning);
             throw new \InvalidArgumentException('Wrong parameter: expected \PHPUnit_Framework_Warning or PHPUnit\Framework\Warning, got ' . $argType);
         }
@@ -309,11 +309,53 @@ class SymfonyTestsListener extends BaseTestListener
 
     private function isInstanceOfTestSuite($testSuite)
     {
-        return $testSuite instanceof \PHPUnit_Framework_TestSuite || $testSuite instanceof TestSuite;
+        if (class_exists(\PHPUnit_Framework_TestSuite::class)) {
+            return $testSuite instanceof \PHPUnit_Framework_TestSuite;
+        }
+
+        if (class_exists(TestSuite::class)) {
+            return $testSuite instanceof TestSuite;
+        }
+        
+        return false;
     }
 
     private function isInstanceOfTestCase($testCase)
     {
-        return $testCase instanceof \PHPUnit_Framework_TestCase || $testCase instanceof TestCase;
+        if (class_exists(\PHPUnit_Framework_TestCase::class)) {
+            return $testCase instanceof \PHPUnit_Framework_TestCase;
+        }
+
+        if (class_exists(TestCase::class)) {
+            return $testCase instanceof TestCase;
+        }
+
+        return false;
+    }
+
+    private function isInstanceOfWarning($warning)
+    {
+        if (class_exists(\PHPUnit_Framework_Warning::class)) {
+            return $warning instanceof \PHPUnit_Framework_Warning;
+        }
+
+        if (class_exists(Warning::class)) {
+            return $warning instanceof Warning;
+        }
+
+        return false;
+    }
+
+    private function isInstanceOfTest($test)
+    {
+        if (class_exists(\PHPUnit_Framework_Test::class)) {
+            return $test instanceof \PHPUnit_Framework_Test;
+        }
+
+        if (class_exists(Test::class)) {
+            return $test instanceof Test;
+        }
+
+        return false;
     }
 }

--- a/src/Symfony/Bridge/PhpUnit/Tests/DnsMockTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DnsMockTest.php
@@ -11,9 +11,10 @@
 
 namespace Symfony\Bridge\PhpUnit\Tests;
 
+use Symfony\Bridge\PhpUnit\Compat\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\DnsMock;
 
-class DnsMockTest extends \PHPUnit_Framework_TestCase
+class DnsMockTest extends TestCase
 {
     protected function tearDown()
     {

--- a/src/Symfony/Bridge/PhpUnit/TextUI/Command.php
+++ b/src/Symfony/Bridge/PhpUnit/TextUI/Command.php
@@ -14,7 +14,7 @@ namespace Symfony\Bridge\PhpUnit\TextUI;
 /**
  * {@inheritdoc}
  */
-class Command extends \PHPUnit_TextUI_Command
+class Command extends \Symfony\Bridge\PhpUnit\Compat\TextUI\Command
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Bridge/PhpUnit/TextUI/TestRunner.php
+++ b/src/Symfony/Bridge/PhpUnit/TextUI/TestRunner.php
@@ -16,7 +16,7 @@ use Symfony\Bridge\PhpUnit\SymfonyTestsListener;
 /**
  * {@inheritdoc}
  */
-class TestRunner extends \PHPUnit_TextUI_TestRunner
+class TestRunner extends \Symfony\Bridge\PhpUnit\Compat\TextUI\TestRunner
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Bridge/PhpUnit/bootstrap.php
+++ b/src/Symfony/Bridge/PhpUnit/bootstrap.php
@@ -13,7 +13,7 @@ use Doctrine\Common\Annotations\AnnotationRegistry;
 use Symfony\Bridge\PhpUnit\DeprecationErrorHandler;
 
 // Detect if we're loaded by an actual run of phpunit
-if (!defined('PHPUNIT_COMPOSER_INSTALL') && !class_exists('PHPUnit_TextUI_Command', false)) {
+if (!defined('PHPUNIT_COMPOSER_INSTALL') && !class_exists('PHPUnit_TextUI_Command', false) && !class_exists('PHPUnit\TextUI\Command', false)) {
     return;
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21125
| License       | MIT

This is a new approach after I failed with #21158. I used a mixed approach of extending classes and using the original ones, since I need to avoid breaking BC in every possible scenario.

I copied the compat classes from the previous PR, so I'm following all the review request done there.