### PR TITLE
[Profiler] Fix inline dump rendering

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/profiler.css.twig
@@ -922,6 +922,9 @@ table.logs .metadata {
     font-size: inherit;
     line-height: inherit;
 }
+#collector-content .dump-inline .sf-dump:after {
+    display: none;
+}
 
 #collector-content .sf-dump .trace {
     font-size: 12px;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

I introduced a minor rendering issue in #21109 when adding a clearfix behavior to the `pre.sf-dump` element:

|Before|After|
|-------|-----|
|
<img width="890" alt="screenshot 2017-01-12 a 19 57 34" src="https://cloud.githubusercontent.com/assets/2211145/21903782/6989eb36-d901-11e6-8f02-99c4a8356725.PNG">|<img width="892" alt="screenshot 2017-01-12 a 19 52 56" src="https://cloud.githubusercontent.com/assets/2211145/21903721/407d3bbc-d901-11e6-901b-3f5b65bee650.PNG">|

This will fix the issue by removing it, as we don't need this behavior for inline dumps.