### PR TITLE
[FrameworkBundle] removed a deprecation notice when using autowiring (on kernel.class_cache.cache_warmer)

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ClassCacheCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ClassCacheCacheWarmer.php
@@ -11,10 +11,6 @@
 
 namespace Symfony\Bundle\FrameworkBundle\CacheWarmer;
 
-if (PHP_VERSION_ID >= 70000) {
-    @trigger_error('The '.__NAMESPACE__.'\ClassCacheCacheWarmer class is deprecated since version 3.3 and will be removed in 4.0.', E_USER_DEPRECATED);
-}
-
 use Symfony\Component\ClassLoader\ClassCollectionLoader;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 
@@ -31,6 +27,10 @@ class ClassCacheCacheWarmer implements CacheWarmerInterface
 
     public function __construct(array $declaredClasses = null)
     {
+        if (PHP_VERSION_ID >= 70000) {
+            @trigger_error('The '.__CLASS__.' class is deprecated since version 3.3 and will be removed in 4.0.', E_USER_DEPRECATED);
+        }
+
         $this->declaredClasses = $declaredClasses;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

When using autowiring, Symfony uses reflection to list all available classes. So, each class is loaded, and for the `ClassCacheCacheWarmer`, it means that a deprecation notice is triggered. So, I've moved it to when an instance is created instead.
