### PR TITLE
DX: remove invalid inheritdoc

### DIFF
--- a/src/Symfony/Component/Intl/Data/Generator/AbstractDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/AbstractDataGenerator.php
@@ -42,9 +42,6 @@ abstract class AbstractDataGenerator
         $this->dirName = $dirName;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function generateData(GeneratorConfig $config)
     {
         $filesystem = new Filesystem();

--- a/src/Symfony/Component/Intl/Data/Generator/LocaleDataGenerator.php
+++ b/src/Symfony/Component/Intl/Data/Generator/LocaleDataGenerator.php
@@ -57,9 +57,6 @@ class LocaleDataGenerator
         $this->regionDataProvider = $regionDataProvider;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function generateData(GeneratorConfig $config)
     {
         $filesystem = new Filesystem();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | not related
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

those classes do not extend anything, inherit docs on them are wrong