### PR TITLE
[FrameworkBundle] Prevent an error when the console component isn't installed

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -80,7 +80,9 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new TemplatingPass());
         $container->addCompilerPass(new AddConstraintValidatorsPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $container->addCompilerPass(new AddValidatorInitializersPass());
-        $container->addCompilerPass(new AddConsoleCommandPass());
+        if (class_exists(AddConsoleCommandPass::class)) {
+            $container->addCompilerPass(new AddConsoleCommandPass());
+        }
         $container->addCompilerPass(new FormPass());
         $container->addCompilerPass(new TranslatorPass());
         $container->addCompilerPass(new LoggingTranslatorPass());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21246
| License       | MIT
| Doc PR        |n/a

Finish #19443. Alternative to #21246.