### PR TITLE
[Console] Explicitly passed options without value (or empty) should remain empty

### DIFF
--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -6,6 +6,62 @@ ClassLoader
 
  * The component is deprecated and will be removed in 4.0. Use Composer instead.
 
+Console
+-------
+
+* `Input::getOption()` no longer returns the default value for options
+  with value optional explicitly passed empty.
+
+  For:
+
+  ```php
+  protected function configure()
+  {
+      $this
+          // ...
+          ->setName('command')
+          ->addOption('foo', null, InputOption::VALUE_OPTIONAL, '', 'default')
+       ;
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output)
+  {
+      var_dump($input->getOption('foo'));
+  }
+  ```
+
+  Before:
+
+  ```
+  $ php console.php command
+  "default"
+
+  $ php console.php command --foo
+  "default"
+
+  $ php console.php command --foo ""
+  "default"
+
+  $ php console.php command --foo=
+  "default"
+  ```
+
+  After:
+
+  ```
+  $ php console.php command
+  "default"
+
+  $ php console.php command --foo
+  NULL
+
+  $ php console.php command --foo ""
+  ""
+
+  $ php console.php command --foo=
+  ""
+  ```
+
 Debug
 -----
 

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
 * added `ExceptionListener`
 * added `AddConsoleCommandPass` (originally in FrameworkBundle)
+* [BC BREAK] `Input::getOption()` no longer returns the default value for options
+  with value optional explicitly passed empty
 
 3.2.0
 ------

--- a/src/Symfony/Component/Console/Input/ArrayInput.php
+++ b/src/Symfony/Component/Console/Input/ArrayInput.php
@@ -179,7 +179,9 @@ class ArrayInput extends Input
                 throw new InvalidOptionException(sprintf('The "--%s" option requires a value.', $name));
             }
 
-            $value = $option->isValueOptional() ? $option->getDefault() : true;
+            if (!$option->isValueOptional()) {
+                $value = true;
+            }
         }
 
         $this->options[$name] = $value;

--- a/src/Symfony/Component/Console/Input/Input.php
+++ b/src/Symfony/Component/Console/Input/Input.php
@@ -158,7 +158,7 @@ abstract class Input implements InputInterface, StreamableInputInterface
             throw new InvalidArgumentException(sprintf('The "%s" option does not exist.', $name));
         }
 
-        return isset($this->options[$name]) ? $this->options[$name] : $this->definition->getOption($name)->getDefault();
+        return array_key_exists($name, $this->options) ? $this->options[$name] : $this->definition->getOption($name)->getDefault();
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
@@ -48,7 +48,7 @@ class ArgvInputTest extends TestCase
         $input = new ArgvInput($input);
         $input->bind(new InputDefinition($options));
 
-        $this->assertEquals($expectedOptions, $input->getOptions(), $message);
+        $this->assertSame($expectedOptions, $input->getOptions(), $message);
     }
 
     public function provideOptions()
@@ -75,14 +75,32 @@ class ArgvInputTest extends TestCase
             array(
                 array('cli.php', '--foo='),
                 array(new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL)),
-                array('foo' => null),
-                '->parse() parses long options with optional value which is empty (with a = separator) as null',
+                array('foo' => ''),
+                '->parse() parses long options with optional value which is empty (with a = separator) as empty string',
             ),
             array(
                 array('cli.php', '--foo=', 'bar'),
                 array(new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL), new InputArgument('name', InputArgument::REQUIRED)),
+                array('foo' => ''),
+                '->parse() parses long options with optional value without value specified or an empty string (with a = separator) followed by an argument as empty string',
+            ),
+            array(
+                array('cli.php', 'bar', '--foo'),
+                array(new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL), new InputArgument('name', InputArgument::REQUIRED)),
                 array('foo' => null),
-                '->parse() parses long options with optional value which is empty (with a = separator) followed by an argument',
+                '->parse() parses long options with optional value which is empty (with a = separator) preceded by an argument',
+            ),
+            array(
+                array('cli.php', '--foo', '', 'bar'),
+                array(new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL), new InputArgument('name', InputArgument::REQUIRED)),
+                array('foo' => ''),
+                '->parse() parses long options with optional value which is empty as empty string even followed by an argument',
+            ),
+            array(
+                array('cli.php', '--foo'),
+                array(new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL)),
+                array('foo' => null),
+                '->parse() parses long options with optional value specified with no separator and no value as null',
             ),
             array(
                 array('cli.php', '-f'),
@@ -252,14 +270,14 @@ class ArgvInputTest extends TestCase
 
         $input = new ArgvInput(array('cli.php', '--name=foo', '--name=bar', '--name='));
         $input->bind(new InputDefinition(array(new InputOption('name', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY))));
-        $this->assertSame(array('name' => array('foo', 'bar', null)), $input->getOptions(), '->parse() parses empty array options as null ("--option=value" syntax)');
+        $this->assertSame(array('name' => array('foo', 'bar', '')), $input->getOptions(), '->parse() parses empty array options as null ("--option=value" syntax)');
 
         $input = new ArgvInput(array('cli.php', '--name', 'foo', '--name', 'bar', '--name', '--anotherOption'));
         $input->bind(new InputDefinition(array(
             new InputOption('name', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY),
             new InputOption('anotherOption', null, InputOption::VALUE_NONE),
         )));
-        $this->assertSame(array('name' => array('foo', 'bar', null), 'anotherOption' => true), $input->getOptions(), '->parse() parses empty array options as null ("--option value" syntax)');
+        $this->assertSame(array('name' => array('foo', 'bar', null), 'anotherOption' => true), $input->getOptions(), '->parse() parses empty array options ("--option value" syntax)');
     }
 
     public function testParseNegativeNumberAfterDoubleDash()

--- a/src/Symfony/Component/Console/Tests/Input/ArrayInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArrayInputTest.php
@@ -90,9 +90,15 @@ class ArrayInputTest extends TestCase
                 '->parse() parses long options with a default value',
             ),
             array(
-                array('--foo' => null),
+                array(),
                 array(new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL, '', 'default')),
                 array('foo' => 'default'),
+                '->parse() uses the default value for long options with value optional which are not passed',
+            ),
+            array(
+                array('--foo' => null),
+                array(new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL, '', 'default')),
+                array('foo' => null),
                 '->parse() parses long options with a default value',
             ),
             array(

--- a/src/Symfony/Component/Console/Tests/Input/InputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputTest.php
@@ -37,6 +37,14 @@ class InputTest extends TestCase
         $input = new ArrayInput(array('--name' => 'foo'), new InputDefinition(array(new InputOption('name'), new InputOption('bar', '', InputOption::VALUE_OPTIONAL, '', 'default'))));
         $this->assertEquals('default', $input->getOption('bar'), '->getOption() returns the default value for optional options');
         $this->assertEquals(array('name' => 'foo', 'bar' => 'default'), $input->getOptions(), '->getOptions() returns all option values, even optional ones');
+
+        $input = new ArrayInput(array('--name' => 'foo', '--bar' => ''), new InputDefinition(array(new InputOption('name'), new InputOption('bar', '', InputOption::VALUE_OPTIONAL, '', 'default'))));
+        $this->assertEquals('', $input->getOption('bar'), '->getOption() returns null for options explicitly passed without value (or an empty value)');
+        $this->assertEquals(array('name' => 'foo', 'bar' => ''), $input->getOptions(), '->getOptions() returns all option values.');
+
+        $input = new ArrayInput(array('--name' => 'foo', '--bar' => null), new InputDefinition(array(new InputOption('name'), new InputOption('bar', '', InputOption::VALUE_OPTIONAL, '', 'default'))));
+        $this->assertNull($input->getOption('bar'), '->getOption() returns null for options explicitly passed without value (or an empty value)');
+        $this->assertEquals(array('name' => 'foo', 'bar' => null), $input->getOptions(), '->getOptions() returns all option values');
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21215 https://github.com/symfony/symfony/issues/11572 https://github.com/symfony/symfony/pull/12773
| License       | MIT
| Doc PR        | n/a (maybe look at updating the existing one)

This conserves empty values for options instead of returning their default values.

Code:
```php
// cli.php
$application = new Application();
$application
    ->register('echo')
    ->addOption('prefix', null, InputOption::VALUE_OPTIONAL, null, 'my-default')
    ->addArgument('value', InputArgument::REQUIRED)
    ->setCode(function ($input, $output) {
        var_dump($input->getOption('prefix'));
    });
$application->run();
```

Before:
![before](http://image.prntscr.com/image/157d9c6c054240da8b0dce54c9ce24d6.png)

After:
![after](http://image.prntscr.com/image/4aeded77f8084d3c985687fc8cc7b54e.png)
