### PR TITLE
[Form][FrameworkBundle] Move FormPass to the Form component

### DIFF
--- a/UPGRADE-3.3.md
+++ b/UPGRADE-3.3.md
@@ -35,6 +35,10 @@ FrameworkBundle
 
  * The `Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddConsoleCommandPass` has been deprecated. Use `Symfony\Component\Console\DependencyInjection\AddConsoleCommandPass` instead.
 
+ * The `Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\FormPass` class has been
+   deprecated and will be removed in 4.0. Use the `Symfony\Component\Form\DependencyInjection\FormPass`
+   class instead.
+
 HttpKernel
 -----------
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -156,6 +156,9 @@ FrameworkBundle
 
  * The `Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddConsoleCommandPass` has been removed. Use `Symfony\Component\Console\DependencyInjection\AddConsoleCommandPass` instead.
 
+ * The `Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\FormPass` class has been
+   removed. Use the `Symfony\Component\Form\DependencyInjection\FormPass` class instead.
+
 SecurityBundle
 --------------
 

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -12,7 +12,7 @@ CHANGELOG
    is disabled.
  * Added `GlobalVariables::getToken()`
  * Deprecated `Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddConsoleCommandPass`. Use `Symfony\Component\Console\DependencyInjection\AddConsoleCommandPass` instead.
- * Added configurable paths for validation files 
+ * Deprecated `FormPass`, use `Symfony\Component\Form\DependencyInjection\FormPass` instead.
 
 3.2.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FormPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FormPass.php
@@ -11,74 +11,18 @@
 
 namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+@trigger_error(sprintf('The %s class is deprecated since version 3.3 and will be removed in 4.0. Use Symfony\Component\Form\DependencyInjection\FormPass instead.', FormPass::class), E_USER_DEPRECATED);
+
+use Symfony\Component\Form\DependencyInjection\FormPass as BaseFormPass;
 
 /**
  * Adds all services with the tags "form.type" and "form.type_guesser" as
  * arguments of the "form.extension" service.
  *
+ * @deprecated since version 3.3, to be removed in 4.0. Use {@link BaseFormPass} instead.
+ *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class FormPass implements CompilerPassInterface
+class FormPass extends BaseFormPass
 {
-    use PriorityTaggedServiceTrait;
-
-    public function process(ContainerBuilder $container)
-    {
-        if (!$container->hasDefinition('form.extension')) {
-            return;
-        }
-
-        $definition = $container->getDefinition('form.extension');
-
-        // Builds an array with fully-qualified type class names as keys and service IDs as values
-        $types = array();
-
-        foreach ($container->findTaggedServiceIds('form.type') as $serviceId => $tag) {
-            $serviceDefinition = $container->getDefinition($serviceId);
-            if (!$serviceDefinition->isPublic()) {
-                throw new InvalidArgumentException(sprintf('The service "%s" must be public as form types are lazy-loaded.', $serviceId));
-            }
-
-            // Support type access by FQCN
-            $types[$serviceDefinition->getClass()] = $serviceId;
-        }
-
-        $definition->replaceArgument(1, $types);
-
-        $typeExtensions = array();
-
-        foreach ($this->findAndSortTaggedServices('form.type_extension', $container) as $reference) {
-            $serviceId = (string) $reference;
-            $serviceDefinition = $container->getDefinition($serviceId);
-            if (!$serviceDefinition->isPublic()) {
-                throw new InvalidArgumentException(sprintf('The service "%s" must be public as form type extensions are lazy-loaded.', $serviceId));
-            }
-
-            $tag = $serviceDefinition->getTag('form.type_extension');
-            if (isset($tag[0]['extended_type'])) {
-                $extendedType = $tag[0]['extended_type'];
-            } else {
-                throw new InvalidArgumentException(sprintf('Tagged form type extension must have the extended type configured using the extended_type/extended-type attribute, none was configured for the "%s" service.', $serviceId));
-            }
-
-            $typeExtensions[$extendedType][] = $serviceId;
-        }
-
-        $definition->replaceArgument(2, $typeExtensions);
-
-        // Find all services annotated with "form.type_guesser"
-        $guessers = array_keys($container->findTaggedServiceIds('form.type_guesser'));
-        foreach ($guessers as $serviceId) {
-            $serviceDefinition = $container->getDefinition($serviceId);
-            if (!$serviceDefinition->isPublic()) {
-                throw new InvalidArgumentException(sprintf('The service "%s" must be public as form type guessers are lazy-loaded.', $serviceId));
-            }
-        }
-
-        $definition->replaceArgument(3, $guessers);
-    }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -39,7 +39,7 @@
         "symfony/dom-crawler": "~2.8|~3.0",
         "symfony/polyfill-intl-icu": "~1.0",
         "symfony/security": "~2.8|~3.0",
-        "symfony/form": "~2.8.16|~3.1.9|^3.2.2",
+        "symfony/form": "~3.3",
         "symfony/expression-language": "~2.8|~3.0",
         "symfony/process": "~2.8|~3.0",
         "symfony/security-core": "~3.2",
@@ -57,7 +57,8 @@
     "conflict": {
         "phpdocumentor/reflection-docblock": "<3.0",
         "phpdocumentor/type-resolver": "<0.2.0",
-        "symfony/console": "<3.3"
+        "symfony/console": "<3.3",
+        "symfony/form": "<3.3"
     },
     "suggest": {
         "ext-apcu": "For best performance of the system caches",

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.3.0
+-----
+
+ * added `FormPass`
+
 3.2.0
 -----
 

--- a/src/Symfony/Component/Form/DependencyInjection/FormPass.php
+++ b/src/Symfony/Component/Form/DependencyInjection/FormPass.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+
+/**
+ * Adds all services with the tags "form.type" and "form.type_guesser" as
+ * arguments of the "form.extension" service.
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class FormPass implements CompilerPassInterface
+{
+    use PriorityTaggedServiceTrait;
+
+    private $formExtensionService;
+    private $formTypeTag;
+    private $formTypeExtensionTag;
+    private $formTypeGuesserTag;
+
+    public function __construct($formExtensionService = 'form.extension', $formTypeTag = 'form.type', $formTypeExtensionTag = 'form.type_extension', $formTypeGuesserTag = 'form.type_guesser')
+    {
+        $this->formExtensionService = $formExtensionService;
+        $this->formTypeTag = $formTypeTag;
+        $this->formTypeExtensionTag = $formTypeExtensionTag;
+        $this->formTypeGuesserTag = $formTypeGuesserTag;
+    }
+
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition($this->formExtensionService)) {
+            return;
+        }
+
+        $definition = $container->getDefinition($this->formExtensionService);
+
+        // Builds an array with fully-qualified type class names as keys and service IDs as values
+        $types = array();
+        foreach ($container->findTaggedServiceIds($this->formTypeTag) as $serviceId => $tag) {
+            $serviceDefinition = $container->getDefinition($serviceId);
+            if (!$serviceDefinition->isPublic()) {
+                throw new InvalidArgumentException(sprintf('The service "%s" must be public as form types are lazy-loaded.', $serviceId));
+            }
+
+            // Support type access by FQCN
+            $types[$serviceDefinition->getClass()] = $serviceId;
+        }
+
+        $definition->replaceArgument(1, $types);
+
+        $typeExtensions = array();
+
+        foreach ($this->findAndSortTaggedServices($this->formTypeExtensionTag, $container) as $reference) {
+            $serviceId = (string) $reference;
+            $serviceDefinition = $container->getDefinition($serviceId);
+            if (!$serviceDefinition->isPublic()) {
+                throw new InvalidArgumentException(sprintf('The service "%s" must be public as form type extensions are lazy-loaded.', $serviceId));
+            }
+
+            $tag = $serviceDefinition->getTag($this->formTypeExtensionTag);
+            if (isset($tag[0]['extended_type'])) {
+                $extendedType = $tag[0]['extended_type'];
+            } else {
+                throw new InvalidArgumentException(sprintf('"%s" tagged services must have the extended type configured using the extended_type/extended-type attribute, none was configured for the "%s" service.', $this->formTypeExtensionTag, $serviceId));
+            }
+
+            $typeExtensions[$extendedType][] = $serviceId;
+        }
+
+        $definition->replaceArgument(2, $typeExtensions);
+
+        $guessers = array_keys($container->findTaggedServiceIds($this->formTypeGuesserTag));
+        foreach ($guessers as $serviceId) {
+            $serviceDefinition = $container->getDefinition($serviceId);
+            if (!$serviceDefinition->isPublic()) {
+                throw new InvalidArgumentException(sprintf('The service "%s" must be public as form type guessers are lazy-loaded.', $serviceId));
+            }
+        }
+
+        $definition->replaceArgument(3, $guessers);
+    }
+}

--- a/src/Symfony/Component/Form/Tests/DependencyInjection/FormPassTest.php
+++ b/src/Symfony/Component/Form/Tests/DependencyInjection/FormPassTest.php
@@ -9,17 +9,15 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
+namespace Symfony\Component\Form\Tests\DependencyInjection;
 
-use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\FormPass;
+use Symfony\Component\Form\DependencyInjection\FormPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Form\AbstractType;
 
 /**
- * @group legacy
- *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 class FormPassTest extends \PHPUnit_Framework_TestCase

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -26,7 +26,8 @@
     "require-dev": {
         "doctrine/collections": "~1.0",
         "symfony/validator": "~2.8|~3.0",
-        "symfony/dependency-injection": "~2.8|~3.0",
+        "symfony/dependency-injection": "~3.2",
+        "symfony/config": "~2.7|~3.0",
         "symfony/http-foundation": "~2.8|~3.0",
         "symfony/http-kernel": "~2.8|~3.0",
         "symfony/security-csrf": "~2.8|~3.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

So that anyone using only Form and DI can use it for registering form types/type guessers.
Follows #19443, related to #21284 
