### PR TITLE
[DependencyInjection] Use glob pattern to load config files

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -23,6 +23,7 @@ CHANGELOG
  * using the `PhpDumper` with an uncompiled `ContainerBuilder` is deprecated and
    will not be supported anymore in 4.0
  * deprecated the `DefinitionDecorator` class in favor of `ChildDefinition`
+ * allow config files to be loaded using a glob pattern
 
 3.2.0
 -----

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Loader;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Config\Loader\LoaderResolver;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\FileLoader;
+use Symfony\Component\DependencyInjection\Loader\IniFileLoader;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
+
+class FileLoaderTest extends \PHPUnit_Framework_TestCase
+{
+    protected static $fixturesPath;
+
+    public static function setUpBeforeClass()
+    {
+        self::$fixturesPath = realpath(__DIR__.'/../');
+    }
+
+    public function testImportWithGlobPattern()
+    {
+        $container = new ContainerBuilder();
+        $loader = new TestFileLoader($container, new FileLocator(self::$fixturesPath));
+
+        $resolver = new LoaderResolver(array(
+            new IniFileLoader($container, new FileLocator(self::$fixturesPath.'/ini')),
+            new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml')),
+            new PhpFileLoader($container, new FileLocator(self::$fixturesPath.'/php')),
+            new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml')),
+        ));
+
+        $loader->setResolver($resolver);
+        $loader->import('{F}ixtures/{xml,yaml}/services2.{yml,xml}');
+
+        $actual = $container->getParameterBag()->all();
+        $expected = array(
+            'a string',
+            'foo' => 'bar',
+            'values' => array(
+                0,
+                'integer' => 4,
+                100 => null,
+                'true',
+                true,
+                false,
+                'on',
+                'off',
+                'float' => 1.3,
+                1000.3,
+                'a string',
+                array('foo', 'bar'),
+            ),
+            'mixedcase' => array('MixedCaseKey' => 'value'),
+            'constant' => PHP_EOL,
+            'bar' => '%foo%',
+            'escape' => '@escapeme',
+            'foo_bar' => new Reference('foo_bar'),
+        );
+
+        $this->assertEquals(array_keys($expected), array_keys($actual), '->load() imports and merges imported files');
+    }
+}
+
+class TestFileLoader extends FileLoader
+{
+    public function load($resource, $type = null)
+    {
+        return $resource;
+    }
+
+    public function supports($resource, $type = null)
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #21173
| License       | MIT
| Doc PR        | -

This relates to #21173, but I'm not sure if it completely fixes the issue.

This allows to use a glob pattern to load config files, which makes the following possible:

```
# config.yml
imports:
    - { resource: "*.yml" }
    - { resource: "folder/*.yml" }
    - { resource: "/etc/myapp/*.{yml,xml}" }
```

It can also be used in a container extension, if a bundle uses a lot of configs:

```
$loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
$loader->load('*.yml');
$loader->load('routing/*');
```