### PR TITLE
[Doctrine Bridge] fix UniqueEntityValidator for composite object primary keys

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/CompositeObjectNoToStringIdEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/CompositeObjectNoToStringIdEntity.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * an entity that has two objects (class without toString methods) as primary key.
+ *
+ * @ORM\Entity
+ */
+class CompositeObjectNoToStringIdEntity
+{
+    /**
+     * @var SingleIntIdNoToStringEntity
+     *
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="SingleIntIdNoToStringEntity", cascade={"persist"})
+     * @ORM\JoinColumn(name="object_one_id")
+     */
+    protected $objectOne;
+
+    /**
+     * @var SingleIntIdNoToStringEntity
+     *
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="SingleIntIdNoToStringEntity", cascade={"persist"})
+     * @ORM\JoinColumn(name="object_two_id")
+     */
+    protected $objectTwo;
+
+    public function __construct(SingleIntIdNoToStringEntity $objectOne, SingleIntIdNoToStringEntity $objectTwo)
+    {
+        $this->objectOne = $objectOne;
+        $this->objectTwo = $objectTwo;
+    }
+
+    /**
+     * @return SingleIntIdNoToStringEntity
+     */
+    public function getObjectOne()
+    {
+        return $this->objectOne;
+    }
+
+    /**
+     * @return SingleIntIdNoToStringEntity
+     */
+    public function getObjectTwo()
+    {
+        return $this->objectTwo;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -175,7 +175,7 @@ class UniqueEntityValidatorTest extends AbstractConstraintValidatorTest
         $this->buildViolation('myMessage')
             ->atPath('property.path.name')
             ->setParameter('{{ value }}', '"Foo"')
-            ->setInvalidValue('Foo')
+            ->setInvalidValue($entity2)
             ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
             ->assertRaised();
     }
@@ -200,7 +200,7 @@ class UniqueEntityValidatorTest extends AbstractConstraintValidatorTest
         $this->buildViolation('myMessage')
             ->atPath('property.path.bar')
             ->setParameter('{{ value }}', '"Foo"')
-            ->setInvalidValue('Foo')
+            ->setInvalidValue($entity2)
             ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
             ->assertRaised();
     }
@@ -419,7 +419,7 @@ class UniqueEntityValidatorTest extends AbstractConstraintValidatorTest
 
         $this->buildViolation('myMessage')
             ->atPath('property.path.single')
-            ->setParameter('{{ value }}', $entity1)
+            ->setParameter('{{ value }}', 'object("Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity") identified by (id => 1)')
             ->setInvalidValue($entity1)
             ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
             ->assertRaised();
@@ -452,12 +452,12 @@ class UniqueEntityValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate($associated2, $constraint);
 
-        $expectedValue = 'Object of class "Symfony\Bridge\Doctrine\Tests\Fixtures\AssociationEntity2" identified by "2"';
+        $expectedValue = 'object("Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdNoToStringEntity") identified by (id => 1)';
 
         $this->buildViolation('myMessage')
             ->atPath('property.path.single')
-            ->setParameter('{{ value }}', '"'.$expectedValue.'"')
-            ->setInvalidValue($expectedValue)
+            ->setParameter('{{ value }}', $expectedValue)
+            ->setInvalidValue($entity1)
             ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
             ->assertRaised();
     }
@@ -574,6 +574,11 @@ class UniqueEntityValidatorTest extends AbstractConstraintValidatorTest
 
         $objectOne = new SingleIntIdNoToStringEntity(1, 'foo');
         $objectTwo = new SingleIntIdNoToStringEntity(2, 'bar');
+
+        $this->em->persist($objectOne);
+        $this->em->persist($objectTwo);
+        $this->em->flush();
+
         $entity = new CompositeObjectNoToStringIdEntity($objectOne, $objectTwo);
 
         $this->em->persist($entity);
@@ -583,12 +588,12 @@ class UniqueEntityValidatorTest extends AbstractConstraintValidatorTest
 
         $this->validator->validate($newEntity, $constraint);
 
-        $expectedValue = 'Object of class "Symfony\Bridge\Doctrine\Tests\Fixtures\CompositeObjectNoToStringIdEntity" identified by "(Object of class "Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdNoToStringEntity" identified by "1"), (Object of class "Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdNoToStringEntity" identified by "2")"';
+        $expectedValue = 'object("Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdNoToStringEntity") identified by (id => 1)';
 
         $this->buildViolation('myMessage')
             ->atPath('property.path.objectOne')
-            ->setParameter('{{ value }}', '"'.$expectedValue.'"')
-            ->setInvalidValue($expectedValue)
+            ->setParameter('{{ value }}', $expectedValue)
+            ->setInvalidValue($objectOne)
             ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
             ->assertRaised();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master / 3.1
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    | no
| Deprecations? |no
| Tests pass?   | yes (fail on php 7.1 unrelated?)
| Fixed tickets | https://github.com/symfony/symfony/issues/21274
| License       | MIT
| Doc PR        | -

This PR fixes an issue with the UniqueEntityValidator in case the entity being validated uses a composite primary key via relations to other entities whose classes do not have a `__toString` method.