### PR TITLE
[DI] Implement PSR-11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "doctrine/common": "~2.4",
         "twig/twig": "~1.28|~2.0",
         "psr/cache": "~1.0",
+        "psr/container": "^1.0",
         "psr/log": "~1.0",
         "psr/simple-cache": "^1.0",
         "symfony/polyfill-intl-icu": "~1.0",
@@ -102,6 +103,7 @@
     },
     "provide": {
         "psr/cache-implementation": "1.0",
+        "psr/container-implementation": "1.0",
         "psr/simple-cache-implementation": "1.0"
     },
     "autoload": {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -40,6 +40,7 @@
             <argument type="collection" />
         </service>
 
+        <service id="Psr\Container\ContainerInterface" alias="service_container" public="false" />
         <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false" />
         <service id="Symfony\Component\DependencyInjection\Container" alias="service_container" public="false" />
 

--- a/src/Symfony/Component/DependencyInjection/ContainerInterface.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerInterface.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection;
 
+use Psr\Container\ContainerInterface as PsrContainerInterface;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
@@ -21,7 +22,7 @@ use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-interface ContainerInterface
+interface ContainerInterface extends PsrContainerInterface
 {
     const EXCEPTION_ON_INVALID_REFERENCE = 1;
     const NULL_ON_INVALID_REFERENCE = 2;

--- a/src/Symfony/Component/DependencyInjection/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Exception/ExceptionInterface.php
@@ -11,12 +11,14 @@
 
 namespace Symfony\Component\DependencyInjection\Exception;
 
+use Psr\Container\ContainerExceptionInterface;
+
 /**
  * Base ExceptionInterface for Dependency Injection component.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Bulat Shakirzyanov <bulat@theopenskyproject.com>
  */
-interface ExceptionInterface
+interface ExceptionInterface extends ContainerExceptionInterface
 {
 }

--- a/src/Symfony/Component/DependencyInjection/Exception/ServiceNotFoundException.php
+++ b/src/Symfony/Component/DependencyInjection/Exception/ServiceNotFoundException.php
@@ -11,12 +11,14 @@
 
 namespace Symfony\Component\DependencyInjection\Exception;
 
+use Psr\Container\NotFoundExceptionInterface;
+
 /**
  * This exception is thrown when a non-existent service is requested.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class ServiceNotFoundException extends InvalidArgumentException
+class ServiceNotFoundException extends InvalidArgumentException implements NotFoundExceptionInterface
 {
     private $id;
     private $sourceId;

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -16,7 +16,8 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9"
+        "php": ">=5.5.9",
+        "psr/container": "^1.0"
     },
     "require-dev": {
         "symfony/yaml": "~3.2",
@@ -31,6 +32,9 @@
     },
     "conflict": {
         "symfony/yaml": "<3.2"
+    },
+    "provide": {
+        "psr/container-implementation": "1.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\DependencyInjection\\": "" },


### PR DESCRIPTION
TODO:

- [x] wait for a stable version of the psr/container package;
- [x] ~~deprecate instanciating ServiceNotFoundException directly, or using any of its methods directly;~~ not relevant anymore
- [x] act on the outcome of https://github.com/php-fig/container/issues/8 (solved in https://github.com/php-fig/container/issues/9) ;
- [x] ~~solve the mandatory NotFoundExceptionInterface on non-existing service
problem (with a flag ?);~~ non-issue, see comments below
- [x] provide meta-package psr/container-implementation if all problems can
be solved.

| Q             | A
| ------------- | ---
| Branch?       | master
| New feature?  | yes
| BC breaks?    | not at the moment
| Tests pass?   | didn't pass before pushing, or even starting to code, will see Travis
| License       | MIT
| Doc PR        | TODO

This PR is a first attempt at implementing PSR-11, or at least trying to get closer to it.
Delegate lookup is optional, and thus not implemented for now.