### PR TITLE
[FrameworkBundle] Skip test if xdebug.file_link_format is defined.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -318,6 +318,10 @@ abstract class FrameworkExtensionTest extends TestCase
 
     public function testFileLinkFormat()
     {
+        if (ini_get('xdebug.file_link_format') || get_cfg_var('xdebug.file_link_format')) {
+            $this->markTestSkipped('A custom file_link_format is defined.');
+        }
+
         $container = $this->createContainerFromFile('full');
 
         $this->assertEquals('file%link%format', $container->getParameter('templating.helper.code.file_link_format'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

--- 

The test suite does not pass locally because I use a custom
file_link_format. I do it because it works everywhere.

Then, Symfony tries to read this value before the default one.
We could use ini_set before the test but unfortunatelly there are no way
to define the "cfg_var". For recall, get_cfg_var allows to return the
configuration value even if the extension is not loaded. And again it's
my case: I don't enable xdebug to have better performance.