### PR TITLE
[FrameworkBundle] allow to reference files directly from kernel.root_dir

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -52,6 +52,9 @@
         <service id="file_locator" class="Symfony\Component\HttpKernel\Config\FileLocator">
             <argument type="service" id="kernel" />
             <argument>%kernel.root_dir%/Resources</argument>
+            <argument type="collection">
+                <argument>%kernel.root_dir%</argument>
+            </argument>
         </service>
 
         <service id="uri_signer" class="Symfony\Component\HttpKernel\UriSigner">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

While working on a bundleless app, I want to be able to reference a directory for routing annotations like this:

```yaml
app:
    resource: "../src/Controller/"
    type: annotation
```

but that does not work because Symfony expects a bundle resource (`@AppBundle...`) or a directory referenced from the main app `Resources` directory. But as I don't have such a directory, even using `../../src/Controller` does not work.

So, I propose to add the %kernel.root_dir% to the list of allowed directories.

By the way, we don't have the same issue with the routing annotation **file** loader as it does not use the locator for whatever reason. Should we fix it?


