### PR TITLE
[DX][Cache] Set right cacheItem type hint on AdapterInterface getters

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/AdapterInterface.php
+++ b/src/Symfony/Component/Cache/Adapter/AdapterInterface.php
@@ -21,4 +21,17 @@ use Symfony\Component\Cache\CacheItem;
  */
 interface AdapterInterface extends CacheItemPoolInterface
 {
+    /**
+    * {@inheritdoc}
+    *
+    * @return \Symfony\Component\Cache\CacheItem
+    */
+    public function getItem($key);
+
+   /**
+    * {@inheritdoc}
+    *
+    * return \Symfony\Component\Cache\CacheItem[]
+    */
+    public function getItems(array $keys = []);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

Fixes missing cache item type hint on pool getters so methods on Symfony CacheItem
is correctly suggested when using IDE's or api documentation.

As proposed here: https://github.com/symfony/symfony/issues/19728#issuecomment-269615921

_Note: Specifically sets array of CacheItems as return type of getItems as phpdoc and IDEs supports
this by now, and since this is specifically what is being returned. If Sami does not still support this we can adjust to what was originally suggested._
