### PR TITLE
[Workflow] Fixed support of multiple transitions with the same name.

### DIFF
--- a/src/Symfony/Component/Workflow/Tests/WorkflowBuilderTrait.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowBuilderTrait.php
@@ -49,6 +49,34 @@ trait WorkflowBuilderTrait
         // +---+     +----+     +---+     +----+     +---+
     }
 
+    private function createWorkflowWithSameNameTransition()
+    {
+        $places = range('a', 'c');
+
+        $transitions = array();
+        $transitions[] = new Transition('a_to_bc', 'a', array('b', 'c'));
+        $transitions[] = new Transition('b_to_c', 'b', 'c');
+        $transitions[] = new Transition('to_a', 'b', 'a');
+        $transitions[] = new Transition('to_a', 'c', 'a');
+
+        return new Definition($places, $transitions);
+
+        // The graph looks like:
+        //   +------------------------------------------------------------+
+        //   |                                                            |
+        //   |                                                            |
+        //   |         +----------------------------------------+         |
+        //   v         |                                        v         |
+        // +---+     +---------+     +---+     +--------+     +---+     +------+
+        // | a | --> | a_to_bc | --> | b | --> | b_to_c | --> | c | --> | to_a | -+
+        // +---+     +---------+     +---+     +--------+     +---+     +------+  |
+        //   ^                         |                                  ^       |
+        //   |                         +----------------------------------+       |
+        //   |                                                                    |
+        //   |                                                                    |
+        //   +--------------------------------------------------------------------+
+    }
+
     private function createComplexStateMachineDefinition()
     {
         $places = array('a', 'b', 'c', 'd');

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -89,15 +89,18 @@ class Workflow
      * @param string $transitionName A transition
      *
      * @return bool true if the transition is enabled
-     *
-     * @throws LogicException If the transition does not exist
      */
     public function can($subject, $transitionName)
     {
-        $transitions = $this->getTransitions($transitionName);
-        $marking = $this->getMarking($subject);
+        $transitions = $this->getEnabledTransitions($subject, $this->getMarking($subject));
 
-        return null !== $this->getTransitionForSubject($subject, $marking, $transitions);
+        foreach ($transitions as $transition) {
+            if ($transitionName === $transition->getName()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -113,22 +116,36 @@ class Workflow
      */
     public function apply($subject, $transitionName)
     {
-        $transitions = $this->getTransitions($transitionName);
-        $marking = $this->getMarking($subject);
+        $transitions = $this->getEnabledTransitions($subject, $this->getMarking($subject));
 
-        if (null === $transition = $this->getTransitionForSubject($subject, $marking, $transitions)) {
-            throw new LogicException(sprintf('Unable to apply transition "%s" for workflow "%s".', $transitionName, $this->name));
+        // We can shortcut the getMarking method in order to boost performance,
+        // since the "getEnabledTransitions" method already checks the Marking
+        // state
+        $marking = $this->markingStore->getMarking($subject);
+
+        $applied = false;
+
+        foreach ($transitions as $transition) {
+            if ($transitionName !== $transition->getName()) {
+                continue;
+            }
+
+            $applied = true;
+
+            $this->leave($subject, $transition, $marking);
+
+            $this->transition($subject, $transition, $marking);
+
+            $this->enter($subject, $transition, $marking);
+
+            $this->markingStore->setMarking($subject, $marking);
+
+            $this->announce($subject, $transition, $marking);
         }
 
-        $this->leave($subject, $transition, $marking);
-
-        $this->transition($subject, $transition, $marking);
-
-        $this->enter($subject, $transition, $marking);
-
-        $this->markingStore->setMarking($subject, $marking);
-
-        $this->announce($subject, $transition, $marking);
+        if (!$applied) {
+            throw new LogicException(sprintf('Unable to apply transition "%s" for workflow "%s".', $transitionName, $this->name));
+        }
 
         return $marking;
     }
@@ -146,7 +163,7 @@ class Workflow
         $marking = $this->getMarking($subject);
 
         foreach ($this->definition->getTransitions() as $transition) {
-            if (null !== $this->getTransitionForSubject($subject, $marking, array($transition))) {
+            if ($this->doCan($subject, $marking, $transition)) {
                 $enabled[] = $transition;
             }
         }
@@ -165,6 +182,21 @@ class Workflow
     public function getDefinition()
     {
         return $this->definition;
+    }
+
+    private function doCan($subject, Marking $marking, Transition $transition)
+    {
+        foreach ($transition->getFroms() as $place) {
+            if (!$marking->has($place)) {
+                return false;
+            }
+        }
+
+        if (true === $this->guardTransition($subject, $marking, $transition)) {
+            return false;
+        }
+
+        return true;
     }
 
     /**
@@ -246,56 +278,8 @@ class Workflow
 
         $event = new Event($subject, $marking, $initialTransition);
 
-        foreach ($this->definition->getTransitions() as $transition) {
-            if (null !== $this->getTransitionForSubject($subject, $marking, array($transition))) {
-                $this->dispatcher->dispatch(sprintf('workflow.%s.announce.%s', $this->name, $transition->getName()), $event);
-            }
-        }
-    }
-
-    /**
-     * @param $transitionName
-     *
-     * @return Transition[]
-     */
-    private function getTransitions($transitionName)
-    {
-        $transitions = $this->definition->getTransitions();
-
-        $transitions = array_filter($transitions, function (Transition $transition) use ($transitionName) {
-            return $transitionName === $transition->getName();
-        });
-
-        if (!$transitions) {
-            throw new LogicException(sprintf('Transition "%s" does not exist for workflow "%s".', $transitionName, $this->name));
-        }
-
-        return $transitions;
-    }
-
-    /**
-     * Return the first Transition in $transitions that is valid for the
-     * $subject and $marking. null is returned when you cannot do any Transition
-     * in $transitions on the $subject.
-     *
-     * @param object       $subject
-     * @param Marking      $marking
-     * @param Transition[] $transitions
-     *
-     * @return Transition|null
-     */
-    private function getTransitionForSubject($subject, Marking $marking, array $transitions)
-    {
-        foreach ($transitions as $transition) {
-            foreach ($transition->getFroms() as $place) {
-                if (!$marking->has($place)) {
-                    continue 2;
-                }
-            }
-
-            if (true !== $this->guardTransition($subject, $marking, $transition)) {
-                return $transition;
-            }
+        foreach ($this->getEnabledTransitions($subject) as $transition) {
+            $this->dispatcher->dispatch(sprintf('workflow.%s.announce.%s', $this->name, $transition->getName()), $event);
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

---

The previous behavior was underterministic because it took the first
transition during the `can` and the `apply` method. But the "first"
does not mean anything. Now the workflown apply all possible transitions
with the same name.