### PR TITLE
[Cache] Using strpbrk() instead of strcspn() is faster

### DIFF
--- a/src/Symfony/Component/Cache/CacheItem.php
+++ b/src/Symfony/Component/Cache/CacheItem.php
@@ -101,7 +101,7 @@ final class CacheItem implements CacheItemInterface
      *
      * @param string $key The key to validate
      *
-     * @throws InvalidArgumentException When $key is not valid.
+     * @throws InvalidArgumentException When $key is not valid
      */
     public static function validateKey($key)
     {
@@ -111,7 +111,7 @@ final class CacheItem implements CacheItemInterface
         if (!isset($key[0])) {
             throw new InvalidArgumentException('Cache key length must be greater than zero');
         }
-        if (isset($key[strcspn($key, '{}()/\@:')])) {
+        if (false !== strpbrk($key, '{}()/\@:')) {
             throw new InvalidArgumentException(sprintf('Cache key "%s" contains reserved characters {}()/\@:', $key));
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Keys validation using strpbrk is faster.
Eg on some micro bench:
- `isset($a[strcspn($a, '{}()/\@:')])`: 278ms
- `false !== strpbrk($a, '{}()/\@:')`: 183ms
